### PR TITLE
LoginSupport Helper View

### DIFF
--- a/IHP/LoginSupport/Helper/View.hs
+++ b/IHP/LoginSupport/Helper/View.hs
@@ -1,6 +1,8 @@
 module IHP.LoginSupport.Helper.View
 ( currentUser
 , currentUserOrNothing
+, currentAdmin
+, currentAdminOrNothing
 )
 where
 
@@ -13,3 +15,9 @@ currentUser = fromMaybe (error "Application.Helper.View.currentUser: Not logged 
 
 currentUserOrNothing :: forall user. (?context :: ControllerContext, user ~ CurrentUserRecord, Typeable user) => Maybe user
 currentUserOrNothing = fromFrozenContext @(Maybe user)
+
+currentAdmin :: (?context :: ControllerContext, admin ~ CurrentAdminRecord, Typeable admin) => admin
+currentAdmin = fromMaybe (error "Application.Helper.View.currentAdmin: Not logged in") currentAdminOrNothing
+
+currentAdminOrNothing :: forall admin. (?context :: ControllerContext, admin ~ CurrentAdminRecord, Typeable admin) => Maybe admin
+currentAdminOrNothing = fromFrozenContext @(Maybe admin)

--- a/IHP/LoginSupport/Helper/View.hs
+++ b/IHP/LoginSupport/Helper/View.hs
@@ -8,7 +8,7 @@ where
 
 import IHP.Prelude
 import IHP.Controller.Context
-import IHP.LoginSupport.Helper.Controller (CurrentUserRecord)
+import IHP.LoginSupport.Helper.Controller (CurrentUserRecord, CurrentAdminRecord)
 
 currentUser :: (?context :: ControllerContext, user ~ CurrentUserRecord, Typeable user) => user
 currentUser = fromMaybe (error "Application.Helper.View.currentUser: Not logged in") currentUserOrNothing


### PR DESCRIPTION
Previously didn't have LoginSupport View helper equivalent for `currentAdminOrNothing` and `currentAdmin`. This is just boilerplate that would otherwise be added in the application level. Only requires import `CurrentAdminRecord` type family and exporting the helper functions.

Non-breaking change. 

Tested by creating small IHP application with Admin Authentication and expected View rendering on Admin Sessions.