### PR TITLE
Allow dotless email addresses in `isEmail`

### DIFF
--- a/IHP/ValidationSupport/ValidateField.hs
+++ b/IHP/ValidationSupport/ValidateField.hs
@@ -215,13 +215,16 @@ isPhoneNumber text = Failure "is not a valid phone number (has to start with +, 
 -- >>> isEmail "ॐ@मणिपद्मे.हूँ"
 -- Success
 --
--- >>> isEmail "marc@localhost" -- missing TLD
--- Failure "is not a valid email"
+-- >>> isEmail "marc@localhost" -- Although discouraged by ICANN, dotless TLDs are legal. See https://www.icann.org/news/announcement-2013-08-30-en
+-- Success
 --
 -- >>> isEmail "loremipsum"
 -- Failure "is not a valid email"
+--
+-- >>> isEmail "A@b@c@domain.com"
+-- Failure "is not a valid email"
 isEmail :: Text -> ValidatorResult
-isEmail text | text =~ ("^[^ @]+@[^ @_+]+\\.[^ @_+-]+$" :: Text) = Success
+isEmail text | text =~ ("^[^ @]+@[^ @_+]+\\.?[^ @_+-]+$" :: Text) = Success
 isEmail text = Failure "is not a valid email"
 {-# INLINE isEmail #-}
 

--- a/Test/ValidationSupport/ValidateFieldSpec.hs
+++ b/Test/ValidationSupport/ValidateFieldSpec.hs
@@ -53,8 +53,8 @@ tests = do
         it "should allow Unicode characters" do
             isEmail "ॐ@मणिपद्मे.हूँ" `shouldBe` Success
             
-        it "should reject servers consisting of just TLD" do
-            isEmail "foo@localhost" `shouldSatisfy` isFailure
+        it "should allow dotless domains" do
+            isEmail "foo@localhost" `shouldBe` Success
 
     describe "The isInRange validator" do
         it "should handle trivial cases" do


### PR DESCRIPTION
Although their usage are prohibited by ICANN for the wider internet, dotless email addresses are perfectly valid as per the standards. I included a warning leading to the announcement made in 2013 by ICANN regarding the usage of dotless email addresses.

references:
* https://en.wikipedia.org/wiki/Email_address#Examples
* https://www.icann.org/news/announcement-2013-08-30-en