### PR TITLE
Uncomment background workers

### DIFF
--- a/Guide/jobs.markdown
+++ b/Guide/jobs.markdown
@@ -38,7 +38,7 @@ instance Job EmailCustomersJob where
     perform EmailCustomersJob { .. } = do
       customers <- query @Customer |> fetch
       forEach customers sendToCustomer
-      where 
+      where
         sendToCustomer customer = sendMail (MarketingMail customer)
 ```
 
@@ -55,6 +55,8 @@ This can be done in a controller action or in a script as will be shown below.
 #### Development vs. Production
 
 In development mode, these watchers are started with the dev server. In production however, use `make build/bin/RunJobs` to build a binary that you can deploy along side your IHP app to watch for added jobs and run them.
+
+**NOTE: Jobs running automatically in development are currently broken on v0.9. Please run on master if you need this until the next release**
 
 ### Viewing job status
 

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -54,13 +54,13 @@ run configBuilder = do
     staticMiddleware <- initStaticMiddleware frameworkConfig
     let requestLoggerMiddleware = get #requestLoggerMiddleware frameworkConfig
 
-    let run = withBackgroundWorkers frameworkConfig do
-        runServer frameworkConfig $
-            staticMiddleware $
-                sessionMiddleware $
-                        requestLoggerMiddleware $
-                                methodOverridePost $
-                                    application
+    let run = withBackgroundWorkers frameworkConfig $
+            runServer frameworkConfig $
+                staticMiddleware $
+                    sessionMiddleware $
+                            requestLoggerMiddleware $
+                                    methodOverridePost $
+                                        application
 
     run `finally` do
         frameworkConfig |> get #logger |> get #cleanup

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -54,8 +54,8 @@ run configBuilder = do
     staticMiddleware <- initStaticMiddleware frameworkConfig
     let requestLoggerMiddleware = get #requestLoggerMiddleware frameworkConfig
 
-    -- let run = withBackgroundWorkers frameworkConfig do
-    let run = runServer frameworkConfig $
+    let run = withBackgroundWorkers frameworkConfig do
+        runServer frameworkConfig $
             staticMiddleware $
                 sessionMiddleware $
                         requestLoggerMiddleware $


### PR DESCRIPTION
Fixes #816 

some development code made its way through to master -- I comment out background workers when running in ghci since when running the server in ghci with background workers you're unable to CTRL-C to stop execution for some reason