### PR TITLE
Typos, grammar and readability in the Guide

### DIFF
--- a/Guide/architecture.markdown
+++ b/Guide/architecture.markdown
@@ -7,7 +7,7 @@
 
 This section tries to answer common questions on where to place your code. These are recommendations found by digitally induced to be working well.
 
-In general remember that all specific web app logic should stay in the `Web/` space. The `Application/` space is for sharing code across all your different application. E.g. code shared between your web application and your admin backend.
+In general remember that all specific web app logic should stay in the `Web/` space. The `Application/` space is for sharing code across all your different applications. E.g. code shared between your web application and your admin backend.
 
 
 ## Directory Structure
@@ -18,14 +18,14 @@ In general remember that all specific web app logic should stay in the `Web/` sp
 | Config/                       |                                                                             |
 | Config/Config.hs              | Configuration for the framework and your application                        |
 | Config/nix/nixpkgs-config.nix | Configuration for the nix package manager                                   |
-| Config/nix/haskell-packages/  | Custom haskell dependencies can be placed here                              |
+| Config/nix/haskell-packages/  | Custom Haskell dependencies can be placed here                              |
 | Application/                          | Your domain logic lives here                                           |
 | Application/Schema.sql           | Models and database tables are defined here                                 |
 | Web/Controller       | Web application controllers                                                             |
 | Web/View/            | Web application html template files                                                         |
 | Web/Types.hs            | Central place for all web application types                                                         |
 | static/                       | Images, css and javascript files                                            |
-| .ghci                         | Default config file for the haskell interpreter                             |
+| .ghci                         | Default config file for the Haskell interpreter                             |
 | .gitignore                    | List of files to be ignored by git                                          |
 | App.cabal, Setup.hs           | Config for the cabal package manager (TODO: maybe move to Config/App.cabal) |
 | default.nix                   | Declares your app dependencies (like package.json or composer.json)         |
@@ -55,9 +55,9 @@ A IHP project can consist of multiple applications. Run `new-application admin` 
 
 ##### How to structure my CSS?
 
-CSS files, as all your other static assets, should be place in the `static` directory.
+CSS files, as all your other static assets, should be placed in the `static` directory.
 
-Create an `static/app.css`. In there use CSS imports to import your other stylesheets. An example `app.css` could look like this:
+Create a `static/app.css`. In there use CSS imports to import your other stylesheets. An example `app.css` could look like this:
 
 ```css
 @import "/layout.css";
@@ -69,7 +69,7 @@ Create an `static/app.css`. In there use CSS imports to import your other styles
 
 ###### Page-specific CSS rules
 
-Place page-specific CSS used by e.g. views of the `Web.Controller.Users` controller in the `users.css`. Use [currentViewId](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:currentViewId) to scope your css rules to the view.
+Place page-specific CSS used by e.g. views of the `Web.Controller.Users` controller in `users.css`. Use [currentViewId](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:currentViewId) to scope your css rules to the view.
 
 Given the view:
 
@@ -109,7 +109,7 @@ CSS files from external libraries or components should be placed in `static/vend
 
 JS files, as all your other static assets, should be place in the `static` directory.
 
-In general we follow an approach where most of the business logic resides on the haskell server. Only for small interactions we try to use a small isolated bit of javascript.
+In general we follow an approach where most of the business logic resides on the Haskell server. Only for small interactions we try to use a small isolated bit of javascript.
 
 Your global, non-page specific, javascript code can be placed in `app.js`.
 

--- a/Guide/authentication.markdown
+++ b/Guide/authentication.markdown
@@ -9,7 +9,7 @@ IHP provides a basic authentication toolkit out of the box.
 
 The usual convention in IHP is to call your user record `User`. When there is an admin user, we usually call the record `Admin`. In general the authentication can work with any kind of record. The only requirement is that it has an id field.
 
-To use the authentication module, your `users` table needs to have atleast an `id`, `email`, `password_hash`, `locked_at` and `failed_login_attempts` field:
+To use the authentication module, your `users` table needs to have at least an `id`, `email`, `password_hash`, `locked_at` and `failed_login_attempts` field:
 ```sql
 CREATE TABLE users (
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
@@ -43,7 +43,7 @@ module Application.Helper.Controller (
 -- import IHP.LoginSupport.Helper.Controller
 ```
 
-Enable the import and re-export for `IHP.LoginSupport.Helper.Controller` and a type instance `type instance CurrentUserRecord = User`:
+Enable the import and re-export for `IHP.LoginSupport.Helper.Controller` and add a type instance `type instance CurrentUserRecord = User`:
 
 ```haskell
 module Application.Helper.Controller (
@@ -122,7 +122,7 @@ instance InitControllerContext WebApplication where
         initAuthentication @User
 ```
 
-This will fetch the user from the database when a `userId` is given in the session. The fetched user record is saved to the special `?controllerContext` variable and is used by all the helpers functions we have imported before.
+This will fetch the user from the database when a `userId` is given in the session. The fetched user record is saved to the special `?controllerContext` variable and is used by all the helper functions we have imported before.
 
 #### Adding a Session Controller
 

--- a/Guide/controller.markdown
+++ b/Guide/controller.markdown
@@ -7,9 +7,9 @@
 
 In IHP an action is a place for request handling logic. A controller is just a group of related actions.
 
-You can think about actions a message sent to your application, e.g. a `ShowPostAction { postId :: Id Post }` is basically the message "Show me the post with id $postId".
+You can think about an action as a message sent to your application, e.g. a `ShowPostAction { postId :: Id Post }` is basically the message "Show me the post with id $postId".
 
-Each action needs to be define as a data structure inside `Web/Types.hs`. Therefore you can see an overview of all the messages which can be sent to your application just by looking at `Web/Types.hs`.
+Each action needs to be defined as a data structure inside `Web/Types.hs`. Therefore you can see an overview of all the messages which can be sent to your application just by looking at `Web/Types.hs`.
 
 ## Creating a new Controller
 
@@ -38,7 +38,7 @@ instance Controller PostsController where
     action ShowPostAction { postId } = renderPlain "Hello World"
 ```
 
-This implementation for `ShowPostAction` responds with a simple plain text message. The `action` implementation is usally a big pattern match over all possible actions of a controller.
+This implementation for `ShowPostAction` responds with a simple plain text message. The `action` implementation is usually a big pattern match over all possible actions of a controller.
 
 ## Reading Query and Body Parameters
 
@@ -124,7 +124,7 @@ action ExampleAction = do
 
 This will pass the firstname `"Tester"` to our view.
 
-We can also make it more dynamically and allow the user to specify the firstname via a query parameter:
+We can also make it act more dynamically and allow the user to specify the firstname via a query parameter:
 ```haskell
 action ExampleAction = do
     let firstname = paramOrDefault @Text "firstname" "Unnamed"
@@ -188,7 +188,7 @@ instance Controller PostsController where
 
 ## Accessing the Current Action
 
-Inside the `beforeAction` and `action` you can access the current action using the special `?theAction` variable. That is useful when writing controller helpers, because the variable is passed implicit.
+Inside the `beforeAction` and `action` you can access the current action using the special `?theAction` variable. That is useful when writing controller helpers, because the variable is passed implicitly.
 
 ## Accessing the Current Request
 
@@ -228,20 +228,20 @@ In this example, when the `User-Agent` header is not provided by the request
 the `userAgent` variable will be set to `Nothing`. Otherwise it will be set
 to `Just "the user agent value"`.
 
-The header is looked up in the request case insensitive.
+The lookup for the header in the request is case insensitive.
 
 
 ## Rendering Responses
 
 ### Rendering Views
 
-Inside a controller, you have several ways of sending a response. The most-common way is to use the `render` function with a `View` data structure, like this:
+Inside a controller, you have several ways of sending a response. The most common way is to use the `render` function with a `View` data structure, like this:
 
 ```
 render ShowPostView { .. }
 ```
 
-The `render` function automatically picks the right response format based on the `Accept` header of the browser. It will try to send a html response, when html is requested and will also try to send a json response when a json response is expected. A [`406 Not Acceptable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) will be send when the `render` function cannot fullfil the requested `Accept` formats.
+The `render` function automatically picks the right response format based on the `Accept` header of the browser. It will try to send a html response when html is requested, and will also try to send a json response when a json response is expected. A [`406 Not Acceptable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) will be send when the `render` function cannot fullfil the requested `Accept` formats.
 
 ### Rendering Plain Text
 
@@ -254,9 +254,9 @@ action ExampleAction = do
 
 ### Rendering HTML
 
-Usually you want render your html using a view. See `Rendering Views` for details.
+Usually you want to render your html using a view. See `Rendering Views` for details.
 
-Sometimes you want render html without using views, e.g. doing it inline in the action. Call `respondHtml` for that:
+Sometimes you want to render html without using views, e.g. doing it inline in the action. Call `respondHtml` for that:
 
 ```haskell
 action ExampleAction = do
@@ -294,9 +294,9 @@ action ExampleAction = do
     redirectTo ShowPostAction { postId = ... }
 ```
 
-When you need to pass custom query parameter, you cannot use the `redirectTo` function. See `Redirect to a Path` for that.
+When you need to pass a custom query parameter, you cannot use the `redirectTo` function. See `Redirect to a Path` for that.
 
-The redirect will use http status code `302`. The `baseUrl` in `Config/Config.hs` will be used. In development mode, the `baseUrl` might not be specified `Config/Config.hs` in. Then it will be set to localhost by default.
+The redirect will use http status code `302`. The `baseUrl` in `Config/Config.hs` will be used. In development mode, the `baseUrl` might not be specified in `Config/Config.hs`. Then it will be set to localhost by default.
 
 ### Redirect to a Path
 

--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -7,9 +7,9 @@
 
 IHP provides a few basic functions to access the database. On top of Postgres SQL we try to provide a thin layer to make it easy to do all the common tasks your web application usually does.
 
-The only supported database platform is Postgres. Focussing on Postgres allows us to better integrate advanced postgres specific solutions into your application.
+The only supported database platform is Postgres. Focussing on Postgres allows us to better integrate advanced Postgres-specific solutions into your application.
 
-In development you do not need to set up anything to use postgres. The built-in development server automatically starts a Postgres instance to work with your application. The built-in development postgres servers is only listening on a unix socket and is not available via TCP.
+In development you do not need to set up anything to use postgres. The built-in development server automatically starts a Postgres instance to work with your application. The built-in development postgres server is only listening on a unix socket and is not available via TCP.
 
 When the dev server is running, you can connect to it via `postgresql:///app?host=YOUR_PROJECT_DIRECTORY/build/db` with your favorite database tool. When inside the project directory you can also use `make psql` to open a postgres REPL connected to the development database. The web interface of the dev server also has a GUI-based database editor (like phpmyadmin) at [http://localhost:8001/ShowDatabase](http://localhost:8001/ShowDatabase).
 
@@ -39,7 +39,7 @@ CREATE TABLE users (
 );
 ```
 
-Haskell data structures and types are automatically generated from the `Schema.sql` file. They are re-generated on every file change of the `Schema.sql`. We use the well known `postgresql-simple` haskell library to connect to the database. 
+Haskell data structures and types are automatically generated from the `Schema.sql` file. They are re-generated on every file change of the `Schema.sql`. We use the well-known `postgresql-simple` Haskell library to connect to the database. 
 
 ### Schema Designer
 
@@ -49,7 +49,7 @@ Because the SQL syntax is sometimes hard to remember, the framework provides a G
 
 Keep in mind that the Schema Editor also only modifies the `Schema.sql`. This works by parsing the SQL DDL-statements and applying transformations on the AST and the compiling and writing it back to `Schema.sql`. When there is an syntax error in the `Schema.sql` file the visual mode will be unavailable and you have to work with the code editor to fix the problem.
 
-You can add tables, columns, foreing key constraints, and enums. You can also edit these objects by right clicking them. New tables have a `id` column by default. Lots of opinionated short-cuts for rapid application development like automatically offering to add foreign key constraints are built-in.
+You can add tables, columns, foreign key constraints, and enums. You can also edit these objects by right-clicking them. New tables have a `id` column by default. Lots of opinionated short-cuts for rapid application development like automatically offering to add foreign key constraints are built-in.
 
 ![An example of using the context menu for editing a table](images/database/schema-designer-context-menu.png)
 
@@ -59,7 +59,7 @@ When the Visual Editor is not powerful enough, just switch back to the code edit
 
 ### Push to DB
 
-Afer we have added a few data structures to our `Schema.sql`, our running Postgres database is still empty. This is because we still need to import our database schema into the database.
+After we have added a few data structures to our `Schema.sql`, our running Postgres database is still empty. This is because we still need to import our database schema into the database.
 
 **In the Schema Designer:** Click on `Push to DB`:
 
@@ -87,7 +87,7 @@ You can also update the database while keeping its contents.
 
 ![Push to DB Button](images/database/schema-designer-push-to-db.png)
 
-**In the command line:** Run `make dumbdb` and after that `make db`.
+**In the command line:** Run `make dumpdb` and after that `make db`.
 
 When dumping the database into the `Fixtures.sql` first and then rebuilding the database with the dump, the contents will be kept when changing the schema.
 
@@ -95,7 +95,7 @@ When dumping the database into the `Fixtures.sql` first and then rebuilding the 
 
 ### Model Context
 
-In a pure functional programming language like haskell we need to pass the database connection to all functions which need to access the database. We use a implicit parameter `?modelContext :: ModelContext` to pass around the database connection without always specifying it. The `ModelContext` data structure is basically just a wrapper around the actually database connection.
+In a pure functional programming language like Haskell we need to pass the database connection to all functions which need to access the database. We use a implicit parameter `?modelContext :: ModelContext` to pass around the database connection without always specifying it. The `ModelContext` data structure is basically just a wrapper around the actual database connection.
 
 An implicit paramter is a parameter which is automatically passed to certain functions, it just needs to be available in the current scope.
 
@@ -107,11 +107,11 @@ myFunc :: (?modelContext :: ModelContext) => IO SomeResult
 
 All controller actions already have `?modelContext` in scope and thus can run database queries. Other application entry-points, like e.g. Scripts, also have this in scope.
 
-This also means, that when a function does not specify that it depends on the database connection in it's type signature (like `?modelContext :: ModelContext => ..`), you can be sure that it's not doing any database operations.
+This also means, that when a function does not specify that it depends on the database connection in its type signature (like `?modelContext :: ModelContext => ..`), you can be sure that it's not doing any database operations.
 
 ### Haskell Data Structures
 
-For every table in the `Schema.sql` a coresponding data structure will be generated on the haskell side. For example given a table:
+For every table in the `Schema.sql` a coresponding data structure will be generated on the Haskell side. For example given a table:
 
 ```sql
 CREATE TABLE users (
@@ -121,7 +121,7 @@ CREATE TABLE users (
 );
 ```
 
-The generated haskell data structure for this table will look like this:
+The generated Haskell data structure for this table will look like this:
 
 ```haskell
 data User = User
@@ -131,11 +131,11 @@ data User = User
     }
 ```
 
-The `id` field type `Id User` is basically just a wrapper around `UUID` for type-safety reasons. All database field names are mapped from `under_score` to `camelCase` on the haskell side.
+The `id` field type `Id User` is basically just a wrapper around `UUID` for type-safety reasons. All database field names are mapped from `under_score` to `camelCase` on the Haskell side.
 
-When a sql field can be `NULL`, the haskell field type will be contained in `Maybe`.
+When a sql field can be `NULL`, the Haskell field type will be contained in `Maybe`.
 
-In the Schema Designer you can take a look at the generated haskell code by right-clicking the table and clicking `Show Generated Haskell Code`.
+In the Schema Designer you can take a look at the generated Haskell code by right-clicking the table and clicking `Show Generated Haskell Code`.
 
 ## Retrieving Records
 
@@ -318,7 +318,7 @@ do
         |> updateRecord
 ```
 
-This will set the lastname of user `cf633b17-c409-4df5-a2fc-8c3b3d6c2ea7` to `Tester` and run and `UPDATE` query to persist that:
+This will set the lastname of user `cf633b17-c409-4df5-a2fc-8c3b3d6c2ea7` to `Tester` and run an `UPDATE` query to persist that:
 
 ```sql
 UPDATE users SET firstname = firstname, lastname = "Tester" WHERE id = "cf633b17-c409-4df5-a2fc-8c3b3d6c2ea7"
@@ -376,7 +376,7 @@ Next add the enum values by right clicking into the `Values` pane and click on `
 
 ### Adding enums via SQL
 
-Instead of using the Schema Designer you can also just add the requires SQL statement manually into `Application/Schema.hs`:
+Instead of using the Schema Designer you can also just add the required SQL statement manually into `Application/Schema.hs`:
 
 ```sql
 CREATE TYPE colors AS ENUM ('blue', 'red', 'yellow');

--- a/Guide/form.markdown
+++ b/Guide/form.markdown
@@ -7,7 +7,7 @@
 
 In IHP Forms are an essential way to interact with your application. Dealing with a lot of form markup can quickly become complex because of the need to deal with consistent styling and especially when dealing with lots of validation. IHP provides helpers to generate form markup to help you deal with the complexity.
 
-By default forms in IHP follows the class names used by Bootstrap 4. Therefore the forms work with Bootstrap 4 out of the box. Of course the default form generation can be customized to support other CSS frameworks.
+By default forms in IHP follow the class names used by Bootstrap 4. Therefore the forms work with Bootstrap 4 out of the box. Of course the default form generation can be customized to support other CSS frameworks.
 
 Unless javascript helpers have been deactivated, your form will be submitted using AJAX and TurboLinks instead of a real browser based form submission.
 
@@ -48,7 +48,7 @@ All inputs have auto-generated class names and ids for styling. Also all `name` 
 
 ## Form Controls
 
-IHP has the most commonly used form controls built in. In general the form control helpers just need to be passed the field name. Here is a list of all built-in form control helpers:
+IHP has the most commonly-used form controls built in. In general the form control helpers just need to be passed the field name. Here is a list of all built-in form control helpers:
 
 ```html
 {textField #title}
@@ -335,7 +335,7 @@ Will render as:
 
 #### Don't render `<div class="form-group">`
 
-You can specifiy `disableGroup` to stop the outter `<div class="form-group">` element from being generated:
+You can specifiy `disableGroup` to stop the outer `<div class="form-group">` element from being generated:
 
 ```html
 {(textField #title) { disableGroup = True }
@@ -357,7 +357,7 @@ You can specify `disableValidationResult` to stop the validation error message b
 ```
 
 
-This works out of the box for most haskell data types. When you are working with a custom data type, e.g. a custom enum value, you need to add a `InputValue MyDataType` implementation. We will cover this later in this Guide.
+This works out of the box for most Haskell data types. When you are working with a custom data type, e.g. a custom enum value, you need to add a `InputValue MyDataType` implementation. We will cover this later in this Guide.
 
 ## Select Inputs
 
@@ -406,22 +406,22 @@ IHP by default sets its session cookies using the Lax [SameSite](https://develop
 
 By default your form will be submitted using AJAX and [TurboLinks](https://github.com/turbolinks/turbolinks) instead of a real browser based form submission. It's implemented this way to support [SPA](https://en.wikipedia.org/wiki/Single-page_application)-like page transitions using TurboLinks and [morphdom](https://github.com/patrick-steele-idem/morphdom).
 
-Additional to integrate the form submission into TurboLinks, the javascript helpers will also disable the form submit button after the form has been submitted. Also any flash messages inside the form are removed.
+Additionally to integrate the form submission into TurboLinks, the javascript helpers will also disable the form submit button after the form has been submitted. Also any flash messages inside the form are removed.
 
 When the IHP javascript helpers are included in a page, it will automatically hook into your form submissions. You can also call `window.submitForm(formElement)` to trigger a form submission from javascript.
 
 
-The form helpers are designed to improve the User Experience for browser where javascript is enabled. In case javascript is not enabled or blocked by a plugin, the form submission will still work as expected.
+The form helpers are designed to improve the User Experience for browsers where javascript is enabled. In case javascript is not enabled or blocked by a plugin, the form submission will still work as expected.
 
 You can disable the form helpers by removing the IHP javascript helpers from your layout. In `Web/View/Layout.hs` remove the following line:
 ```html
 <script src="/helpers.js"></script>
 ```
 
-This way no special behavior will be attach to your forms.
+This way no special behavior will be attached to your forms.
 
 To dig deeper into the javascript, [take a look at the source in helpers.js](https://github.com/digitallyinduced/ihp/blob/master/lib/IHP/static/helpers.js#L115).
 
 ## Working with other CSS Frameworks
 
-TODO: This section still has to be implemented. The gist of how rendering can be completly overriden to support a different layout or CSS framework can be found in the implementation of [horizontalFormFor](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:horizontalFormFor) (renders a bootstrap 4 form in a horizontal way).
+TODO: This section still has to be implemented. The gist of how rendering can be completely overriden to support a different layout or CSS framework can be found in the implementation of [horizontalFormFor](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:horizontalFormFor) (renders a bootstrap 4 form in a horizontal way).

--- a/Guide/hsx.markdown
+++ b/Guide/hsx.markdown
@@ -5,13 +5,13 @@
 
 ## Introduction
 
-HSX can be written pretty much like normal HTML. You can write a HSX expression inside your haskell code by wrapping it with `[hsx|YOUR HSX CODE|]`. HSX expressions are just a syntax for blaze html and thus are automatically escaped as described in the blaze documentation.
+HSX can be written pretty much like normal HTML. You can write a HSX expression inside your Haskell code by wrapping it with `[hsx|YOUR HSX CODE|]`. HSX expressions are just a syntax for blaze html and thus are automatically escaped as described in the blaze documentation.
 
 Because the HSX is parsed, you will get a syntax error when you type in invalid html.
 
 ### Inline Haskell
 
-HSX can access haskell variables wrapped with `{}` like this:
+HSX can access Haskell variables wrapped with `{}` like this:
 
 ```haskell
 let
@@ -20,9 +20,9 @@ in
     [hsx|Hello {x}!|]
 ```
 
-**If the variable is another hsx expression a blaze html element, a text or string**: it is just included as it you will expect.
+**If the variable is another hsx expression, a blaze html element, a text or string**: it is just included as you would expect.
 
-**If the variable is any other custom haskell data structure**: it will first be converted to a string representation by calling `show` on it. You can use add a custom `ToHtml` (import it from `IHP.HtmlSupport.ToHtml`) instance, to customize rendering a data structure.
+**If the variable is any other custom Haskell data structure**: it will first be converted to a string representation by calling `show` on it. You can add a custom `ToHtml` (import it from `IHP.HtmlSupport.ToHtml`) instance, to customize rendering a data structure.
 
 You can also write more complex code like:
 
@@ -34,7 +34,7 @@ in
     [hsx|Complex demo: {forEach items renderItem}!|]
 ```
 
-As the HSX expressions are compiled to haskell code at compile-time, type errors inside these `{}` expression will be reported to your by the compiler.
+As the HSX expressions are compiled to Haskell code at compile-time, type errors inside these `{}` expressions will be reported to you by the compiler.
 
 ### Dynamic Attributes
 

--- a/Guide/index.markdown
+++ b/Guide/index.markdown
@@ -1,21 +1,21 @@
 # Getting Started With Integrated Haskell Platform
 IHP is a full stack framework focused on rapid application development while striving for robust code quality.
 
-We believe that functional programing is the future of software development and want to make functional programing with haskell and nix available to anyone. We try to offer a solution which can be used by developers who have not worked with haskell yet. IHP comes with everything you need to build great web applications with haskell and nix. We have made a lot of pragmatic decision to get you started faster. This way you can just pick up haskell along the way :-)
+We believe that functional programing is the future of software development and want to make functional programing with Haskell and nix available to anyone. We try to offer a solution which can be used by developers who have not worked with Haskell yet. IHP comes with everything you need to build great web applications with Haskell and nix. We have made a lot of pragmatic decision to get you started faster. This way you can just pick up Haskell along the way :-)
 
 ## Feature Overview
 
 - **Fully managed dev environment:** Works on any machine because all dependencies (including PostgreSQL) are managed using the nix package manager. You only need to know a single command to start the app.
 - **Auto live reload using virtual dom in dev mode:** Each code change automatically triggers the web page to refresh. The refresh uses a diff based patch to avoid resetting the page state. This means: Changes are reflected instantly.
-- **Build robust, type-safe applications:** With the power of haskell your application are going to be a lot more robust. Pretty much no runtime errors in production. You can refactor with confidence.
+- **Build robust, type-safe applications:** With the power of Haskell your applications are going to be a lot more robust. Pretty much no runtime errors in production. You can refactor with confidence.
 - **Fast dev enviroment:** While we use a compiled language, the built-in dev server automatically reloads your code changes using the fastest way possible. Usually changes are reflected in less than 50ms (alot faster than your average webpack setup).
-- **Faster production environment:** Production response times around 30ms. With help of [instant click](http://instantclick.io/) it is faster than most single page applications.
+- **Faster production environment:** Production response times are around 30ms. With help of [instant click](http://instantclick.io/) it is faster than most single page applications.
 - **Integrated dev tooling:** You only need a text editor, everything else is taken care of.
-- **Scalable Application Architecture:** IHP is the result of building lots of real world applications with haskell.
+- **Scalable Application Architecture:** IHP is the result of building lots of real world applications with Haskell.
 
 ## Professional Use
 
-Before open sourcing, IHP has already been used in production by [digitally induced](https://www.digitallyinduced.com/) since 2017. Therefore you can expect continious support and development in the future.
+Before open sourcing, IHP has already been used in production by [digitally induced](https://www.digitallyinduced.com/) since 2017. Therefore you can expect continuous support and development in the future.
 
 Additionally IHP is used by companies such as [Prokapi](https://prokapi.com/) and [CodeKarussell (rausgegangen.de)](https://rausgegangen.de/).
 

--- a/Guide/installation.markdown
+++ b/Guide/installation.markdown
@@ -7,12 +7,12 @@
 
 The framework uses the nix package manager to manage the whole set of dependencies of your application
 
-For example, postgresql and the haskell compiler are both dependencies of your app, as well as all the haskell or javascript packages you want to use. We use nix to make sure that these dependencies are available to the app - in development, as well as in production.
+For example, postgresql and the Haskell compiler are both dependencies of your app, as well as all the Haskell or javascript packages you want to use. We use nix to make sure that these dependencies are available to the app - in development, as well as in production.
 
 That's why we first need to make sure that you have nix installed.
 
 ### Mac
-Run this commands in your terminal to install nix on your machine.
+Run this command in your terminal to install nix on your machine.
 
 ```bash
 sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume
@@ -59,7 +59,7 @@ To download a Linux Distribution, open the Microsoft Store and search for Ubuntu
 
 Note: You **do not** need a Microsoft account to download. You can simply cancel or close the login forms and the download will continue.
 
-With the Distro Downloaded, run it and update it using your package manager. In Ubuntu you would use:
+With the Distro downloaded, run it and update it using your package manager. In Ubuntu you would use:
 
 ```bash
 sudo apt update

--- a/Guide/naming-conventions.markdown
+++ b/Guide/naming-conventions.markdown
@@ -97,7 +97,7 @@ Controller modules should always follow this naming schema:
 module <app>.Controller.<controller>
 ```
 
-The `<controller>` should not end in `Controller`. It should usually be in plural form, unless it's only working on a single single entity. E.g. you might have a `UserController` when only dealing with the current user, because from the users point of view, the is only a single user resource he can interact with.
+The `<controller>` should not end in `Controller`. It should usually be in plural form, unless it's only working on a single entity. E.g. you might have a `UserController` when only dealing with the current user, because from the users point of view, there is only a single user resource they can interact with.
 
 
 Here are some examples of good names:

--- a/Guide/querybuilder.markdown
+++ b/Guide/querybuilder.markdown
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-The QueryBuilder module allows you to compose database queries in a type-safe way. Below you find a short reference to all the commonly used functions.
+The QueryBuilder module allows you to compose database queries in a type-safe way. Below you can find a short reference to all the commonly-used functions.
 
 ## Creating a new query
 To query the database for some records, you first need to build a query.
@@ -46,7 +46,7 @@ example = do
 ```
 
 ### single row: `fetchOne`
-To run a query which will return a single and **throws an error if no record is found** row use `fetchOne`:
+To run a query which will return a single row and **throw an error if no record is found** use `fetchOne`:
 ```haskell
 example :: IO Project
 example = do
@@ -144,7 +144,7 @@ let projectId :: ProjectId = ...
 project <- projectId |> fetch
 ```
 
-For convience there is also a `fetch` implementation for `Maybe SomeId`:
+For convenience there is also a `fetch` implementation for `Maybe SomeId`:
 
 ```haskell
 let assignedUserId :: Maybe UserId = project |> get #assignedUserId

--- a/Guide/recipes.markdown
+++ b/Guide/recipes.markdown
@@ -116,11 +116,11 @@ If running, stop your development server. Now run `make` again. This will instal
 
 When you are inside the project with your terminal, you can also call `imagemagick` to see that it's available.
 
-You can look up the package name for the software you dependend on inside the nixpkgs repository. [Just open it on GitHub](https://github.com/NixOS/nixpkgs) and use the GitHub search to look up the package name.
+You can look up the package name for the software you depend on inside the nixpkgs repository. [Just open it on GitHub](https://github.com/NixOS/nixpkgs) and use the GitHub search to look up the package name.
 
 ## Uploading a user profile picture
 
-You can easily upload a user profile pictures using `uploadImageWithOptions` inside your `UpdateUserAction`:
+You can easily upload a user profile picture using `uploadImageWithOptions` inside your `UpdateUserAction`:
 
 ```haskell
 action UpdateUserAction { userId } = do
@@ -143,7 +143,7 @@ action UpdateUserAction { userId } = do
                 redirectTo EditUserAction { .. }
 ```
 
-This accepts any kind of image file compatible with imagemagick, resize it, reduce the image quality, stripe all meta information and save it as jpg. The file is stored inside the `static/uploads` folder in the project (directory will be created if it does not exist).
+This accepts any kind of image file compatible with imagemagick, resize it, reduce the image quality, strip all meta information and save it as jpg. The file is stored inside the `static/uploads` folder in the project (directory will be created if it does not exist).
 
 In your view, just use the image url like `<img src={get #pictureUrl currentUser}/>`.
 
@@ -182,7 +182,7 @@ When using VSCode you need to install a plugin which loads the `.envrc` in your 
 
 ## Don't auto-open the app in the browser
 
-To prevent the IHP dev server to automatically open the dev tooling in your web browser when running `./start`, set the `IHP_BROWSER` env variable to `echo`:
+To prevent the IHP dev server automatically opening the dev tooling in your web browser when running `./start`, set the `IHP_BROWSER` env variable to `echo`:
 
 ```bash
 export IHP_BROWSER=echo

--- a/Guide/relationships.markdown
+++ b/Guide/relationships.markdown
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-The following sections asume the following database schema being given. It's basically the same as in "Your First Project".
+The following sections assume the following database schema being given. It's basically the same as in "Your First Project".
 
 ```sql
 CREATE TABLE posts (
@@ -28,7 +28,7 @@ ALTER TABLE comments ADD CONSTRAINT comments_ref_post_id FOREIGN KEY (post_id) R
 
 ## Has Many Relationships
 
-Given a specific post, we can fetch the post and all it's comments like this:
+Given a specific post, we can fetch the post and all its comments like this:
 
 ```haskell
 let postId :: Id Post = ...
@@ -37,7 +37,7 @@ post <- fetch postId
     >>= fetchRelated #comments
 ```
 
-This haskell code will trigger the following sql queries to be executed:
+This Haskell code will trigger the following sql queries to be executed:
 
 ```sql
 SELECT posts.* FROM posts WHERE id = ?  LIMIT 1
@@ -96,9 +96,9 @@ posts <- query @Post
     >>= collectionFetchRelated #comments
 ```
 
-This will query all posts with all it's comments. The type of posts is `[Include "comments" Post]`.
+This will query all posts with all their comments. The type of posts is `[Include "comments" Post]`.
 
-The above haskell code will trigger the following two sql queries to be executed:
+The above Haskell code will trigger the following two sql queries to be executed:
 
 ```sql
 SELECT posts.* FROM posts

--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -5,7 +5,7 @@
 
 ## Routing Basics
 
-In your project routes are defined in the `Web/Routes.hs`. Additionally to the defining a route, it also has to be added in `Web/FrontController.hs` to be picked up by the routing system.
+In your project routes are defined in the `Web/Routes.hs`. In addition to defining that route, it also has to be added in `Web/FrontController.hs` to be picked up by the routing system.
 
 The simplest way to define a route is by using `AutoRoute`, which automatically maps each controller action to an url. For a `PostsController`, the definition in `Web/Routes.hs` will look like this:
 
@@ -104,7 +104,7 @@ This way the `name` argument is passed as `Text` instead of `UUID`.
 Right now AutoRoute supports only a single type for all given parameters. E.g. an action which takes an UUID and a Text is not supported with AutoRoute right now:
 ```haskell
 data HelloController = HelloAction { userId :: !(Id User), name :: Text }
-instance AutRoute HelloController -- This will fail at runtime
+instance AutoRoute HelloController -- This will fail at runtime
 ```
 
 This is a technical problem we hope to fix in the future. Until then consider using `param` for the `Text` parameter.
@@ -130,7 +130,7 @@ instance AutoRoute HelloWorldController where
 
 ### Application Prefix
 
-When using multiple application in your IHP project, e.g. having an admin backend, AutoRoute will prefix the action urls with the application name. E.g. a controller `HelloWorldController` defined in `Admin/Types.hs` will be automatically prefixed with `/admin` and generate urls such as `/admin/HelloAction`.
+When using multiple applications in your IHP project, e.g. having an admin backend, AutoRoute will prefix the action urls with the application name. E.g. a controller `HelloWorldController` defined in `Admin/Types.hs` will be automatically prefixed with `/admin` and generate urls such as `/admin/HelloAction`.
 
 This prefixing has special handling for the `Web` module, so that all controllers in the default `Web` module don't have a prefix.
 
@@ -150,7 +150,7 @@ MyAction?{firstArgument}={secondArgument}
 
 The last argument `d` cannot be implemented in a typesafe way. This is implemented by calling `unsafeCoerce` on our result value before returning it. The result of this is later used with [`fromConstrM`](http://hackage.haskell.org/package/base-4.14.0.0/docs/Data-Data.html#fromConstrM). Therefore misusing `parseArgument` can result in a runtime crash. Again, consider not using this API.
 
-Given we have a custom argument type in the format `ID-{numeric}` like `ID-0`, `ID-1`, etc. We can define a custom `parseCustomIdArgument` like this:
+Given we have a custom argument type in the format `ID-{numeric}` like `ID-0`, `ID-1`, etc, we can define a custom `parseCustomIdArgument` like this:
 
 ```haskell
 import qualified Data.Attoparsec.ByteString.Char8 as Attoparsec
@@ -169,9 +169,9 @@ parseCustomIdArgument field value =
 
 ## Custom Routing
 
-Sometimes you have special needs for your routing. For this case IHP provides a lower-level routing API on which `AutoRoute` is built on.
+Sometimes you have special needs for your routing. For this case IHP provides a lower-level routing API on which `AutoRoute` is built.
 
-Let's say we have controller like this:
+Let's say we have a controller like this:
 
 ```haskell
 data PostsController = ShowAllMyPostsAction

--- a/Guide/scripts.markdown
+++ b/Guide/scripts.markdown
@@ -30,7 +30,7 @@ run = do
 
 The `run` function is our entrypoint. There we can write our logic, just like inside an action. This means we can call other framework functions, access the database using the usual way, send emails, render views, etc.
 
-Let's print out an hello world to all our users in the console:
+Let's print out a hello world to all our users in the console:
 
 
 ```haskell

--- a/Guide/session.markdown
+++ b/Guide/session.markdown
@@ -22,7 +22,7 @@ action SessionExampleAction = do
     setSession "userEmail" "hi@digitallyinduced.com"
 ```
 
-Right now, `setSession` only accept `Text` values. Other types like `Int` have to be converted to `Text` using `tshow theIntValue`.
+Right now, `setSession` only accepts `Text` values. Other types like `Int` have to be converted to `Text` using `tshow theIntValue`.
 
 ### Reading
 

--- a/Guide/validation.markdown
+++ b/Guide/validation.markdown
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-IHP provides a simple infrastructure to validation incoming data. This guide will tell you more about validating new and existing records, as well as how to use more complex validations with database access.
+IHP provides a simple infrastructure for validation of incoming data. This guide will tell you more about validating new and existing records, as well as how to use more complex validations with database access.
 
 ## Quickstart
 
@@ -99,13 +99,13 @@ You can find [the full list of built-in validators in the API Documentation](htt
 
 When using `fill`, like `|> fill @'["title", "body"]`, any error parsing the input is also added as a validation error.
 
-E.g. when `fill` fills in an integer attribute, but the string `"hello"` is submitted, an error will be added to the record and the record is not valid anymore. The record attribute will then keep it's old value (before applying `fill`) and later re-render in the error case of `ifValid`. This applies to all arguments read via `fill`. It's very helpful when dealing with strings expected in a certain format, like date times.
+E.g. when `fill` fills in an integer attribute, but the string `"hello"` is submitted, an error will be added to the record and the record is not valid anymore. The record attribute will then keep its old value (before applying `fill`) and later re-render in the error case of `ifValid`. This applies to all arguments read via `fill`. It's very helpful when dealing with strings expected in a certain format, like date times.
 
 As IHP is never putting raw strings into the records, without previously parsing them, it does not provide validators like rails's `:only_integer`.
 
 ### Rendering Errors
 
-When post with an empty title is now submitted to this action, an error message will be written into the record. The call to `|> ifValid` will see, that there is an error and then run the `Left post -> render NewView { post } `, which displays the form to the user again. The form will be rendered, and errors will automatically pop up next to the form field.
+When a post with an empty title is now submitted to this action, an error message will be written into the record. The call to `|> ifValid` will see that there is an error, and then run the `Left post -> render NewView { post } `, which displays the form to the user again. The form will be rendered, and errors will automatically pop up next to the form field.
 
 The default form helpers like `{textField #title}` automatically render the error message below the field. Here is how this looks:
 
@@ -114,7 +114,7 @@ The default form helpers like `{textField #title}` automatically render the erro
 
 ### Validating An Email Is Unique
 
-For example when dealing with users, you usually want to make sure that an email is only used once for single user. You can use `|> validateIsUnique #email` to validate that an email is unique for a given record.
+For example when dealing with users, you usually want to make sure that an email is only used once for a single user. You can use `|> validateIsUnique #email` to validate that an email is unique for a given record.
 
 This function queries the database and checks whether there exists a record with the same email value. The function ignores the current entity of course.
 
@@ -181,7 +181,7 @@ user |> validateField #age isAge`
 
 ### Checking If A Record Is Valid
 
-Use `ifValid` to check for validness of a record:
+Use `ifValid` to check for validity of a record:
 
 ```haskell
 post |> ifValid \case
@@ -256,7 +256,7 @@ post |> validateField #title nonEmpty
 -- }
 ```
 
-As you can see, the errors is tracked inside the `MetaBag`. When you apply another `validateField` to the record, the errors will be appended to the `annotations` list.
+As you can see, the errors are tracked inside the `MetaBag`. When you apply another `validateField` to the record, the errors will be appended to the `annotations` list.
 
 ### Validation Functions
 
@@ -272,7 +272,7 @@ isColor text = Failure "is not a valid color"
 
 Calling `isColor "#ffffff"` will return `Success`. Calling `isColor "something bad"` will result in `Failure "is not a valid color"`.
 
-It might be useful to take a look at the definition of some more validation functions to see how it's work. [You can find them in the API Docs](https://ihp.digitallyinduced.com/api-docs/src/IHP.ValidationSupport.ValidateField.html#isColor).
+It might be useful to take a look at the definition of some more validation functions to see how it works. [You can find them in the API Docs](https://ihp.digitallyinduced.com/api-docs/src/IHP.ValidationSupport.ValidateField.html#isColor).
 
 ### Attaching Errors To A Record Field
 
@@ -285,9 +285,9 @@ post
     |> attachFailure #title "This error will show up"
 ```
 
-This record now has a validation errors attached to it's title.
+This record now has a validation error attached to its title.
 
-### Retrieving The First Errors Message For A Field
+### Retrieving The First Error Message For A Field
 
 You can also access an error for a specific field using `getValidationFailure`:
 
@@ -299,7 +299,7 @@ post
 
 This returns `Just "Field cannot be empty"` or `Nothing` when the post has a title.
 
-### Retrieving All Errors Messages For A Record
+### Retrieving All Error Messages For A Record
 
 Access them from the `meta :: MetaBag` attribute like this:
 

--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -5,9 +5,9 @@
 
 ## Introduction
 
-IHP views are usually represented as HTML, but can also be represented a json or other formats.
+IHP views are usually represented as HTML, but can also be represented as json or other formats.
 
-The html templating is implemented on top of the well-known blaze-html haskell library. To quickly build html views, IHP supports a JSX-like syntax called HSX. HSX is type-checked and compiled to haskell code at compile-time.
+The html templating is implemented on top of the well-known blaze-html Haskell library. To quickly build html views, IHP supports a JSX-like syntax called HSX. HSX is type-checked and compiled to Haskell code at compile-time.
 
 To render a view, it has to be provided with a custom data structure called a ViewContext. A ViewContext provides the view with information it might need to render, without always explicitly passing it. This is usually used to pass e.g. the current http request, current logged in user, flash messages, the layout, etc..
 
@@ -87,7 +87,7 @@ Use `theRequest` to access the current [WAI request](https://hackage.haskell.org
 
 ### Highlighting the current active link
 
-Use [`isActivePath`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:isActivePath) to check wheter the current request url matches a given action.
+Use [`isActivePath`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:isActivePath) to check whether the current request url matches a given action.
 
 ```haskell
 <a href={ShowProjectAction} class={classes ["nav-link", ("active", isActivePath ShowProjectAction)]}>
@@ -119,7 +119,7 @@ When in development, your views will automatically refresh on code changes. This
 
 In production mode your application is using a custom integration of morphdom and [TurboLinks](https://github.com/turbolinks/turbolinks) together with [InstantClick](http://instantclick.io/). TurboLinks makes navigating the application even faster because it's not doing a full page refresh. We've integrated TurboLinks with morphdom to only update the parts of your HTML that have actually changed. This was inspired by react.js's DOM patch approach and allows for e.g. CSS animations to run on a page transition. Using this makes your app feel like a [SPA](https://en.wikipedia.org/wiki/Single-page_application) without you writing any javascript code.
 
-To improve latency, TurboLinks is configured to prefetch the URL on mouse-hover already. Usually the time between a mouse-hover of a link and mouse click is 100ms - 200ms. As long as the server responds in less than 100ms, the response is already there when the click event is fired. This makes your app faster than most single page application (most SPAs still need to fetch some data after clicking).
+To improve latency, TurboLinks is configured to prefetch the URL immediately on mouse-hover. Usually the time between a mouse-hover of a link and mouse click is 100ms - 200ms. As long as the server responds in less than 100ms, the response is already there when the click event is fired. This makes your app faster than most single page application (most SPAs still need to fetch some data after clicking).
 
 This setup is designed as a progressive enhancement. Your application is still usable when javascript is disabled.
 Even when disabled, your application will still be amazingly fast.

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -65,7 +65,7 @@ In the background, the built-in development server starts a PostgreSQL database 
 
 For our blog project, let's first build a way to manage posts.
 
-For working with posts, we first need to create a `posts` table inside our database. A single post has a title and a body and of course also an id. IHP is using UUIDs instead of the typical numerics ids.
+For working with posts, we first need to create a `posts` table inside our database. A single post has a title and a body and of course also an id. IHP is using UUIDs instead of the typical numerical ids.
 
 **This is how our `posts` table can look like for our blog:**
 
@@ -133,7 +133,7 @@ app=# SELECT * FROM posts;
 ----+-------+------
 (0 rows)
 
--- Look's alright! :)
+-- Looks alright! :)
 
 
 
@@ -168,7 +168,7 @@ By specificing the above schema, the framework automatically provides several ty
 
 IHP follows the well-known [MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) (Model-View-Controller) structure. Controllers and actions are used to deal with incoming requests.
 
-A controller belongs to an application. The default application is called `Web` (that's why all controller and views are located there). Your whole project can consis of multiple sub applications. Typically your production app will need e.g. an admin backend application next to the default web application.
+A controller belongs to an application. The default application is called `Web` (that's why all controller and views are located there). Your whole project can consist of multiple sub-applications. Typically your production app will need e.g. an admin backend application next to the default web application.
 
 We can use the built-in code generators to generate a controller for our posts. Inside the dev server, click on `CODEGEN` to open the [Code Generator](http://localhost:8001/Generators). There you can see everything that can be generated. Click on `Controller`:
 
@@ -260,7 +260,7 @@ This is where the interesting part begins. As we will see below, the controller 
         render IndexView { .. }
 ```
 
-This is the index action. It's called when opening `/Posts`. First it fetches all the posts from the database and then passes it along to the view. The `IndexView { .. }` is just shorthand for `IndexView { posts = posts }`.
+This is the index action. It's called when opening `/Posts`. First it fetches all the posts from the database and then passes them along to the view. The `IndexView { .. }` is just shorthand for `IndexView { posts = posts }`.
 
 #### New Action
 
@@ -361,7 +361,7 @@ This empty instance magically sets up the routing for all the actions. Later you
 
 We should also quickly take a look at our views.
 
-Let first look at the show view in `Web/View/Posts/Show.hs`:
+Let's first look at the show view in `Web/View/Posts/Show.hs`:
 
 ```haskell
 module Web.View.Posts.Show where
@@ -566,7 +566,7 @@ Stop the development server by pressing CTRL+C. Then update the local developmen
 
 #### Markdown Rendering
 
-Now that we have `mmark` installed, we need to integrate it into our `ShowView`. First we need to import it: Add the following line to the top of `Web/View/Posts/Show.hs`:
+Now that we have `mmark` installed, we need to integrate it into our `ShowView`. First we need to import it: add the following line to the top of `Web/View/Posts/Show.hs`:
 ```haskell
 import qualified Text.MMark as MMark
 ```
@@ -897,9 +897,9 @@ Add a `Include "comments"` like this:
 data ShowView = ShowView { post :: Include "comments" Post }
 ```
 
-This specifies that our view requires a post and also including it's comments. This will trigger a type error to be shown in the browser because our `ShowPostAction` is not passing the comments yet.
+This specifies that our view requires a post and should also include its comments. This will trigger a type error to be shown in the browser because our `ShowPostAction` is not passing the comments yet.
 
-To archive this, open `Web/Controller/Posts.hs` and take a look at the`ShowPostAction`. Right now we have a `fetch` call:
+To fix this, open `Web/Controller/Posts.hs` and take a look at the`ShowPostAction`. Right now we have a `fetch` call:
 ```haskell
 post <- fetch postId
 ```
@@ -931,7 +931,7 @@ We also need to define the `renderComment` at the end of the file:
 renderComment comment = [hsx|<div>{comment}</div>|]
 ```
 
-Let's also add some more structure to displaying the comments:
+Let's also add some more structure for displaying the comments:
 ```haskell
 renderComment comment = [hsx|
         <div class="mt-4">


### PR DESCRIPTION
The guide is an excellently-written piece of documentation, and should show other Haskell projects how documentation really can complement well-typed code. There are some small typos and grammatical errors, however, that I have fixed in this commit.

I hope this is useful and not too nit-picky, and will contribute to the overall polish of the project.