### PR TITLE
basicAuth support

### DIFF
--- a/Guide/authentication.markdown
+++ b/Guide/authentication.markdown
@@ -3,9 +3,19 @@
 ```toc
 ```
 
-## Introduction
+## Quick-and-Dirty: HTTP Basic Auth
 
-IHP provides a basic authentication toolkit out of the box.
+While IHP provides an authentication toolkit out of the box, it also provides a shortcut for cases where you just want the simplest possible way to enforce a hard-coded username/password before accessing your new web application. This shortcut leverages HTTP Basic Authentication built in to all browsers:
+
+```haskell
+instance Controller WidgetsController where
+    beforeAction = basicAuth "sanja" "hunter2" "myapp"
+```
+
+The parameters are: username, password and authentication realm. The realm can be thought of as an area of validity for the credentials. It is common to put the project name, but it can also be blank (meaning the entire domain).
+
+
+## Introduction - Real Authentication
 
 The usual convention in IHP is to call your user record `User`. When there is an admin user, we usually call the record `Admin`. In general the authentication can work with any kind of record. The only requirement is that it has an id field.
 

--- a/IHP/Controller/Session.hs
+++ b/IHP/Controller/Session.hs
@@ -56,6 +56,13 @@ getSessionUUID name = do
             Just (Just value) -> Just value
             _                 -> Nothing
 
+-- | Adds basic http authentication
+--
+-- Mainly for protecting a site during external review.
+-- Meant for use in the controller:
+-- 
+-- > beforeAction = basicAuth ... 
+-- 
 basicAuth :: (?requestContext::RequestContext) => Text -> Text -> Text -> IO ()
 basicAuth uid pw realm = do
     let mein = Just (encodeUtf8 uid, encodeUtf8 pw)

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -26,7 +26,6 @@ common shared-properties
             , blaze-html
             , blaze-markup
             , wai-extra
-            , wai
             , http-types
             , inflections
             , text
@@ -65,9 +64,6 @@ common shared-properties
             , async
             , network
             , unliftio
-            , basic-prelude
-            , megaparsec
-            , async
             , unix
             , fsnotify
             , websockets


### PR DESCRIPTION
Adds http basic authentication support (including docs). Also removes some duplicate entries in the cabal file.
Solves issue #96 