### PR TITLE
Refactor Troubleshooting Script

### DIFF
--- a/Guide/troubleshooting.markdown
+++ b/Guide/troubleshooting.markdown
@@ -9,7 +9,7 @@ In case your problem cannot be solved with the steps on this page, [join our awe
 Run this to automatically check for the most common IHP issues:
 
 ```bash
-curl https://raw.githubusercontent.com/digitallyinduced/ihp/master/Troubleshoot/ihp-troubleshoot | bash
+curl --silent https://raw.githubusercontent.com/digitallyinduced/ihp/master/Troubleshoot/ihp-troubleshoot | python3
 ```
 
 It will tell you what is wrong and the steps you need to do to fix it.
@@ -153,7 +153,6 @@ rm -rf ~/.cache/nix
 
 After removing your nix cache, running `ihp-new <project-name>` will remain silent for a while since it will
 re-cache a substantial number of nix dependencies.
-
 
 ### Ubuntu on Windows Subsystem for Linux (WSL): `ghc-pkg: Couldn't open database /nix/store/gsbpadkxlbswrfva70i8g8lpp2yw967z-ghc-8.10.3-with-packages/lib/ghc-8.10.3/package.conf.d for modification: {handle: /nix/store/gsbpadkxlbswrfva70i8g8lpp2yw967z-ghc-8.10.3-with-packages/lib/ghc-8.10.3/package.conf.d/package.cache.lock}: hLock: invalid argument (Invalid argument)`
 

--- a/Troubleshoot/README.md
+++ b/Troubleshoot/README.md
@@ -1,17 +1,17 @@
 # Provides the `ihp-troubleshoot` command
 
-This script detects common error in the dev environment where IHP is running.
+This script detects common errors in the dev environment where IHP is running.
 
 The script checks:
 
-- that the current directory looks like an ihp project
-- that the `.ghci` file exists and has the right permissions to be loaded
-- that `build/ihp-lib` symlink exists and references a valid IHP build
-- that `direnv` is loaded correctly into the shell
-- that `direnv` can correctly load the .envrc
-- that the digitallyinduced cachix cache is installed
-- that the old deprecated cachix key is not used
-- nix is correctly installed
+-   that the current directory looks like an IHP project
+-   that the `.ghci` file exists and has the right permissions to be loaded
+-   that `build/ihp-lib` symlink exists and references a valid IHP build
+-   that `direnv` is loaded correctly into the shell
+-   that `direnv` can correctly load the .envrc
+-   that the digitallyinduced cachix cache is installed
+-   that the old deprecated cachix key is not used
+-   nix is correctly installed
 
 ## Design Goals
 

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -40,7 +40,8 @@ def path_exists(file_path, success_message, error_message):
 
 def run_command(commands, maybe_input=None):
     input = maybe_input.encode('utf-8') if maybe_input is not None else None
-    return run(commands, capture_output=True, input=input).stdout.decode('utf-8')
+    output = run(commands, capture_output=True, input=input)
+    return (output.stdout.decode('utf-8'), output.stderr.decode('utf-8'))
 
 
 show_step("Checking that the current directory is an IHP project")
@@ -71,7 +72,7 @@ path_exists(
     ".envrc missing. Try 'make .envrc'"
 )
 
-direnv_output = run_command(["direnv", "status"])
+direnv_output, _ = run_command(["direnv", "status"])
 envrc_path = path.join(getcwd(), ".envrc")
 
 if f"Found RC path {envrc_path}" in direnv_output:
@@ -86,7 +87,7 @@ if "Found RC allowed true" in direnv_output:
 else:
     show_failure("direnv denied .envrc, run `direnv allow` to allow .envrc")
 
-ghci_path = run_command(["which", "ghci"])
+ghci_path, _ = run_command(["which", "ghci"])
 
 if "/nix/store" in ghci_path:
     show_success("ghci is loaded from nix store")
@@ -103,7 +104,7 @@ path_exists(
     ".ghci missing"
 )
 
-ghci_output = run_command(["ghci", "2>&1"], "putStrLn \"ok\"")
+ghci_output, _ = run_command(["ghci", "2>&1"], "putStrLn \"ok\"")
 
 if ".ghci is writable by someone else" in ghci_output:
     show_failure(
@@ -138,7 +139,7 @@ else:
 
 show_step("Checking Cachix")
 
-cachix_output = run_command(["cachix", "--help"])
+cachix_output, _ = run_command(["cachix", "--help"])
 
 if "https://cachix.org command line interface" in cachix_output:
     show_success("Cachix exists")
@@ -162,6 +163,21 @@ with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
     else:
         show_success("No legacy cachix key found")
 
+show_step("Validating and repairing /nix/store/ (could take a minute)")
+
+_, nix_store_troubleshooting_output = run_command(
+    ["nix-store", "--verify",
+     "--check-contents", "--repair",
+     "--quiet", "--no-build-output"]
+)
+
+if "warning: not all errors were fixed" in nix_store_troubleshooting_output:
+    show_failure(
+        "Errors where found in /nix/store/, run `rm -rf build; nix-shell --run 'make build/ihp-lib'`"
+    )
+else:
+    show_success("Nix store looks good")
+
 show_step("Debugging Details")
 
 show_step("GHCI Output")
@@ -183,3 +199,6 @@ with open("default.nix") as file:
 
 show_step("OS")
 print(platform())
+
+show_step("/nix/store/ checksums verification")
+print(nix_store_troubleshooting_output)

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -32,7 +32,7 @@ def show_failure(message):
 
 
 def path_exists(file_path, success_message, error_message):
-    if path.exists(file_path):
+    if file_path is not None and path.exists(file_path):
         show_success(success_message)
     else:
         show_failure(error_message)
@@ -114,14 +114,16 @@ else:
 
 show_step("Checking IHP")
 
-if path.islink("build/ihp-lib"):
+ihp_lib_is_link = path.islink("build/ihp-lib")
+
+if ihp_lib_is_link:
     show_success("Symlink build/ihp-lib exists")
 else:
     show_failure(
         "Symlink build/ihp-lib is missing. Try 'make build/ihp-lib' to fix this"
     )
 
-ihp_lib_link = readlink("build/ihp-lib")
+ihp_lib_link = readlink("build/ihp-lib") if ihp_lib_is_link else None
 
 path_exists(
     ihp_lib_link,

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -46,8 +46,7 @@ def path_exists(file_path, success_message, error_message):
 
 
 def run_command(commands, maybe_input=None):
-    command_input = maybe_input.encode(
-        'utf-8') if maybe_input is not None else None
+    command_input = maybe_input.encode('utf-8') if maybe_input else None
     command_output = run(
         commands,
         input=command_input,
@@ -212,11 +211,12 @@ for file_details in boilerplate_contents():
     file_path = file_details["path"]
     if file_path in SENSITIVE_FILES:
         local_file_sha, _ = run_command(
-            ["git", "hash-object", file_path])
+            ["git", "hash-object", file_path]
+        )
         if local_file_sha.rstrip() != file_details["sha"]:
             show_warning(
                 (f"The file `{file_path}` was edited manually.\n  "
-                    f"Try reverting your changes to {file_details['html_url']} to see whether that affects the issue")
+                 f"Try reverting your changes to {file_details['html_url']} to see whether that affects the issue")
             )
 
 show_step("Debugging Details")

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -175,17 +175,18 @@ show_step("Checking IHP files")
 SENSITIVE_FILES = [".ghci", "start", "hie.yaml", "default.nix"]
 with request.urlopen("https://api.github.com/repos/digitallyinduced/ihp-boilerplate/contents/") as response:
     if response.status is not 200:
-        exit("Failed to send GET request to GitHub API")
-
-    deserialized = load(response)
-    for file_details in deserialized:
-        file_path = file_details["path"]
-        if file_path in SENSITIVE_FILES:
-            local_file_sha, _ = run_command(["git", "hash-object", file_path])
-            if local_file_sha.rstrip() != file_details["sha"]:
-                show_warning(
-                    f"Make sure the `{file_path}` file is same as {file_details['html_url']}"
-                )
+        show_failure("Failed to send GET request to GitHub API")
+    else:
+        deserialized = load(response)
+        for file_details in deserialized:
+            file_path = file_details["path"]
+            if file_path in SENSITIVE_FILES:
+                local_file_sha, _ = run_command(
+                    ["git", "hash-object", file_path])
+                if local_file_sha.rstrip() != file_details["sha"]:
+                    show_warning(
+                        f"Make sure the `{file_path}` file is same as {file_details['html_url']}"
+                    )
 
 show_step("Validating and repairing /nix/store/ (could take a minute)")
 

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -188,7 +188,7 @@ with request.urlopen("https://api.github.com/repos/digitallyinduced/ihp-boilerpl
                         f"Make sure the `{file_path}` file is same as {file_details['html_url']}"
                     )
 
-show_step("Validating and repairing /nix/store/ (could take a minute)")
+show_step("Checking and repairing /nix/store/ (could take a minute)")
 
 _, nix_store_troubleshooting_output = run_command(
     ["nix-store", "--verify",

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -57,6 +57,7 @@ def run_command(commands, maybe_input=None) -> CommandOutput:
     command_input = maybe_input.encode('utf-8') if maybe_input else None
     command_output = run(
         commands,
+        check=False,
         input=command_input,
         capture_output=True,
     )

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -2,9 +2,11 @@
 
 from os import path, getcwd, readlink
 from enum import Enum, unique
+from json import load
+from urllib import request
+from pathlib import Path
 from platform import platform
 from subprocess import run
-from pathlib import Path
 
 
 @unique
@@ -12,6 +14,7 @@ class Color(Enum):
     END = "\033[0m"
     RED = "\033[31m"
     BOLD = "\033[1m"
+    BLUE = "\033[34m"
     GREEN = "\033[32m"
 
 
@@ -25,6 +28,10 @@ def show_step(message):
 
 def show_success(message):
     print(show(Color.GREEN, f"+ {message}"))
+
+
+def show_warning(message):
+    print(show(Color.BLUE, f"- {message}"))
 
 
 def show_failure(message):
@@ -162,6 +169,23 @@ with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
         )
     else:
         show_success("No legacy cachix key found")
+
+show_step("Checking IHP files")
+
+SENSITIVE_FILES = [".ghci", "start", "hie.yaml", "default.nix"]
+with request.urlopen("https://api.github.com/repos/digitallyinduced/ihp-boilerplate/contents/") as response:
+    if response.status is not 200:
+        exit("Failed to send GET request to GitHub API")
+
+    deserialized = load(response)
+    for file_details in deserialized:
+        file_path = file_details["path"]
+        if file_path in SENSITIVE_FILES:
+            local_file_sha, _ = run_command(["git", "hash-object", file_path])
+            if local_file_sha.rstrip() != file_details["sha"]:
+                show_warning(
+                    f"Make sure the `{file_path}` file is same as {file_details['html_url']}"
+                )
 
 show_step("Validating and repairing /nix/store/ (could take a minute)")
 

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -46,9 +46,17 @@ def path_exists(file_path, success_message, error_message):
 
 
 def run_command(commands, maybe_input=None):
-    input = maybe_input.encode('utf-8') if maybe_input is not None else None
-    output = run(commands, capture_output=True, input=input)
-    return (output.stdout.decode('utf-8'), output.stderr.decode('utf-8'))
+    command_input = maybe_input.encode(
+        'utf-8') if maybe_input is not None else None
+    command_output = run(
+        commands,
+        input=command_input,
+        capture_output=True,
+    )
+    return (
+        command_output.stdout.decode('utf-8'),
+        command_output.stderr.decode('utf-8')
+    )
 
 
 show_step("Checking that the current directory is an IHP project")
@@ -86,7 +94,8 @@ if f"Found RC path {envrc_path}" in direnv_output:
     show_success("direnv loads .envrc")
 else:
     show_failure(
-        "direnv didn't load the project .envrc. Did you set up direnv in your shell?"
+        ("direnv didn't load the project .envrc. "
+         "Did you set up direnv in your shell?")
     )
 
 if "Found RC allowed true" in direnv_output:
@@ -100,7 +109,8 @@ if "/nix/store" in ghci_path:
     show_success("ghci is loaded from nix store")
 else:
     show_failure(
-        "ghci is not loaded from /nix/store/... Is direnv hooked into your shell?"
+        ("ghci is not loaded from /nix/store/... "
+         "Is direnv hooked into your shell?")
     )
 
 show_step("Checking .ghci")
@@ -128,7 +138,8 @@ if ihp_lib_is_link:
     show_success("Symlink build/ihp-lib exists")
 else:
     show_failure(
-        "Symlink build/ihp-lib is missing. Try 'make build/ihp-lib' to fix this"
+        ("Symlink build/ihp-lib is missing. "
+         "Try 'make build/ihp-lib' to fix this")
     )
 
 ihp_lib_link = readlink("build/ihp-lib") if ihp_lib_is_link else None
@@ -136,7 +147,8 @@ ihp_lib_link = readlink("build/ihp-lib") if ihp_lib_is_link else None
 path_exists(
     ihp_lib_link,
     "Symlink build/ihp-lib target exists",
-    "Symlink build/ihp-lib target directory does not exist. Try `nix-shell --run \"make -B build/ihp-lib\"` to fix this"
+    ("Symlink build/ihp-lib target directory does not exist. "
+     "Try `nix-shell --run \"make -B build/ihp-lib\"` to fix this")
 )
 
 if path.exists("IHP"):
@@ -151,7 +163,7 @@ cachix_output, _ = run_command(["cachix", "--help"])
 if "https://cachix.org command line interface" in cachix_output:
     show_success("Cachix exists")
 else:
-    "Cachix is missing. Is cachix installed?"
+    show_failure("Cachix is missing. Is cachix installed?")
 
 with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
     nix_conf = file.read()
@@ -160,12 +172,14 @@ with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
         show_success("digitallyinduced.cachix.org configured")
     else:
         show_failure(
-            "digitallyinduced.cachix.org binary cache missing. Try 'cachix use digitallyinduced'"
+            ("digitallyinduced.cachix.org binary cache missing. "
+             "Try 'cachix use digitallyinduced'")
         )
 
     if "digitallyinduced.cachix.org-1:3mGU1b6u5obFp2VUfI55Xe8/+mawl7y9Eztu3rb94PI=" in nix_conf:
         show_failure(
-            "Found legacy cachix public key for digitallyinduced.cachix.org. Try to remove digitallyinduced.cachix.org-1:3mGU1b6u5obFp2VUfI55Xe8/+mawl7y9Eztu3rb94PI= from ~/.config/nix/nix.conf"
+            ("Found legacy cachix public key for digitallyinduced.cachix.org. "
+             "Try to remove digitallyinduced.cachix.org-1:3mGU1b6u5obFp2VUfI55Xe8/+mawl7y9Eztu3rb94PI= from ~/.config/nix/nix.conf")
         )
     else:
         show_success("No legacy cachix key found")
@@ -173,8 +187,11 @@ with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
 show_step("Checking IHP files")
 
 SENSITIVE_FILES = [".ghci", "start", "hie.yaml", "default.nix"]
-with request.urlopen("https://api.github.com/repos/digitallyinduced/ihp-boilerplate/contents/") as response:
-    if response.status is not 200:
+api_request = request.Request(
+    "https://api.github.com/repos/digitallyinduced/ihp-boilerplate/contents/"
+)
+with request.urlopen(api_request) as response:
+    if response.status != 200:
         show_failure("Failed to send GET request to GitHub API")
     else:
         deserialized = load(response)
@@ -198,7 +215,8 @@ _, nix_store_troubleshooting_output = run_command(
 
 if "warning: not all errors were fixed" in nix_store_troubleshooting_output:
     show_failure(
-        "Errors where found in /nix/store/, run `rm -rf build; nix-shell --run 'make build/ihp-lib'`"
+        ("Errors where found in /nix/store/, "
+         "run `rm -rf build; nix-shell --run 'make build/ihp-lib'`")
     )
 else:
     show_success("Nix store looks good")

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -1,120 +1,183 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
-function step {
-    echo -e "\e[1m$1:\e[0m"    
-}
-
-function ok {
-    echo -e "\e[32m+ $1\e[0m"
-}
-
-function fail {
-    echo -e "\e[31m- $1\e[0m"
-}
-
-step "Checking that the current directory is an IHP project"
-if test -f Main.hs; then
-    ok "Found Main.hs"
-else
-    fail "Main.hs missing. Is this an IHP project?"
-fi
-
-if test -f start; then
-    ok "Found start"
-else
-    fail "start missing. Is this an IHP project?"
-fi
-
-step "Checking nix"
-if [ -d "/nix" ]; then
-    ok "Nix installed"
-else
-    fail "Nix store not found. Is nix installed?"
-fi
-
-step "Checking direnv"
-if test -f .envrc; then
-    ok "Found .envrc"
-else
-    fail ".envrc missing. Try 'make .envrc'"
-fi
-direnv_output=$(direnv status 2>&1)
-if [[ "$direnv_output" =~ "Found RC path $PWD/.envrc" ]]; then
-    ok "direnv loads .envrc"
-else
-    fail "direnv didn't load the project .envrc. Did you set up direnv in your shell?"
-fi
-which_direnv_output=$(which ghci)
-if [[ "$which_direnv_output" =~ "/nix/store" ]]; then
-    ok "ghci is loaded from nix store"
-else
-    fail "ghci is not loaded from /nix/store/... Is direnv hooked into your shell?"
-fi
-
-step "Checking .ghci"
-if test -f .ghci; then
-    ok "Found .ghci"
-else
-    fail ".ghci missing"
-fi
-
-ghci_output=$(echo 'putStrLn "ok"'|ghci 2>&1)
-if [[ "$ghci_output" =~ ".ghci is writable by someone else" ]]; then
-    fail ".ghci permissions are wrong. Try 'chmod go-w .ghci' to fix this"
-else
-    ok ".ghci permissions are ok"
-fi
-
-step "Checking IHP"
-if [[ -L "build/ihp-lib" ]]; then
-    ok "Symlink build/ihp-lib exists"
-else
-    fail "Symlink build/ihp-lib is missing. Try 'make build/ihp-lib' to fix this"
-fi
-
-ihplib_link=$(readlink -f build/ihp-lib)
-if [ -d "$ihplib_link" ]; then
-    ok "Symlink build/ihp-lib target exists"
-else
-    fail "Symlink build/ihp-lib target directory does not exist. Try 'nix-shell --run \"make -B build/ihp-lib\"' to fix this"
-fi
-
-if [ -d "IHP" ]; then
-    ok "Local IHP directory exists"
-else
-    ok "IHP used from nix"
-fi
+from os import path, getcwd, readlink
+from enum import Enum, unique
+from platform import platform
+from subprocess import run
+from pathlib import Path
 
 
-step "Checking Cachix"
-if [ -d "$HOME/.config/cachix" ]; then
-    ok "Cachix config exists"
-else
-    fail "Cachix config is missing. Is cachix installed?"
-fi
+@unique
+class Color(Enum):
+    END = "\033[0m"
+    RED = "\033[31m"
+    BOLD = "\033[1m"
+    GREEN = "\033[32m"
 
-if [[ "$(cat ~/.config/nix/nix.conf)" =~ "digitallyinduced.cachix.org-1:y+wQvrnxQ+PdEsCt91rmvv39qRCYzEgGQaldK26hCKE=" ]]; then
-    ok "digitallyinduced.cachix.org configured"
-else
-    fail "digitallyinduced.cachix.org binary cache missing. Try 'cachix use digitallyinduced'"
-fi
 
-if [[ "$(cat ~/.config/nix/nix.conf)" =~ "digitallyinduced.cachix.org-1:3mGU1b6u5obFp2VUfI55Xe8/+mawl7y9Eztu3rb94PI=" ]]; then
-    fail "Found legacy cachix public key for digitallyinduced.cachix.org. Try to remove digitallyinduced.cachix.org-1:3mGU1b6u5obFp2VUfI55Xe8/+mawl7y9Eztu3rb94PI= from ~/.config/nix/nix.conf"
-else
-    ok "No legacy cachix key found"
-fi
+def show(color, message):
+    return f"{color.value}{message}{Color.END.value}"
 
-step "Debugging Details"
-step "GHCI Output"
-echo "$ghci_output"
-step "build/ihp-lib Target"
-echo "$ihplib_link"
-step "Direnv Output"
-echo "$direnv_output"
-step "which direnv Output"
-echo "$which_direnv_output"
-step "default.nix"
-head -n5 default.nix
-step "OS"
-uname
+
+def show_step(message):
+    print(show(Color.BOLD, f"{message}:"))
+
+
+def show_success(message):
+    print(show(Color.GREEN, f"+ {message}"))
+
+
+def show_failure(message):
+    print(show(Color.RED, f"- {message}"))
+
+
+def path_exists(file_path, success_message, error_message):
+    if path.exists(file_path):
+        show_success(success_message)
+    else:
+        show_failure(error_message)
+
+
+def run_command(commands, maybe_input=None):
+    input = maybe_input.encode('utf-8') if maybe_input is not None else None
+    return run(commands, capture_output=True, input=input).stdout.decode('utf-8')
+
+
+show_step("Checking that the current directory is an IHP project")
+
+path_exists(
+    "Main.hs",
+    "Found Main.hs",
+    "Main.hs missing. Is this an IHP project?"
+)
+
+path_exists(
+    "start",
+    "Found start script",
+    "start script missing. Is this an IHP project?"
+)
+
+path_exists(
+    "/nix",
+    "Nix installed",
+    "Nix store not found. Is nix installed?"
+)
+
+show_step("Checking direnv")
+
+path_exists(
+    ".envrc",
+    "Found .envrc",
+    ".envrc missing. Try 'make .envrc'"
+)
+
+direnv_output = run_command(["direnv", "status"])
+envrc_path = path.join(getcwd(), ".envrc")
+
+if f"Found RC path {envrc_path}" in direnv_output:
+    show_success("direnv loads .envrc")
+else:
+    show_failure(
+        "direnv didn't load the project .envrc. Did you set up direnv in your shell?"
+    )
+
+if "Found RC allowed true" in direnv_output:
+    show_success("direnv allows .envrc")
+else:
+    show_failure("direnv denied .envrc, run `direnv allow` to allow .envrc")
+
+ghci_path = run_command(["which", "ghci"])
+
+if "/nix/store" in ghci_path:
+    show_success("ghci is loaded from nix store")
+else:
+    show_failure(
+        "ghci is not loaded from /nix/store/... Is direnv hooked into your shell?"
+    )
+
+show_step("Checking .ghci")
+
+path_exists(
+    ".ghci",
+    "Found .ghci",
+    ".ghci missing"
+)
+
+ghci_output = run_command(["ghci", "2>&1"], "putStrLn \"ok\"")
+
+if ".ghci is writable by someone else" in ghci_output:
+    show_failure(
+        ".ghci permissions are wrong. Try 'chmod go-w .ghci' to fix this"
+    )
+else:
+    show_success(".ghci permissions are ok")
+
+show_step("Checking IHP")
+
+if path.islink("build/ihp-lib"):
+    show_success("Symlink build/ihp-lib exists")
+else:
+    show_failure(
+        "Symlink build/ihp-lib is missing. Try 'make build/ihp-lib' to fix this"
+    )
+
+ihp_lib_link = readlink("build/ihp-lib")
+
+path_exists(
+    ihp_lib_link,
+    "Symlink build/ihp-lib target exists",
+    "Symlink build/ihp-lib target directory does not exist. Try `nix-shell --run \"make -B build/ihp-lib\"` to fix this"
+)
+
+if path.exists("IHP"):
+    show_success("Local IHP directory exists")
+else:
+    show_success("IHP used from nix")
+
+show_step("Checking Cachix")
+
+cachix_output = run_command(["cachix", "--help"])
+
+if "https://cachix.org command line interface" in cachix_output:
+    show_success("Cachix exists")
+else:
+    "Cachix is missing. Is cachix installed?"
+
+with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
+    nix_conf = file.read()
+
+    if "digitallyinduced.cachix.org-1:y+wQvrnxQ+PdEsCt91rmvv39qRCYzEgGQaldK26hCKE=" in nix_conf:
+        show_success("digitallyinduced.cachix.org configured")
+    else:
+        show_failure(
+            "digitallyinduced.cachix.org binary cache missing. Try 'cachix use digitallyinduced'"
+        )
+
+    if "digitallyinduced.cachix.org-1:3mGU1b6u5obFp2VUfI55Xe8/+mawl7y9Eztu3rb94PI=" in nix_conf:
+        show_failure(
+            "Found legacy cachix public key for digitallyinduced.cachix.org. Try to remove digitallyinduced.cachix.org-1:3mGU1b6u5obFp2VUfI55Xe8/+mawl7y9Eztu3rb94PI= from ~/.config/nix/nix.conf"
+        )
+    else:
+        show_success("No legacy cachix key found")
+
+show_step("Debugging Details")
+
+show_step("GHCI Output")
+print(ghci_output)
+
+show_step("build/ihp-lib Target")
+print(ihp_lib_link)
+
+show_step("Direnv Output")
+print(direnv_output)
+
+show_step("which direnv Output")
+print(ghci_path)
+
+show_step("default.nix")
+with open("default.nix") as file:
+    head = [next(file) for x in range(5)]
+    print("".join(head))
+
+show_step("OS")
+print(platform())

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -7,6 +7,7 @@ from urllib import request
 from pathlib import Path
 from platform import platform
 from subprocess import run
+from dataclasses import dataclass
 
 
 @unique
@@ -45,16 +46,24 @@ def path_exists(file_path, success_message, error_message):
         show_failure(error_message)
 
 
-def run_command(commands, maybe_input=None):
+@dataclass
+class CommandOutput:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+def run_command(commands, maybe_input=None) -> CommandOutput:
     command_input = maybe_input.encode('utf-8') if maybe_input else None
     command_output = run(
         commands,
         input=command_input,
         capture_output=True,
     )
-    return (
+    return CommandOutput(
         command_output.stdout.decode('utf-8'),
-        command_output.stderr.decode('utf-8')
+        command_output.stderr.decode('utf-8'),
+        command_output.returncode
     )
 
 
@@ -104,7 +113,7 @@ path_exists(
     ".envrc missing. Try 'make .envrc'"
 )
 
-direnv_output, _ = run_command(["direnv", "status"])
+direnv_output = run_command(["direnv", "status"]).stdout
 envrc_path = path.join(getcwd(), ".envrc")
 
 if f"Found RC path {envrc_path}" in direnv_output:
@@ -120,7 +129,7 @@ if "Found RC allowed true" in direnv_output:
 else:
     show_failure("direnv denied .envrc, run `direnv allow` to allow .envrc")
 
-ghci_path, _ = run_command(["which", "ghci"])
+ghci_path = run_command(["which", "ghci"]).stdout
 
 if "/nix/store" in ghci_path:
     show_success("ghci is loaded from nix store")
@@ -138,7 +147,7 @@ path_exists(
     ".ghci missing"
 )
 
-ghci_output, _ = run_command(["ghci", "2>&1"], "putStrLn \"ok\"")
+ghci_output = run_command(["ghci", "2>&1"], "putStrLn \"ok\"").stdout
 
 if ".ghci is writable by someone else" in ghci_output:
     show_failure(
@@ -175,9 +184,9 @@ else:
 
 show_step("Checking Cachix")
 
-cachix_output, _ = run_command(["cachix", "--help"])
+cachix_returncode = run_command(["cachix", "--help"]).returncode
 
-if "https://cachix.org command line interface" in cachix_output:
+if cachix_returncode == 0:
     show_success("Cachix exists")
 else:
     show_failure("Cachix is missing. Is cachix installed?")
@@ -210,9 +219,9 @@ SENSITIVE_FILES = [
 for file_details in boilerplate_contents():
     file_path = file_details["path"]
     if file_path in SENSITIVE_FILES:
-        local_file_sha, _ = run_command(
+        local_file_sha = run_command(
             ["git", "hash-object", file_path]
-        )
+        ).stdout
         if local_file_sha.rstrip() != file_details["sha"]:
             show_warning(
                 (f"The file `{file_path}` was edited manually.\n  "

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -205,22 +205,6 @@ with request.urlopen(api_request) as response:
                         f"Make sure the `{file_path}` file is same as {file_details['html_url']}"
                     )
 
-show_step("Checking and repairing /nix/store/ (could take a minute)")
-
-_, nix_store_troubleshooting_output = run_command(
-    ["nix-store", "--verify",
-     "--check-contents", "--repair",
-     "--quiet", "--no-build-output"]
-)
-
-if "warning: not all errors were fixed" in nix_store_troubleshooting_output:
-    show_failure(
-        ("Errors where found in /nix/store/, "
-         "run `rm -rf build; nix-shell --run 'make build/ihp-lib'`")
-    )
-else:
-    show_success("Nix store looks good")
-
 show_step("Debugging Details")
 
 show_step("GHCI Output")
@@ -242,6 +226,3 @@ with open("default.nix") as file:
 
 show_step("OS")
 print(platform())
-
-show_step("/nix/store/ checksums verification")
-print(nix_store_troubleshooting_output)

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -202,7 +202,8 @@ with request.urlopen(api_request) as response:
                     ["git", "hash-object", file_path])
                 if local_file_sha.rstrip() != file_details["sha"]:
                     show_warning(
-                        f"Make sure the `{file_path}` file is same as {file_details['html_url']}"
+                        (f"The file `{file_path}` was edited manually. "
+                         f"Try reverting your changes to {file_details['html_url']} to see whether that affects the issue")
                     )
 
 show_step("Debugging Details")
@@ -221,7 +222,7 @@ print(ghci_path)
 
 show_step("default.nix")
 with open("default.nix") as file:
-    head = [next(file) for x in range(5)]
+    head = [next(file) for _ in range(5)]
     print("".join(head))
 
 show_step("OS")

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -59,6 +59,24 @@ def run_command(commands, maybe_input=None):
     )
 
 
+def boilerplate_contents():
+    response_data = []
+    base_url = "https://api.github.com/repos/digitallyinduced/ihp-boilerplate"
+    directories = [
+        base_url + "/contents",
+        base_url + "/contents/Config/nix"
+    ]
+    requests = map(request.urlopen, directories)
+    for response in requests:
+        if response.status != 200:
+            show_failure("Failed to send GET request to GitHub API")
+        else:
+            deserialized = load(response)
+            response_data = [*response_data, *deserialized]  # Merge Results
+
+    return response_data
+
+
 show_step("Checking that the current directory is an IHP project")
 
 path_exists(
@@ -186,25 +204,20 @@ with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
 
 show_step("Checking IHP files")
 
-SENSITIVE_FILES = [".ghci", "start", "hie.yaml", "default.nix"]
-api_request = request.Request(
-    "https://api.github.com/repos/digitallyinduced/ihp-boilerplate/contents/"
-)
-with request.urlopen(api_request) as response:
-    if response.status != 200:
-        show_failure("Failed to send GET request to GitHub API")
-    else:
-        deserialized = load(response)
-        for file_details in deserialized:
-            file_path = file_details["path"]
-            if file_path in SENSITIVE_FILES:
-                local_file_sha, _ = run_command(
-                    ["git", "hash-object", file_path])
-                if local_file_sha.rstrip() != file_details["sha"]:
-                    show_warning(
-                        (f"The file `{file_path}` was edited manually. "
-                         f"Try reverting your changes to {file_details['html_url']} to see whether that affects the issue")
-                    )
+SENSITIVE_FILES = [
+    ".ghci", "start", "hie.yaml", "default.nix",
+    "Makefile", "Config/nix/nixpkgs-config.nix"
+]
+for file_details in boilerplate_contents():
+    file_path = file_details["path"]
+    if file_path in SENSITIVE_FILES:
+        local_file_sha, _ = run_command(
+            ["git", "hash-object", file_path])
+        if local_file_sha.rstrip() != file_details["sha"]:
+            show_warning(
+                (f"The file `{file_path}` was edited manually.\n  "
+                    f"Try reverting your changes to {file_details['html_url']} to see whether that affects the issue")
+            )
 
 show_step("Debugging Details")
 

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -3,6 +3,7 @@
 from os import path, getcwd, readlink
 from enum import Enum, unique
 from json import load
+from typing import List, Optional
 from urllib import request
 from pathlib import Path
 from platform import platform
@@ -19,27 +20,31 @@ class Color(Enum):
     GREEN = "\033[32m"
 
 
-def show(color, message):
+def show(color: Color, message: str) -> str:
     return f"{color.value}{message}{Color.END.value}"
 
 
-def show_step(message):
+def show_step(message: str) -> None:
     print(show(Color.BOLD, f"{message}:"))
 
 
-def show_success(message):
+def show_success(message: str) -> None:
     print(show(Color.GREEN, f"+ {message}"))
 
 
-def show_warning(message):
+def show_warning(message: str) -> None:
     print(show(Color.BLUE, f"- {message}"))
 
 
-def show_failure(message):
+def show_failure(message: str) -> None:
     print(show(Color.RED, f"- {message}"))
 
 
-def path_exists(file_path, success_message, error_message):
+def path_exists(
+    file_path: Optional[str],
+    success_message: str,
+    error_message: str
+) -> None:
     if file_path is not None and path.exists(file_path):
         show_success(success_message)
     else:
@@ -53,7 +58,10 @@ class CommandOutput:
     returncode: int
 
 
-def run_command(commands, maybe_input=None) -> CommandOutput:
+def run_command(
+    commands: List[str],
+    maybe_input: Optional[str] = None
+) -> CommandOutput:
     command_input = maybe_input.encode('utf-8') if maybe_input else None
     command_output = run(
         commands,
@@ -68,8 +76,8 @@ def run_command(commands, maybe_input=None) -> CommandOutput:
     )
 
 
-def boilerplate_contents():
-    response_data = []
+def boilerplate_contents() -> List[dict]:
+    response_data: List[dict] = []
     base_url = "https://api.github.com/repos/digitallyinduced/ihp-boilerplate"
     directories = [
         base_url + "/contents",


### PR DESCRIPTION
In preparation for https://github.com/digitallyinduced/ihp/issues/689, I've wanted to make it easier working with the script as it becomes more complex. If a user has bash installed, they most likely also have python.

Also removed this:
```bash
step "Checking Cachix"
if [ -d "$HOME/.config/cachix" ]; then
    ok "Cachix config exists"
else
    fail "Cachix config is missing. Is cachix installed?"
fi
```
When installing `cachix`, it does not create a `~/.config/cachix` directory.

Fixes #689, with https://github.com/digitallyinduced/ihp/issues/689#issuecomment-761710557