### PR TITLE
Run nix-shell with --pure when creating the .envrc

### DIFF
--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -83,7 +83,7 @@ all: build/ihp-lib build/Generated/Types.hs
 
 .envrc: default.nix ## Rebuild nix packages and .envrc
 	rm -f .envrc
-	echo "PATH_add $$(nix-shell -j auto --cores 0 --run 'echo $$PATH')" > .envrc
+	echo "PATH_add $$(nix-shell -j auto --cores 0 --pure --run 'echo $$PATH')" > .envrc
 	direnv allow
 
 build/bin:


### PR DESCRIPTION
This fixes a bug where the `.envrc` keeps growing every time you regenerate it.

By default, nix-shell gets the current $PATH and prepends the nix store $PATH. That means that if you already have the current `.envrc` loaded, both the current content of `.envrc` and the new computed path will be save to `.envrc`, making it grow over time. This is fixed by calling nix-shell with `--pure`.