### PR TITLE
Respect `data-turbolinks-preload='false'` attribute

### DIFF
--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -165,8 +165,9 @@ Preloading with InstantClick on hover will only happen with links that
 1. Use the GET method
 2. Do not link to an anchor or end in `#`
 3. Actually link to a different url than `location.href`
+4. Do not have an attribute `data-turbolinks-preload='false'`
 
-(So putting an anchor on a link will let you selectively turn off preloading for that link.)
+(So putting an anchor on a link, or explicitly setting the `data-turbolinks-preload` attribute to `false`, will let you selectively turn off preloading for that link.)
 
 ## JSON
 

--- a/lib/IHP/static/vendor/turbolinksInstantClick.js
+++ b/lib/IHP/static/vendor/turbolinksInstantClick.js
@@ -57,14 +57,16 @@ Turbolinks.SnapshotCache.prototype.delete = function(location) {
 };
 
 const preloadAttribute = function(link) {
-return true;
-  const linkAttr = link.attributes['data-turbolinks-preload']
-  if (!linkAttr || linkAttr.value === 'false') {
+  const linkAttr = link.attributes['data-turbolinks-preload'];
+  if (!linkAttr) {
+    return true;
+  }
+  else if (linkAttr.value === 'false') {
     return false;
   } else {
     return true;
   }
-}
+};
 
 const isNotGetMethod = function(link) {
   return link.classList.contains('js-delete');


### PR DESCRIPTION
(But still preload if that attribute does not exist at all!)

See #536. Just removing the `return true` would turn off preloading if
the attribute wasn't there at all – pretty sure we don't want
that. Now it should only turn off preloading if it's explicitly there
and false.