### PR TITLE
Disable all fancy debugging error handlers in production

### DIFF
--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -42,6 +42,7 @@ import qualified Data.TMap as TypeMap
 import qualified Control.Exception as Exception
 import qualified IHP.ErrorController as ErrorController
 import qualified Data.Typeable as Typeable
+import IHP.FrameworkConfig (FrameworkConfig)
 
 type Action' = IO ResponseReceived
 
@@ -75,7 +76,7 @@ class InitControllerContext application where
     initContext context = pure context
 
 {-# INLINE runAction #-}
-runAction :: forall controller. (Controller controller, ?requestContext :: RequestContext, ?controllerContext :: ControllerContext, ?modelContext :: ModelContext) => controller -> IO ResponseReceived
+runAction :: forall controller. (Controller controller, ?requestContext :: RequestContext, ?controllerContext :: ControllerContext, ?modelContext :: ModelContext, FrameworkConfig) => controller -> IO ResponseReceived
 runAction controller = do
     let ?theAction = controller
     let respond = ?requestContext |> get #respond
@@ -90,7 +91,7 @@ runAction controller = do
     doRunAction `catches` [ Handler handleResponseException, Handler (\exception -> ErrorController.displayException exception controller "")]
 
 {-# INLINE runActionWithNewContext #-}
-runActionWithNewContext :: forall application controller. (Controller controller, ?applicationContext :: ApplicationContext, ?requestContext :: RequestContext, InitControllerContext application, ?application :: application, Typeable application, Typeable controller) => controller -> IO ResponseReceived
+runActionWithNewContext :: forall application controller. (Controller controller, ?applicationContext :: ApplicationContext, ?requestContext :: RequestContext, InitControllerContext application, ?application :: application, Typeable application, Typeable controller, FrameworkConfig) => controller -> IO ResponseReceived
 runActionWithNewContext controller = do
     let ?modelContext = ApplicationContext.modelContext ?applicationContext
     let context = TypeMap.empty

--- a/IHP/FrameworkConfig.hs
+++ b/IHP/FrameworkConfig.hs
@@ -4,7 +4,6 @@ import ClassyPrelude
 import qualified System.Environment as Environment
 import System.Directory (getCurrentDirectory)
 import IHP.Environment
-import IHP.ControllerSupport
 import System.IO.Unsafe (unsafePerformIO)
 import Data.String.Conversions (cs)
 import qualified System.Directory as Directory

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -368,6 +368,7 @@ get :: (Controller action
     , ?requestContext :: RequestContext
     , Typeable application
     , Typeable action
+    , FrameworkConfig.FrameworkConfig
     ) => ByteString -> action -> Parser (IO ResponseReceived)
 get path action = do
     method <- getMethod
@@ -397,6 +398,7 @@ post :: (Controller action
     , ?requestContext :: RequestContext
     , Typeable application
     , Typeable action
+    , FrameworkConfig.FrameworkConfig
     ) => ByteString -> action -> Parser (IO ResponseReceived)
 post path action = do
     method <- getMethod
@@ -408,6 +410,7 @@ post path action = do
 {-# INLINE post #-}
 
 -- | Defines the start page for a router (when @\/@ is requested).
+startPage :: (Controller action, InitControllerContext application, ?application::application, ?applicationContext::ApplicationContext, ?requestContext::RequestContext, Typeable application, Typeable action, FrameworkConfig.FrameworkConfig) => action -> Parser (IO ResponseReceived)
 startPage action = get "/" action
 {-# INLINE startPage #-}
 
@@ -435,11 +438,11 @@ mountFrontController :: forall frontController application. (?applicationContext
 mountFrontController application = let ?application = application in choice (map (\r -> r <* endOfInput) controllers)
 {-# INLINE mountFrontController #-}
 
-parseRoute :: forall controller application. (?applicationContext :: ApplicationContext, ?requestContext :: RequestContext, Controller controller, CanRoute controller, InitControllerContext application, ?application :: application, Typeable application, Data controller) => Parser (IO ResponseReceived)
+parseRoute :: forall controller application. (?applicationContext :: ApplicationContext, ?requestContext :: RequestContext, Controller controller, CanRoute controller, InitControllerContext application, ?application :: application, Typeable application, Data controller, FrameworkConfig.FrameworkConfig) => Parser (IO ResponseReceived)
 parseRoute = parseRoute' @controller >>= pure . runActionWithNewContext @application
 {-# INLINE parseRoute #-}
 
-catchAll :: forall action application. (?applicationContext :: ApplicationContext, ?requestContext :: RequestContext, Controller action, InitControllerContext application, Typeable action, ?application :: application, Typeable application, Data action) => action -> Parser (IO ResponseReceived)
+catchAll :: forall action application. (?applicationContext :: ApplicationContext, ?requestContext :: RequestContext, Controller action, InitControllerContext application, Typeable action, ?application :: application, Typeable application, Data action, FrameworkConfig.FrameworkConfig) => action -> Parser (IO ResponseReceived)
 catchAll action = do
     string (actionPrefix @action)
     _ <- takeByteString


### PR DESCRIPTION
We don't want to display all the fancy error messages which sometimes include sql queries for normal users.