### PR TITLE
remove bad commas from OPTIONS_GHC pragma

### DIFF
--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -116,7 +116,7 @@ compileTypes options schema@(Schema statements) =
     where
         prelude = "-- This file is auto generated and will be overriden regulary. Please edit `Application/Schema.sql` to change the Types\n"
                   <> "{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, InstanceSigs, MultiParamTypeClasses, TypeFamilies, DataKinds, TypeOperators, UndecidableInstances, ConstraintKinds, StandaloneDeriving  #-}\n"
-                  <> "{-# OPTIONS_GHC -Wno-unused-imports, -Wno-dodgy-imports, -Wno-unused-matches #-}\n"
+                  <> "{-# OPTIONS_GHC -Wno-unused-imports -Wno-dodgy-imports -Wno-unused-matches #-}\n"
                   <> "module Generated.Types where\n\n"
                   <> "import IHP.HaskellSupport\n"
                   <> "import IHP.ModelSupport\n"


### PR DESCRIPTION
I was debugging IHP for some other reason, when I realized my earlier "fix" (https://github.com/digitallyinduced/ihp/pull/797) didn't fully fix the issue. I've made sure this time that this actually gets the warnings removed...