### PR TITLE
Disabled external interpreter to avoid issues on certain Linux systems

### DIFF
--- a/IHP/IDE/DevServer.hs
+++ b/IHP/IDE/DevServer.hs
@@ -208,7 +208,7 @@ stopFileWatcher _ = pure ()
 
 startGHCI :: IO ManagedProcess
 startGHCI = do
-    let args = ["-threaded", "-fexternal-interpreter", "-fomit-interface-pragmas", "-j", "-O0", "+RTS", "-A512m", "-n4m", "-H512m", "-G3", "-qg"]
+    let args = ["-threaded", "-fomit-interface-pragmas", "-j", "-O0", "+RTS", "-A512m", "-n4m", "-H512m", "-G3", "-qg"]
     createManagedProcess (Process.proc "ghci" args)
             { Process.std_in = Process.CreatePipe
             , Process.std_out = Process.CreatePipe

--- a/IHP/IDE/ToolServer.hs
+++ b/IHP/IDE/ToolServer.hs
@@ -21,7 +21,6 @@ import IHP.ApplicationContext
 import IHP.ModelSupport
 import IHP.RouterSupport hiding (get)
 import qualified Web.Cookie as Cookie
-import Network.Wai.Session.Map (mapStore_)
 import qualified Data.Time.Clock
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
@@ -65,9 +64,7 @@ startToolServer' port isDebugMode = do
     writeIORef Config.portRef port
 
     session <- Vault.newKey
-    store <- case os of
-        "linux" -> mapStore_
-        _ -> fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
+    store <- fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
     let sessionCookie = def
                 { Cookie.setCookiePath = Just "/"
                 , Cookie.setCookieMaxAge = Just (fromIntegral (60 * 60 * 24 * 30))

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -9,7 +9,6 @@ import Network.Wai.Session (withSession, Session)
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
 import qualified Data.Vault.Lazy as Vault
-import Network.Wai.Session.Map (mapStore_)
 import qualified Web.Cookie as Cookie
 import qualified Data.Time.Clock
 import IHP.ModelSupport
@@ -31,9 +30,7 @@ run = do
     conn <- connectPostgreSQL databaseUrl 
     session <- Vault.newKey
     port <- FrameworkConfig.initAppPort
-    store <- case os of
-        "linux" -> mapStore_
-        _ -> fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
+    store <- fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
     let applicationContext = ApplicationContext { modelContext = (ModelContext conn), session }
     let application :: Application = \request respond -> do
             let ?applicationContext = applicationContext


### PR DESCRIPTION

Additonally this improves the performance on VMs a lot when loading IHP as a source module.
Especially fixes the issue with clientsession (#182).