### PR TITLE
codegen: import Generated.Types in layout view

### DIFF
--- a/IHP/IDE/CodeGen/ApplicationGenerator.hs
+++ b/IHP/IDE/CodeGen/ApplicationGenerator.hs
@@ -106,6 +106,7 @@ generateGenericApplication applicationName =
                 <> "import IHP.Environment\n"
                 <> "import qualified Text.Blaze.Html5            as H\n"
                 <> "import qualified Text.Blaze.Html5.Attributes as A\n"
+                <> "import Generated.Types\n"
                 <> "import " <> applicationName <> ".Types\n"
                 <> "import " <> applicationName <> ".Routes\n"
                 <> "import qualified IHP.FrameworkConfig as FrameworkConfig\n"


### PR DESCRIPTION
By importing that module by default, developers can easily use types like the User when rendering the Layout view.