### PR TITLE
Add support for SVG elements in hsx

### DIFF
--- a/IHP/HtmlSupport/Parser.hs
+++ b/IHP/HtmlSupport/Parser.hs
@@ -361,7 +361,18 @@ parents = Set.fromList
         , "summary", "sup", "table", "tbody", "td", "textarea", "tfoot", "th"
         , "thead", "time", "title", "tr", "u", "ul", "var", "video"
         , "svg", "path", "text", "circle", "marquee", "blink"
-        , "loading"
+        , "loading", "animate", "animateMotion", "animateTransform"
+        , "clipPath", "defs", "desc", "discard", "ellipse", "feBlend"
+        , "feColorMatrix", "feComponentTransfer", "feComposite"
+        , "feConvolveMatrix", "feDiffuseLighting", "feDisplacementMap"
+        , "feDistantLight", "feDropShadow", "feFlood", "feFuncA", "feFuncB"
+        , "feFuncG", "feFuncR", "feGaussianBlur", "feImage", "feMerge"
+        , "feMergeNode", "feMorphology", "feOffset", "fePointLight"
+        , "feSpecularLighting", "feSpotLight", "feTile", "feTurbulence"
+        , "filter", "foreignObject", "g", "line", "linearGradient", "marker"
+        , "mask", "metadata", "mpath", "path", "pattern", "polygon", "polyline"
+        , "radialGradient", "rect", "set", "stop", "switch", "symbol"
+        , "textPath", "tspan", "unknown", "use", "view"
         ]
 
 leafs :: Set Text


### PR DESCRIPTION
I added all the elements that weren't already in the `parents` list from the link below. I wasn't sure whether to name a new list and/or sort alphabetically, but hopefully it at least checks out functionally.

Element index [reference](https://www.w3.org/TR/SVG2/eltindex.html)

W3C Candidate Recommendation
Appendix F: Element Index
