### PR TITLE
Allow hsx to parse spaces in closing tags

### DIFF
--- a/IHP/HtmlSupport/Parser.hs
+++ b/IHP/HtmlSupport/Parser.hs
@@ -195,7 +195,7 @@ hsxSplicedValue = do
 
 hsxClosingElement name = (hsxClosingElement' name) <?> friendlyErrorMessage
     where
-        friendlyErrorMessage = Text.unpack ("\"</" <> name <> ">\"")
+        friendlyErrorMessage = show (Text.unpack ("</" <> name <> ">"))
         hsxClosingElement' name = do
             _ <- string ("</" <> name)
             space

--- a/IHP/HtmlSupport/Parser.hs
+++ b/IHP/HtmlSupport/Parser.hs
@@ -193,9 +193,15 @@ hsxSplicedValue = do
             Left error -> fail (show error)
     pure (ExpressionValue haskellExpression)
 
-hsxClosingElement name = do
-    _ <- string ("</" <> name <> ">")
-    pure ()
+hsxClosingElement name = (hsxClosingElement' name) <?> friendlyErrorMessage
+    where
+        friendlyErrorMessage = Text.unpack ("\"</" <> name <> ">\"")
+        hsxClosingElement' name = do
+            _ <- string ("</" <> name)
+            space
+            char ('>')
+            pure ()
+
 
 hsxChild = hsxElement <|> hsxSplicedNode <|> hsxText
 


### PR DESCRIPTION
Some people structure their `HTML` code in a way that introduces spaces in
the closing tags. This is valid `HTML`, but the hsx parser will
complain when copying the `HTML` into hsx.

The following should be valid hsx after this change:
```html
<!-- Example 1 -->
<span>
    <i class="fab fa-html5"></i
                        >
</span>

<!-- Example 2 -->
<span>
    <i class="fab fa-html5"></i >
</span>
```
The downside is that the readability of parse failure error messages is
reduced because the closing `>` does not appear as part of the tag.


_Before_:
```
expecting "</div">, identifier, or text
```

_After_:
```
expecting "</div", identifier, or text
```

The difference in the error message causes a test failure (note the missing closing `<`):
```
Failures:

  ./Test/HtmlSupport/ParserSpec.hs:29:13:
  1) HSX Parser should fail on unmatched tags
       expected: "1:7:\n  |\n1 | <div></span>\n  |       ^\nunexpected '/'\nexpecting \"</div>\" or identifier\n"
        but got: "1:7:\n  |\n1 | <div></span>\n  |       ^\nunexpected '/'\nexpecting \"</div\" or identifier\n"

  To rerun use: --match "/HSX Parser/should fail on unmatched tags/"

Randomized with seed 987210073
```

If there is no way to resolve this, we'll need to update the test case and accept the readability trade-off. 

A workaround to this patch would be to use a formatter to get rid of white-space in closing tags, but I find this unsatisfactory as a gap between hsx and valid `HTML` remains.

**Summary**
There is a trade-off in developer ergonomics between the readability of hsx parser error messages and the expectation of the similarity of hsx to valid `HTML`.