### PR TITLE
Fix curl command in Installation Guide

### DIFF
--- a/Guide/installation.markdown
+++ b/Guide/installation.markdown
@@ -15,7 +15,7 @@ That's why we first need to make sure that you have nix installed.
 Run this commands in your terminal to install nix on your machine.
 
 ```bash
-sh <(curl https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume
+sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume
 ```
 After this restart your terminal.
 
@@ -36,7 +36,7 @@ sudo apt install curl git -y
 Install nix by running the following command in your shell and follow the instructions on the screen:
 
 ```bash
-curl https://nixos.org/nix/install | sh
+curl -L https://nixos.org/nix/install | sh
 ```
 
 There are also other ways to install nix, [take a look at the documentation](https://nixos.org/nix/download.html).
@@ -77,7 +77,7 @@ use-sqlite-wal = false
 After saving the file, you can now install nix:
 
 ```bash
-curl https://nixos.org/nix/install | sh
+curl -L https://nixos.org/nix/install | sh
 ```
 
 When the installation finishes successfuly, you will be prompted to either reload your environment with the given command, or restart your shell. 


### PR DESCRIPTION
Nix install URL `https://nixos.org/nix/install` uses a redirect, `-L` flag needs to specified to `curl`, otherwise empty response is returned:

```
$ curl https://nixos.org/nix/install -v
*   Trying 68.183.215.91:443...
* TCP_NODELAY set
* Connected to nixos.org (68.183.215.91) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=*.nixos.org
*  start date: Jun  5 09:04:54 2020 GMT
*  expire date: Sep  3 09:04:54 2020 GMT
*  subjectAltName: host "nixos.org" matched cert's "nixos.org"
*  issuer: C=US; O=Let's Encrypt; CN=Let's Encrypt Authority X3
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x5648e19be480)
> GET /nix/install HTTP/2
> Host: nixos.org
> User-Agent: curl/7.66.0
> Accept: */*
> 
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Connection state changed (MAX_CONCURRENT_STREAMS == 150)!
< HTTP/2 301 
< content-length: 0
< date: Tue, 23 Jun 2020 16:21:31 GMT
< location: https://releases.nixos.org/nix/nix-2.3.6/install
< server: Netlify
< via: 1.1 999a435eb37a050d3de26fe63534c416.cloudfront.net (CloudFront)
< x-amz-cf-id: QobbCkGYh_OieOKcTGXmJsPK0kk796gUg5bUZvz7gcH1UxE0S52iwg==
< x-amz-cf-pop: FRA2-C2
< x-cache: Miss from cloudfront
< age: 2991
< x-nf-request-id: cfb47bb6-b81e-4653-952a-df0d6f0eb5b7-3600583
< 
* Connection #0 to host nixos.org left intact
```