### PR TITLE
The type variable of `QueryBuilder typeVar` now is the table name instead of the model type

### DIFF
--- a/IHP/AuthSupport/Controller/Sessions.hs
+++ b/IHP/AuthSupport/Controller/Sessions.hs
@@ -73,6 +73,7 @@ createSessionAction :: forall record action passwordField.
     , CanUpdate record
     , FrameworkConfig
     , Show (PrimaryKey (GetTableName record))
+    , record ~ GetModelByTableName (GetTableName record)
     ) => IO ()
 createSessionAction = do
     query @record

--- a/IHP/HaskellSupport.hs
+++ b/IHP/HaskellSupport.hs
@@ -28,6 +28,7 @@ module IHP.HaskellSupport (
 , debug
 , includes
 , stripTags
+, symbolToText
 ) where
 
 import ClassyPrelude
@@ -241,3 +242,14 @@ stripTags :: Text -> Text
 stripTags "" = ""
 stripTags html | Text.head html == '<' = stripTags (Text.drop 1 (Text.dropWhile (/= '>') (Text.tail html)))
 stripTags html = let (a, b) = Text.splitAt 1 html in a <> stripTags b
+
+-- | Returns the value of a type level symbol as a text
+--
+-- >>> symbolToText @"hello"
+-- "hello"
+--
+-- >>> symbolToText @(GetTableName User)
+-- "users"
+symbolToText :: forall symbol. (KnownSymbol symbol) => Text
+symbolToText = Text.pack (symbolVal @symbol Proxy)
+{-# INLINE symbolToText #-}

--- a/IHP/LoginSupport/Middleware.hs
+++ b/IHP/LoginSupport/Middleware.hs
@@ -26,7 +26,7 @@ initAuthentication :: forall user.
         , GetTableName (NormalizeModel user) ~ GetTableName user
         , FromRow (NormalizeModel user)
         , PrimaryKey (GetTableName user) ~ UUID
-        , FilterPrimaryKey (NormalizeModel user)
+        , FilterPrimaryKey (GetTableName user)
     ) => TypeMap.TMap -> IO TypeMap.TMap
 initAuthentication context = do
     user <- getSessionUUID (sessionKey @user)

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -314,7 +314,7 @@ sqlQueryScalar query parameters = do
 -- "users"
 --
 tableName :: forall model. (KnownSymbol (GetTableName model)) => Text
-tableName = Text.pack (symbolVal @(GetTableName model) Proxy)
+tableName = symbolToText @(GetTableName model)
 {-# INLINE tableName #-}
 
 logQuery :: (?modelContext :: ModelContext, Show query, Show parameters) => query -> parameters -> IO ()

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -187,7 +187,7 @@ compileTypeAlias table@(CreateTable { name, columns }) =
     where
         modelName = tableNameToModelName name
         hasManyDefaults = columnsReferencingTable name
-                |> map (\(tableName, columnName) -> "(QueryBuilder.QueryBuilder " <> tableNameToModelName tableName <> ")")
+                |> map (\(tableName, columnName) -> "(QueryBuilder.QueryBuilder \"" <> tableName <> "\")")
                 |> unwords
 
 primaryKeyTypeName :: Text -> Text
@@ -530,7 +530,7 @@ compilePrimaryKeyInstance :: (?schema :: Schema) => CreateTable -> Text
 compilePrimaryKeyInstance table@(CreateTable { name, columns, constraints }) = cs [i|
 type instance PrimaryKey #{tshow name} = #{idType}
 
-instance QueryBuilder.FilterPrimaryKey #{tableNameToModelName name} where
+instance QueryBuilder.FilterPrimaryKey "#{name}" where
     filterWhereId #{primaryKeyPattern} builder =
         builder |> #{intercalate " |> " primaryKeyFilters}
 |]

--- a/IHP/ValidationSupport/ValidateIsUnique.hs
+++ b/IHP/ValidationSupport/ValidateIsUnique.hs
@@ -40,6 +40,7 @@ validateIsUnique :: forall field model savedModel validationState fieldValue val
         , HasField "id" model modelId
         , savedModelId ~ modelId
         , Eq modelId
+        , GetModelByTableName (GetTableName savedModel) ~ savedModel
     ) => Proxy field -> model -> IO model
 validateIsUnique fieldProxy model = do
     let value = getField @field model


### PR DESCRIPTION
This solves a problem where tables with self referencing has many relations could not be used with IHP due to a infinite self reference at the type level

Previously:

```haskell
let queryBuilder :: QueryBuilder User = query @User
```

Now:

```haskell
let queryBuilder :: QueryBuilder "users" = query @User
```

Fixes https://github.com/digitallyinduced/ihp/issues/501
Fixes https://github.com/digitallyinduced/ihp/issues/321