### PR TITLE
Whitelist the classes attribute

### DIFF
--- a/IHP/HtmlSupport/Parser.hs
+++ b/IHP/HtmlSupport/Parser.hs
@@ -346,7 +346,7 @@ attributes = Set.fromList
         , "stroke-linejoin", "stroke-miterlimit", "stroke-opacity", "stroke-width"
         , "stroke", "text-anchor", "text-decoration", "text-rendering", "unicode-bidi"
         , "visibility", "word-spacing", "writing-mode", "is"
-        , "cellspacing", "cellpadding", "bgcolor"
+        , "cellspacing", "cellpadding", "bgcolor", "classes"
         ]
 
 parents :: Set Text


### PR DESCRIPTION
This allows the use of the htmx [class-tools](https://htmx.org/extensions/class-tools/) Extension.