### PR TITLE
support for custom text on js-delete

### DIFF
--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -50,7 +50,7 @@ function initDelete() {
 
             if (!event.target.classList.contains('js-delete-no-confirm')) {
                 var confirmText = event.target.dataset.confirm || 'Are you sure you want to delete this?';
-                if (!confirm(txt ? txt : 'Are you sure you want to delete this?')) {
+                if (!confirm(confirmText)) {
                     return;
                 }
             }

--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -49,7 +49,8 @@ function initDelete() {
             event.preventDefault();
 
             if (!event.target.classList.contains('js-delete-no-confirm')) {
-                if (!confirm('Are you sure you want to delete this?')) {
+                let txt = event.target.dataset.confirmtext;
+                if (!confirm(txt ? txt : 'Are you sure you want to delete this?')) {
                     return;
                 }
             }

--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -49,7 +49,7 @@ function initDelete() {
             event.preventDefault();
 
             if (!event.target.classList.contains('js-delete-no-confirm')) {
-                let txt = event.target.dataset.confirmtext;
+                var confirmText = event.target.dataset.confirm || 'Are you sure you want to delete this?';
                 if (!confirm(txt ? txt : 'Are you sure you want to delete this?')) {
                     return;
                 }


### PR DESCRIPTION
Adds support for data-confirmtext="Your custom are you sure text here" on any link having class js-delete.

The standard text bugs me for two reasons:
1) too generic (warning should confirm exactly what is about to be deleted)
2) language is english. While users will tolerate english error messages, messages in ordinary usage should be localized.

If the approach taken here is accepted (add a comment), I will also update the docs with this feature in a separate commit (same PR)
