### PR TITLE
troubleshoot script: use absolute path when verifying link

### DIFF
--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -72,7 +72,7 @@ else
     fail "Symlink build/ihp-lib is missing. Try 'make build/ihp-lib' to fix this"
 fi
 
-ihplib_link=$(readlink build/ihp-lib)
+ihplib_link=$(readlink -f build/ihp-lib)
 if [ -d "$ihplib_link" ]; then
     ok "Symlink build/ihp-lib target exists"
 else


### PR DESCRIPTION
When developing on IHP itself the link will be a relative path starting with `../`, making the script think it's broken. Using the `-f` flag on readlink we get an absolute path which works in all cases.