### PR TITLE
Ignore Global Packages When Running Haddock

### DIFF
--- a/build-haddock
+++ b/build-haddock
@@ -42,4 +42,6 @@ haddock --html --hyperlinked-source --built-in-themes --quickjump -o haddock-bui
     --optghc="-XFunctionalDependencies" \
     --optghc="-package typerep-map" \
     --optghc="-XDefaultSignatures" \
-    --optghc="-XStandaloneDeriving"
+    --optghc="-XStandaloneDeriving" \
+    --optghc="-package-env -"
+


### PR DESCRIPTION
Maybe we need a single file with all GHC options. Or maybe GHC supports a variable we could set, something like `export GHC_OPTIONS=''` and all instance of GHC will use it.