### PR TITLE
Fix date-times to correctly show abbreviated timezone suffix.

### DIFF
--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -108,7 +108,7 @@ timeAgo (get #createdAt post) -- "1 minute ago"
 #### `dateTime`
 
 ```haskell
-dateTime (get #createdAt post) -- "10.6.2019, 15:58 Uhr"
+dateTime (get #createdAt post) -- "10.6.2019, 15:58"
 ```
 
 ## Diff-Based DOM Updates

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -522,7 +522,7 @@ Let's also show the creation time in the `ShowView` in `Web/View/Posts/Show.hs`.
 <div>{get #body post}</div>
 ```
 
-Open the view to check that it's working. If everything is fine, you will see something like `5 minutes ago` below the title. The `timeAgo` helper uses a bit of JavaScript to automatically display the given timestamp in the current time zone and in a relative format. In case you want to show the absolute time (like `10.6.2019, 15:58 Uhr`), just use `dateTime` instead of `timeAgo`.
+Open the view to check that it's working. If everything is fine, you will see something like `5 minutes ago` below the title. The `timeAgo` helper uses a bit of JavaScript to automatically display the given timestamp in the current time zone and in a relative format. In case you want to show the absolute time (like `10.6.2019, 15:58`), just use `dateTime` instead of `timeAgo`.
 
 ![Schema Designer created at view](images/first-project/created_at_view.png)
 

--- a/IHP/View/TimeAgo.hs
+++ b/IHP/View/TimeAgo.hs
@@ -33,7 +33,7 @@ import qualified Text.Blaze.Html5.Attributes as A
 timeAgo :: UTCTime -> Html
 timeAgo = timeElement "time-ago"
 
--- | __Display time like @31.08.2007, 16:47 Uhr@__
+-- | __Display time like @31.08.2007, 16:47@__
 --
 -- Render's a @\<time\>@ HTML-Element for displaying time and date.
 -- 

--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -273,7 +273,7 @@ function initDatePicker() {
         time_24hr: true,
         dateFormat: 'Z',
         altInput: true,
-        altFormat: 'd.m.y\,\ H:i \\U\\h\\r'
+        altFormat: 'd.m.y\,\ H:i'
     });
 }
 

--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -32,7 +32,7 @@ function initTime() {
 
     document.querySelectorAll(".date-time").forEach(function(elem){
         var date = new Date(elem.dateTime);
-        elem.innerHTML = date.toLocaleDateString() +", " + date.toLocaleTimeString().substr(0,5)+" Uhr";
+        elem.innerHTML = date.toLocaleDateString() +", " + date.toLocaleTimeString().substr(0,5);
     });
 
     document.querySelectorAll(".date").forEach(function(elem){


### PR DESCRIPTION
It looks like 'Uhr' abbreviated suffix is hard coded into the date-time JavaScript helper.