### PR TITLE
support LocalTime for dateField and dateTimeField

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,3 +137,13 @@ Perhaps a package was added to IHP recently. Start a `nix-shell` in the IHP dire
 ### Trouble adding packages to IHP
 
 Either add the package to your project's `default.nix` as well, or change the section `ihp = builtins.fetchGit ...` to `ihp = ./IHP;`in your project's `default.nix`. Then the `IHP/ihp.nix` will be used to fetch packages.
+
+### Reverting back to running with stock IHP library
+
+If you want to go back and use the standard IHP library instead of the cloned source, for instance when your much needed, contributed and approved feature becomes part of the release, then in your project directory:
+
+```
+rm -rf IHP
+rm build/ihp-lib
+./start
+```

--- a/IHP/Controller/Param.hs
+++ b/IHP/Controller/Param.hs
@@ -399,6 +399,24 @@ instance ParamReader UTCTime where
     readParameterJSON (Aeson.String string) = readParameter (cs string)
     readParameterJSON _ = Left "ParamReader UTCTime: Expected String"
 
+-- | Accepts values such as @2020-11-08T12:03:35Z@ or @2020-11-08@
+instance ParamReader LocalTime where
+    {-# INLINABLE readParameter #-}
+    readParameter "" = Left "ParamReader LocalTime: Parameter missing"
+    readParameter byteString =
+        let
+            input = (cs byteString)
+            dateTime = parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" input
+            date = parseTimeM True defaultTimeLocale "%Y-%-m-%-d" input
+        in case dateTime of
+            Nothing -> case date of
+                Just value -> Right value
+                Nothing -> Left ("ParamReader LocalTime: Failed parsing " ++ cs input)
+            Just value -> Right value
+
+    readParameterJSON (Aeson.String string) = readParameter (cs string)
+    readParameterJSON _ = Left "ParamReader LocalTime: Expected String"
+
 -- | Accepts values such as @2020-11-08@
 instance ParamReader Day where
     {-# INLINABLE readParameter #-}

--- a/IHP/Controller/Param.hs
+++ b/IHP/Controller/Param.hs
@@ -411,7 +411,7 @@ instance ParamReader LocalTime where
         in case dateTime of
             Nothing -> case date of
                 Just value -> Right value
-                Nothing -> Left ("ParamReader LocalTime: Failed parsing " ++ cs input)
+                Nothing -> Left "ParamReader LocalTime: Failed parsing"
             Just value -> Right value
 
     readParameterJSON (Aeson.String string) = readParameter (cs string)

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -120,6 +120,9 @@ instance InputValue () where
 instance InputValue UTCTime where
     inputValue time = cs (iso8601Show time)
 
+instance InputValue LocalTime where
+    inputValue time = cs (iso8601Show time)
+
 instance InputValue Day where
     inputValue date = cs (iso8601Show date)
 

--- a/IHP/Prelude.hs
+++ b/IHP/Prelude.hs
@@ -21,6 +21,7 @@ module IHP.Prelude
 , module Data.String.Conversions
 , module Data.Time.Clock
 , module Data.Time.Calendar
+, module Data.Time.LocalTime
 , module Data.Text
 , module GHC.OverloadedLabels
 , plain
@@ -55,6 +56,7 @@ import qualified Data.List as List
 import Data.String.Conversions (ConvertibleStrings (convertString), cs)
 import Data.Time.Clock
 import Data.Time.Calendar
+import Data.Time.LocalTime
 import Data.Text (words, unwords, lines, unlines, intersperse, intercalate, toLower, toUpper, isInfixOf, isSuffixOf, isPrefixOf, splitAt)
 import qualified Data.String.Interpolate
 import GHC.OverloadedLabels

--- a/Test/Controller/ParamSpec.hs
+++ b/Test/Controller/ParamSpec.hs
@@ -258,7 +258,20 @@ tests = do
                 
                 it "should accept JSON strings" do
                     (tshow (readParameterJSON @UTCTime (json "\"2020-11-08T12:03:35Z\""))) `shouldBe` ("Right 2020-11-08 12:03:35 UTC")
-            
+
+            describe "LocalTime" do
+                it "should accept timestamps" do
+                    (tshow (readParameter @LocalTime "2020-11-08T12:03:35Z")) `shouldBe` ("Right 2020-11-08 12:03:35")
+                
+                it "should accept dates" do
+                    (tshow (readParameter @LocalTime "2020-11-08")) `shouldBe` ("Right 2020-11-08 00:00:00")
+                
+                it "should fail on invalid inputs" do
+                    (readParameter @LocalTime "not a timestamp") `shouldBe` (Left "ParamReader LocalTime: Failed parsing")
+                
+                it "should accept JSON strings" do
+                    (tshow (readParameterJSON @UTCTime (json "\"2020-11-08T12:03:35Z\""))) `shouldBe` ("Right 2020-11-08 12:03:35")
+
             describe "Day" do
                 it "should accept dates" do
                     (tshow (readParameter @Day "2020-11-08")) `shouldBe` ("Right 2020-11-08")

--- a/Test/Controller/ParamSpec.hs
+++ b/Test/Controller/ParamSpec.hs
@@ -270,7 +270,7 @@ tests = do
                     (readParameter @LocalTime "not a timestamp") `shouldBe` (Left "ParamReader LocalTime: Failed parsing")
                 
                 it "should accept JSON strings" do
-                    (tshow (readParameterJSON @UTCTime (json "\"2020-11-08T12:03:35Z\""))) `shouldBe` ("Right 2020-11-08 12:03:35")
+                    (tshow (readParameterJSON @LocalTime (json "\"2020-11-08T12:03:35Z\""))) `shouldBe` ("Right 2020-11-08 12:03:35")
 
             describe "Day" do
                 it "should accept dates" do


### PR DESCRIPTION
While LocalTime was supported in the IDE for DB columns, it was not supported in the input fields.
Since localtime vs utc is just a flag in postgresql (just different field types, identical storage) no time zones are involved. It is just a matter of interpretation (local time or utc). Hence, we don't need any change in settings in the flatpickr and we happily parse Z(ulu) just as for UTCTime.