### PR TITLE
Custom error page (requires discussion)

### DIFF
--- a/IHP/ErrorController.hs
+++ b/IHP/ErrorController.hs
@@ -8,6 +8,7 @@ module IHP.ErrorController
 , handleNoResponseReturned
 , handleNotFound
 , handleRouterException
+, renderErrorView
 ) where
 
 import IHP.Prelude hiding (displayException)
@@ -245,7 +246,10 @@ recordNotFoundExceptionHandler exception controller additionalInfo = do
         Nothing -> Nothing
 
 renderError :: _
-renderError errorTitle view = H.docTypeHtml ! A.lang "en" $ [hsx|
+renderError errorTitle view = H.docTypeHtml ! A.lang "en" $ renderErrorView errorTitle view
+
+renderErrorView :: _
+renderErrorView errorTitle view = [hsx|
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
@@ -318,4 +322,4 @@ renderError errorTitle view = H.docTypeHtml ! A.lang "en" $ [hsx|
         </div>
     </div>
 </body>
-    |]
+|]

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -429,9 +429,7 @@ runApp routes notFoundAction = do
     case routedAction of
         Left message -> case notFoundAction' of
                 Left _ -> notFoundAction
-                Right action -> do
-                    putStrLn "dingindg"
-                    action
+                Right action -> action
         Right action -> action
 {-# INLINE runApp #-}
 

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -425,8 +425,13 @@ runApp routes notFoundAction = do
         handleException exception = pure $ Right (ErrorController.handleRouterException exception)
 
     routedAction <- (evaluate $ parseOnly (routes <* endOfInput) path) `Exception.catch` handleException
+    notFoundAction' <- (evaluate $ parseOnly (routes <* endOfInput) "/NotFound") `Exception.catch` handleException
     case routedAction of
-        Left message -> notFoundAction
+        Left message -> case notFoundAction' of
+                Left _ -> notFoundAction
+                Right action -> do
+                    putStrLn "dingindg"
+                    action
         Right action -> action
 {-# INLINE runApp #-}
 


### PR DESCRIPTION
### Summary
- A default error controller is generated as part of a new project (using the default error view)
- The runApp function tries to lookup the /NotFound action before defaulting to previous behavior

### Known problems
- [ ] Fix the layout (the bg color is not working, probably through the addition of the layout default css)

### Discussion points
- A default project now contains extra files. Is this desirable or is there a way to implement default behavior in the package rather than a fresh project?
- This change is not backwards compatible, is that a problem? What is our policy on this matter?