### PR TITLE
Signed Int readParam bugfix, added JSONB column in IDE and two other minor fixes

### DIFF
--- a/Guide/installation.markdown
+++ b/Guide/installation.markdown
@@ -64,7 +64,7 @@ With the Distro downloaded, run it and update it using your package manager. In 
 ```bash
 sudo apt update
 sudo apt upgrade
-sudo apt install git curl make -y
+sudo apt install git curl make xdg-utils -y
 ```
 
 WSL will add your Windows System Paths in your Linux Subsystem. These tend to generate errors due to spaces and brackets in folder names. Also, due to Linux not loading the `.profile`, we need to add the nix.sh manually. To fix these two issues, just add these lines to the end of your `.bashrc`
@@ -101,6 +101,8 @@ If in doubt, just close and reopen Ubuntu/Your Distro.
 When using Windows, you will be asked if tasks like ghc-iserv or rundevserver should be allowed by the firewall. This is needed to access the devserver interface and the webapp itself.
 
 Installing nix for IHP was done using [this guide](https://nathan.gs/2019/04/12/nix-on-windows/).
+
+Note that nix can gradually grow to use several GB of disk space, especially after upgrading IHP. You can always run `nix-collect-garbage` in a `nix-shell` which will delete older/unused files.
 
 ## 2. Installing IHP
 

--- a/Guide/recipes.markdown
+++ b/Guide/recipes.markdown
@@ -81,6 +81,7 @@ must check the `Nullable` select box with a default `Null`. This ensures your
 `pictureUrl` data has a `Maybe Text` type and can handle 
 cases where the user has not uploaded any image.
 
+If ImageMagick is not installed you will get a `picture.upload` in the uploads folder, but no `picture.jpg`. Install ImageMagick, on Ubuntu it is `sudo apt-get install imagemagick`.
 
 There is currently no special form helper for file uploads. Just specificy it manually like this:
 
@@ -144,6 +145,8 @@ isAge :: Int -> ValidatorResult
 isAge = isInRange (0, 100)
 ```
 
+This is also useful if you need the messages to be in another language.
+
 ## Checking that an email is unique
 
 Use [`validateIsUnique`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateIsUnique.html#v:validateIsUnique).
@@ -187,6 +190,14 @@ In case the id is hardcoded, you can just type UUID value with the right type si
 
 ```haskell
 let projectId = "ca63aace-af4b-4e6c-bcfa-76ca061dbdc6" :: Id Project
+```
+
+## Having an image as Logout button
+
+The `DeleteSessionAction` expects a `HTTP DELETE` request, which is set by Javascript on click. This does not currently work well with an image inside a link. A workaround is to have the image be the background, like this:
+
+```html
+<a href={DeleteSessionAction} class="js-delete js-delete-no-confirm" style="background:url(/logout.svg) left center no-repeat;width:40px"></a>
 ```
 
 ## Making a dynamic Login/Logout button

--- a/IHP/Controller/Param.hs
+++ b/IHP/Controller/Param.hs
@@ -276,7 +276,7 @@ instance ParamReader Integer where
     readParameter byteString =
         case Attoparsec.parseOnly ((Attoparsec.signed Attoparsec.decimal) <* Attoparsec.endOfInput) byteString of
             Right value -> Right value
-            Left error -> Left ("ParamReader Int: " <> cs error)
+            Left error -> Left ("ParamReader Integer: " <> cs error)
 
     readParameterJSON (Aeson.Number number) =
             case Scientific.floatingOrInteger number of

--- a/IHP/Controller/Param.hs
+++ b/IHP/Controller/Param.hs
@@ -261,7 +261,7 @@ instance ParamReader ByteString where
 instance ParamReader Int where
     {-# INLINE readParameter #-}
     readParameter byteString =
-        case Attoparsec.parseOnly (Attoparsec.decimal <* Attoparsec.endOfInput) byteString of
+        case Attoparsec.parseOnly ((Attoparsec.signed Attoparsec.decimal) <* Attoparsec.endOfInput) byteString of
             Right value -> Right value
             Left error -> Left ("ParamReader Int: " <> cs error)
 
@@ -274,7 +274,7 @@ instance ParamReader Int where
 instance ParamReader Integer where
     {-# INLINE readParameter #-}
     readParameter byteString =
-        case Attoparsec.parseOnly (Attoparsec.decimal <* Attoparsec.endOfInput) byteString of
+        case Attoparsec.parseOnly ((Attoparsec.signed Attoparsec.decimal) <* Attoparsec.endOfInput) byteString of
             Right value -> Right value
             Left error -> Left ("ParamReader Int: " <> cs error)
 

--- a/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
@@ -126,6 +126,7 @@ typeSelector postgresType enumNames = [hsx|
             {option selected "Time" "Time"}
             {option selected "SERIAL" "Serial"}
             {option selected "BIGSERIAL" "Bigserial"}
+            {option selected "JSONB" "JSON"}
             {forEach enumNames renderEnumType}
         </select>
 |]

--- a/Test/Controller/ParamSpec.hs
+++ b/Test/Controller/ParamSpec.hs
@@ -27,6 +27,9 @@ tests = do
                 it "should accept numeric input" do
                     (readParameter @Int "1337") `shouldBe` (Right 1337)
                 
+                it "should accept negative numbers" do
+                    (readParameter @Int "-1337") `shouldBe` (Right (-1337))
+
                 it "should accept JSON numerics " do
                     (readParameterJSON @Int (json "1337")) `shouldBe` (Right 1337)
                 
@@ -37,6 +40,9 @@ tests = do
                 it "should accept numeric input" do
                     (readParameter @Integer "1337") `shouldBe` (Right 1337)
                 
+                it "should accept negative numbers" do
+                    (readParameter @Integer "-1337") `shouldBe` (Right (-1337))
+
                 it "should accept JSON numerics " do
                     (readParameterJSON @Integer (json "1337")) `shouldBe` (Right 1337)
                 

--- a/lib/IHP/static/ihp-schemadesigner.js
+++ b/lib/IHP/static/ihp-schemadesigner.js
@@ -67,6 +67,12 @@ function initSchemaDesigner() {
                 .append(new Option("no default", "", false, false))
                 .trigger('change');
                 break;
+            case "TIMESTAMP WITHOUT TIME ZONE":
+                $('#defaultSelector').empty()
+                .append(new Option("NOW()", 'NOW()', true, true))
+                .append(new Option("no default", "", false, false))
+                .trigger('change');
+                break;
             case "TEXT":
                 $('#defaultSelector').empty()
                 .append(new Option("no default", "", true, true))


### PR DESCRIPTION
- FIX: numberField with negative number gives `ParamReader Int: Failed reading: takeWhile1` because `readParam Int` does not allow minus sign.
- ADD: JSONB column was missing from IDE (but otherwise supported).
- FIX: Timezone without timezone field did not have NOW() available as default in IDE
- FIX: Spawning browser on `./start`does not work in windows due to missing package in install guide.
- Added hint of nix gc in install docs. Saves people many GB.
