### PR TITLE
Link to current nix.trustedUsers docs

### DIFF
--- a/Guide/installation.markdown
+++ b/Guide/installation.markdown
@@ -136,7 +136,7 @@ You have to add this to your NixOS configuration:
 nix.trustedUsers = [ "root" "USERNAME_HERE" ];
 ```
 
-[See the documentation for `nix.trustedUsers` to learn more about what this is doing](https://github.com/NixOS/nixpkgs/blob/db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6/nixos/modules/services/misc/nix-daemon.nix#L319).
+[See the documentation for `nix.trustedUsers` to learn more about what this is doing](https://search.nixos.org/options?show=nix.trustedUsers&query=nix.trustedUsers).
 
 ## 3. Next
 


### PR DESCRIPTION
Link to [current `nix.trustedUsers` documentation](https://search.nixos.org/options?show=nix.trustedUsers&query=nix.trustedUsers) instead of to a hard-coded revision of the source code of it.