### PR TITLE
Add mocking framework for controllers

### DIFF
--- a/Guide/Makefile
+++ b/Guide/Makefile
@@ -9,6 +9,7 @@ HTML_FILES+= installation.html
 HTML_FILES+= index.html
 HTML_FILES+= database.html
 HTML_FILES+= debugging.html
+HTML_FILES+= testing.html
 HTML_FILES+= querybuilder.html
 HTML_FILES+= view.html
 HTML_FILES+= form.html

--- a/Guide/layout.html
+++ b/Guide/layout.html
@@ -48,6 +48,7 @@
                 <a class="nav-link secondary" href="javascript:alert('This cookie section is not ready yet')">Cookies</a>
                 <a class="nav-link secondary" href="scripts.html">Scripts</a>
                 <a class="nav-link secondary" href="debugging.html">Debugging</a>
+                <a class="nav-link secondary" href="testing.html">Testing</a>
                 
                 <a class="nav-link secondary" href="editors.html">Editors & Tooling</a>
                 

--- a/Guide/testing.markdown
+++ b/Guide/testing.markdown
@@ -1,0 +1,113 @@
+# Testing
+
+This section provides some guidelines for testing your IHP applications.
+
+```toc
+
+```
+
+## Setup
+
+Start by creating a new module for your tests (perhaps for an individual controller, something like `test/Web/Controller/SomeControllerSpec.hs`), then import the IHP testing mock framework and [Hspec](http://hspec.github.io/) (a Haskell testing library). You will also need to import your project's `Main` module (this is usually where a project's `InitControllerContext` instance is defined). Your imports will likely look something like this:
+
+```haskell
+module ExampleSpec where
+
+import           Test.Hspec
+import           IHP.Test.Mocking
+import           IHP.FrameworkConfig (ConfigBuilder(..))
+import           IHP.Prelude
+import           IHP.QueryBuilder (fetch, query)
+
+import           Web.Types
+import           Web.Routes
+import           Generated.Types
+import           Main ()
+```
+
+## Writing a test module
+The `IHP.Test.Mocking` module has functions to mock `ModelContext`, `RequestContext` and `ApplicationContext`. These contexts are created with the `mockContext` function, which requires a `ConfigBuilder` and an IHP application as inputs. This function should be called before the tests start:
+
+```haskell
+-- a function like this probably already exists in your Config module:
+makeConfig :: IO ConfigBuilder
+makeConfig = ...
+
+spec :: Spec
+spec = beforeAll (makeConfig >>= mockContext WebApplication) do
+  ...
+```
+
+In order to execute database queries and run controller actions, the implicit context paramaters must be bound in the testing environment using `withContext`. Here is an example test to check there are no users in the database:
+
+```haskell
+  describe "User controller" $ do
+    it "has no existing users" $ withContext do
+      users <- query @User |> fetch
+      users `shouldBe` []
+```
+
+The response of a controller action can be tested (but currently only the raw HTML content is returned):
+```haskell
+    it "responds with content" $ withContext do
+      content <- mockActionResponse NewUserAction
+      content `shouldBe` "<!DOCTYPE HTML>...</html>"
+```
+
+It is also possible to check the HTTP status of a controller response and response headers:
+```haskell
+    it "returns a redirect header" $ withContext do
+      hs <- headers (mockAction NewUserAction)
+      lookup "Location" hs `shouldNotBe` Nothing
+
+    it "creates a new user" $ withParams [("a-test-param","some-value")] do
+      mockActionStatus CreateUserAction `shouldReturn` status200
+```
+
+## Runing a test
+To execute a single test spec, load the test module into GHCI and run `hspec spec` (make sure your database server is running).
+
+## Next steps
+For more details on how to structure test suites see the [Hspec manual](http://hspec.github.io/) (a Haskell testing library). You also might want to check out the cool [Hedgehog](https://hedgehog.qa/) library for automated property tests.
+
+## Complete example
+The following is a complete example of the above code:
+
+```haskell
+module ExampleSpec where
+
+import           Network.HTTP.Types.Status (status200)
+
+import           Test.Hspec
+import           IHP.Test.Controller.Mocking
+import           IHP.FrameworkConfig (ConfigBuilder(..))
+import           IHP.Prelude
+import           IHP.QueryBuilder (fetch, query)
+
+import           Web.Types
+import           Web.Routes
+import           Generated.Types
+import           Main ()
+
+-- a function like this probably already exists in your Config module:
+makeConfig :: IO ConfigBuilder
+makeConfig = ...
+
+spec :: Spec
+spec = beforeAll (makeConfig >>= mockContext WebApplication) do
+  describe "User controller" $ do
+    it "has no existing users" $ withContext do
+      users <- query @User |> fetch
+      users `shouldBe` []
+
+    it "responds with some content" $ withContext do
+      content <- mockActionResponse NewUserAction
+      content `shouldBe` "<!DOCTYPE HTML>...</html>"
+
+    it "creates a new user" $ withParams [("a-test-param","some-value")] do
+      mockActionStatus CreateUserAction `shouldReturn` status200
+
+    it "returns a redirect header" $ withContext do
+      hs <- headers (mockAction NewUserAction)
+      lookup "Location" hs `shouldNotBe` Nothing
+```

--- a/IHP/Test/Mocking.hs
+++ b/IHP/Test/Mocking.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE ImplicitParams        #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE ExistentialQuantification   #-}
+
+module IHP.Test.Mocking where
+
+import           Data.ByteString.Builder                   (toLazyByteString)
+import qualified Data.ByteString.Lazy                      as LBS
+import qualified Data.Vault.Lazy                           as Vault
+import           Database.PostgreSQL.Simple                (connectPostgreSQL)
+import           Network.HTTP.Types.Header
+import qualified Network.HTTP.Types.Status                 as HTTP
+import           Network.Wai
+import           Network.Wai.Internal                      (ResponseReceived (..))
+import           Network.Wai.Parse                         (Param (..))
+
+import qualified IHP.ApplicationContext                    as ApplicationContext
+import           IHP.ApplicationContext                    (ApplicationContext (..))
+import qualified IHP.AutoRefresh.Types                     as AutoRefresh
+import qualified IHP.Controller.Context                    as Context
+import           IHP.FlashMessages.ControllerFunctions     (initFlashMessages)
+import           IHP.Controller.RequestContext             (RequestBody (..), RequestContext (..))
+import           IHP.ControllerSupport                     (InitControllerContext, Controller, ResponseException(..), initContext,action)
+import           IHP.FrameworkConfig                       (ConfigBuilder (..), FrameworkConfig (..))
+import qualified IHP.FrameworkConfig                       as FrameworkConfig
+import           IHP.ModelSupport                          (createModelContext)
+import           IHP.Prelude
+
+type ContextParameters application = (?applicationContext :: ApplicationContext, ?context :: RequestContext, ?modelContext :: ModelContext, ?application :: application, InitControllerContext application, ?mocking :: MockContext application)
+
+data MockContext application = InitControllerContext application => MockContext {
+    modelContext :: ModelContext
+  , requestContext :: RequestContext
+  , applicationContext :: ApplicationContext
+  , application :: application
+  }
+
+-- | Create contexts that can be used for mocking
+mockContext :: (InitControllerContext application) => application -> ConfigBuilder -> IO (MockContext application)
+mockContext application configBuilder = do
+   frameworkConfig@(FrameworkConfig {dbPoolMaxConnections, dbPoolIdleTime, databaseUrl}) <- FrameworkConfig.buildFrameworkConfig configBuilder
+   databaseConnection <- connectPostgreSQL databaseUrl
+   modelContext <- (\modelContext -> modelContext { queryDebuggingEnabled = False }) <$> createModelContext dbPoolIdleTime dbPoolMaxConnections databaseUrl
+
+   autoRefreshServer <- newIORef AutoRefresh.newAutoRefreshServer
+   session <- Vault.newKey
+   let sessionVault = Vault.insert session mempty Vault.empty
+   let applicationContext = ApplicationContext { modelContext = modelContext, session, autoRefreshServer, frameworkConfig }
+
+   let requestContext = RequestContext
+         { request = defaultRequest {vault = sessionVault}
+         , requestBody = FormBody [] []
+         , respond = \resp -> pure ResponseReceived
+         , vault = session
+         , frameworkConfig = frameworkConfig }
+
+   pure MockContext{..}
+
+-- | Run a IO action, setting implicit params based on supplied mock context
+withContext :: (ContextParameters application => IO a) -> MockContext application -> IO a
+withContext action mocking@MockContext{..} = let
+    ?modelContext = modelContext
+    ?context = requestContext
+    ?applicationContext = applicationContext
+    ?application = application
+    ?mocking = mocking
+  in do
+    action
+
+setupWithContext :: (ContextParameters application => IO a) -> MockContext application -> IO (MockContext application)
+setupWithContext action context = withContext action context >> pure context
+
+-- | Runs a controller action in a mock environment
+mockAction :: forall application controller. (Controller controller, ContextParameters application) => controller -> IO Response
+mockAction controller = do
+  let ?modelContext = ApplicationContext.modelContext ?applicationContext
+  let ?requestContext = ?context
+  controllerContext <- Context.newControllerContext
+  let ?context = controllerContext
+  initContext @application
+  let ?theAction = controller
+  initFlashMessages
+  let doRunAction = action controller >> error "no ResponseException given"
+  doRunAction `catch` \(ResponseException response) -> pure response
+
+-- | Get contents of response
+mockActionResponse :: forall application controller. (Controller controller, ContextParameters application) => controller -> IO LBS.ByteString
+mockActionResponse = (responseBody =<<) . mockAction
+
+-- | Get HTTP status of the controller
+mockActionStatus :: forall application controller. (Controller controller, ContextParameters application) => controller -> IO HTTP.Status
+mockActionStatus = fmap responseStatus . mockAction
+
+-- | Add params to the request context, run the action
+withParams :: [Param] -> (ContextParameters application => IO a) -> MockContext application -> IO a
+withParams ps action context = withContext action context'
+  where
+    context' = context{requestContext=(requestContext context){requestBody=FormBody ps []}}
+
+headers :: IO Response -> IO ResponseHeaders
+headers = fmap responseHeaders
+
+responseBody :: Response -> IO LBS.ByteString
+responseBody res =
+  let (status,headers,body) = responseToStream res in
+  body $ \f -> do
+    content <- newIORef mempty
+    f (\chunk -> modifyIORef' content (<> chunk)) (return ())
+    toLazyByteString <$> readIORef content

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -254,6 +254,7 @@ library IHPFramework
         , IHP.SchemaMigration
         , IHP.LibDir
         , IHP.Telemetry
+        , IHP.Test.Mocking
         , IHP.Version
         , IHP.Point
         , Paths_ihp


### PR DESCRIPTION
Is this useful to incorporate into IHP framework? Is this the right spot for it?

Example usage:
```
import Test.Controller.Mocking

spec :: Spec
spec = beforeAll (configBuilder >>= mockContext >>= \c -> withContext c (pure ()) do
  describe "Run mock test" do

    it "checks headers" $ c -> withParams [("param","val"] c do
      heads <- headers (mockAction SomeAction)
      let loc = lookup "Location" heads
      loc `shouldNotBe` Nothing

    it "checks status" $ c -> withParams [("param","val"] c do
      mockActionStatus AnotherAction `shouldReturn` status200
```