### PR TITLE
Migration System

### DIFF
--- a/IHP/IDE/CodeGen/Controller.hs
+++ b/IHP/IDE/CodeGen/Controller.hs
@@ -9,6 +9,7 @@ import IHP.IDE.CodeGen.View.NewView
 import IHP.IDE.CodeGen.View.NewMail
 import IHP.IDE.CodeGen.View.NewAction
 import IHP.IDE.CodeGen.View.NewApplication
+import IHP.IDE.CodeGen.View.NewMigration
 import IHP.IDE.CodeGen.Types
 import IHP.IDE.CodeGen.ControllerGenerator as ControllerGenerator
 import IHP.IDE.CodeGen.ScriptGenerator as ScriptGenerator
@@ -24,6 +25,7 @@ import qualified Data.Text.IO as Text
 import qualified Text.Inflections as Inflector
 import Control.Exception
 import System.Directory
+import qualified IHP.SchemaMigration as SchemaMigration
 
 
 instance Controller CodeGenController where
@@ -141,6 +143,18 @@ instance Controller CodeGenController where
         (Right plan) <- ApplicationGenerator.buildPlan applicationName
         executePlan plan
         setSuccessMessage "Application generated"
+        redirectTo GeneratorsAction
+
+    action NewMigrationAction = do
+        let description = paramOrDefault "" "description"
+        render NewMigrationView { .. }
+    
+    action CreateMigrationAction = do
+        let description = param "description"
+        migration <- SchemaMigration.createMigration description
+        let path = SchemaMigration.migrationPath migration
+        setSuccessMessage ("Migration generated: " <> path)
+        openEditor path 0 0
         redirectTo GeneratorsAction
 
     action OpenControllerAction = do

--- a/IHP/IDE/CodeGen/View/Generators.hs
+++ b/IHP/IDE/CodeGen/View/Generators.hs
@@ -41,6 +41,11 @@ instance View GeneratorsView where
                         <div class="generator-name">Script</div>
                     </a>
 
+                    <a href={NewMigrationAction} class="generator">
+                        <div class="generator-icon">{databaseIcon}</div>
+                        <div class="generator-name">Migration</div>
+                    </a>
+
                     <a href={NewApplicationAction} class="generator">
                         <div class="generator-icon">{copyIcon}</div>
                         <div class="generator-name">Application</div>
@@ -49,7 +54,6 @@ instance View GeneratorsView where
             </div>
         </div>
     |]
-
 
 renderPlan (Left error) = [hsx|{error}|]
 renderPlan (Right actions) = [hsx|<div class="generator-actions">{forEach actions renderGeneratorAction}</div>|]

--- a/IHP/IDE/CodeGen/View/NewMigration.hs
+++ b/IHP/IDE/CodeGen/View/NewMigration.hs
@@ -1,0 +1,38 @@
+module IHP.IDE.CodeGen.View.NewMigration where
+
+import IHP.ViewPrelude
+import IHP.IDE.SchemaDesigner.Types
+import IHP.IDE.ToolServer.Types
+import IHP.IDE.ToolServer.Layout
+import IHP.IDE.SchemaDesigner.View.Layout
+import IHP.IDE.CodeGen.Types
+import IHP.IDE.CodeGen.View.Generators (renderPlan)
+
+data NewMigrationView = NewMigrationView { description :: Text }
+
+instance View NewMigrationView where
+    html NewMigrationView { .. } = [hsx|
+        <div class="generators">
+            {renderFlashMessages}
+            <div class="container pt-5">
+                <div class="code-generator new-script">
+                    {renderForm}
+                </div>
+            </div>
+        </div>
+    |]
+        where
+            renderForm = [hsx|
+                <form method="POST" action={CreateMigrationAction} class="d-flex">
+                    <input
+                        type="text"
+                        name="description"
+                        placeholder="Migration description"
+                        class="form-control"
+                        autofocus="autofocus"
+                        value={description}
+                        />
+
+                    <button class="btn btn-primary" type="submit">Generate</button>
+                </form>
+            |]

--- a/IHP/IDE/ToolServer/Types.hs
+++ b/IHP/IDE/ToolServer/Types.hs
@@ -90,12 +90,14 @@ data CodeGenController
     | NewMailAction
     | NewActionAction
     | NewApplicationAction
+    | NewMigrationAction
     | CreateControllerAction
     | CreateScriptAction
     | CreateViewAction
     | CreateMailAction
     | CreateActionAction
     | CreateApplicationAction
+    | CreateMigrationAction
     | OpenControllerAction
     deriving (Eq, Show, Data)
 

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -273,8 +273,10 @@ instance Default (PrimaryKey model) => Default (Id' model) where
 -- > users <- sqlQuery "SELECT id, firstname, lastname FROM users" ()
 --
 -- Take a look at "IHP.QueryBuilder" for a typesafe approach on building simple queries.
-sqlQuery :: (?modelContext :: ModelContext) => (PG.ToRow q, PG.FromRow r) => Query -> q -> IO [r]
-sqlQuery theQuery theParameters = withDatabaseConnection \connection -> PG.query connection theQuery theParameters
+sqlQuery :: (?modelContext :: ModelContext, PG.ToRow q, PG.FromRow r, Show q) => Query -> q -> IO [r]
+sqlQuery theQuery theParameters = do
+    logQuery theQuery theParameters
+    withDatabaseConnection \connection -> PG.query connection theQuery theParameters
 {-# INLINE sqlQuery #-}
 
 
@@ -283,8 +285,10 @@ sqlQuery theQuery theParameters = withDatabaseConnection \connection -> PG.query
 -- __Example:__
 --
 -- > sqlExec "CREATE TABLE users ()" ()
-sqlExec :: (?modelContext :: ModelContext) => (PG.ToRow q) => Query -> q -> IO Int64
-sqlExec theQuery theParameters = withDatabaseConnection \connection -> PG.execute connection theQuery theParameters
+sqlExec :: (?modelContext :: ModelContext, PG.ToRow q, Show q) => Query -> q -> IO Int64
+sqlExec theQuery theParameters = do
+    logQuery theQuery theParameters
+    withDatabaseConnection \connection -> PG.execute connection theQuery theParameters
 {-# INLINE sqlExec #-}
 
 withDatabaseConnection :: (?modelContext :: ModelContext) => (Connection -> IO a) -> IO a

--- a/IHP/SchemaMigration.hs
+++ b/IHP/SchemaMigration.hs
@@ -1,0 +1,122 @@
+{-|
+Module: IHP.SchemaMigration
+Description: Managing Database Migrations
+Copyright: (c) digitally induced GmbH, 2020
+-}
+module IHP.SchemaMigration where
+
+import IHP.Prelude
+import qualified System.Directory as Directory
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import IHP.ModelSupport
+import qualified Database.PostgreSQL.Simple.Types as PG
+import qualified Data.Time.Clock.POSIX as POSIX
+import qualified IHP.NameSupport as NameSupport
+
+data Migration = Migration
+    { revision :: Int
+    , migrationFile :: Text
+    } deriving (Show, Eq)
+
+-- | Migrates the database schema to the latest version
+migrate :: (?modelContext :: ModelContext) => IO ()
+migrate = do
+    createSchemaMigrationsTable
+
+    -- Print out all sql queries during the migration. This might be set to false in it's called inside a production env
+    let modelContext = ?modelContext
+    let ?modelContext = modelContext { queryDebuggingEnabled = True }
+
+    openMigrations <- findOpenMigrations
+    forEach openMigrations runMigration
+
+-- | The sql statements contained in the migration file are executed. Then the revision is inserted into the @schema_migrations@ table.
+--
+-- All queries are executed inside a database transaction to make sure that it can be restored when something goes wrong.
+runMigration :: (?modelContext :: ModelContext) => Migration -> IO ()
+runMigration migration@Migration { revision, migrationFile } = do
+    migrationSql <- Text.readFile (cs $ migrationPath migration)
+    
+    withTransaction do
+        sqlExec (fromString . cs $ migrationSql) ()
+        sqlExec "INSERT INTO schema_migrations (revision) VALUES (?)" [revision]
+
+    pure ()
+
+withTransaction :: (?modelContext :: ModelContext) => IO a -> IO a
+withTransaction block = do
+    _ <- sqlExec "BEGIN" ()
+    result <- block
+    _ <- sqlExec "COMMIT" ()
+    pure result
+
+-- | Creates the @schema_migrations@ table if it doesn't exist yet
+createSchemaMigrationsTable :: (?modelContext :: ModelContext) => IO ()
+createSchemaMigrationsTable = do
+    let ddl = "CREATE TABLE IF NOT EXISTS schema_migrations (revision BIGINT NOT NULL UNIQUE)"
+    _ <- sqlExec ddl ()
+    pure ()
+
+-- | Returns all migrations that haven't been executed yet. The result is sorted so that the oldest revision is first.
+findOpenMigrations :: (?modelContext :: ModelContext) => IO [Migration]
+findOpenMigrations = do
+    migratedRevisions <- findMigratedRevisions
+    migrations <- findAllMigrations
+    migrations
+        |> filter (\Migration { revision } -> not (migratedRevisions |> includes revision))
+        |> sortBy (comparing revision)
+        |> pure
+
+-- | Returns all migration revisions applied to the database schema
+--
+-- >>> findMigratedRevisions
+-- [ 1604850570, 1604850660 ]
+--
+findMigratedRevisions :: (?modelContext :: ModelContext) => IO [Int]
+findMigratedRevisions = map (\[revision] -> revision) <$> sqlQuery "SELECT revision FROM schema_migrations ORDER BY revision" ()
+
+-- | Returns all migrations found in @Application/Migration@
+--
+-- >>> findAllMigrations
+-- [ Migration { revision = 1604850570, migrationFile = "Application/Migration/1604850570-create-projects.sql" } ]
+--
+findAllMigrations :: IO [Migration]
+findAllMigrations = do
+    directoryFiles <- Directory.listDirectory "Application/Migration"
+    directoryFiles
+        |> map cs
+        |> filter (\path -> ".sql" `isSuffixOf` path)
+        |> mapMaybe pathToMigration
+        |> pure
+
+-- | Given a path such as Application/Migrate/00-initial-migration.sql it returns a Migration
+--
+-- Returns Nothing if the path is not following the usual migration file path convention.
+--
+-- >>> pathToMigration "Application/Migration/1604850570-create-projects.sql"
+-- Migration { revision = 1604850570, migrationFile = "Application/Migration/1604850570-create-projects.sql" }
+--
+pathToMigration :: Text -> Maybe Migration
+pathToMigration fileName = case revision of
+        Just revision -> Just Migration { migrationFile = fileName, revision }
+        Nothing -> Nothing
+    where
+        revision :: Maybe Int
+        revision = fileName
+                |> Text.split (== '-')
+                |> head
+                |> fmap textToInt
+                |> join
+
+migrationPath :: Migration -> Text
+migrationPath Migration { migrationFile } = "Application/Migration/" <> migrationFile
+
+-- | Generates a new migration @.sql@ file in @Application/Migration@
+createMigration :: Text -> IO Migration
+createMigration description = do
+    revision <- round <$> POSIX.getPOSIXTime 
+    let slug = NameSupport.toSlug description
+    let migrationFile = tshow revision <> (if isEmpty slug then "" else "-" <> slug) <> ".sql"
+    Text.writeFile ("Application/Migration/" <> cs migrationFile) "-- Write your SQL migration code in here\n"
+    pure Migration { .. }

--- a/exe/IHP/CLI/Migrate.hs
+++ b/exe/IHP/CLI/Migrate.hs
@@ -1,0 +1,13 @@
+module Main where
+
+import IHP.Prelude
+import IHP.SchemaMigration
+import IHP.ModelSupport
+import IHP.FrameworkConfig
+
+main :: IO ()
+main = do
+    frameworkConfig <- buildFrameworkConfig (pure ())
+    modelContext <- createModelContext (get #dbPoolIdleTime frameworkConfig) (get #dbPoolMaxConnections frameworkConfig) (get #databaseUrl frameworkConfig)
+    let ?modelContext = modelContext
+    migrate

--- a/exe/IHP/CLI/NewMigration.hs
+++ b/exe/IHP/CLI/NewMigration.hs
@@ -13,7 +13,7 @@ main = do
 
     let doCreateMigration description = do
             migration <- createMigration description
-            let path = pathToMigration migration
+            let path = migrationPath migration
             putStrLn $ "Created migration: " <> path
             openEditor path 0 0
     

--- a/exe/IHP/CLI/NewMigration.hs
+++ b/exe/IHP/CLI/NewMigration.hs
@@ -1,0 +1,32 @@
+module Main where
+
+import IHP.Prelude
+import IHP.SchemaMigration
+import qualified System.Posix.Env.ByteString as Posix
+import qualified System.Directory as Directory
+import Control.Monad.Fail
+import IHP.IDE.ToolServer.Helper.Controller (openEditor)
+
+main :: IO ()
+main = do
+    ensureIsInAppDirectory
+
+    let doCreateMigration description = do
+            migration <- createMigration description
+            let path = pathToMigration migration
+            putStrLn $ "Created migration: " <> path
+            openEditor path 0 0
+    
+    args <- Posix.getArgs
+    case headMay args of
+        Just "--help" -> usage
+        Just description -> doCreateMigration (cs description)
+        Nothing -> doCreateMigration ""
+
+usage :: IO ()
+usage = putStrLn "Usage: new-migration [DESCRIPTION]"
+
+ensureIsInAppDirectory :: IO ()
+ensureIsInAppDirectory = do
+    mainHsExists <- Directory.doesFileExist "Main.hs"
+    unless mainHsExists (fail "You have to be in a project directory to run the generator")

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -179,6 +179,7 @@ library IHPFramework
         , IHP.IDE.CodeGen.View.NewController
         , IHP.IDE.CodeGen.View.NewScript
         , IHP.IDE.CodeGen.View.NewView
+        , IHP.IDE.CodeGen.View.NewMigration
         , IHP.IDE.CodeGen.ViewGenerator
         , IHP.IDE.Data.Controller
         , IHP.IDE.Data.View.EditRow
@@ -242,6 +243,7 @@ library IHPFramework
         , IHP.FlashMessages.Types
         , IHP.FlashMessages.ControllerFunctions
         , IHP.FlashMessages.ViewFunctions
+        , IHP.SchemaMigration
 
 executable RunDevServer
     import: shared-properties
@@ -278,6 +280,18 @@ executable new-script
     build-depends: IHPFramework
     hs-source-dirs: exe
     main-is: IHP/CLI/NewScript.hs
+
+executable new-migration
+    import: shared-properties
+    build-depends: IHPFramework
+    hs-source-dirs: exe
+    main-is: IHP/CLI/NewMigration.hs
+
+executable migrate
+    import: shared-properties
+    build-depends: IHPFramework
+    hs-source-dirs: exe
+    main-is: IHP/CLI/Migrate.hs
 
 executable hash-password
     import: shared-properties

--- a/lib/IHP/static/ihp-codegen.css
+++ b/lib/IHP/static/ihp-codegen.css
@@ -57,7 +57,7 @@
     background-color: #ebebeb;
 }
 
-.code-generator input[name="name"] {
+.code-generator input[name="name"], .code-generator input[name="description"] {
     font-size: 24px;
     outline: none;
     border-top-left-radius: 8px;
@@ -69,14 +69,14 @@
     background-color: #ebebeb;
 }
 
-.code-generator input[name="name"]:focus {
+.code-generator input[name="name"]:focus, .code-generator input[name="description"]:focus {
     outline: none !important;
     border-bottom: 1px solid #c0c0c0;
     box-shadow: none;
     background-color: #ebebeb;
 }
 
-.code-generator input[name="name"]::placeholder {
+.code-generator input[name="name"]::placeholder, .code-generator input[name="description"]::placeholder {
     color: #ababaa;
 }
 


### PR DESCRIPTION
Adds a migration system for production schema changes.


Generate a migration from the web or CLI:

```bash
new-migration create-projects
```

Creates a file at `Application/Migration/1604854836-create-projects.sql`. The migration sql code can be placed in there.

In production you need to run `migrate` from the project directory. This will run all migrations that haven't been executed yet. The `migrate` tool also generates a `schema_migrations` table to keep track of which migrations have been executed already.