### PR TITLE
Update nixpkgs

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc883", ihp, haskellDeps ? (p: []), otherDeps ? (p: []), projectPath ? ./. }:
+{ compiler ? "ghc8102", ihp, haskellDeps ? (p: []), otherDeps ? (p: []), projectPath ? ./. }:
 
 let
     pkgs = import "${toString projectPath}/Config/nix/nixpkgs-config.nix" { ihp = ihp; };

--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc8102", ihp, haskellDeps ? (p: []), otherDeps ? (p: []), projectPath ? ./. }:
+{ compiler ? "ghc8103", ihp, haskellDeps ? (p: []), otherDeps ? (p: []), projectPath ? ./. }:
 
 let
     pkgs = import "${toString projectPath}/Config/nix/nixpkgs-config.nix" { ihp = ihp; };

--- a/NixSupport/make-nixpkgs-from-options.nix
+++ b/NixSupport/make-nixpkgs-from-options.nix
@@ -6,9 +6,9 @@
 , dontCheckPackages ? []
 , doJailbreakPackages ? []
 , dontHaddockPackages ? []
-, nixPkgsRev ? "2ae527c50e049570dd25132f9325527aa2320e32"
-, nixPkgsSha256 ? "0rggj7d5j6mmn5l4p72pj0bdxcsid0wxyjqfivdhmfvlsmh8hadn"
-, compiler ? "ghc8102"
+, nixPkgsRev ? "c7f75838c360473805afcf5fb2fa65e678efd94b"
+, nixPkgsSha256 ? "04vx1j2gybm1693a8wxw6bpcsd4h1jdw541vwic8nfm3n80r4ckm"
+, compiler ? "ghc8103"
 , manualOverrides ? haskellPackagesNew: haskellPackagesOld: { } # More exotic overrides go here
 }:
 let

--- a/NixSupport/make-nixpkgs-from-options.nix
+++ b/NixSupport/make-nixpkgs-from-options.nix
@@ -36,6 +36,10 @@ let
 
   composeExtensionsList = pkgs.lib.fold pkgs.lib.composeExtensions (_: _: {});
 
+  ihpDontCheckPackages = [];
+  ihpDoJailbreakPackages = [];
+  ihpDontHaddockPackages = [];
+
   config = {
     allowBroken = true;
     packageOverrides = pkgs: rec {
@@ -45,6 +49,13 @@ let
           pkgs.haskell.packages."${compiler}".override {
             overrides = composeExtensionsList [
               generatedOverrides
+              
+              # Overrides provided by IHP
+              (makeOverrides pkgs.haskell.lib.dontCheck   ihpDontCheckPackages  )
+              (makeOverrides pkgs.haskell.lib.doJailbreak ihpDoJailbreakPackages)
+              (makeOverrides pkgs.haskell.lib.dontHaddock ihpDontHaddockPackages)
+
+              # Project specific overrides
               (makeOverrides pkgs.haskell.lib.dontCheck   dontCheckPackages  )
               (makeOverrides pkgs.haskell.lib.doJailbreak doJailbreakPackages)
               (makeOverrides pkgs.haskell.lib.dontHaddock dontHaddockPackages)

--- a/NixSupport/make-nixpkgs-from-options.nix
+++ b/NixSupport/make-nixpkgs-from-options.nix
@@ -1,0 +1,70 @@
+# This function is imported from the apps Config/nix/nixpkgs-config.nix
+# It takes a few parameter as an input and returns a nixpkgs version used for building
+# the project
+{ ihp
+, haskellPackagesDir
+, dontCheckPackages ? []
+, doJailbreakPackages ? []
+, dontHaddockPackages ? []
+, nixPkgsRev ? "2ae527c50e049570dd25132f9325527aa2320e32"
+, nixPkgsSha256 ? "0rggj7d5j6mmn5l4p72pj0bdxcsid0wxyjqfivdhmfvlsmh8hadn"
+, compiler ? "ghc8102"
+, manualOverrides ? haskellPackagesNew: haskellPackagesOld: { } # More exotic overrides go here
+}:
+let
+  generatedOverrides = haskellPackagesNew: haskellPackagesOld:
+    let
+      toPackage = dir: file: _: {
+        name = builtins.replaceStrings [ ".nix" ] [ "" ] file;
+
+        value = haskellPackagesNew.callPackage ("${dir}/${file}") {};
+      };
+      makePackageSet = dir: pkgs.lib.mapAttrs' (toPackage dir) (builtins.readDir dir);
+    in
+      { "ihp" = ((haskellPackagesNew.callPackage "${ihp}/ihp.nix") { }); } // (makePackageSet haskellPackagesDir) // (makePackageSet "${ihp}/NixSupport/haskell-packages/.");
+
+  makeOverrides =
+    function: names: haskellPackagesNew: haskellPackagesOld:
+      let
+        toPackage = name: {
+          inherit name;
+
+          value = function haskellPackagesOld.${name};
+        };
+      in
+      builtins.listToAttrs (map toPackage names);
+
+  composeExtensionsList = pkgs.lib.fold pkgs.lib.composeExtensions (_: _: {});
+
+  config = {
+    allowBroken = true;
+    packageOverrides = pkgs: rec {
+      haskell = pkgs.haskell // {
+        packages = pkgs.haskell.packages // {
+          "${compiler}" =
+          pkgs.haskell.packages."${compiler}".override {
+            overrides = composeExtensionsList [
+              generatedOverrides
+              (makeOverrides pkgs.haskell.lib.dontCheck   dontCheckPackages  )
+              (makeOverrides pkgs.haskell.lib.doJailbreak doJailbreakPackages)
+              (makeOverrides pkgs.haskell.lib.dontHaddock dontHaddockPackages)
+              manualOverrides
+            ];
+          };
+        }
+        ;
+      }
+      ;
+    };
+  };
+
+
+  pkgs = (import ((import <nixpkgs> {}).fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = nixPkgsRev;
+    sha256 = nixPkgsSha256;
+  })) { inherit config; };
+
+in
+    pkgs

--- a/NixSupport/pkgs.nix
+++ b/NixSupport/pkgs.nix
@@ -23,7 +23,7 @@ let
     nixPkgsRev = "c985bf793e6ab7d54a9182381b4b610fe0ae6936";
     nixPkgsSha256 = "0zsj9imjbnhkb65r169xxqmjgqd5593insrvncvabg1iqdsrcxz1";
 
-    compiler = "ghc8102";
+    compiler = "ghc8103";
 
     generatedOverrides = haskellPackagesNew: haskellPackagesOld:
         let

--- a/NixSupport/pkgs.nix
+++ b/NixSupport/pkgs.nix
@@ -20,8 +20,8 @@ let
 
     dontHaddockPackages = [];
 
-    nixPkgsRev = "c985bf793e6ab7d54a9182381b4b610fe0ae6936";
-    nixPkgsSha256 = "0zsj9imjbnhkb65r169xxqmjgqd5593insrvncvabg1iqdsrcxz1";
+    nixPkgsRev = "c7f75838c360473805afcf5fb2fa65e678efd94b";
+    nixPkgsSha256 = "04vx1j2gybm1693a8wxw6bpcsd4h1jdw541vwic8nfm3n80r4ckm";
 
     compiler = "ghc8103";
 

--- a/NixSupport/pkgs.nix
+++ b/NixSupport/pkgs.nix
@@ -23,7 +23,7 @@ let
     nixPkgsRev = "c985bf793e6ab7d54a9182381b4b610fe0ae6936";
     nixPkgsSha256 = "0zsj9imjbnhkb65r169xxqmjgqd5593insrvncvabg1iqdsrcxz1";
 
-    compiler = "ghc883";
+    compiler = "ghc8102";
 
     generatedOverrides = haskellPackagesNew: haskellPackagesOld:
         let

--- a/NixSupport/pkgs.nix
+++ b/NixSupport/pkgs.nix
@@ -48,14 +48,6 @@ let
     composeExtensionsList = pkgs.lib.fold pkgs.lib.composeExtensions (_: _: {});
 
     manualOverrides = haskellPackagesNew: haskellPackagesOld: {
-        haskell-language-server = haskellPackagesOld.haskell-language-server.overrideScope ( self: super: { aeson = pkgs.haskell.lib.dontCheck haskellPackagesNew.aeson_1_5_2_0; } );
-        hls-plugin-api = haskellPackagesOld.hls-plugin-api.overrideScope ( self: super: { aeson = pkgs.haskell.lib.dontCheck haskellPackagesNew.aeson_1_5_2_0; } );
-        yaml = haskellPackagesOld.yaml.overrideScope ( self: super: { aeson = pkgs.haskell.lib.dontCheck haskellPackagesNew.aeson_1_5_2_0; } );
-        lsp-test = haskellPackagesOld.lsp-test.overrideScope ( self: super: { aeson = pkgs.haskell.lib.dontCheck haskellPackagesNew.aeson_1_5_2_0; } );
-        haskell-lsp-types = haskellPackagesOld.haskell-lsp-types.overrideScope ( self: super: { aeson = pkgs.haskell.lib.dontCheck haskellPackagesNew.aeson_1_5_2_0; } );
-        haskell-lsp = haskellPackagesOld.haskell-lsp.overrideScope ( self: super: { aeson = pkgs.haskell.lib.dontCheck haskellPackagesNew.aeson_1_5_2_0; } );
-        aeson-pretty = haskellPackagesOld.aeson-pretty.overrideScope ( self: super: { aeson = pkgs.haskell.lib.dontCheck haskellPackagesNew.aeson_1_5_2_0; } );
-        aeson = pkgs.haskell.lib.dontCheck haskellPackagesOld.aeson_1_5_2_0;
     };
 
     #mkDerivation = args: super.mkDerivation (args // {

--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,6 @@
 let
     pkgs = import ./NixSupport/pkgs.nix;
-    compiler = "ghc8102";
+    compiler = "ghc8103";
     ihp = builtins.fetchGit {
         url = "https://github.com/digitallyinduced/ihp.git";
         rev = "26a3ec4096bb2e9e58590bb99afbbe6421de5e66";

--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,6 @@
 let
     pkgs = import ./NixSupport/pkgs.nix;
-    compiler = "ghc883";
+    compiler = "ghc8102";
     ihp = builtins.fetchGit {
         url = "https://github.com/digitallyinduced/ihp.git";
         rev = "26a3ec4096bb2e9e58590bb99afbbe6421de5e66";

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 let
 	pkgs = import ./NixSupport/pkgs.nix;
-	ghc = pkgs.haskell.packages.ghc883;
+	ghc = pkgs.haskell.packages.ghc8102;
 	haskellDeps = ghc.ghcWithPackages (p: with p; [
 	    cabal-install
 	    base

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 let
 	pkgs = import ./NixSupport/pkgs.nix;
-	ghc = pkgs.haskell.packages.ghc8102;
+	ghc = pkgs.haskell.packages.ghc8103;
 	haskellDeps = ghc.ghcWithPackages (p: with p; [
 	    cabal-install
 	    base


### PR DESCRIPTION
Updates nixpkgs and GHC (v8.10.3)

The project's `Config/nix/nixpkgs-config.nix` needs to be updated:

```nix
# See https://ihp.digitallyinduced.com/Guide/package-management.html
{ ihp }:
import "${toString ihp}/NixSupport/make-nixpkgs-from-options.nix" {
    ihp = ihp;
    haskellPackagesDir = ./haskell-packages/.;
}
```

This new format for the `nixpkgs-config.nix` allows us to update nixpkgs in the future without users needing to patch their project's `nixpkgs-config.nix`

- Fixes https://github.com/digitallyinduced/ihp/issues/606
- Fixes https://github.com/digitallyinduced/ihp/issues/484
- Fixes https://github.com/digitallyinduced/ihp/issues/543