### PR TITLE
Added remainingText function which replaces the old getInput

### DIFF
--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -240,7 +240,7 @@ instance CanRoute PostsController where
     parseRoute' = do
         string "/posts/"
         let postById = do id <- parseId; endOfInput; pure ShowPostAction { postId, slug = Nothing }
-        let postBySlug = do slug <- getInput; pure ShowPostAction { postId = Nothing, slug }
+        let postBySlug = do slug <- remainingText; pure ShowPostAction { postId = Nothing, slug }
         postById <|> postBySlug
 ```
 

--- a/IHP/RouterPrelude.hs
+++ b/IHP/RouterPrelude.hs
@@ -1,13 +1,18 @@
+{-|
+Module: IHP.RouterPrelude
+Description: Prelude used by modules like Web.Routes, Admin.Routes, etc.
+Copyright: (c) digitally induced GmbH, 2020
+-}
 module IHP.RouterPrelude
-    ( module IHP.RouterSupport
-    , module Data.Attoparsec.ByteString.Char8
-    , module ClassyPrelude
-    , module Data.String.Conversions
-    , module IHP.ModelSupport
-    )
+( module IHP.RouterSupport
+, module Data.Attoparsec.ByteString.Char8
+, module ClassyPrelude
+, module Data.String.Conversions
+, module IHP.ModelSupport
+)
 where
 
-import Data.Attoparsec.ByteString.Char8 (string, Parser, (<?>), parseOnly, take, endOfInput)
+import Data.Attoparsec.ByteString.Char8 (string, Parser, (<?>), parseOnly, take, endOfInput, takeByteString)
 import IHP.RouterSupport
 import ClassyPrelude hiding (index, delete, show, take)
 import Data.String.Conversions (cs)

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -22,6 +22,7 @@ CanRoute (..)
 , urlTo
 , parseUUID
 , parseId
+, remainingText
 ) where
 
 import qualified Prelude
@@ -454,3 +455,7 @@ parseUUID = do
 parseId :: Parser (ModelSupport.Id record)
 parseId = ModelSupport.Id <$> parseUUID
 {-# INLINE parseId #-}
+
+-- | Returns all the remaining text until the end of the input
+remainingText :: Parser Text
+remainingText = cs <$> takeByteString

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -23,6 +23,7 @@ CanRoute (..)
 , parseUUID
 , parseId
 , remainingText
+, parseText
 ) where
 
 import qualified Prelude
@@ -459,3 +460,7 @@ parseId = ModelSupport.Id <$> parseUUID
 -- | Returns all the remaining text until the end of the input
 remainingText :: Parser Text
 remainingText = cs <$> takeByteString
+
+-- | Parses until the next @/@
+parseText :: Parser Text
+parseText = cs <$> takeTill ('/' ==)


### PR DESCRIPTION
Fixes #213 

The "old" `getInput` has been renamed to `takeByteString` in the latest attoparsec version. We also usually want the result as a `Text` value, therefore a new `remainingText` has been added :) 