### PR TITLE
Flexible Whitespace In Enum Definition

### DIFF
--- a/IDE/IHP/IDE/SchemaDesigner/Parser.hs
+++ b/IDE/IHP/IDE/SchemaDesigner/Parser.hs
@@ -111,7 +111,8 @@ createEnumType = do
     name <- identifier
     lexeme "AS"
     lexeme "ENUM"
-    values <- between (char '(' >> space) (char ')' >> space) (textExpr' `sepBy` (char ',' >> space))
+    values <- between (char '(' >> space) (space >> char ')' >> space) (textExpr' `sepBy` (char ',' >> space))
+    space
     char ';'
     pure CreateEnumType { name, values }
 
@@ -354,12 +355,12 @@ table = [ [ binary  "<>"  NotEqExpression ] ]
         postfix name f = Postfix (f <$ symbol name)
 
 -- | Parses a SQL expression
--- 
+--
 -- This parser makes use of makeExprParser as described in https://hackage.haskell.org/package/parser-combinators-1.2.0/docs/Control-Monad-Combinators-Expr.html
 expression :: Parser Expression
 expression = do
     e <- makeExprParser term table <?> "expression"
-    space 
+    space
     pure e
 
 varExpr :: Parser Expression

--- a/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -144,7 +144,7 @@ tests = do
             parseSql "ALTER TABLE users ADD CONSTRAINT users_ref_company_id FOREIGN KEY (company_id) REFERENCES companies (id) ON DELETE RESTRICT;" `shouldBe` AddConstraint
                     { tableName = "users"
                     , constraintName = "users_ref_company_id"
-                    , constraint = ForeignKeyConstraint 
+                    , constraint = ForeignKeyConstraint
                         { columnName = "company_id"
                         , referenceTable = "companies"
                         , referenceColumn = "id"
@@ -156,7 +156,7 @@ tests = do
             parseSql "ALTER TABLE users ADD CONSTRAINT users_ref_company_id FOREIGN KEY (company_id) REFERENCES companies (id) ON DELETE NO ACTION;" `shouldBe` AddConstraint
                     { tableName = "users"
                     , constraintName = "users_ref_company_id"
-                    , constraint = ForeignKeyConstraint 
+                    , constraint = ForeignKeyConstraint
                         { columnName = "company_id"
                         , referenceTable = "companies"
                         , referenceColumn = "id"
@@ -168,7 +168,7 @@ tests = do
             parseSql "ALTER TABLE users ADD CONSTRAINT users_ref_company_id FOREIGN KEY (company_id) REFERENCES companies (id);" `shouldBe` AddConstraint
                     { tableName = "users"
                     , constraintName = "users_ref_company_id"
-                    , constraint = ForeignKeyConstraint 
+                    , constraint = ForeignKeyConstraint
                         { columnName = "company_id"
                         , referenceTable = "companies"
                         , referenceColumn = "id"
@@ -187,7 +187,10 @@ tests = do
 
         it "should parse CREATE TYPE .. AS ENUM" do
             parseSql "CREATE TYPE colors AS ENUM ('yellow', 'red', 'green');" `shouldBe` CreateEnumType { name = "colors", values = ["yellow", "red", "green"] }
-        
+
+        it "should parse CREATE TYPE .. AS ENUM with extra whitespace" do
+            parseSql "CREATE TYPE Numbers AS ENUM (\n\t'One',\t'Two',\t'Three',\t'Four',\t'Five',\t'Six',\t'Seven',\t'Eight',\t'Nine',\t'Ten'\n);" `shouldBe` CreateEnumType { name = "Numbers", values = ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"] }
+
         -- When creating a new Enum Type, it is empty at first.
         -- Throwing an error for empty Enums renders the visual editor inaccessible.
         -- Catching empty Enums results in the "Create Enum" UI button being useless.

--- a/run-tests
+++ b/run-tests
@@ -1,0 +1,4 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash
+
+runghc $(make -f lib/IHP/Makefile.dist print-ghc-extensions) -iIDE Test/Main.hs


### PR DESCRIPTION
Keep getting parser errors for SQL formatted as:

```sql
CREATE TYPE Stuff AS ENUM (
    'One',
    'Two',
    'Three',
    'Four',
    'Five',
    'Six',
    'Seven',
    'Eight',
    'Nine',
    'Ten'
);
```

Currently IHP only allowed:
```sql
CREATE TYPE Stuff AS ENUM (
    'One',
    'Two',
    'Three',
    'Four',
    'Five',
    'Six',
    'Seven',
    'Eight',
    'Nine',
    'Ten');
```