### PR TITLE
Auth updates

### DIFF
--- a/Guide/authentication.markdown
+++ b/Guide/authentication.markdown
@@ -33,10 +33,6 @@ CREATE TABLE users (
 
 The password authentication saves the passwords as a salted hash using the [pwstore-fast library](https://hackage.haskell.org/package/pwstore-fast-2.4.4/docs/Crypto-PasswordStore.html). By default, a user will be locked for an hour after 10 failed login attempts.
 
-### Aside: Admin authentication
-
-If you are creating an admin sub-application, first use the code generator to create an application called `Admin`, then follow this guide replacing `Web` with `Admin` and `User` with `Admin` everywhere (except for the lower-case `user` in the file `Admin/View/Sessions/New.hs`, which comes from an imported module).
-
 ## Setup
 
 Currently, the authentication toolkit has to be enabled manually. We plan to do this setup using a code generator in the future.
@@ -331,3 +327,9 @@ sha256|17|Y32Ga1uke5CisJvVp6p2sg==|TSDuEs1+Xdaels6TYCkyCgIBHxWA/US7bvBlK0vHzvc=
 Use [`hashPassword`](https://ihp.digitallyinduced.com/api-docs/IHP-AuthSupport-Authentication.html#v:hashPassword) to hash a password from inside your application.
 
 [Next: Authorization](https://ihp.digitallyinduced.com/Guide/authorization.html)
+
+
+
+## Aside: Admin authentication
+
+If you are creating an admin sub-application, first use the code generator to create an application called `Admin`, then follow this guide replacing `Web` with `Admin` and `User` with `Admin` everywhere (except for the lower-case `user` in the file `Admin/View/Sessions/New.hs`, which comes from an imported module).

--- a/IHP/ControllerPrelude.hs
+++ b/IHP/ControllerPrelude.hs
@@ -26,6 +26,7 @@ module IHP.ControllerPrelude
     , module IHP.Modal.ControllerFunctions
     , module IHP.Controller.Layout
     , module IHP.Job.Types
+    , module IHP.LoginSupport.Helper.Controller
     , Only (..)
     ) where
 import IHP.Prelude
@@ -59,3 +60,5 @@ import IHP.Modal.ControllerFunctions
 
 import IHP.Job.Types
 import IHP.AutoRefresh (initAutoRefresh, autoRefresh)
+
+import IHP.LoginSupport.Helper.Controller

--- a/IHP/LoginSupport/Helper/Controller.hs
+++ b/IHP/LoginSupport/Helper/Controller.hs
@@ -19,7 +19,10 @@ module IHP.LoginSupport.Helper.Controller
 , module IHP.AuthSupport.Authentication
 ) where
 
-import IHP.ControllerPrelude
+import IHP.Prelude
+import IHP.Controller.Context
+import IHP.Controller.Redirect
+import IHP.Controller.Session
 import IHP.LoginSupport.Types
 import IHP.Controller.RequestContext
 import qualified IHP.Controller.Session as Session
@@ -32,9 +35,6 @@ import Control.Monad.Fail
 import IHP.AuthSupport.Authorization
 import IHP.AuthSupport.Authentication
 import IHP.Controller.Context
-
-type family CurrentUserRecord
-type family CurrentAdminRecord
 
 {-# INLINABLE currentUser #-}
 currentUser :: forall user. (?context :: ControllerContext, HasNewSessionUrl user, Typeable user, user ~ CurrentUserRecord) => user

--- a/IHP/LoginSupport/Types.hs
+++ b/IHP/LoginSupport/Types.hs
@@ -1,8 +1,15 @@
 {-# LANGUAGE ConstraintKinds, ConstrainedClassMethods, AllowAmbiguousTypes #-}
 
-module IHP.LoginSupport.Types ( HasNewSessionUrl (newSessionUrl) ) where
+module IHP.LoginSupport.Types
+( HasNewSessionUrl (newSessionUrl)
+, CurrentUserRecord
+, CurrentAdminRecord
+) where
 
 import IHP.Prelude
 
 class HasNewSessionUrl user where
     newSessionUrl :: Proxy user -> Text
+
+type family CurrentUserRecord
+type family CurrentAdminRecord

--- a/IHP/ViewPrelude.hs
+++ b/IHP/ViewPrelude.hs
@@ -29,7 +29,8 @@ module IHP.ViewPrelude (
     module IHP.Controller.Layout,
     module IHP.Modal.Types,
     module IHP.Modal.ViewFunctions,
-    module IHP.Job.Types
+    module IHP.Job.Types,
+    module IHP.LoginSupport.Helper.View
 ) where
 
 import IHP.Prelude
@@ -58,3 +59,5 @@ import IHP.Controller.Layout
 import IHP.Modal.Types
 import IHP.Modal.ViewFunctions
 import IHP.Job.Types
+
+import IHP.LoginSupport.Helper.View


### PR DESCRIPTION
Auth helpers like `currentUser` are now part of the `IHP.ControllerPrelude` and `IHP.ViewPrelude` modules and so don't need to be added to the `Application.Helper.View` and `Application.Helper.Controller` files anymore

The `CurrentUserRecord` is now specified in `Web.Types` which fixes #641