### PR TITLE
Fixed scripts not running in dev mode

### DIFF
--- a/exe/IHP/CLI/run-script
+++ b/exe/IHP/CLI/run-script
@@ -28,7 +28,7 @@ fi
 
 echo "import IHP.ScriptSupport" >> "$GHCI_SCRIPT"
 echo ":set -i." >> "$GHCI_SCRIPT"
-echo ":l Application/Script/$TASK_MODULE.hs" >> "$GHCI_SCRIPT"
+echo ":l Config/Config.hs Application/Script/$TASK_MODULE.hs" >> "$GHCI_SCRIPT"
 echo "import qualified Application.Script.$TASK_MODULE as Script" >> "$GHCI_SCRIPT"
 echo "IHP.ScriptSupport.runScript Script.run" >> "$GHCI_SCRIPT"
 echo ":quit" >> "$GHCI_SCRIPT"


### PR DESCRIPTION
This was caused by a recent change to more modules requiring a FrameworkConfig constraint. Fixes #421