### PR TITLE
Bug fix + different message suggestion for column name

### DIFF
--- a/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/Edit.hs
@@ -6,6 +6,7 @@ import qualified IHP.IDE.SchemaDesigner.Compiler as Compiler
 import IHP.IDE.ToolServer.Types
 import IHP.IDE.ToolServer.Layout
 import IHP.IDE.SchemaDesigner.View.Layout
+import Text.Countable (singularize)
 
 data EditColumnView = EditColumnView
     { statements :: [Statement]
@@ -70,6 +71,7 @@ instance View EditColumnView where
                             class="form-control"
                             autofocus="autofocus"
                             value={get #name column}
+                            data-table-name-singular={singularize tableName}
                             />
                     </div>
 

--- a/IHP/IDE/SchemaDesigner/View/Columns/New.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/New.hs
@@ -7,6 +7,7 @@ import IHP.IDE.ToolServer.Layout
 import IHP.IDE.SchemaDesigner.View.Layout
 import qualified Text.Countable as Countable
 import IHP.IDE.SchemaDesigner.View.Columns.Edit (typeSelector)
+import Text.Countable (singularize)
 
 data NewColumnView = NewColumnView
     { statements :: [Statement]
@@ -39,6 +40,7 @@ instance View NewColumnView where
                             class="form-control"
                             autofocus="autofocus"
                             placeholder="Name:"
+                            data-table-name-singular={singularize tableName}
                             />
                     </div>
 

--- a/IHP/IDE/SchemaDesigner/View/Layout.hs
+++ b/IHP/IDE/SchemaDesigner/View/Layout.hs
@@ -295,8 +295,8 @@ getDefaultValue columnType value = case Megaparsec.runParser Parser.expression "
         Left _ -> Nothing
         Right expression -> Just expression
 
-isIllegalKeyword :: Text -> Bool
-isIllegalKeyword input = case (toUpper input) of
+isSQLKeyword :: Text -> Bool
+isSQLKeyword input = case (toUpper input) of
     "BIGINT" -> True
     "BIT" -> True
     "BOOLEAN" -> True
@@ -429,3 +429,62 @@ isIllegalKeyword input = case (toUpper input) of
     "VERBOSE" -> True
     "BYTEA" -> True
     _ -> False
+
+-- "toLower" feels more natural for Haskell keywords
+isHaskellKeyword :: Text -> Bool
+isHaskellKeyword input =
+    case (toLower input) of
+        "as" -> True
+        "case" -> True
+        "class" -> True
+        "data" -> True
+        "default" -> True
+        "deriving" -> True
+        "do" -> True
+        "else" -> True
+        "hiding" -> True
+        "if" -> True
+        "import" -> True
+        "in" -> True
+        "infix" -> True
+        "infixl" -> True
+        "infixr" -> True
+        "instance" -> True
+        "let" -> True
+        "module" -> True
+        "newtype" -> True
+        "of" -> True
+        "qualified" -> True
+        "then" -> True
+        "type" -> True
+        "where" -> True
+        "forall" -> True
+        "mdo" -> True
+        "family" -> True
+        "role" -> True
+        "pattern" -> True
+        "static" -> True
+        "group" -> True
+        "by" -> True
+        "using" -> True
+        "foreign" -> True
+        "export" -> True
+        "label" -> True
+        "dynamic" -> True
+        "safe" -> True
+        "interruptible" -> True
+        "unsafe" -> True
+        "stdcall" -> True
+        "ccall" -> True
+        "capi" -> True
+        "prim" -> True
+        "javascript" -> True
+        "rec" -> True
+        "proc" -> True
+        _ -> False
+
+isIllegalKeyword :: Text -> Bool
+isIllegalKeyword input =
+    case input of
+        "_" -> True
+        _ -> isSQLKeyword input || isHaskellKeyword input

--- a/lib/IHP/static/ihp-schemadesigner.js
+++ b/lib/IHP/static/ihp-schemadesigner.js
@@ -8,7 +8,11 @@ function initSchemaDesigner() {
         if (reservedKeywords.includes(this.value)) {
             this.classList = "form-control is-invalid"
             var warning = document.createElement("div");
-            warning.innerHTML = "'" + this.value + "' is a reserved keyword in Haskell. Your element will be named '" + this.value + "_'.";
+            warning.innerHTML =
+		"'" + this.value + "' is a reserved keyword in Haskell. "
+		+ "Consider renaming it to '"
+		+ this.dataset.tableNameSingular + "_" + this.value
+		+ "'.";
             warning.classList = "invalid-feedback";
             warning.setAttribute("id", "warningText");
             this.parentNode.insertBefore(warning, this.nextSibling);


### PR DESCRIPTION
This PR has 2 commits,

Commit 1:
Bugfix: Consider Haskell keywords as illegal keywords as well.

Commit 2:
Change suggested column name from `*reserved keyword_` to `*singular table name*_*reserved keyword*`