### PR TITLE
Add  Hoogle(/Haddock) support

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -1,9 +1,13 @@
-{ compiler ? "ghc8103", ihp, haskellDeps ? (p: []), otherDeps ? (p: []), projectPath ? ./. }:
+{ compiler ? "ghc8103", ihp, haskellDeps ? (p: []), otherDeps ? (p: []), projectPath ? ./., withHoogle ? false }:
 
 let
     pkgs = import "${toString projectPath}/Config/nix/nixpkgs-config.nix" { ihp = ihp; };
     ghc = pkgs.haskell.packages.${compiler};
-    allHaskellPackages = ghc.ghcWithPackages (p: builtins.concatLists [ [p.haskell-language-server] (haskellDeps p) ] );
+    allHaskellPackages =
+      (if withHoogle
+      then ghc.ghcWithHoogle
+      else ghc.ghcWithPackages)
+        (p: builtins.concatLists [ [p.haskell-language-server] (haskellDeps p) ] );
     allNativePackages = builtins.concatLists [ (otherDeps pkgs) [pkgs.postgresql] (if pkgs.stdenv.isDarwin then [] else []) ];
 in
     pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
One pain point I've had developing with IHP is that I would often need to google various functions to look up their type signature. Having a Hoogle instance that's built along with IHP will make it much easier for discovering functions and type signatures (especially so since IHP provides a custom Prelude).

I can imagine enabling this by default and putting a link in the dev server UI, but one drawback to this would be increased build time. I imagine cachix alleviates this to some extent, but I don't think there's no getting around `make -B .envrc` taking a bit longer when adding custom Haskell packages. What do the devs think?