### PR TITLE
Add support for Integer ID types

### DIFF
--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -136,6 +136,16 @@ pathTo (MyController []) ==> "/Default"
 pathTo (MyController [1,2,3]) ==> "/Default?listParam=1,2,3"
 ```
 
+## For Integer ID types
+
+AutoRoute needs some help if your model does not use UUID as the id type and uses an integer based type instead. To get this to work, add the following to the
+`AutoRoute` instance declarations for each controller that needs to parse an integer ID type as an argument:
+
+```haskell
+instance AutoRoute TestController where
+    autoRoute = autoRouteWithIdType (parseIntegerId @(Id ModelType))
+```
+
 ### Request Methods
 
 When an action is named a certain way, AutoRoute will pick a certain request method for the route. E.g. for a `DeletePostAction` it will only allow requests with the request method `DELETE` because the action name starts with `Delete`. Here is an overview of all naming patterns and their corresponding request method:

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -616,13 +616,13 @@ didChange field record = didTouchField && didChangeField
             |> get #meta
             |> get #touchedFields
             |> includes (cs $! symbolVal field)
-        
+
         didChangeField :: Bool
         didChangeField = originalFieldValue /= fieldValue
 
         fieldValue :: fieldValue
         fieldValue = record |> getField @fieldName
-        
+
         originalFieldValue :: fieldValue
         originalFieldValue =
             record


### PR DESCRIPTION
Currently AutoRoute can't handle non-UUID ID types. This introduces the ability for custom ID parsing through Type Application, and changes AutoRoute to be a wrapper around a new function

```haskell
 autoRouteWithIdType :: (?context :: RequestContext, Data idType) => (ByteString -> Maybe idType) -> Parser controller
```

This allows for passing in a function which can convert to another ID type, such as the included `parseIntegerId`

```haskell
parseIntegerId :: (Data idType) => ByteString -> Maybe idType
parseIntegerId queryVal = let
    rawValue :: Maybe Integer = readMay (cs queryVal :: String)
    in
       rawValue >>= Just . unsafeCoerce
```

Users need to manually tell AutoRoute which custom Id type in needs to parse in the instance declaration:

```haskell
instance AutoRoute TestController where
    autoRoute = autoRouteWithIdType (parseIntegerId @(Id ModelType))
```

If no custom types are parsed then this is not needed. This is not a breaking change.
