### PR TITLE
IDE support for array types

### DIFF
--- a/IHP/IDE/Data/View/EditValue.hs
+++ b/IHP/IDE/Data/View/EditValue.hs
@@ -1,4 +1,3 @@
-
 module IHP.IDE.Data.View.EditValue where
 
 import IHP.ViewPrelude

--- a/IHP/IDE/SchemaDesigner/Controller/Columns.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Columns.hs
@@ -41,7 +41,7 @@ instance Controller ColumnsController where
             redirectTo ShowTableAction { .. }
         let column = Column
                 { name = columnName
-                , columnType = param "columnType"
+                , columnType = arrayifytype (param "isArray") (param "columnType")
                 , defaultValue = defaultValue
                 , notNull = (not (param "allowNull"))
                 , isUnique = param "isUnique"
@@ -82,7 +82,7 @@ instance Controller ColumnsController where
         let columnId = param "columnId"
         let column = Column
                 { name = columnName
-                , columnType = param "columnType"
+                , columnType = arrayifytype (param "isArray") (param "columnType")
                 , defaultValue = defaultValue
                 , notNull = (not (param "allowNull"))
                 , isUnique = param "isUnique"
@@ -228,3 +228,9 @@ isCreateEnumType CreateEnumType {} = True
 isCreateEnumType _ = False
 
 nameList statements = map (get #name) statements
+
+arrayifytype :: Bool -> PostgresType -> PostgresType
+arrayifytype False   (PArray coltype) = coltype
+arrayifytype True  a@(PArray coltype) = a
+arrayifytype False coltype = coltype
+arrayifytype True  coltype = PArray coltype

--- a/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
@@ -52,7 +52,14 @@ instance View EditColumnView ViewContext where
             isUniqueCheckbox = if get #isUnique column
                 then preEscapedToHtml [plain|<input type="checkbox" name="isUnique" class="mr-2" checked/>|]
                 else preEscapedToHtml [plain|<input type="checkbox" name="isUnique" class="mr-2"/>|]
-            
+
+            isArrayTypeCheckbox = if (isArrayType (get #columnType column))
+                then preEscapedToHtml [plain|<input type="checkbox" name="isArray" class="mr-2" checked/>|]
+                else preEscapedToHtml [plain|<input type="checkbox" name="isArray" class="mr-2"/>|]
+
+            isArrayType (PArray _) = True
+            isArrayType _ = False
+
             modalContent = [hsx|
                 <form method="POST" action={UpdateColumnAction}>
                     <input type="hidden" name="tableName" value={tableName}/>
@@ -80,6 +87,9 @@ instance View EditColumnView ViewContext where
                                 {isUniqueCheckbox} Unique
                             </label>
                             {primaryKeyCheckbox}
+                            <label class="ml-1" style="font-size: 12px">
+                                {isArrayTypeCheckbox} Array Type
+                            </label>
                         </div>
                     </div>
 
@@ -93,6 +103,7 @@ instance View EditColumnView ViewContext where
                     <input type="hidden" name="primaryKey" value={inputValue False}/>
                     <input type="hidden" name="allowNull" value={inputValue False}/>
                     <input type="hidden" name="isUnique" value={inputValue False}/>
+                    <input type="hidden" name="isArray" value={inputValue False}/>
                 </form>
             |]
             modalFooter = mempty 
@@ -128,7 +139,7 @@ typeSelector postgresType enumNames = [hsx|
         option selected value text = case selected of
             Nothing -> [hsx|<option value={value}>{text}</option>|]
             Just selection ->
-                if selection == value
+                if selection == value || selection == value <> "[]"
                     then [hsx|<option value={value} selected="selected">{text}</option>|]
                     else [hsx|<option value={value}>{text}</option>|]      
 
@@ -141,7 +152,7 @@ defaultSelector defValue = [hsx|
     </div>
 |]
     where
-        suggestedValues = [Nothing, Just (TextExpression ""), Just (VarExpression "null"), Just (CallExpression "NOW" [])]
+        suggestedValues = [Nothing, Just (TextExpression ""), Just (VarExpression "NULL"), Just (CallExpression "NOW" [])]
         values = if defValue `elem` suggestedValues then suggestedValues else defValue:suggestedValues
 
         renderValue :: Maybe Expression -> Html

--- a/IHP/IDE/SchemaDesigner/View/Columns/New.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/New.hs
@@ -59,6 +59,9 @@ instance View NewColumnView ViewContext where
                             <label class="mx-2" style="font-size: 12px">
                                 <input type="checkbox" name="primaryKey" class="mr-1"/>Primary Key
                             </label>
+                            <label class="ml-1" style="font-size: 12px">
+                                <input type="checkbox" name="isArray" class="mr-1"/>Array Type
+                            </label>
                         </div>
                     </div>
 
@@ -73,6 +76,7 @@ instance View NewColumnView ViewContext where
                     <input type="hidden" name="primaryKey" value={inputValue False}/>
                     <input type="hidden" name="allowNull" value={inputValue False}/>
                     <input type="hidden" name="isUnique" value={inputValue False}/>
+                    <input type="hidden" name="isArray" value={inputValue False}/>
                     <input type="hidden" name="isReference" value={inputValue False}/>
                     <input type="hidden" name="referenceTable" value=""/>
                 </form>

--- a/lib/IHP/static/ihp-schemadesigner.js
+++ b/lib/IHP/static/ihp-schemadesigner.js
@@ -95,7 +95,8 @@ function initSchemaDesigner() {
     });
     $('#allowNull').change(function() {
         if ($('#allowNull').is(":checked")) {
-            $('#defaultSelector').append(new Option("null", "NULL", true, true));
+            if(0 == $("#defaultSelector option:contains('NULL')").length)
+                $('#defaultSelector').append(new Option("NULL", "NULL", true, true));
         } else {
             $("#defaultSelector option[value='NULL']").remove();
         }


### PR DESCRIPTION
Postgres Array types have been supported in Schema.sql and codegen for a few weeks now, but there hasn't been any support in the IDE. I also lumped in a bugfix for the duplicate null/NULL occasionally showing in the default dropdown. 