### PR TITLE
Add GHC_OPTIONS to supress some -Wall warnings for generated file

### DIFF
--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -114,10 +114,9 @@ compileTypes options schema@(Schema statements) =
             in intercalate "\n\n" (map (compileStatement options) statements)
         <> section
     where
-        prelude = "-- This file is auto generated and will be overriden regulary. Please edit `Application/Schema.sql` to change the Types"
-                  <> section
-                  <> "{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, InstanceSigs, MultiParamTypeClasses, TypeFamilies, DataKinds, TypeOperators, UndecidableInstances, ConstraintKinds, StandaloneDeriving  #-}"
-                  <> section
+        prelude = "-- This file is auto generated and will be overriden regulary. Please edit `Application/Schema.sql` to change the Types\n"
+                  <> "{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, InstanceSigs, MultiParamTypeClasses, TypeFamilies, DataKinds, TypeOperators, UndecidableInstances, ConstraintKinds, StandaloneDeriving  #-}\n"
+                  <> "{-# GHC_OPTIONS -Wno-unused-imports, -Wno-dodgy-imports, -Wno-unused-matches #-}"
                   <> "module Generated.Types where\n\n"
                   <> "import IHP.HaskellSupport\n"
                   <> "import IHP.ModelSupport\n"


### PR DESCRIPTION
When setting -Wall in .ghci, I get a bunch of warnings in build/Generated/Types.hs which essentially can't be suppressed since they're constantly re-generated. This adds a GHC_OPTIONS pragma to suppress them.

As a side note, I also get the following warning; is this intentional, or should `hiding (Field)` be removed?
```
build/Generated/Types.hs:16:1: warning: [-Wdodgy-imports]
    Module ‘Database.PostgreSQL.Simple.ToField’ does not export ‘Field’
   |
16 | import Database.PostgreSQL.Simple.ToField hiding (Field)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```