### PR TITLE
Unique enum values

### DIFF
--- a/IHP/IDE/SchemaDesigner/Controller/EnumValues.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/EnumValues.hs
@@ -26,9 +26,16 @@ instance Controller EnumValuesController where
         render NewEnumValueView { .. }
 
     action CreateEnumValueAction = do
+        statements <- readSchema
         let enumName = param "enumName"
         let enumValueName = param "enumValueName"
-        updateSchema (map (addValueToEnum enumName enumValueName))
+        let enumValuesInUse = getAllEnumValues statements
+        let validationResult = enumValueName |> validateAll [nonEmptyEnumValue, isUniqueEnumValue enumValuesInUse Nothing]
+        case validationResult of 
+            Failure message -> 
+                setErrorMessage message
+            Success ->  
+                updateSchema (map (addValueToEnum enumName enumValueName))
         redirectTo ShowEnumAction { .. }
 
     action EditEnumValueAction { .. } = do
@@ -48,10 +55,13 @@ instance Controller EnumValuesController where
         let enum = findStatementByName enumName statements
         let values = maybe [] (get #values) enum
         let value = values !! valueId
-        when (newValue == "") do
-            setErrorMessage ("Column Name can not be empty")
-            redirectTo ShowEnumAction { enumName }
-        updateSchema (map (updateValueInEnum enumName newValue valueId))
+        let enumValuesInUse = getAllEnumValues statements
+        let validationResult = newValue |> validateAll [nonEmptyEnumValue, isUniqueEnumValue enumValuesInUse (Just value)]
+        case validationResult of
+            Failure message ->
+                setErrorMessage message
+            Success ->
+                updateSchema (map (updateValueInEnum enumName newValue valueId))
         redirectTo ShowEnumAction { .. }
 
     action DeleteEnumValueAction { .. } = do
@@ -75,3 +85,18 @@ deleteValueInEnum :: Text -> Int -> Statement -> Statement
 deleteValueInEnum enumName valueId (table@CreateEnumType { name, values }) | name == enumName =
     table { values = delete (values !! valueId) values}
 deleteValueInEnum enumName valueId statement = statement
+
+nonEmptyEnumValue :: Validator Text
+nonEmptyEnumValue "" = Failure "Enum Value cannot be empty" 
+nonEmptyEnumValue _  = Success
+
+isUniqueEnumValue :: [Text] -> Maybe Text -> Validator Text
+isUniqueEnumValue enumValuesInUse oldEnumValue enumValue 
+    | enumValue `elem` enumValuesInUse && Just enumValue /= oldEnumValue  = Failure "Enum Value must be globally unique"
+    | otherwise                                                           = Success
+
+getAllEnumValues :: [Statement] -> [Text]
+getAllEnumValues statements = concat $ mapMaybe extractEnumValues statements 
+    where 
+        extractEnumValues CreateEnumType { values } = Just values
+        extractEnumValues _                         = Nothing 

--- a/IHP/IDE/SchemaDesigner/Controller/EnumValues.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/EnumValues.hs
@@ -6,16 +6,8 @@ import IHP.IDE.ToolServer.Types
 import IHP.IDE.SchemaDesigner.View.EnumValues.New
 import IHP.IDE.SchemaDesigner.View.EnumValues.Edit
 
-import IHP.IDE.SchemaDesigner.Parser
-import IHP.IDE.SchemaDesigner.Compiler
 import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.SchemaDesigner.View.Layout (findStatementByName, findStatementByName, removeQuotes, replace)
-import qualified IHP.SchemaCompiler as SchemaCompiler
-import qualified System.Process as Process
-import IHP.IDE.SchemaDesigner.Parser (schemaFilePath)
-import qualified Data.Text.IO as Text
-import IHP.IDE.SchemaDesigner.Controller.Schema
-import IHP.IDE.SchemaDesigner.View.Layout
+import IHP.IDE.SchemaDesigner.View.Layout (findStatementByName, replace, schemaDesignerLayout)
 import IHP.IDE.SchemaDesigner.Controller.Helper
 
 instance Controller EnumValuesController where

--- a/Test/IDE/SchemaDesigner/Controller/EnumValuesSpec.hs
+++ b/Test/IDE/SchemaDesigner/Controller/EnumValuesSpec.hs
@@ -1,0 +1,33 @@
+module Test.IDE.SchemaDesigner.Controller.EnumValuesSpec where
+
+import Test.Hspec
+import IHP.Prelude 
+import IHP.IDE.SchemaDesigner.Controller.EnumValues
+import IHP.ValidationSupport.Types 
+import IHP.IDE.SchemaDesigner.Types
+
+tests :: SpecWith ()
+tests = do 
+    describe "IHP.IDE.SchemaDesigner.Controller.EnumValues" do
+        describe "the isUniqueEnumValue validator" do
+            it "should handle cases wihout old enum value" do
+                isUniqueEnumValue [] Nothing "hello" `shouldBe` Success
+                isUniqueEnumValue ["hi", "bye"] Nothing "hello" `shouldBe` Success 
+                isUniqueEnumValue ["hi"] Nothing "hi" `shouldSatisfy` isFailure
+            it "should handle cases with old enum value" do
+                isUniqueEnumValue ["bye"] (Just "bye") "hello" `shouldBe` Success
+                isUniqueEnumValue ["bye", "hi"] (Just "hi") "hi" `shouldBe` Success
+                isUniqueEnumValue ["bye", "hi"] (Just "bye") "hi" `shouldSatisfy` isFailure
+
+        describe "getAllEnumValues" do 
+            it "should return a list of all enum values" do
+                getAllEnumValues [] `shouldBe` []
+                getAllEnumValues [ CreateExtension { name ="a", ifNotExists = True } ] `shouldBe` []
+                getAllEnumValues [ CreateEnumType { name = "first_enum", values=["a", "b", "c"] }] `shouldBe` ["a", "b", "c"]
+                getAllEnumValues 
+                    [ CreateEnumType {name = "first_enum", values = ["a", "b"]}
+                    , CreateExtension {name = "extension", ifNotExists = True}
+                    , CreateEnumType {name = "second_enum", values = ["c"]}
+                    , CreateEnumType {name = "third_enum", values = []}
+                    ]
+                    `shouldBe` ["a","b","c"]

--- a/Test/Main.hs
+++ b/Test/Main.hs
@@ -18,6 +18,7 @@ import IHP.Prelude
 
 import qualified Test.IDE.SchemaDesigner.CompilerSpec
 import qualified Test.IDE.SchemaDesigner.ParserSpec
+import qualified Test.IDE.SchemaDesigner.Controller.EnumValuesSpec
 import qualified Test.ValidationSupport.ValidateFieldSpec
 import qualified Test.IDE.CodeGeneration.ControllerGenerator
 import qualified Test.IDE.CodeGeneration.ViewGenerator
@@ -40,6 +41,7 @@ main :: IO ()
 main = hspec do
     Test.IDE.SchemaDesigner.CompilerSpec.tests
     Test.IDE.SchemaDesigner.ParserSpec.tests
+    Test.IDE.SchemaDesigner.Controller.EnumValuesSpec.tests
     Test.ValidationSupport.ValidateFieldSpec.tests
     Test.IDE.CodeGeneration.ControllerGenerator.tests
     Test.IDE.CodeGeneration.ViewGenerator.tests


### PR DESCRIPTION
This change ensures that enum values created or updated via EnumValuesController are both non-empty and unique. 

Fixes #782 