### PR TITLE
Only log sql queries in development mode

### DIFF
--- a/IHP/IDE/ToolServer.hs
+++ b/IHP/IDE/ToolServer.hs
@@ -71,7 +71,7 @@ startToolServer' port isDebugMode = do
                 , Cookie.setCookieSameSite = Just Cookie.sameSiteLax
                 }
     let sessionMiddleware :: Wai.Middleware = withSession store "SESSION" sessionCookie session    
-    let applicationContext = ApplicationContext { modelContext = (ModelContext (error "Not connected")), session }
+    let applicationContext = ApplicationContext { modelContext = notConnectedModelContext, session }
     let toolServerApplication = ToolServerApplication { devServerContext = ?context }
     let application :: Wai.Application = \request respond -> do
             let ?applicationContext = applicationContext

--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -140,14 +140,14 @@ instance Fetchable (QueryBuilder model) model where
     fetch :: (KnownSymbol (GetTableName model), PG.FromRow model, ?modelContext :: ModelContext) => QueryBuilder model -> IO [model]
     fetch !queryBuilder = do
         let !(theQuery, theParameters) = toSQL' (buildQuery queryBuilder)
-        putStrLn $! tshow (theQuery, theParameters)
+        logQuery theQuery theParameters
         sqlQuery (Query $ cs theQuery) theParameters
 
     {-# INLINE fetchOneOrNothing #-}
     fetchOneOrNothing :: (?modelContext :: ModelContext) => (PG.FromRow model, KnownSymbol (GetTableName model)) => QueryBuilder model -> IO (Maybe model)
     fetchOneOrNothing !queryBuilder = do
         let !(theQuery, theParameters) = toSQL' (buildQuery queryBuilder) { limitClause = Just "LIMIT 1"}
-        putStrLn $! tshow (theQuery, theParameters)
+        logQuery theQuery theParameters
         results <- sqlQuery (Query $ cs theQuery) theParameters
         pure $ listToMaybe results
 
@@ -174,7 +174,7 @@ fetchCount :: (?modelContext :: ModelContext, KnownSymbol (GetTableName model)) 
 fetchCount !queryBuilder = do
     let !(theQuery', theParameters) = toSQL' (buildQuery queryBuilder)
     let theQuery = "SELECT COUNT(*) FROM (" <> theQuery' <> ") AS _count_values"
-    putStrLn $! tshow (theQuery, theParameters)
+    logQuery theQuery theParameters
     [PG.Only count] <- sqlQuery (Query $! cs theQuery) theParameters
     pure count
 {-# INLINE fetchCount #-}
@@ -193,7 +193,7 @@ fetchExists :: (?modelContext :: ModelContext, KnownSymbol (GetTableName model))
 fetchExists !queryBuilder = do
     let !(theQuery', theParameters) = toSQL' (buildQuery queryBuilder)
     let theQuery = "SELECT EXISTS FROM (" <> theQuery' <> ") AS _exists_values"
-    putStrLn $! tshow (theQuery, theParameters)
+    logQuery theQuery theParameters
     [PG.Only exists] <- sqlQuery (Query $! cs theQuery) theParameters
     pure exists
 {-# INLINE fetchExists #-}

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -361,13 +361,13 @@ compileCreate table@(CreateTable { name, columns }) =
         <> indent (
             "create :: (?modelContext :: ModelContext) => " <> modelName <> " -> IO " <> modelName <> "\n"
                 <> "create model = do\n"
-                <> indent ("let (ModelContext conn) = ?modelContext\n"
-                    <> "result <- Database.PostgreSQL.Simple.query conn \"INSERT INTO " <> name <> " (" <> columnNames <> ") VALUES (" <> values <> ") RETURNING *\" (" <> compileToRowValues bindings <> ")\n"
+                <> indent ("let ModelContext { databaseConnection } = ?modelContext\n"
+                    <> "result <- Database.PostgreSQL.Simple.query databaseConnection \"INSERT INTO " <> name <> " (" <> columnNames <> ") VALUES (" <> values <> ") RETURNING *\" (" <> compileToRowValues bindings <> ")\n"
                     <> "pure (List.head result)\n"
                     )
                 <> "createMany models = do\n"
-                <> indent ("let (ModelContext conn) = ?modelContext\n"
-                    <> createManyQueryFn <> " conn (Query $ \"INSERT INTO " <> name <> " (" <> columnNames <> ") VALUES \" <> (ByteString.intercalate \", \" (List.map (\\_ -> \"(" <> values <> ")\") models)) <> \" RETURNING *\") " <> createManyFieldValues <> "\n"
+                <> indent ("let ModelContext { databaseConnection } = ?modelContext\n"
+                    <> createManyQueryFn <> " databaseConnection (Query $ \"INSERT INTO " <> name <> " (" <> columnNames <> ") VALUES \" <> (ByteString.intercalate \", \" (List.map (\\_ -> \"(" <> values <> ")\") models)) <> \" RETURNING *\") " <> createManyFieldValues <> "\n"
                     )
             )
 
@@ -395,8 +395,8 @@ compileUpdate table@(CreateTable { name, columns }) =
     in
         "instance CanUpdate " <> modelName <> " where\n"
         <> indent ("updateRecord model = do\n"
-                <> indent ("let (ModelContext conn) = ?modelContext\n"
-                    <> "result <- Database.PostgreSQL.Simple.query conn \"UPDATE " <> name <> " SET " <> updates <> " WHERE id = ? RETURNING *\" (" <> bindings <> ")\n"
+                <> indent ("let ModelContext { databaseConnection } = ?modelContext\n"
+                    <> "result <- Database.PostgreSQL.Simple.query databaseConnection \"UPDATE " <> name <> " SET " <> updates <> " WHERE id = ? RETURNING *\" (" <> bindings <> ")\n"
                     <> "pure (List.head result)\n"
                 )
             )

--- a/IHP/ScriptSupport.hs
+++ b/IHP/ScriptSupport.hs
@@ -7,6 +7,7 @@ module IHP.ScriptSupport (runScript, Script) where
 
 import IHP.Prelude
 import qualified IHP.FrameworkConfig as Config
+import qualified IHP.Environment as Env
 import IHP.ModelSupport
 import qualified Database.PostgreSQL.Simple as PG
 
@@ -14,14 +15,16 @@ import qualified Database.PostgreSQL.Simple as PG
 type Script = (?modelContext :: ModelContext) => IO ()
 
 -- | Initializes IHP and then runs the script inside the framework context
-runScript :: Script -> IO ()
+runScript :: Config.FrameworkConfig => Script -> IO ()
 runScript taskMain = do
     modelContext <- createModelContext    
     let ?modelContext = modelContext
     taskMain
 
+createModelContext :: Config.FrameworkConfig => IO ModelContext
 createModelContext = do
     databaseUrl <- Config.appDatabaseUrl
-    conn <- PG.connectPostgreSQL databaseUrl 
-    pure (ModelContext conn)
+    databaseConnection <- PG.connectPostgreSQL databaseUrl 
+    let queryDebuggingEnabled = Env.isDevelopment Config.environment
+    pure ModelContext { .. }
     


### PR DESCRIPTION
Previous all sql queries have been printed to stdout all the time. This change adds a new option queryDebuggingEnabled to the modelContext. Depending on this setting queries will be logged. By default this will be set to True in dev mode, and to False in Production mode

Fixes https://github.com/digitallyinduced/ihp/issues/358