### PR TITLE
Fix Haddock Script

### DIFF
--- a/Troubleshoot/README.md
+++ b/Troubleshoot/README.md
@@ -13,7 +13,6 @@ The script checks:
 - that the old deprecated cachix key is not used
 - nix is correctly installed
 
-
 ## Design Goals
 
 The script should be runnable by just downloading a single file. The script should also test that nix is working correctly, so we cannot offer a simple nix package. So this script needs to be a standalone shell script that can be distributed by just downloading the file.

--- a/build-haddock
+++ b/build-haddock
@@ -1,11 +1,14 @@
-#!/bin/sh
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash
+
 # Builds the api documentation for all IHP modules
 # Output is placed in directory haddock-build
 # After building, you can view the api docs with: open haddock-build/index.html
+
 mkdir -p haddock-build
 
 haddock --html --hyperlinked-source --built-in-themes --quickjump -o haddock-build \
-    $(find IHP -regex '.+\.hs' -not \( -regex '.+GenericController.hs' \) -not \( -regex '.+CLI/.+.hs' \) |xargs) \
+    $(find IHP -regex '.+\.hs' -not \( -regex '.+GenericController.hs' \) -not \( -regex '.+CLI/.+.hs' \) | xargs) \
     --optghc="-i." \
     --optghc="-XOverloadedStrings" \
     --optghc="-XNoImplicitPrelude" \


### PR DESCRIPTION
When running `./build-haddock` it fails due to some Haskell packages not being loaded, so now we run it inside a `nix-shell`.