### PR TITLE
Fixed SchemaCompiler only accepting null values written `null`, and not `NULL`

### DIFF
--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -421,8 +421,11 @@ toDefaultValueExpr Column { columnType, notNull, defaultValue = Just theDefaultV
             let
                 wrapNull False value = "(Just " <> value <> ")"
                 wrapNull True value = value
+
+                isNullExpr (VarExpression varName) = toUpper varName == "NULL"
+                isNullExpr _ = False
             in
-                if theDefaultValue == VarExpression "null"
+                if isNullExpr theDefaultValue
                     then "Nothing"
                     else
                         case columnType of


### PR DESCRIPTION
Fixes