### PR TITLE
Show html response when the form submission triggers an error

### DIFF
--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -123,7 +123,6 @@ window.submitForm = function (form, possibleClickedButton) {
         }
         if (request.status !== 200) {
             console.error('Something went wrong, status code: ' + request.status);
-            return;
         }
 
         if (window.Turbolinks) {


### PR DESCRIPTION
Right now when a server errors is caused by a form submission, the error is just logged via `console.log()`. But the browser will not show the actual error message. With this change the actual error response will be shown.

Fixes https://github.com/digitallyinduced/ihp/issues/206