### PR TITLE
Re-exporting Only from postgresql-simple

### DIFF
--- a/IHP/ControllerPrelude.hs
+++ b/IHP/ControllerPrelude.hs
@@ -17,6 +17,7 @@ module IHP.ControllerPrelude
     , module IHP.ValidationSupport
     , module IHP.AutoRefresh
     , module IHP.Mail
+    , Only (..)
     ) where
 import IHP.Prelude
 import IHP.Controller.Param
@@ -36,3 +37,4 @@ import IHP.Controller.Redirect
 import Control.Newtype.Generics
 import IHP.AutoRefresh (autoRefresh)
 import IHP.Mail (sendMail)
+import Database.PostgreSQL.Simple.Types (Only (..))

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs, GeneralizedNewtypeDeriving #-}
 
-module IHP.ModelSupport (module IHP.ModelSupport, Only (..)) where
+module IHP.ModelSupport where
 
 import IHP.HaskellSupport
 import IHP.NameSupport
@@ -9,7 +9,7 @@ import ClassyPrelude hiding (UTCTime, find, ModifiedJulianDay)
 import qualified ClassyPrelude
 import Database.PostgreSQL.Simple (Connection)
 import qualified Text.Inflections
-import Database.PostgreSQL.Simple.Types (Query (Query), Only (..))
+import Database.PostgreSQL.Simple.Types (Query (Query))
 import Database.PostgreSQL.Simple.FromField hiding (Field, name)
 import Database.PostgreSQL.Simple.ToField
 import Data.Default

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, TypeInType, ConstraintKinds, TypeOperators, GADTs, GeneralizedNewtypeDeriving #-}
 
-module IHP.ModelSupport where
+module IHP.ModelSupport (module IHP.ModelSupport, Only (..)) where
 
 import IHP.HaskellSupport
 import IHP.NameSupport
@@ -9,7 +9,7 @@ import ClassyPrelude hiding (UTCTime, find, ModifiedJulianDay)
 import qualified ClassyPrelude
 import Database.PostgreSQL.Simple (Connection)
 import qualified Text.Inflections
-import Database.PostgreSQL.Simple.Types (Query (Query))
+import Database.PostgreSQL.Simple.Types (Query (Query), Only (..))
 import Database.PostgreSQL.Simple.FromField hiding (Field, name)
 import Database.PostgreSQL.Simple.ToField
 import Data.Default


### PR DESCRIPTION
The type Only is not available in controllers. Strange as there is an example in the documentation showing use of it, but it does not actually compile. Fixed with this PR.