### PR TITLE
Added support for SERIAL primary keys

### DIFF
--- a/IHP/AuthSupport/Controller/Sessions.hs
+++ b/IHP/AuthSupport/Controller/Sessions.hs
@@ -72,6 +72,7 @@ createSessionAction :: forall record action passwordField.
     , SetField "failedLoginAttempts" record Int
     , CanUpdate record
     , FrameworkConfig
+    , Show (PrimaryKey (GetTableName record))
     ) => IO ()
 createSessionAction = do
     query @record

--- a/IHP/Controller/FileUpload.hs
+++ b/IHP/Controller/FileUpload.hs
@@ -72,6 +72,7 @@ uploadImageWithOptions :: forall (fieldName :: Symbol) context record (tableName
         , SetField fieldName record (Maybe Text)
         , KnownSymbol fieldName
         , HasField "id" record (ModelSupport.Id (ModelSupport.NormalizeModel record))
+        , Show (ModelSupport.PrimaryKey (ModelSupport.GetTableName (ModelSupport.NormalizeModel record)))
         , tableName ~ ModelSupport.GetTableName record
         , KnownSymbol tableName
     ) => ImageUploadOptions -> Proxy fieldName -> record -> IO record
@@ -122,6 +123,7 @@ uploadImageFile :: forall (fieldName :: Symbol) context record (tableName :: Sym
         , SetField fieldName record (Maybe Text)
         , KnownSymbol fieldName
         , HasField "id" record (ModelSupport.Id (ModelSupport.NormalizeModel record))
+        , Show (ModelSupport.PrimaryKey (ModelSupport.GetTableName (ModelSupport.NormalizeModel record)))
         , tableName ~ ModelSupport.GetTableName record
         , KnownSymbol tableName
     ) => Text -> Proxy fieldName -> record -> IO record

--- a/IHP/Controller/Param.hs
+++ b/IHP/Controller/Param.hs
@@ -196,6 +196,13 @@ instance ParamReader Int where
             Right value -> Right value
             Left error -> Left ("ParamReader Int: " <> cs error)
 
+instance ParamReader Integer where
+    {-# INLINE readParameter #-}
+    readParameter byteString =
+        case Attoparsec.parseOnly (Attoparsec.decimal <* Attoparsec.endOfInput) byteString of
+            Right value -> Right value
+            Left error -> Left ("ParamReader Int: " <> cs error)
+
 instance ParamReader Double where
     {-# INLINE readParameter #-}
     readParameter byteString =
@@ -248,10 +255,10 @@ instance ParamReader Day where
             Just value -> Right value
             Nothing -> Left "ParamReader Day: Failed parsing"
 
-instance {-# OVERLAPS #-} ParamReader (ModelSupport.Id' model') where
+instance {-# OVERLAPS #-} (ParamReader (ModelSupport.PrimaryKey model')) => ParamReader (ModelSupport.Id' model') where
     {-# INLINE readParameter #-}
     readParameter uuid =
-        case (readParameter uuid) :: Either ByteString UUID of
+        case (readParameter uuid) :: Either ByteString (ModelSupport.PrimaryKey model') of
             Right uuid -> pure (ModelSupport.Id uuid)
             Left error -> Left error
 

--- a/IHP/LoginSupport/Middleware.hs
+++ b/IHP/LoginSupport/Middleware.hs
@@ -14,6 +14,7 @@ import IHP.LoginSupport.Helper.Controller
 import IHP.Controller.Session
 import IHP.QueryBuilder
 import IHP.ControllerSupport
+import IHP.ModelSupport
 
 {-# INLINE initAuthentication #-}
 initAuthentication :: forall user.
@@ -24,6 +25,7 @@ initAuthentication :: forall user.
         , KnownSymbol (GetTableName (NormalizeModel user))
         , KnownSymbol (GetModelName user)
         , FromRow (NormalizeModel user)
+        , PrimaryKey (GetTableName user) ~ UUID
     ) => TypeMap.TMap -> IO TypeMap.TMap
 initAuthentication context = do
     user <- getSessionUUID (sessionKey @user)

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DatatypeContexts, MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs #-}
 
 module IHP.ModelSupport where
 
@@ -120,6 +120,19 @@ isNew model = def == (getField @"id" model)
 {-# INLINE isNew #-}
 
 type family GetModelName model :: Symbol
+
+-- | Provides the primary key type for a given table. The instances are usually declared
+-- by the generated haskell code in Generated.Types
+--
+-- __Example:__ Defining the primary key for a users table
+--
+-- > type instance PrimaryKey "users" = UUID
+--
+--
+-- __Example:__ Defining the primary key for a table with a SERIAL pk
+--
+-- > type instance PrimaryKey "projects" = Int
+--
 type family PrimaryKey (tableName :: Symbol)
 
 -- | Returns the model name of a given model as Text
@@ -139,8 +152,6 @@ newtype Id' table = Id (PrimaryKey table)
 
 deriving instance (Eq (PrimaryKey table)) => Eq (Id' table)
 deriving instance (KnownSymbol table, Data (PrimaryKey table)) => Data (Id' table)
-
-class (Eq primaryKey, Data primaryKey, ToField primaryKey) => IsPrimaryKey primaryKey where
 
 -- | We need to map the model to it's table name to prevent infinite recursion in the model data definition
 -- E.g. `type Project = Project' { id :: Id Project }` will not work

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs #-}
+{-# LANGUAGE DatatypeContexts, MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs #-}
 
 module IHP.ModelSupport where
 
@@ -60,6 +60,9 @@ instance InputValue Text where
 instance InputValue Int where
     inputValue = tshow
 
+instance InputValue Integer where
+    inputValue = tshow
+
 instance InputValue Double where
     inputValue = tshow
 
@@ -117,6 +120,7 @@ isNew model = def == (getField @"id" model)
 {-# INLINE isNew #-}
 
 type family GetModelName model :: Symbol
+type family PrimaryKey (tableName :: Symbol)
 
 -- | Returns the model name of a given model as Text
 --
@@ -131,47 +135,52 @@ getModelName :: forall model. KnownSymbol (GetModelName model) => Text
 getModelName = cs $! symbolVal (Proxy :: Proxy (GetModelName model))
 {-# INLINE getModelName #-}
 
-newtype Id' table = Id UUID deriving (Eq, Data)
+newtype Id' table = Id (PrimaryKey table)
+
+deriving instance (Eq (PrimaryKey table)) => Eq (Id' table)
+deriving instance (KnownSymbol table, Data (PrimaryKey table)) => Data (Id' table)
+
+class (Eq primaryKey, Data primaryKey, ToField primaryKey) => IsPrimaryKey primaryKey where
 
 -- | We need to map the model to it's table name to prevent infinite recursion in the model data definition
 -- E.g. `type Project = Project' { id :: Id Project }` will not work
 -- But `type Project = Project' { id :: Id "projects" }` will
 type Id model = Id' (GetTableName model)
 
-instance InputValue (Id' model') where
+instance InputValue (PrimaryKey model') => InputValue (Id' model') where
     {-# INLINE inputValue #-}
     inputValue = inputValue . Newtype.unpack
 
-recordToInputValue :: (HasField "id" entity (Id entity)) => entity -> Text
+recordToInputValue :: (HasField "id" entity (Id entity), Show (PrimaryKey (GetTableName entity))) => entity -> Text
 recordToInputValue entity =
     getField @"id" entity
     |> Newtype.unpack
-    |> Data.UUID.toText
+    |> tshow
 {-# INLINE recordToInputValue #-}
 
-instance FromField (Id' model) where
+instance FromField (PrimaryKey model) => FromField (Id' model) where
     {-# INLINE fromField #-}
     fromField value metaData = do
         fieldValue <- fromField value metaData
         pure (Id fieldValue)
 
-instance ToField (Id' model) where
+instance ToField (PrimaryKey model) => ToField (Id' model) where
     {-# INLINE toField #-}
     toField = toField . Newtype.unpack
 
-instance Show (Id' model) where
+instance Show (PrimaryKey model) => Show (Id' model) where
     {-# INLINE show #-}
     show = show . Newtype.unpack
 
 instance Newtype.Newtype (Id' model) where
-    type O (Id' model) = UUID
+    type O (Id' model) = PrimaryKey model
     pack = Id
     unpack (Id uuid) = uuid
 
-instance IsString (Id' model) where
+instance Read (PrimaryKey model) => IsString (Id' model) where
     fromString uuid = Id (Prelude.read uuid)
 
-instance Default (Id' model) where
+instance Default (PrimaryKey model) => Default (Id' model) where
     {-# INLINE def #-}
     def = Newtype.pack def
 

--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -408,7 +408,7 @@ queryOr :: (qb ~ QueryBuilder model) => (qb -> qb) -> (qb -> qb) -> qb -> qb
 queryOr a b queryBuilder = a queryBuilder `UnionQueryBuilder` b queryBuilder
 {-# INLINE queryOr #-}
 
-instance (model ~ GetModelById (Id' model'), HasField "id" model id, id ~ Id' model') => Fetchable (Id' model') model where
+instance (model ~ GetModelById (Id' model'), HasField "id" model id, id ~ Id' model', ToField (PrimaryKey model')) => Fetchable (Id' model') model where
     type FetchResult (Id' model') model = model
     {-# INLINE fetch #-}
     fetch = genericFetchIdOne
@@ -417,7 +417,7 @@ instance (model ~ GetModelById (Id' model'), HasField "id" model id, id ~ Id' mo
     {-# INLINE fetchOne #-}
     fetchOne = genericFetchIdOne
 
-instance (model ~ GetModelById (Id' model'), HasField "id" model id, id ~ Id' model') => Fetchable (Maybe (Id' model')) model where
+instance (model ~ GetModelById (Id' model'), HasField "id" model id, id ~ Id' model', ToField (PrimaryKey model')) => Fetchable (Maybe (Id' model')) model where
     type FetchResult (Maybe (Id' model')) model = [model]
     {-# INLINE fetch #-}
     fetch (Just a) = genericFetchId a
@@ -429,7 +429,7 @@ instance (model ~ GetModelById (Id' model'), HasField "id" model id, id ~ Id' mo
     fetchOne (Just a) = genericFetchIdOne a
     fetchOne Nothing = error "Fetchable (Maybe Id): Failed to fetch because given id is 'Nothing', 'Just id' was expected"
 
-instance (model ~ GetModelById (Id' model'), value ~ Id' model', HasField "id" model value) => Fetchable [Id' model'] model where
+instance (model ~ GetModelById (Id' model'), value ~ Id' model', HasField "id" model value, ToField (PrimaryKey model')) => Fetchable [Id' model'] model where
     type FetchResult [Id' model'] model = [model]
     {-# INLINE fetch #-}
     fetch = genericFetchIds

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -456,7 +456,7 @@ parseUUID = do
 {-# INLINE parseUUID #-}
 
 -- | Parses an UUID, afterwards wraps it in an Id
-parseId :: Parser (ModelSupport.Id record)
+parseId :: ((ModelSupport.PrimaryKey (ModelSupport.GetTableName record)) ~ UUID) => Parser (ModelSupport.Id record)
 parseId = ModelSupport.Id <$> parseUUID
 {-# INLINE parseId #-}
 

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -550,4 +550,4 @@ hasExplicitOrImplicitDefault column = case column of
         Column { defaultValue = Just _ } -> True
         Column { columnType = PSerial } -> True
         Column { columnType = PBigserial } -> True
-        _ -> True
+        _ -> False

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -138,6 +138,7 @@ compileStatement CompilerOptions { compileGetAndSetFieldInstances } table@(Creat
     <> compileFromRowInstance table
     <> compileHasTableNameInstance table
     <> compileGetModelName table
+    <> compilePrimaryKeyInstance table
     <> compileInclude table
     <> compileCreate table
     <> section
@@ -293,10 +294,11 @@ compileCreate table@(CreateTable { name, columns }) =
         columnNames = commaSep (map (get #name) columns)
         values = commaSep (map (const "?") columns)
 
-        toBinding Column { name, defaultValue } =
-          case defaultValue of
-            Nothing -> "get #" <> columnNameToFieldName name <> " model"
-            Just _ -> "fieldWithDefault #" <> columnNameToFieldName name <> " model"
+        toBinding column@(Column { name }) =
+            if hasExplicitOrImplicitDefault column
+                then "fieldWithDefault #" <> columnNameToFieldName name <> " model"
+                else "get #" <> columnNameToFieldName name <> " model"
+            
 
         bindings :: [Text]
         bindings = map toBinding columns
@@ -447,6 +449,19 @@ compileHasTableNameInstance table@(CreateTable { name }) =
     "type instance GetTableName (" <> tableNameToModelName name <> "' " <> unwords (map (const "_") (dataTypeArguments table)) <>  ") = " <> tshow name <> "\n"
     <> "type instance GetModelByTableName " <> tshow name <> " = " <> tableNameToModelName name <> "\n"
 
+compilePrimaryKeyInstance :: (?schema :: Schema) => Statement -> Text
+compilePrimaryKeyInstance table@(CreateTable { name, columns }) = "type instance PrimaryKey " <> tshow name <> " = " <> idType <> "\n"
+    where
+        idColumn :: Column
+        (Just idColumn) = find (get #primaryKey) columns
+
+        idType :: Text
+        idType = case get #columnType idColumn of
+                PUUID -> "UUID"
+                PSerial -> "Int"
+                PBigserial -> "Integer"
+                otherwise -> error ("Unexpected type for primary key column in table" <> cs name)
+
 compileGetModelName :: (?schema :: Schema) => Statement -> Text
 compileGetModelName table@(CreateTable { name }) = "type instance GetModelName (" <> tableNameToModelName name <> "' " <> unwords (map (const "_") (dataTypeArguments table)) <>  ") = " <> tshow (tableNameToModelName name) <> "\n"
 
@@ -529,3 +544,10 @@ indent code = code
         indentLine ""   = ""
         indentLine line = "    " <> line
 
+-- | Returns 'True' when the column has an explicit default value or when it's a SERIAL or BIGSERIAL
+hasExplicitOrImplicitDefault :: Column -> Bool
+hasExplicitOrImplicitDefault column = case column of
+        Column { defaultValue = Just _ } -> True
+        Column { columnType = PSerial } -> True
+        Column { columnType = PBigserial } -> True
+        _ -> True


### PR DESCRIPTION
UUIDs are still the default and recommended way for the id column. For cases where UUIDs don't work, you can now change the column type to SERIAL or BIGSERIAL to work with integers.

Fixes https://github.com/digitallyinduced/ihp/issues/302