### PR TITLE
Improved sql parser

### DIFF
--- a/IHP/IDE/SchemaDesigner/Controller/Columns.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Columns.hs
@@ -18,6 +18,7 @@ import qualified System.Process as Process
 import IHP.IDE.SchemaDesigner.Parser (schemaFilePath)
 import qualified Data.Text.IO as Text
 import IHP.IDE.SchemaDesigner.Controller.Schema
+import IHP.IDE.SchemaDesigner.Controller.Helper
 
 instance Controller ColumnsController where
     

--- a/IHP/IDE/SchemaDesigner/Controller/Helper.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Helper.hs
@@ -1,0 +1,11 @@
+module IHP.IDE.SchemaDesigner.Controller.Helper where
+
+import IHP.ControllerPrelude
+import IHP.IDE.SchemaDesigner.Types
+import qualified IHP.IDE.SchemaDesigner.Parser as Parser
+import qualified Text.Megaparsec as Megaparsec
+
+instance ParamReader PostgresType where
+    readParameter byteString = case Megaparsec.runParser Parser.sqlType "" (cs byteString) of
+        Left error -> Left (cs $ tshow error)
+        Right result -> Right result

--- a/IHP/IDE/SchemaDesigner/Controller/Tables.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Tables.hs
@@ -75,7 +75,7 @@ instance Controller TablesController where
 addTable :: Text -> [Statement] -> [Statement]
 addTable tableName list = list <> [CreateTable { name = tableName, columns = [Column
                 { name = "id"
-                , columnType = "UUID"
+                , columnType = PUUID
                 , primaryKey = True
                 , defaultValue = Just (CallExpression "uuid_generate_v4" [])
                 , notNull = True

--- a/IHP/IDE/SchemaDesigner/Parser.hs
+++ b/IHP/IDE/SchemaDesigner/Parser.hs
@@ -68,6 +68,9 @@ createExtension = do
 createTable = do
     lexeme "CREATE"
     lexeme "TABLE"
+    optional do
+        lexeme "public"
+        char '.'
     name <- identifier
     columns <- between (char '(' >> space) (char ')' >> space) (column `sepBy` (char ',' >> space))
     char ';'

--- a/IHP/IDE/SchemaDesigner/Types.hs
+++ b/IHP/IDE/SchemaDesigner/Types.hs
@@ -23,7 +23,7 @@ data Statement
 
 data Column = Column
     { name :: Text
-    , columnType :: Text
+    , columnType :: PostgresType
     , primaryKey :: Bool
     , defaultValue :: Maybe Expression
     , notNull :: Bool
@@ -55,4 +55,19 @@ data Expression =
     | VarExpression Text
     -- | Simple call, like @COALESCE(name, 'unknown name')@
     | CallExpression Text [Expression]
+    deriving (Eq, Show)
+
+data PostgresType
+    = PUUID
+    | PText
+    | PInt
+    | PBigInt
+    | PBoolean
+    | PTimestampWithTimezone
+    | PReal
+    | PDouble
+    | PDate
+    | PBinary
+    | PTime
+    | PCustomType Text
     deriving (Eq, Show)

--- a/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
@@ -2,7 +2,7 @@ module IHP.IDE.SchemaDesigner.View.Columns.Edit where
 
 import IHP.ViewPrelude
 import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.SchemaDesigner.Compiler (compileExpression)
+import qualified IHP.IDE.SchemaDesigner.Compiler as Compiler
 import IHP.IDE.ToolServer.Types
 import IHP.IDE.ToolServer.Layout
 import IHP.View.Modal
@@ -97,8 +97,8 @@ instance View EditColumnView ViewContext where
             modalTitle = "Edit Column"
             modal = Modal { modalContent, modalFooter, modalCloseUrl, modalTitle }
 
-typeSelector :: Maybe Text -> [Text] -> Html
-typeSelector selected enumNames = [hsx|
+typeSelector :: Maybe PostgresType -> [Text] -> Html
+typeSelector postgresType enumNames = [hsx|
         <select id="typeSelector" name="columnType" class="form-control select2-simple">
             {option selected "TEXT" "Text"}
             {option selected "INT" "Int"}
@@ -114,6 +114,9 @@ typeSelector selected enumNames = [hsx|
         </select>
 |]
     where
+        selected :: Maybe Text
+        selected = fmap Compiler.compilePostgresType postgresType
+
         renderEnumType enum = option selected enum enum
         option :: Maybe Text -> Text -> Text -> Html
         option selected value text = case selected of
@@ -136,9 +139,9 @@ defaultSelector defValue = [hsx|
         values = if defValue `elem` suggestedValues then suggestedValues else defValue:suggestedValues
 
         renderValue :: Maybe Expression -> Html
-        renderValue e@(Just expression) = [hsx|<option value={compileExpression expression} selected={e == defValue}>{displayedValue}</option>|]
+        renderValue e@(Just expression) = [hsx|<option value={Compiler.compileExpression expression} selected={e == defValue}>{displayedValue}</option>|]
             where
                 displayedValue = case expression of
                     TextExpression "" -> "\"\""
-                    _ -> compileExpression expression
+                    _ -> Compiler.compileExpression expression
         renderValue Nothing = [hsx|<option value="" selected={Nothing == defValue}>No default</option>|]

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -55,19 +55,18 @@ haskellType table column@(Column { columnType, notNull }) =
     let
         atomicType = 
             case columnType of
-                "INT" -> "Int"
-                "TEXT" -> "Text"
-                "BOOL"   -> "Bool"
-                "BOOLEAN"   -> "Bool"
-                "TIMESTAMP WITH TIME ZONE" -> "UTCTime"
-                "UUID" -> "UUID"
-                "FLOAT" -> "Float"
-                "DOUBLE PRECISION" -> "Double"
-                "DATE" -> "Data.Time.Calendar.Day"
-                "BINARY" -> "Binary"
-                "TIME" -> "TimeOfDay"
-                "REAL" -> "Float"
-                customType -> tableNameToModelName customType
+                PInt -> "Int"
+                PBigInt -> "INTEGER"
+                PText -> "Text"
+                PBoolean   -> "Bool"
+                PTimestampWithTimezone -> "UTCTime"
+                PUUID -> "UUID"
+                PReal -> "Float"
+                PDouble -> "Double"
+                PDate -> "Data.Time.Calendar.Day"
+                PBinary -> "Binary"
+                PTime -> "TimeOfDay"
+                PCustomType theType -> tableNameToModelName theType
         actualType =
             case findForeignKeyConstraint table column of
                 Just (ForeignKeyConstraint { referenceTable }) -> "(" <> primaryKeyTypeName' referenceTable <> ")"
@@ -426,10 +425,10 @@ toDefaultValueExpr Column { columnType, notNull, defaultValue = Just theDefaultV
                     then "Nothing"
                     else
                         case columnType of
-                            "TEXT" -> case theDefaultValue of
+                            PText -> case theDefaultValue of
                                 TextExpression value -> wrapNull notNull (tshow value)
                                 otherwise            -> error ("toDefaultValueExpr: TEXT column needs to have a TextExpression as default value. Got: " <> show otherwise)
-                            "BOOl" -> case theDefaultValue of
+                            PBoolean -> case theDefaultValue of
                                 VarExpression value -> wrapNull notNull (tshow (toLower value == "true"))
                                 otherwise           -> error ("toDefaultValueExpr: BOOL column needs to have a VarExpression as default value. Got: " <> show otherwise)
                             _ -> "def"

--- a/Test/IDE/SchemaDesigner/CompilerSpec.hs
+++ b/Test/IDE/SchemaDesigner/CompilerSpec.hs
@@ -40,7 +40,7 @@ tests = do
                     , columns = [
                         Column
                             { name = "id"
-                            , columnType = "UUID"
+                            , columnType = PUUID
                             , primaryKey = True
                             , defaultValue = Just (CallExpression "uuid_generate_v4" [])
                             , notNull = True
@@ -48,7 +48,7 @@ tests = do
                             }
                         , Column
                             { name = "firstname"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -56,7 +56,7 @@ tests = do
                             }
                         , Column
                             { name = "lastname"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -64,7 +64,7 @@ tests = do
                             }
                         , Column
                             { name = "password_hash"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -72,7 +72,7 @@ tests = do
                             }
                         , Column
                             { name = "email"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -80,7 +80,7 @@ tests = do
                             }
                         , Column
                             { name = "company_id"
-                            , columnType = "UUID"
+                            , columnType = PUUID
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -88,7 +88,7 @@ tests = do
                             }
                         , Column
                             { name = "picture_url"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = False
@@ -96,7 +96,7 @@ tests = do
                             }
                         , Column
                             { name = "created_at"
-                            , columnType = "TIMESTAMP WITH TIME ZONE"
+                            , columnType = PTimestampWithTimezone
                             , primaryKey = False
                             , defaultValue = Just (CallExpression "NOW" [])
                             , notNull = True
@@ -182,7 +182,7 @@ tests = do
                     , columns = [
                         Column
                             { name = "content"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Just (TextExpression "example text")
                             , notNull = True

--- a/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -40,7 +40,7 @@ tests = do
                     , columns = [
                         Column
                             { name = "id"
-                            , columnType = "UUID"
+                            , columnType = PUUID
                             , primaryKey = True
                             , defaultValue = Just (CallExpression "uuid_generate_v4" [])
                             , notNull = True
@@ -48,7 +48,7 @@ tests = do
                             }
                         , Column
                             { name = "firstname"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -56,7 +56,7 @@ tests = do
                             }
                         , Column
                             { name = "lastname"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -64,7 +64,7 @@ tests = do
                             }
                         , Column
                             { name = "password_hash"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -72,7 +72,7 @@ tests = do
                             }
                         , Column
                             { name = "email"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -80,7 +80,7 @@ tests = do
                             }
                         , Column
                             { name = "company_id"
-                            , columnType = "UUID"
+                            , columnType = PUUID
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = True
@@ -88,7 +88,7 @@ tests = do
                             }
                         , Column
                             { name = "picture_url"
-                            , columnType = "TEXT"
+                            , columnType = PText
                             , primaryKey = False
                             , defaultValue = Nothing
                             , notNull = False
@@ -96,7 +96,7 @@ tests = do
                             }
                         , Column
                             { name = "created_at"
-                            , columnType = "TIMESTAMP WITH TIME ZONE"
+                            , columnType = PTimestampWithTimezone
                             , primaryKey = False
                             , defaultValue = Just (CallExpression "NOW" [])
                             , notNull = True
@@ -180,6 +180,57 @@ tests = do
         -- Thats why empty Enums will not throw errors.
         it "should parse CREATE TYPE .. AS ENUM without values" do
             parseSql "CREATE TYPE colors AS ENUM ();" `shouldBe` CreateEnumType { name = "colors", values = [] }
+
+        it "should parse a CREATE TABLE with INTEGER / INT / INT4 / BIGINT / INT 8 columns" do
+            parseSql "CREATE TABLE ints (int_a INTEGER, int_b INT, int_c int4, bigint_a BIGINT, bigint_b int8);" `shouldBe` CreateTable
+                    { name = "ints"
+                    , columns =
+                        [ col { name = "int_a", columnType = PInt }
+                        , col { name = "int_b", columnType = PInt }
+                        , col { name = "int_c", columnType = PInt }
+                        , col { name = "bigint_a", columnType = PBigInt }
+                        , col { name = "bigint_b", columnType = PBigInt }
+                        ]
+                    }
+
+        it "should parse a CREATE TABLE with TIMESTAMP WITH TIMEZONE / TIMESTAMPZ columns" do
+            parseSql "CREATE TABLE timestamps (a TIMESTAMP WITH TIME ZONE, b TIMESTAMPZ);" `shouldBe` CreateTable
+                    { name = "timestamps"
+                    , columns =
+                        [ col { name = "a", columnType = PTimestampWithTimezone }
+                        , col { name = "b", columnType = PTimestampWithTimezone }
+                        ]
+                    }
+
+        it "should parse a CREATE TABLE with BOOLEAN / BOOL columns" do
+            parseSql "CREATE TABLE bools (a BOOLEAN, b BOOL);" `shouldBe` CreateTable
+                    { name = "bools"
+                    , columns =
+                        [ col { name = "a", columnType = PBoolean }
+                        , col { name = "b", columnType = PBoolean }
+                        ]
+                    }
+
+        it "should parse a CREATE TABLE with REAL, FLOAT4, DOUBLE, FLOAT8 columns" do
+            parseSql "CREATE TABLE bools (a REAL, b FLOAT4, c DOUBLE PRECISION, d FLOAT8);" `shouldBe` CreateTable
+                    { name = "bools"
+                    , columns =
+                        [ col { name = "a", columnType = PReal }
+                        , col { name = "b", columnType = PReal }
+                        , col { name = "c", columnType = PDouble }
+                        , col { name = "d", columnType = PDouble }
+                        ]
+                    }
+
+col :: Column
+col = Column
+    { name = ""
+    , columnType = PCustomType ""
+    , primaryKey = False
+    , defaultValue = Nothing
+    , notNull = False
+    , isUnique = False
+    }
 
 parseSql :: Text -> Statement
 parseSql sql = let [statement] = parseSqlStatements sql in statement

--- a/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -108,6 +108,9 @@ tests = do
         it "should parse a CREATE TABLE with quoted identifiers" do
             parseSql "CREATE TABLE \"quoted name\" ();" `shouldBe` CreateTable { name = "quoted name", columns = [] }
 
+        it "should parse a CREATE TABLE with public schema prefix" do
+            parseSql "CREATE TABLE public.users ();" `shouldBe` CreateTable { name = "users", columns = [] }
+
         it "should parse ALTER TABLE .. ADD FOREIGN KEY .. ON DELETE CASCADE" do
             parseSql "ALTER TABLE users ADD CONSTRAINT users_ref_company_id FOREIGN KEY (company_id) REFERENCES companies (id) ON DELETE CASCADE;" `shouldBe` AddConstraint
                     { tableName = "users"


### PR DESCRIPTION
Sql Types previously have been stored as just a Text. Now we have a new data structure PostgresType instead of the Text value. This will make it easier to support types like `Numeric (p, s)` in the future.

Additionally the sql parser now can parse a lot more types. Completly new are:
- Bigint
- Real

Missing aliases for already existing type have been added as well:
- FLOAT8 (= DOUBLE PRECISION)
- INT4 (=INT)
- INTEGER (=INT)
- BOOL (=BOOLEAN)
- TIMESTAMPZ (=TIMESTAMP WITH TIME ZONE)

Previously the sql types had to be written in upper case form, so `boolean` was disallowed while `BOOLEAN` was ok. This has been fixed and now both forms will be parsed as expected.