### PR TITLE
Use "prinf %q" instead of "echo" in Makefile.dist

### DIFF
--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -83,7 +83,7 @@ all: build/ihp-lib build/Generated/Types.hs
 
 .envrc: default.nix ## Rebuild nix packages and .envrc
 	rm -f .envrc
-	echo "PATH_add $$(nix-shell -j auto --cores 0 --pure --run 'echo $$PATH')" > .envrc
+	echo "PATH_add $$(nix-shell -j auto --cores 0 --pure --run 'printf %q $$PATH')" > .envrc
 	direnv allow
 
 build/bin:


### PR DESCRIPTION
$PATH might contain spaces and other special characters. We need to quote them else the script will fail.