### PR TITLE
Correct wrong url in Adding Validation section

### DIFF
--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -460,7 +460,7 @@ buildPost post = post
     |> validateField #title nonEmpty
 ```
 
-Now open [http://localhost:8000/Posts/new](http://localhost:8000/Posts/new) and click `Save Post` without filling the text fields. You will get a "This field cannot be empty" error message next to the empty title field.
+Now open [http://localhost:8000/NewPost](http://localhost:8000/Posts/new) and click `Save Post` without filling the text fields. You will get a "This field cannot be empty" error message next to the empty title field.
 
 ![Schema Designer Title non empty](images/first-project/title_non_empty.png)
 


### PR DESCRIPTION
corrected wrong url in "Adding Validation" section

from ```/Posts/new``` to ```/NewPost``` as the former does not work, at least at this point in the guide.