### PR TITLE
Remove code already present in schemaDesignerLayout

### DIFF
--- a/IHP/IDE/SchemaDesigner/View/Schema/Error.hs
+++ b/IHP/IDE/SchemaDesigner/View/Schema/Error.hs
@@ -12,22 +12,7 @@ data ErrorView = ErrorView
 
 instance View ErrorView where
     html ErrorView { .. } = [hsx|
-        <div class="container">
-            <div class="row pt-5" style="height: 102px">
-                <div class="col" style="display: flex; align-self: center;">
-                    {visualNav}
-                </div>
-
-                <div class="col" style="display: flex; align-self: center; justify-content: center">
-                    Application/Schema.sql
-                </div>
-
-                <div class="col"></div>
-            </div>
-            <div>
-                <div class="bg-white visual-error">
-                    <pre>{error}</pre>
-                </div>
-            </div>
+        <div class="bg-white visual-error">
+            <pre>{error}</pre>
         </div>
     |]


### PR DESCRIPTION
When some error is raised after reading the schema file, the header (toggle and update db buttons) are duplicated,  because that HTML is in the [`schemaDesignerLayout`](https://github.com/digitallyinduced/ihp/blob/master/IHP/IDE/SchemaDesigner/View/Layout.hs#L12:L29) function, resulting in something like this:

![Screen Shot 2020-12-27 at 19 34 37](https://user-images.githubusercontent.com/11888191/103177510-7cfc0300-487b-11eb-81f0-940d64962786.png)

I made the less changes possible to keep the `bg-white visual-error` div inside a `container`.