### PR TITLE
Adding instances for Ord and Hashable to PrimaryKeys

### DIFF
--- a/IHP/IDE/CodeGen/ActionGenerator.hs
+++ b/IHP/IDE/CodeGen/ActionGenerator.hs
@@ -22,7 +22,7 @@ data ActionConfig = ActionConfig
 buildPlan :: Text -> Text -> Text -> Bool -> IO (Either Text [GeneratorAction])
 buildPlan actionName applicationName controllerName doGenerateView=
     if (null actionName || null controllerName)
-        then pure $ Left "Action name and controller name cannot be empty"
+        then pure $ Left "Neither action name nor controller name can be empty"
         else do 
             schema <- SchemaDesigner.parseSchemaSql >>= \case
                 Left parserError -> pure []
@@ -37,9 +37,9 @@ buildPlan actionName applicationName controllerName doGenerateView=
                         Left error -> pure $ Left error
                 else pure $ Right $ actionPlan
     where
-        viewName = if "Action" `isSuffixOf` actionName
-                        then Text.dropEnd 6 actionName
-                        else actionName
+        viewName = ucfirst $ if "Action" `isSuffixOf` actionName
+                             then Text.dropEnd 6 actionName
+                             else actionName
         modelName = tableNameToModelName controllerName
 
 -- E.g. qualifiedViewModuleName config "Edit" == "Web.View.Users.Edit"

--- a/IHP/IDE/CodeGen/Controller.hs
+++ b/IHP/IDE/CodeGen/Controller.hs
@@ -105,7 +105,7 @@ instance Controller CodeGenController where
         let doGenerateView = paramOrDefault False "doGenerateView"
         (Right plan) <- ActionGenerator.buildPlan actionName applicationName controllerName doGenerateView
         executePlan plan
-        setSuccessMessage "Action generated"
+        setSuccessMessage $ "Action" ++ (if doGenerateView then " and View " else "") ++ " generated"
         redirectTo GeneratorsAction
 
     action NewApplicationAction = do

--- a/IHP/IDE/CodeGen/View/NewAction.hs
+++ b/IHP/IDE/CodeGen/View/NewAction.hs
@@ -79,6 +79,7 @@ instance View NewActionView ViewContext where
                     <input type="hidden" name="name" value={actionName}/>
                     <input type="hidden" name="controllerName" value={controllerName}/>
                     <input type="hidden" name="applicationName" value={applicationName}/>
+                    <input type="hidden" name="doGenerateView" value={(if doGenerateView then "on" else "off") :: Text}/>
 
                     <button class="btn btn-primary" type="submit">Generate</button>
                 </form>

--- a/IHP/IDE/CodeGen/ViewGenerator.hs
+++ b/IHP/IDE/CodeGen/ViewGenerator.hs
@@ -21,7 +21,7 @@ data ViewConfig = ViewConfig
 buildPlan :: Text -> Text -> Text -> IO (Either Text [GeneratorAction])
 buildPlan viewName applicationName controllerName' =
     if (null viewName || null controllerName')
-        then pure $ Left "View name and controller name cannot be empty"
+        then pure $ Left "Neither view name nor controller name can be empty"
         else do
             schema <- SchemaDesigner.parseSchemaSql >>= \case
                 Left parserError -> pure []
@@ -97,7 +97,8 @@ buildPlan' schema config =
                 <> "            </ol>\n"
                 <> "        </nav>\n"
                 <> "        <h1>Show " <> singularName <> "</h1>\n"
-                <> "    |]\n"
+                <> "        <p>{" <> singularVariableName <> "}</p>\n"
+                 <> "    |]\n"
 
             newView =
                 viewHeader
@@ -117,7 +118,7 @@ buildPlan' schema config =
                 <> "\n"
                 <> "renderForm :: " <> singularName <> " -> Html\n"
                 <> "renderForm " <> singularVariableName <> " = formFor " <> singularVariableName <> " [hsx|\n"
-                <> (intercalate "\n" (map (\field -> "    {textField #" <> field <> "}") modelFields)) <> "\n"
+                <> (intercalate "\n" (map (\field -> "    {(textField #" <> field <> ")}") modelFields)) <> "\n"
                 <> "    {submitButton}\n"
                 <> "|]\n"
 
@@ -139,7 +140,7 @@ buildPlan' schema config =
                 <> "\n"
                 <> "renderForm :: " <> singularName <> " -> Html\n"
                 <> "renderForm " <> singularVariableName <> " = formFor " <> singularVariableName <> " [hsx|\n"
-                <> (intercalate "\n" (map (\field -> "    {textField #" <> field <> "}") modelFields)) <> "\n"
+                <> (intercalate "\n" (map (\field -> "    {(textField #" <> field <> ")}") modelFields)) <> "\n"
                 <> "    {submitButton}\n"
                 <> "|]\n"
 

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs, GeneralizedNewtypeDeriving #-}
 
 module IHP.ModelSupport where
 
@@ -175,6 +175,8 @@ getModelName = cs $! symbolVal (Proxy :: Proxy (GetModelName model))
 newtype Id' table = Id (PrimaryKey table)
 
 deriving instance (Eq (PrimaryKey table)) => Eq (Id' table)
+deriving instance (Ord (PrimaryKey table)) => Ord (Id' table)
+deriving instance (Hashable (PrimaryKey table)) => Hashable (Id' table)
 deriving instance (KnownSymbol table, Data (PrimaryKey table)) => Data (Id' table)
 
 -- | We need to map the model to it's table name to prevent infinite recursion in the model data definition

--- a/lib/IHP/static/ihp-codegen.css
+++ b/lib/IHP/static/ihp-codegen.css
@@ -139,7 +139,7 @@
 }
 
 .code-generator .generator-options {
-    font-size: 11px;
+    font-size: 13px;
     margin-top: 0.5rem;
     margin-left: 0.5rem;
 }


### PR DESCRIPTION
This allows for use of PrimaryKeys as keys in data structures such as Data.Map and Data.Hashable. When working on older databases without defined relations, or for cases where native joins (or fetchRelated) performs poorly, the ability to manually look up data based on key is useful.