### PR TITLE
Faster Builds

### DIFF
--- a/ihp.cabal
+++ b/ihp.cabal
@@ -132,6 +132,7 @@ common shared-properties
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
             -flate-dmd-anal
+            -flate-specialise
             -fmax-worker-args=200
             -fspec-constr-keen
             -fspecialise-aggressively
@@ -316,6 +317,7 @@ executable RunDevServer
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
             -flate-dmd-anal
+            -flate-specialise
             -fmax-worker-args=200
             -fspec-constr-keen
             -fspecialise-aggressively

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -12,6 +12,7 @@ maintainer:          hello@digitallyinduced.com
 build-type:          Simple
 
 Flag FastBuild
+    Default: False
     Description: Disables all optimisations, leads to faster build time
 
 common shared-properties

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -11,8 +11,8 @@ maintainer:          hello@digitallyinduced.com
 -- category:
 build-type:          Simple
 
-Flag FastBuild
-    Description: Disables all optimisations, leads to faster build time
+Flag OptimizedBuild
+    Description: Enables all optimisations, at a cost of longer build time
 
 common shared-properties
     default-language: Haskell2010
@@ -121,13 +121,7 @@ common shared-properties
         , BlockArguments
         , LambdaCase
         , StandaloneDeriving
-    if flag(FastBuild)
-        ghc-options:
-            -j
-            -O0
-            -threaded
-            +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
-    else
+    if flag(OptimizedBuild)
         ghc-options:
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
@@ -144,6 +138,12 @@ common shared-properties
             -O2
             -threaded
             +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
+    else
+        ghc-options:
+            -j
+            -O0
+            -threaded
+            +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
 
 library IHPFramework
     import: shared-properties
@@ -306,13 +306,7 @@ executable RunDevServer
     build-depends: IHPIDE, IHPFramework
     hs-source-dirs: exe
     main-is: IHP/IDE/DevServer.hs
-    if flag(FastBuild)
-        ghc-options:
-            -j
-            -O0
-            -threaded
-            +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
-    else
+    if flag(OptimizedBuild)
         ghc-options:
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
@@ -332,6 +326,12 @@ executable RunDevServer
             -with-rtsopts=-N
             -with-rtsopts=-n4m
             +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
+    else
+        ghc-options:
+            -j
+            -O0
+            -threaded
+            +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
 
 executable new-application
     import: shared-properties

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -11,8 +11,8 @@ maintainer:          hello@digitallyinduced.com
 -- category:
 build-type:          Simple
 
-Flag OptimizedBuild
-    Description: Enables all optimisations, at a cost of longer build time
+Flag FastBuild
+    Description: Disables all optimisations, leads to faster build time
 
 common shared-properties
     default-language: Haskell2010
@@ -121,7 +121,13 @@ common shared-properties
         , BlockArguments
         , LambdaCase
         , StandaloneDeriving
-    if flag(OptimizedBuild)
+    if flag(FastBuild)
+        ghc-options:
+            -j
+            -O0
+            -threaded
+            +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
+    else
         ghc-options:
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
@@ -138,12 +144,6 @@ common shared-properties
             -O2
             -threaded
             +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
-    else
-        ghc-options:
-            -j
-            -O0
-            -threaded
-            +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
 
 library IHPFramework
     import: shared-properties
@@ -306,7 +306,13 @@ executable RunDevServer
     build-depends: IHPIDE, IHPFramework
     hs-source-dirs: exe
     main-is: IHP/IDE/DevServer.hs
-    if flag(OptimizedBuild)
+    if flag(FastBuild)
+        ghc-options:
+            -j
+            -O0
+            -threaded
+            +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
+    else
         ghc-options:
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
@@ -326,12 +332,6 @@ executable RunDevServer
             -with-rtsopts=-N
             -with-rtsopts=-n4m
             +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
-    else
-        ghc-options:
-            -j
-            -O0
-            -threaded
-            +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
 
 executable new-application
     import: shared-properties

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -323,7 +323,6 @@ executable RunDevServer
             -fspec-constr-keen
             -fspecialise-aggressively
             -fstatic-argument-transformation
-            -fstatic-argument-transformation
             -funbox-strict-fields
             -funfolding-use-threshold=16
             -j

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -319,7 +319,7 @@ executable RunDevServer
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
             -flate-dmd-anal
-            -fspec-constr-keen 
+            -fspec-constr-keen
             -fspecialise-aggressively
             -fstatic-argument-transformation
             -threaded

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -123,27 +123,26 @@ common shared-properties
         , StandaloneDeriving
     if flag(FastBuild)
         ghc-options:
-            -O0
-            +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
             -j
+            -O0
             -threaded
+            +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
     else
         ghc-options:
-            -funfolding-use-threshold=16
-            -funbox-strict-fields
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
             -flate-dmd-anal
+            -fmax-worker-args=200
             -fspec-constr-keen
             -fspecialise-aggressively
             -fstatic-argument-transformation
-            -fmax-worker-args=200
-            -threaded
+            -funbox-strict-fields
+            -funfolding-use-threshold=16
             -haddock
             -j
             -O2
+            -threaded
             +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
-
 
 library IHPFramework
     import: shared-properties
@@ -308,28 +307,28 @@ executable RunDevServer
     main-is: IHP/IDE/DevServer.hs
     if flag(FastBuild)
         ghc-options:
-            -O0
-            +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
             -j
+            -O0
             -threaded
+            +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
     else
         ghc-options:
-            -funfolding-use-threshold=16
-            -funbox-strict-fields
             -fconstraint-solver-iterations=100
             -fexpose-all-unfoldings
             -flate-dmd-anal
+            -fmax-worker-args=200
             -fspec-constr-keen
             -fspecialise-aggressively
             -fstatic-argument-transformation
-            -threaded
-            -fmax-worker-args=200
             -fstatic-argument-transformation
-            -with-rtsopts=-A512m
-            -with-rtsopts=-n4m
-            -with-rtsopts=-N
+            -funbox-strict-fields
+            -funfolding-use-threshold=16
             -j
             -O2
+            -threaded
+            -with-rtsopts=-A512m
+            -with-rtsopts=-N
+            -with-rtsopts=-n4m
             +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
 
 executable new-application

--- a/ihp.nix
+++ b/ihp.nix
@@ -57,7 +57,7 @@
 mkDerivation {
   pname = "ihp";
   version = "v0.8.0";
-  src = (import <nixpkgs> {}).nix-gitignore.gitignoreSource [] ./.;
+  src = (import <nixpkgs> { }).nix-gitignore.gitignoreSource [ ] ./.;
   isLibrary = true;
   isExecutable = true;
   allowInconsistentDependencies = true;
@@ -123,8 +123,9 @@ mkDerivation {
   enableLibraryForGhci = true;
   homepage = "https://ihp.digitallyinduced.com";
 
-  # Enable these flags locally for faster builds when hacking on IHP:
-  #
-  # configureFlags = ["--flag FastBuild"];
+  # For faster builds when hacking on IHP:
+  # Commenting this out will build without optimizations
+  configureFlags = [ "--flag -FastBuild" ];
+  # Uncommenting will not generate documentation
   # doHaddock = false;
 }

--- a/ihp.nix
+++ b/ihp.nix
@@ -124,8 +124,8 @@ mkDerivation {
   homepage = "https://ihp.digitallyinduced.com";
 
   # For faster builds when hacking on IHP:
-  # Commenting this out will build without optimizations
-  configureFlags = [ "--flag -FastBuild" ];
+  # Uncommenting will build without optimizations
+  # configureFlags = [ "--flag -OptimizedBuild" ];
   # Uncommenting will not generate documentation
   # doHaddock = false;
 }

--- a/ihp.nix
+++ b/ihp.nix
@@ -124,8 +124,8 @@ mkDerivation {
   homepage = "https://ihp.digitallyinduced.com";
 
   # For faster builds when hacking on IHP:
-  # Commenting this out will build without optimizations
-  configureFlags = [ "--flag -FastBuild" ];
+  # Uncommenting will build without optimizations
+  # configureFlags = [ "--flag FastBuild" ];
   # Uncommenting will not generate documentation
   # doHaddock = false;
 }

--- a/ihp.nix
+++ b/ihp.nix
@@ -124,8 +124,8 @@ mkDerivation {
   homepage = "https://ihp.digitallyinduced.com";
 
   # For faster builds when hacking on IHP:
-  # Uncommenting will build without optimizations
-  # configureFlags = [ "--flag -OptimizedBuild" ];
+  # Commenting this out will build without optimizations
+  configureFlags = [ "--flag -FastBuild" ];
   # Uncommenting will not generate documentation
   # doHaddock = false;
 }

--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -61,7 +61,7 @@ GHC_RTS_FLAGS := -A256m -n2m -N
 
 GHC_OPTIONS=-threaded -i. -ibuild -iConfig -iIHP
 GHC_OPTIONS+= ${GHC_EXTENSIONS}
-GHC_OPTIONS+= -j2
+GHC_OPTIONS+= -j
 GHC_OPTIONS+= -package-env - # https://github.com/digitallyinduced/ihp/issues/130
 
 ifneq ($(GHC_RTS_FLAGS),)


### PR DESCRIPTION
Intended to be merged back into https://github.com/digitallyinduced/ihp/pull/688

~~It seems flags defined in `*.cabal` [default to true](https://cabal.readthedocs.io/en/3.4/setup-commands.html#controlling-flag-assignments), so I've added `-FastBuild` to explicitly define it to false.~~
Also added the `-flate-specialise` flag

~~Since the flags default to true, now it makes more sense to have `OptimizedBuild` instead of `FastBuild`.~~