### PR TITLE
Removed redundant buttons from schema designer to simplify

### DIFF
--- a/IHP/IDE/SchemaDesigner/View/Layout.hs
+++ b/IHP/IDE/SchemaDesigner/View/Layout.hs
@@ -34,7 +34,7 @@ databaseControls = [hsx|
     <form method="POST" action={pathTo UpdateDbAction} id="update-db-form"/>
     <form method="POST" action={pathTo PushToDbAction} id="push-to-db-form"/>
     <form method="POST" action={pathTo DumpDbAction} id="db-to-fixtures-form"/>
-    <div class="btn-group">
+    <div class="btn-group btn-group-sm mb-2">
         <button
             type="submit"
             form="update-db-form"
@@ -99,9 +99,6 @@ renderColumnSelector tableName columns statements = [hsx|
 <div class="col-8 column-selector" oncontextmenu="showContextMenu('context-menu-column-root')">
     <div class="d-flex">
         <h5>Columns</h5>
-        <div class="toolbox">
-            <a href={NewColumnAction tableName} class="btn btn-sm btn-outline-primary m-1" id="new-column">New Column</a>
-        </div>
     </div>
     <table class="table table-hover table-sm">
         <tbody>
@@ -190,22 +187,12 @@ renderValue value valueId enumName = [hsx|
         contextMenuId = "context-menu-value-" <> tshow valueId
 
 renderObjectSelector statements activeObjectName = [hsx|
-    <div class="col object-selector" oncontextmenu="showContextMenu('context-menu-object-root')">
+    <div class={classes ["col", "object-selector", ("empty", isEmpty statements)]} oncontextmenu="showContextMenu('context-menu-object-root')">
         <div class="d-flex">
             <h5>Objects</h5>
-            <div class="toolbox">
-                <div class="btn-group m-1">
-                    <a href={NewTableAction} class="btn btn-sm btn-outline-primary">New Table</a>
-                    <button type="button" class="btn btn-sm btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="sr-only">Toggle Dropdown</span>
-                    </button>
-                    <div class="dropdown-menu">
-                        <a href={NewEnumAction} class="dropdown-item">New Enum</a>
-                    </div>
-                </div>
-            </div>
         </div>
         {forEach statements (\statement -> renderObject (snd statement) (fst statement))}
+        <div class="text-muted context-menu-notice">Right click to open context menu</div>
     </div>
     <div class="custom-menu menu-for-table shadow backdrop-blur" id="context-menu-object-root">
         <a href={NewTableAction}>Add Table</a>

--- a/lib/IHP/static/schema-designer.css
+++ b/lib/IHP/static/schema-designer.css
@@ -41,6 +41,22 @@
     border: 1px solid #d5d4d5;
     user-select: none;
     min-height: 800px;
+    display: flex;
+    flex-direction: column;
+}
+
+.context-menu-notice {
+    font-size: 10px;
+    margin-top: auto;
+    margin-bottom: 0.5rem;
+    margin-left: 0.5rem;
+    opacity: 0.5;
+}
+
+.object-selector.empty .context-menu-notice {
+    margin-bottom: auto;
+    font-size: 2rem;
+    text-align: center;
 }
 
 .visual-error {


### PR DESCRIPTION
This small update removes the create buttons which are redundant because the primary way should be the context menu. When the schema is fully empty, the notice to use the right click menu is shown at the center of the screen. This PR also fixes the margin of the "Update DB" button :) 

Fixes https://github.com/digitallyinduced/ihp/issues/147 and https://app.clubhouse.io/digitallyinduced/story/1620/schemadesigner-kontextmen%C3%BC-verbessern-bzw-duplicate-buttons-entfernen

![image](https://user-images.githubusercontent.com/2072185/88815434-a6750d80-d1bb-11ea-81f6-6949448da2d2.png)
![image](https://user-images.githubusercontent.com/2072185/88815461-ad038500-d1bb-11ea-8b8c-e5faddb08c88.png)
