### PR TITLE
Accept empty strings in optional parameter parsers, returning Nothing

### DIFF
--- a/IHP/Controller/Param.hs
+++ b/IHP/Controller/Param.hs
@@ -249,6 +249,7 @@ instance ParamReader param => ParamReader (Maybe param) where
     readParameter param =
         case (readParameter param) :: Either ByteString param of
             Right value -> Right (Just value)
+            Left error | param == "" -> Right Nothing
             Left error -> Left error
 
 -- | Custom error hint when the 'param' is called with do-notation


### PR DESCRIPTION
Nothing will only be returned after the read is attempted, which will continue to allow empty stringy types to parse successfully as `Just ""`