### PR TITLE
guide: Address confusion with PostsController / HTTP POST

### DIFF
--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -358,6 +358,8 @@ instance AutoRoute PostsController
 
 This empty instance magically sets up the routing for all the actions. Later you will learn how you can customize the urls according to your needs (e.g. "beautiful urls" for SEO).
 
+<sup>Note that the word 'Post' here still refers to a post on our blog and is unrelated to the HTTP-POST request method.</sup>
+
 #### Views
 
 We should also quickly take a look at our views.


### PR DESCRIPTION
There was a discussion in the gitter about how the name PostsController can be confusing, especially in the context of routing. I added a small note to elaborate the difference