### PR TITLE
forceRedirectToPath

### DIFF
--- a/IHP/Controller/Redirect.hs
+++ b/IHP/Controller/Redirect.hs
@@ -3,7 +3,7 @@ Module: IHP.Controller.Redirect
 Description: redirect helpers
 Copyright: (c) digitally induced GmbH, 2020
 -}
-module IHP.Controller.Redirect (redirectTo, redirectToPath, redirectToUrl) where
+module IHP.Controller.Redirect (redirectTo, redirectToPath, redirectToUrl, forceRedirectToPath) where
 
 import IHP.Prelude
 import qualified Network.Wai.Util
@@ -12,9 +12,12 @@ import IHP.Controller.RequestContext
 import IHP.RouterSupport (HasPath (pathTo))
 import IHP.FrameworkConfig
 import qualified Network.Wai as Wai
+import qualified Data.Text.Encoding as TE
 import Data.String.Conversions (cs)
 import Data.Maybe (fromJust)
 import Network.HTTP.Types (status200, status302)
+import Network.HTTP.Types.Status
+import Network.HTTP.Types.Header (hLocation)
 import GHC.Records
 
 import IHP.Controller.Context
@@ -44,6 +47,18 @@ redirectToPath :: (?context :: ControllerContext) => Text -> IO ()
 redirectToPath path = redirectToUrl (fromConfig baseUrl <> path)
 {-# INLINABLE redirectToPath #-}
 
+-- | like 'redirectToPath', but forcing full page reload
+--
+-- Forces reload by using a custom HTTP OK header mimicking a HTTP redirect
+-- which is used as a signal to the AJAX call to perform page reload.
+-- currently this is a workaround of last resort when you can't make your Javscript 
+-- code behave properly together with morphdom and/or turbolinks
+-- 
+-- use 'forceRedirectToPath (pathTo action)' if you want to redirect to a controller action
+forceRedirectToPath :: (?context :: ControllerContext) => Text -> IO ()
+forceRedirectToPath path = respondAndExit $ Wai.responseLBS (Status 280 "IHP ForceRedirect") [(hLocation,TE.encodeUtf8 (fromConfig baseUrl <> path))] ""
+{-# INLINABLE forceRedirectToPath #-}
+
 -- | Redirects to a url (given as a string)
 -- 
 -- __Example:__
@@ -62,6 +77,7 @@ redirectToUrl url = do
             (Network.Wai.Util.redirect status302 [] parsedUrl)
     respondAndExit redirectResponse
 {-# INLINABLE redirectToUrl #-}
+
 
 -- | Redirects back to the last page
 --

--- a/IHP/Controller/Redirect.hs
+++ b/IHP/Controller/Redirect.hs
@@ -56,7 +56,7 @@ redirectToPath path = redirectToUrl (fromConfig baseUrl <> path)
 -- 
 -- use 'forceRedirectToPath (pathTo action)' if you want to redirect to a controller action
 forceRedirectToPath :: (?context :: ControllerContext) => Text -> IO ()
-forceRedirectToPath path = respondAndExit $ Wai.responseLBS (Status 280 "IHP ForceRedirect") [(hLocation,TE.encodeUtf8 (fromConfig baseUrl <> path))] ""
+forceRedirectToPath path = respondAndExit $ Wai.responseLBS (Status 280 "IHP ForceRedirect") [(hLocation,  cs (fromConfig baseUrl <> path))] ""
 {-# INLINABLE forceRedirectToPath #-}
 
 -- | Redirects to a url (given as a string)

--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -150,10 +150,15 @@ window.submitForm = function (form, possibleClickedButton) {
         if (request.readyState !== request.DONE) {
             return;
         }
-        if (request.status !== 200) {
-            console.error(
-                'Something went wrong, status code: ' + request.status
-            );
+        if (request.status !== 200 && request.status !== 280) {
+            console.error('Something went wrong, status code: ' + request.status);
+        }
+
+        if (280 == request.status){ // see IHP.Controller.Redirect.forceRedirectToPath for motivation
+            // history.pushState({}, '', request.responseURL);
+            var newloc = request.getResponseHeader('Location');
+            location.assign(newloc);
+            return;
         }
 
         if (window.Turbolinks) {


### PR DESCRIPTION
This addition has been discussed in slack a few times.
To keep the footprint small (it is a workaround, after all), I have added just one method instead of the full redirectX-set.
This workaround is mostly useful just for actions and paths anyway.
Very useful when you need it.