### PR TITLE
Add support for timestamp without time zone (i.e. localtime)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,19 @@ cd ihp-test-project
 git clone git@github.com:digitallyinduced/ihp.git IHP
 ```
 
+Note that the `./start` is necessary, even if you don't intend to run it this way (e.g. you intend to contribute and don't intend to run it "normally"), to do some initial setup like creating the database. When it starts normally, just CTRL+C to exit.
+
 The best workflow is to use `ghci` to load your application together with the framework version in `IHP`. Then, in your app directory (NOT the IHP directory):
 
 ```
 make -B build/ihp-lib # only needs to be run once
+```
+
+On Windows (in WSL), this will show 3 commands, but not actually run them. Copy and run them yourself.
+
+Next, in a `nix-shell`:
+
+```
 ghci
 $ghci> :l Main
 ```
@@ -117,3 +126,7 @@ main
 If you get an error like `can't satisify package ihp` or all other IHP packages when running `ghci` most likely the symlink in `build/ihp-lib` is not set up as expected. IHP uses the symlink `build/ihp-lib` in your application's `.ghci` file to access [`IHP/lib/IHP/applicationGhciConfig`](https://github.com/digitallyinduced/ihp/blob/master/lib/IHP/applicationGhciConfig#L39). This `applicationGhciConfig` sets up all the required options for `ghci`.
 
 Try to run `make -B build/ihp-lib` to create the symlink.
+
+### `direnv: error .envrc file not found`
+
+In the project directory, try `make -B .envrc`

--- a/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
@@ -34,7 +34,7 @@ instance View EditColumnView ViewContext where
             primaryKeyCheckbox
                 | [name] == primaryKeyColumns =
                     preEscapedToHtml [plain|<label class="ml-1" style="font-size: 12px">
-                            <input type="checkbox" name="primaryKey" class="mr-2" checked disabled> Primary Key
+                            <input type="checkbox" name="primaryKey" class="mr-2" checked> Primary Key
                         </label>|]
                 | name `elem` primaryKeyColumns =
                     preEscapedToHtml [plain|<label class="ml-1" style="font-size: 12px">
@@ -107,7 +107,8 @@ typeSelector postgresType enumNames = [hsx|
             {option selected "INT" "Int"}
             {option selected "UUID" "UUID"}
             {option selected "BOOLEAN" "Bool"}
-            {option selected "TIMESTAMP WITH TIME ZONE" "Timestamp"}
+            {option selected "TIMESTAMP WITH TIME ZONE" "Timestamp (UTCTime)"}
+            {option selected "TIMESTAMP WITHOUT TIME ZONE" "Timestamp (LocalTime)"}
             {option selected "REAL" "Float"}
             {option selected "DOUBLE PRECISION" "Double"}
             {option selected "DATE" "Date"}

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -16,6 +16,7 @@ import Data.Default
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Data.String.Conversions (cs ,ConvertibleStrings)
 import Data.Time.Clock
+import Data.Time.LocalTime
 import Data.Time.Calendar
 import Unsafe.Coerce
 import Data.UUID
@@ -349,6 +350,9 @@ type family Include (name :: GHC.Types.Symbol) model
 type family Include' (name :: [GHC.Types.Symbol]) model where
     Include' '[] model = model
     Include' (x:xs) model = Include' xs (Include x model)
+
+instance Default LocalTime where
+    def = LocalTime def (TimeOfDay 0 0 0)
 
 instance Default Day where
     def = ModifiedJulianDay 0

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -110,17 +110,18 @@ compileTypes options schema@(Schema statements) =
             in intercalate "\n\n" (map (compileStatement options) statements)
         <> section
     where
-        prelude = "-- This file is auto generated and will be overriden regulary. Please edit `Application/Schema.hs` to customize the Types"
+        prelude = "-- This file is auto generated and will be overriden regulary. Please edit `Application/Schema.sql` to change the Types"
                   <> section
                   <> "{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, InstanceSigs, MultiParamTypeClasses, TypeFamilies, DataKinds, TypeOperators, UndecidableInstances, ConstraintKinds, StandaloneDeriving  #-}"
                   <> section
                   <> "module Generated.Types where\n\n"
                   <> "import IHP.HaskellSupport\n"
                   <> "import IHP.ModelSupport\n"
-                  <> "import CorePrelude hiding (id) \n"
-                  <> "import Data.Time.Clock \n"
+                  <> "import CorePrelude hiding (id)\n"
+                  <> "import Data.Time.Clock\n"
+                  <> "import Data.Time.LocalTime\n"
                   <> "import qualified Data.Time.Calendar\n"
-                  <> "import qualified Data.List as List \n"
+                  <> "import qualified Data.List as List\n"
                   <> "import qualified Data.ByteString as ByteString \n"
                   <> "import Database.PostgreSQL.Simple\n"
                   <> "import Database.PostgreSQL.Simple.FromRow\n"


### PR DESCRIPTION
There was some support already (seemed to be started but not finished) in the code generator. In addition to adding support for localtime this PR also solves an unrelated bug: editing a primary key (.e.g. setting unique on/off) always deselects it as a primary key. Also added a couple of clarifications to contributing doc.