### PR TITLE
Allow hsx to parse spaces in closing tags

### DIFF
--- a/IHP/HtmlSupport/Parser.hs
+++ b/IHP/HtmlSupport/Parser.hs
@@ -193,9 +193,14 @@ hsxSplicedValue = do
             Left error -> fail (show error)
     pure (ExpressionValue haskellExpression)
 
-hsxClosingElement name = do
-    _ <- string ("</" <> name <> ">")
-    pure ()
+hsxClosingElement name = (hsxClosingElement' name) <?> friendlyErrorMessage
+    where
+        friendlyErrorMessage = show (Text.unpack ("</" <> name <> ">"))
+        hsxClosingElement' name = do
+            _ <- string ("</" <> name)
+            space
+            char ('>')
+            pure ()
 
 hsxChild = hsxElement <|> hsxSplicedNode <|> hsxText
 

--- a/Test/HtmlSupport/ParserSpec.hs
+++ b/Test/HtmlSupport/ParserSpec.hs
@@ -27,3 +27,7 @@ tests = do
             let errorText = "1:7:\n  |\n1 | <div></span>\n  |       ^\nunexpected '/'\nexpecting \"</div>\" or identifier\n"
             let (Left error) = parseHsx position "<div></span>"
             (Megaparsec.errorBundlePretty error) `shouldBe` errorText
+
+        it "should parse a closing tag with spaces" do
+            let p = parseHsx position "<div></div >"
+            p `shouldBe` (Right (Children [Node "div" [] [] False]))


### PR DESCRIPTION
Some people structure their HTML code in a way that introduces spaces in
the closing tags. This is valid HTML, but the hsx parser will
complain when copying the HTML into hsx.

The following should be valid hsx after this change:
```html
<!-- Example 1 -->
<span>
    <i class="fab fa-html5"></i
                        >
</span>

<!-- Example 2 -->
<span>
    <i class="fab fa-html5"></i >
</span>
```