### PR TITLE
use session store, even on Linux

### DIFF
--- a/IHP/IDE/ToolServer.hs
+++ b/IHP/IDE/ToolServer.hs
@@ -21,7 +21,6 @@ import IHP.ApplicationContext
 import IHP.ModelSupport
 import IHP.RouterSupport hiding (get)
 import qualified Web.Cookie as Cookie
-import Network.Wai.Session.Map (mapStore_)
 import qualified Data.Time.Clock
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
@@ -65,9 +64,7 @@ startToolServer' port isDebugMode = do
     writeIORef Config.portRef port
 
     session <- Vault.newKey
-    store <- case os of
-        "linux" -> mapStore_
-        _ -> fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
+    store <- fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
     let sessionCookie = def
                 { Cookie.setCookiePath = Just "/"
                 , Cookie.setCookieMaxAge = Just (fromIntegral (60 * 60 * 24 * 30))

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -9,7 +9,6 @@ import Network.Wai.Session (withSession, Session)
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
 import qualified Data.Vault.Lazy as Vault
-import Network.Wai.Session.Map (mapStore_)
 import qualified Web.Cookie as Cookie
 import qualified Data.Time.Clock
 import IHP.ModelSupport
@@ -31,9 +30,7 @@ run = do
     conn <- connectPostgreSQL databaseUrl 
     session <- Vault.newKey
     port <- FrameworkConfig.initAppPort
-    store <- case os of
-        "linux" -> mapStore_
-        _ -> fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
+    store <- fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
     let applicationContext = ApplicationContext { modelContext = (ModelContext conn), session }
     let application :: Application = \request respond -> do
             let ?applicationContext = applicationContext


### PR DESCRIPTION
Apparently there was a segfault on Linux earlier, so a memory cache was used for the session store on Linux. This causes frequent logouts though, so I removed it. No segfaults so far. If they happen again, let's fix the root cause :-)