### PR TITLE
update dateTime so that it works correctly for 12-hour locales

### DIFF
--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -32,7 +32,7 @@ function initTime() {
 
     document.querySelectorAll(".date-time").forEach(function(elem){
         var date = new Date(elem.dateTime);
-        elem.innerHTML = date.toLocaleDateString() +", " + date.toLocaleTimeString().substr(0,5);
+        elem.innerHTML = date.toLocaleDateString() +", " + date.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
     });
 
     document.querySelectorAll(".date").forEach(function(elem){


### PR DESCRIPTION
Hi! I'd like to propose this fix for https://github.com/digitallyinduced/ihp/issues/390, an issue I encountered when using dateTime in a 12-hour locale. This change will produce canonical time stamps with hours, minutes, and without seconds, for both 12- and 24-hour locales.