### PR TITLE
Jobs dashboard

### DIFF
--- a/Guide/jobs.markdown
+++ b/Guide/jobs.markdown
@@ -162,21 +162,21 @@ Most views in the dashboard can be customized by providing a custom implementati
 These methods can be overriden to allow for custom behavior:
 
 ```haskell
-makeSection :: (?modelContext :: ModelContext) => IO SomeView
+makeSection :: (?context::ControllerContext, ?modelContext::ModelContext) => IO SomeView
 ```
 
 How this job's section should be displayed in the dashboard. By default it's displayed as a table,
 but this can be any arbitrary view! Make some cool graphs :)
 
 ```haskell
-makeDetailView :: (?modelContext :: ModelContext) => job -> IO SomeView
+makeDetailView :: (?context::ControllerContext, ?modelContext::ModelContext) => job -> IO SomeView
 ```
 The content of the page that will be displayed for a detail view of this job.
 By default, the ID, Status, Created/Updated at times, and last error are displayed.
 Can be defined as any arbitrary view.
 
 ```haskell
-makeNewJobView :: (?modelContext :: ModelContext) => IO SomeView
+makeNewJobView :: (?context::ControllerContext, ?modelContext::ModelContext) => IO SomeView
 ```
 The content of the page that will be displayed for the "new job" form of this job.
 By default, only the submit button is rendered. For additonal form data, define your own implementation.
@@ -188,7 +188,7 @@ createNewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO
 ```
 The action run to create and insert a new value of this job into the database.
 By default, create an empty record and insert it.
-To add more data, define your own implementation.
+To add more data, define your own implementation. See the case study below for a real world example.
 
 ### TableViewable
 
@@ -263,3 +263,6 @@ instance {-# OVERLAPS #-} DisplayableJob InitialScrapeJob where
         newRecord @InitialScrapeJob |> set #bandId bandId |> create
         pure ()
 ```
+
+Since `InitialScrapeJob` also matches the constraints for a DisplayableJob, we need to add the `{-# OVERLAPS #-}` tag
+to tell GHC it's okay that this instance overlaps with the original.

--- a/Guide/jobs.markdown
+++ b/Guide/jobs.markdown
@@ -215,7 +215,9 @@ See the below case study for how to implement your own instance.
 
 ### Case study: Attics app
 
-One common use to to show some data from a record the job belongs to. Here's how it's done in the Attics app, for example:
+One common use to to show some data from a record the job belongs to. Here's how it's done in the Attics app, for example.
+In this case, each "Initial Scrape Job" is run for a single band. I wanted to display the name of the band in the table for the job to
+make the table more useful. So I defined a TableViewable instance for `InitialScrapeJob` with its band info included.
 
 ``` haskell
 instance TableViewable (IncludeWrapper "bandId" InitialScrapeJob) where
@@ -355,3 +357,6 @@ instance FrontController AdminApplication where
         , parseRoute @BandsController
         , parseRoute @AtticsJobDashboard
         ]
+```
+
+If you use many of these custom jobs, it'll be worth abstracting some of the HTML in these functions to avoid excessive duplication.

--- a/Guide/jobs.markdown
+++ b/Guide/jobs.markdown
@@ -98,6 +98,8 @@ you want displayed in the dashboard, you construct a custom JobDashboard type th
 
 ### Quick Start
 
+In one of the `FrontController.hs` files for your project (for example, `Web/FrontController.hs` by default), define a type for your dashboard.
+
 ```haskell
 import IHP.Job.Dashboard
 
@@ -106,8 +108,7 @@ type MyJobDashboard = JobsDashboardController
     [UpdateUserJob, CleanDatabaseJob, OtherRandomJob]
 ```
 
-To add the dashboard to your application, you need to add a `parseRoute` call in one of your FrontControllers.
-For example, in `Web/FrontController.hs`, use this type as follows:
+To add the dashboard to your application, you need to add a `parseRoute` call to this type.
 
 ```haskell
 type MyJobDashboard = JobsDashboardController

--- a/Guide/jobs.markdown
+++ b/Guide/jobs.markdown
@@ -91,3 +91,175 @@ We can then create a cron entry such as
 to schedule a job to be run every day at 5am. See [this article by DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-use-cron-to-automate-tasks-ubuntu-1804) for more information on `cron`.
 
 
+## Jobs Dashboard
+
+IHP comes with a built in jobs dashboard for running and viewing your jobs. To define which jobs
+you want displayed in the dashboard, you construct a custom JobDashboard type that IHP will use to determine the dashboard's behavior.
+
+### Quick Start
+
+```haskell
+import IHP.Job.Dashboard
+
+type MyJobDashboard = JobsDashboardController
+    (BasicAuthStatic "jobs" "jobs")
+    [UpdateUserJob, CleanDatabaseJob, OtherRandomJob]
+```
+
+To add the dashboard to your application, you need to add a `parseRoute` call in one of your FrontControllers.
+For example, in `Web/FrontController.hs`, use this type as follows:
+
+```haskell
+type MyJobDashboard = JobsDashboardController
+    (BasicAuthStatic "jobs" "jobs")
+    [UpdateUserJob, CleanDatabaseJob, OtherRandomJob]
+
+instance FrontController WebApplication where
+    controllers =
+        [ startPage HomeView
+        , parseRoute @ProductsController
+        , parseRoute @MyJobDashboard
+        ]
+```
+
+This will mount a jobs dashboard under `/jobs/`.
+
+### Authentication
+
+The second type parameter to `JobsDashboardController` is a type that defines how users should be authenticated when visiting any of the jobs pages.
+IHP provides three types for common use cases.
+- `NoAuth`: No authentication
+- `BasicAuth`: HTTP Basic Auth using environment variables
+- `BasicAuthStatic`: HTTP Basic Auth using static values
+
+To use your own authentication, create an empty type and define an instance of `AuthenticationMethod` for it. Example:
+
+```haskell
+data CustomAuth
+instance AuthenticationMethod CustomAuth where
+    authenticate = do
+        myCustomAuthenticateFunction
+```
+
+Then use it in the dashboard type definition.
+
+```haskell
+type MyJobDashboard = JobsDashboardController
+    CustomAuth
+    [UpdateUserJob, CleanDatabaseJob, OtherRandomJob]
+```
+
+### Jobs to include
+
+The third type parameter to `JobsDashboardController` is a list of job types that the dashboard will display. If you create a job type through the IHP IDE,
+you can just add the name of the generated type to the list and it will be added to the dashboard with a default implementation.
+
+Any type that conforms to `DisplayableJob` can be added to the dashboard. See the documentation for `IHP.Job.Dashboard` for details.
+
+### Customize views
+
+Most views in the dashboard can be customized by providing a custom implementation of `DisplayableJob` for your job type.
+These methods can be overriden to allow for custom behavior:
+
+```haskell
+makeSection :: (?modelContext :: ModelContext) => IO SomeView
+```
+
+How this job's section should be displayed in the dashboard. By default it's displayed as a table,
+but this can be any arbitrary view! Make some cool graphs :)
+
+```haskell
+makeDetailView :: (?modelContext :: ModelContext) => job -> IO SomeView
+```
+The content of the page that will be displayed for a detail view of this job.
+By default, the ID, Status, Created/Updated at times, and last error are displayed.
+Can be defined as any arbitrary view.
+
+```haskell
+makeNewJobView :: (?modelContext :: ModelContext) => IO SomeView
+```
+The content of the page that will be displayed for the "new job" form of this job.
+By default, only the submit button is rendered. For additonal form data, define your own implementation.
+See 'GenericNewJobView' for a guide on how it can look.look
+Can be defined as any arbitrary view, but it should be a form.
+
+```haskell
+createNewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+```
+The action run to create and insert a new value of this job into the database.
+By default, create an empty record and insert it.
+To add more data, define your own implementation.
+
+### TableViewable
+
+The jobs dashboard provides a `TableViewable` type class that makes it easier to customize the appearance of jobs in the dashboard.
+The typeclass defines behavior for how the type should be rendered as a table.
+
+```haskell
+class TableViewable a where
+    tableTitle :: Text
+    tableHeaders :: [Text]
+    createNewForm :: Html
+    renderTableRow :: a -> Html
+    renderTable :: [a] -> Html
+```
+
+See the below case study for how to implement your own instance.
+
+### Case study: Attics app
+
+One common use to to show some data from a record the job belongs to. Here's how it's done in the Attics app, for example:
+
+``` haskell
+instance TableViewable (IncludeWrapper "bandId" InitialScrapeJob) where
+    tableTitle = "Initial Scrape Job"
+    tableHeaders = ["Band", "Updated at", "Status", ""]
+    createNewForm = newJobFormForTableHeader @InitialScrapeJob
+    renderTableRow (IncludeWrapper job) =
+        let
+            table = tableName @InitialScrapeJob
+            linkToView :: Text = "/jobs/ViewJob?tableName=" <> table <> "&id=" <> tshow (get #id job)
+        in [hsx|
+        <tr>
+            <td>{job |> get #bandId |> get #name}</td>
+            <td>{get #updatedAt job}</td>
+            <td>{statusToBadge $ get #status job}</td>
+            <td><a href={linkToView} class="text-primary">Show</a></td>
+        </tr>
+    |]
+```
+
+Note the use of `IncludeWrapper` instead of the normal `Include`. This gets around an unfortunate limitation in Haskell's type system.
+This instance is then used by a custom `DisplayableJob` instance that handles the logic of fetching the parent records.
+
+```haskell
+instance {-# OVERLAPS #-} DisplayableJob InitialScrapeJob where
+    makeSection :: (?modelContext :: ModelContext) => IO SomeView
+    makeSection = do
+        jobsWithBand <- query @InitialScrapeJob
+            |> fetch
+            >>= mapM (fetchRelated #bandId)
+            >>= pure . map (IncludeWrapper @"bandId" @InitialScrapeJob)
+        pure (SomeView (TableView jobsWithBand))
+
+    makeDetailView :: (?modelContext :: ModelContext) => InitialScrapeJob -> IO SomeView
+    makeDetailView job = do
+        pure $ SomeView $ InitialScrapeJobForm job
+
+    makeNewJobView = do
+        bands <- query @Band |> fetch
+        pure $ SomeView $ HtmlView $ form newRecord bands
+        where
+            form :: InitialScrapeJob -> [Band] -> Html
+            form job bands = formFor' job "/jobs/CreateJob" [hsx|
+                {selectField #bandId bands}
+                <input type="hidden" id="tableName" name="tableName" value={getTableName job}>
+                <button type="submit" class="btn btn-primary">Run again</button>
+            |]
+
+    createNewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    createNewJob = do
+        let bandId = param "bandId"
+        newRecord @InitialScrapeJob |> set #bandId bandId |> create
+        pure ()
+```

--- a/IHP/Controller/Render.hs
+++ b/IHP/Controller/Render.hs
@@ -34,19 +34,19 @@ respondSvg :: (?context :: ControllerContext) => Html -> IO ()
 respondSvg html = respondAndExit $ responseBuilder status200 [(hContentType, "image/svg+xml"), (hConnection, "keep-alive")] (Blaze.renderHtmlBuilder html)
 {-# INLINABLE respondSvg #-}
 
-renderHtml :: forall viewContext view controller. (ViewSupport.View view, ?theAction :: controller, ?context :: ControllerContext, ?modelContext :: ModelContext) => view -> IO Html
+renderHtml :: forall viewContext view controller. (ViewSupport.View view, ?context :: ControllerContext, ?modelContext :: ModelContext) => view -> IO Html
 renderHtml !view = do
     let ?view = view
 
     ViewSupport.beforeRender view
 
     frozenContext <- Context.freeze ?context
-    
+
     let ?context = frozenContext
     let layout = case Context.maybeFromFrozenContext @ViewLayout of
             Just (ViewLayout layout) -> layout
             Nothing -> id
-    
+
     let boundHtml = let ?context = frozenContext in layout (ViewSupport.html ?view)
     pure boundHtml
 {-# INLINABLE renderHtml #-}
@@ -106,10 +106,10 @@ polymorphicRender = PolymorphicRender Nothing Nothing
 
 
 {-# INLINABLE render #-}
-render :: forall view controller. (ViewSupport.View view, ?theAction :: controller, ?context :: ControllerContext, ?modelContext :: ModelContext) => view -> IO ()
+render :: forall view controller. (ViewSupport.View view, ?context :: ControllerContext, ?modelContext :: ModelContext) => view -> IO ()
 render !view = do
     renderPolymorphic PolymorphicRender
             { html = Just $ (renderHtml view) >>= respondHtml
             , json = Just $ renderJson (ViewSupport.json view)
             }
-    
+

--- a/IHP/HtmlSupport/Parser.hs
+++ b/IHP/HtmlSupport/Parser.hs
@@ -347,6 +347,7 @@ attributes = Set.fromList
         , "stroke", "text-anchor", "text-decoration", "text-rendering", "unicode-bidi"
         , "visibility", "word-spacing", "writing-mode", "is"
         , "cellspacing", "cellpadding", "bgcolor", "classes"
+        , "loading"
         ]
 
 parents :: Set Text

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -25,6 +25,7 @@ module IHP.Job.Dashboard (
     IncludeWrapper(..),
     SomeView(..),
     EmptyView(..),
+    HtmlView(..),
     TableViewable(..),
     TableView(..),
 
@@ -163,6 +164,11 @@ instance (View a) => View [a] where
 data EmptyView = EmptyView
 instance View EmptyView where
     html _ = [hsx||]
+
+-- | A view constructed from some HTML.
+newtype HtmlView = HtmlView Html
+instance View HtmlView where
+    html (HtmlView html) = [hsx|{html}|]
 
 -- | Defines the default implementation for a dashboard of a list of job types.
 -- We know the current job is a 'DisplayableJob', and we can recurse on the rest of the list to build the rest of the dashboard.
@@ -515,7 +521,9 @@ instance HasPath (JobsDashboardController authType jobs) where
 
 instance CanRoute (JobsDashboardController authType jobs) where
     parseRoute' = do
-        (string "/jobs/ListJobs" <* endOfInput >> pure AllJobsAction)
+        (string "/jobs" <* endOfInput >> pure AllJobsAction)
+        <|> (string "/jobs/" <* endOfInput >> pure AllJobsAction)
+        <|> (string "/jobs/ListJobs" <* endOfInput >> pure AllJobsAction)
         <|> (string "/jobs/ViewJob" <* endOfInput >> pure ViewJobAction)
         <|> (string "/jobs/CreateJob" <* endOfInput >> pure CreateJobAction)
         <|> (string "/jobs/DeleteJob" <* endOfInput >> pure DeleteJobAction)

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -109,21 +109,21 @@ data JobsDashboardController authType (jobs :: [*])
 -- so you'll get a compile error if you try and include a type that is not a job.
 class JobsDashboard (jobs :: [*]) where
     -- | Creates the entire dashboard by recursing on the type list and calling 'makeSection' on each type.
-    makeDashboard :: (?context::ControllerContext, ?modelContext :: ModelContext) => IO SomeView
+    makeDashboard :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO SomeView
 
     -- | Renders the index page, which is the view returned from 'makeDashboard'.
-    indexPage :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    indexPage :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
 
     -- | Renders the detail view page. Rescurses on the type list to find a type with the
     -- same table name as the "tableName" query parameter.
-    viewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    viewJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
 
     -- | If performed in a POST request, creates a new job depending on the "tableName" query parameter.
     -- If performed in a GET request, renders the new job from depending on said parameter.
-    newJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    newJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
 
     -- | Deletes a job from the database.
-    deleteJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    deleteJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
 
 -- | The only function that should ever be invoked for this class is 'makeDashboard'
 -- which ends the recursion the build the index view. If other cases are reached,
@@ -266,12 +266,12 @@ class ( job ~ GetModelByTableName (GetTableName job)
 
     -- | How this job's section should be displayed in the dashboard. By default it's displayed as a table,
     -- but this can be any arbitrary view! Make some cool graphs :)
-    makeSection :: (?modelContext :: ModelContext) => IO SomeView
+    makeSection :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO SomeView
 
     -- | The content of the page that will be displayed for a detail view of this job.
     -- By default, the ID, Status, Created/Updated at times, and last error are displayed.
     -- Can be defined as any arbitrary view.
-    makeDetailView :: (?modelContext :: ModelContext) => job -> IO SomeView
+    makeDetailView :: (?context :: ControllerContext, ?modelContext :: ModelContext) => job -> IO SomeView
     makeDetailView job = do
         pure $ SomeView $ GenericShowView job
 
@@ -279,13 +279,13 @@ class ( job ~ GetModelByTableName (GetTableName job)
     -- By default, only the submit button is rendered. For additonal form data, define your own implementation.
     -- See 'GenericNewJobView' for a guide on how it can look.look
     -- Can be defined as any arbitrary view, but it should be a form.
-    makeNewJobView :: (?modelContext :: ModelContext) => IO SomeView
+    makeNewJobView :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO SomeView
     makeNewJobView = pure $ SomeView $ GenericNewJobView @job
 
     -- | The action run to create and insert a new value of this job into the database.
     -- By default, create an empty record and insert it.
     -- To add more data, define your own implementation.
-    createNewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    createNewJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
     createNewJob = do
         newRecord @job |> create
         pure ()

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -57,188 +57,6 @@ import IHP.Job.Dashboard.Types
 import IHP.Job.Dashboard.View
 import IHP.Job.Dashboard.Auth
 
--- | Defines implementations for actions for acting on a dashboard made of some list of types.
--- This is included to allow these actions to recurse on the types, isn't possible in an IHP Controller
--- action implementation.
---
--- Later functions and typeclasses introduce constraints on the types in this list,
--- so you'll get a compile error if you try and include a type that is not a job.
-class JobsDashboard (jobs :: [*]) where
-    -- | Creates the entire dashboard by recursing on the type list and calling 'makeSection' on each type.
-    makeDashboard :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO SomeView
-
-    getIncludedJobTableNames :: [Text]
-
-    -- | Renders the index page, which is the view returned from 'makeDashboard'.
-    indexPage :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
-
-    -- | Renders the detail view page. Rescurses on the type list to find a type with the
-    -- same table name as the "tableName" query parameter.
-    viewJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Text -> UUID -> IO ()
-    viewJob' :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Bool -> IO ()
-
-    -- | If performed in a POST request, creates a new job depending on the "tableName" query parameter.
-    -- If performed in a GET request, renders the new job from depending on said parameter.
-    newJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Text -> IO ()
-    newJob' :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Bool -> IO ()
-
-    -- | Deletes a job from the database.
-    deleteJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Text -> UUID -> IO ()
-    deleteJob' :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Bool -> IO ()
-
--- If no types are passed, try to get all tables dynamically and render them as BaseJobs
-instance JobsDashboard '[] where
-
-    -- | Invoked at the end of recursion
-    makeDashboard = pure (SomeView EmptyView)
-
-    getIncludedJobTableNames = []
-
-    indexPage = do
-        tableNames <- map extractText <$> getAllTableNames
-        tables <- mapM buildBaseJobTable tableNames
-        render $ SomeView tables
-        where
-            getAllTableNames = sqlQuery
-                "SELECT table_name FROM information_schema.tables WHERE table_name LIKE '%_jobs'" ()
-
-    viewJob = error "viewJob: Requested job type not in JobsDashboard Type"
-    viewJob' _ = do
-        baseJob <- queryBaseJob (param "tableName") (param "id")
-        render $ HtmlView $ renderBaseJobDetailView baseJob
-
-    newJob = error "newJob: Requested job type not in JobsDashboard Type"
-    newJob' _ = do
-        if requestMethod request == methodPost
-            then do
-                insertJob
-                setSuccessMessage (param "tableName" <> " job started.")
-                redirectTo ListJobsAction
-            else render $ HtmlView $ renderNewBaseJobForm (param "tableName")
-        where insertJob = sqlExec (PG.Query $ "INSERT into " <> param "tableName" <> " DEFAULT VALUES") ()
-
-    deleteJob = error "deleteJob: Requested job type not in JobsDashboard Type"
-    deleteJob' _ = do
-        let id    :: UUID = param "id"
-            table :: Text = param "tableName"
-        delete id table
-        setSuccessMessage (table <> " record deleted.")
-        redirectTo ListJobsAction
-
-        where delete id table = sqlExec (PG.Query $ cs $ "DELETE FROM " <> table <> " WHERE id = ?") (Only id)
-
-
--- | Defines the default implementation for a dashboard of a list of job types.
--- We know the current job is a 'DisplayableJob', and we can recurse on the rest of the list to build the rest of the dashboard.
--- You probably don't want to provide custom implementations for these. Read the documentation for each of the functions if
--- you'd like to know how to customize the behavior. They mostly rely on the functions from 'DisplayableJob'.
-instance {-# OVERLAPPABLE #-} (DisplayableJob job, JobsDashboard rest) => JobsDashboard (job:rest) where
-
-    -- | Recusively create a list of views that are concatenated together as 'SomeView's to build the dashboard.
-    -- To customize, override 'makeSection' for each job.
-    makeDashboard = do
-        section <- makeSection @job
-        restSections <- SomeView <$> makeDashboard @rest
-        pure $ SomeView (section : [restSections])
-
-    -- | Recursively build list of included table names
-    getIncludedJobTableNames = tableName @job : getIncludedJobTableNames @rest
-
-    -- | Build the dashboard and render it.
-    indexPage = do
-        dashboardIncluded <- makeDashboard @(job:rest)
-        notIncluded <- map extractText <$> getNotIncludedTableNames (getIncludedJobTableNames @(job:rest))
-        baseJobTables <- mapM buildBaseJobTable notIncluded
-        render $ dashboardIncluded : baseJobTables
-
-    -- | View the detail page for the job with a given uuid.
-    viewJob _ uuid = do
-        let id :: Id job = unsafeCoerce uuid
-        j <- fetch id
-        view <- makeDetailView @job j
-        render view
-
-    -- | For a given "tableName" parameter, try and recurse over the list of types
-    -- in order to find a type with the some table name as the parameter.
-    -- If one is found, attempt to construct an ID from the "id" parameter,
-    -- and render a page using the type's implementation of 'makeDetailView'.
-    -- If you want to customize the page, override that function instead.
-    viewJob' isFirstTime = do
-        let table = param "tableName"
-
-        when isFirstTime $ do
-            notIncluded <- map extractText <$> getNotIncludedTableNames (getIncludedJobTableNames @(job:rest))
-            when (table `elem` notIncluded) (viewJob' @'[] False)
-
-        if tableName @job == table
-            then viewJob @(job:rest) table (param "id")
-            else viewJob' @rest False
-
-    -- For POST, create a new job using the job's implementation of 'createNewJob'.
-    -- To include other request data and parameters, override that function, not this one.
-    -- If it's a GET request, render a new job form with the job's implementation of 'makeNewJobView'.
-    -- For customizing this form, override 'makeNewJobView'.
-    newJob tableName = do
-        if requestMethod request == methodPost
-            then do
-                createNewJob @job
-                setSuccessMessage (tableName <> " job started.")
-                redirectTo ListJobsAction
-            else do
-                view <- makeNewJobView @job
-                render view
-
-    -- | For a given "tableName" parameter, try and recurse over the list of types
-    -- in order to find a type with the some table name as the parameter.
-    -- If such a type is found, call newJob.
-    newJob' isFirstTime = do
-        let table = param "tableName"
-
-        when isFirstTime $ do
-            notIncluded <- map extractText <$> getNotIncludedTableNames (getIncludedJobTableNames @(job:rest))
-            when (table `elem` notIncluded) (newJob' @'[] False)
-
-        if tableName @job == table
-            then newJob @(job:rest) table
-            else newJob' @rest False
-
-    -- | Delete job in 'table' with ID 'uuid'.
-    deleteJob table uuid = do
-        let id :: Id job = unsafeCoerce uuid
-        j <- fetch id
-        deleteRecord j
-        setSuccessMessage (table <> " record deleted.")
-        redirectTo ListJobsAction
-
-    -- | For a given "tableName" parameter, try and recurse over the list of types
-    -- in order to find a type with the some table name as the parameter.
-    -- If one is found, delete the record with the given id.
-    deleteJob' isFirstTime = do
-        let table = param "tableName"
-
-        when isFirstTime $ do
-            notIncluded <- map extractText <$> getNotIncludedTableNames (getIncludedJobTableNames @(job:rest))
-            when (table `elem` notIncluded) (deleteJob' @'[] False)
-
-        if tableName @job == table
-            then deleteJob @(job:rest) table (param "id")
-            else deleteJob' @rest False
-
-
-extractText = \(Only t) -> t
-getNotIncludedTableNames includedNames = sqlQuery
-    "SELECT table_name FROM information_schema.tables WHERE table_name LIKE '%_jobs' AND table_name NOT IN ?"
-    (Only $ In $ includedNames)
-buildBaseJobTable :: (?modelContext :: ModelContext, ?context :: ControllerContext) => Text -> IO SomeView
-buildBaseJobTable tableName = do
-    baseJobs <- sqlQuery (PG.Query $ cs $ "select ?, id, status, updated_at, created_at, last_error from " <> tableName) (Only tableName)
-    baseJobs
-        |> renderBaseJobTable tableName
-        |> HtmlView
-        |> SomeView
-        |> pure
-
-
 -- | The crazy list of type constraints for this class defines everything needed for a generic "Job".
 -- All jobs created through the IHP dev IDE will automatically satisfy these constraints and thus be able to
 -- be used as a 'DisplayableJob'.
@@ -267,6 +85,8 @@ class ( job ~ GetModelByTableName (GetTableName job)
     -- but this can be any arbitrary view! Make some cool graphs :)
     makeSection :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO SomeView
 
+    makePageView :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Int -> Int -> IO SomeView
+
     -- | The content of the page that will be displayed for a detail view of this job.
     -- By default, the ID, Status, Created/Updated at times, and last error are displayed.
     -- Can be defined as any arbitrary view.
@@ -288,64 +108,228 @@ class ( job ~ GetModelByTableName (GetTableName job)
         newRecord @job |> create
         pure ()
 
--- | The crazy list of type constraints for this instance defines everything needed for a generic "Job".
--- Given all the constraints are satisfied, we can define how this job type can be used to display in a table format.
-instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
-    , FilterPrimaryKey (GetTableName job)
-    , FromRow job
-    , Show (PrimaryKey (GetTableName job))
-    , PG.FromField (PrimaryKey (GetTableName job))
-    , PG.ToField (PrimaryKey (GetTableName job))
-    , KnownSymbol (GetTableName job)
-    , HasField "id" job (Id job)
-    , HasField "status" job JobStatus
-    , HasField "updatedAt" job UTCTime
-    , HasField "createdAt" job UTCTime
-    , HasField "lastError" job (Maybe Text)
-    , CanUpdate job
-    , CanCreate job
-    , Record job
-    , Show job
-    , Eq job
-    , Typeable job
-    ) => TableViewable job where
 
-    tableTitle = tableName @job |> columnNameToFieldLabel
-    tableHeaders = ["ID", "Updated at", "Status", "", ""]
-    createNewForm = renderNewBaseJobForm (tableName @job)
-    renderTableRow job = renderBaseJobTableRow (buildBaseJob job)
 
--- | Given a generic job that is able to be displayed in a table through the 'TableViewable' constraint,
--- define the functions needed for a 'DisplayableJob'.
-instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
-    , FilterPrimaryKey (GetTableName job)
-    , FromRow job
-    , Show (PrimaryKey (GetTableName job))
-    , PG.FromField (PrimaryKey (GetTableName job))
-    , PG.ToField (PrimaryKey (GetTableName job))
-    , KnownSymbol (GetTableName job)
-    , HasField "id" job (Id job)
-    , HasField "status" job JobStatus
-    , HasField "updatedAt" job UTCTime
-    , HasField "createdAt" job UTCTime
-    , HasField "lastError" job (Maybe Text)
-    , CanUpdate job
-    , CanCreate job
-    , Record job
-    , Show job
-    , Eq job
-    , Typeable job
-    , TableViewable job
-    ) => DisplayableJob job where
-    makeSection :: (?modelContext :: ModelContext) => IO SomeView
-    makeSection = do
-        jobs <- query @job |> fetch
-        pure $ SomeView (TableView jobs)
+
+-- | Defines implementations for actions for acting on a dashboard made of some list of types.
+-- This is included to allow these actions to recurse on the types, isn't possible in an IHP Controller
+-- action implementation.
+--
+-- Later functions and typeclasses introduce constraints on the types in this list,
+-- so you'll get a compile error if you try and include a type that is not a job.
+class JobsDashboard (jobs :: [*]) where
+    -- | Creates the entire dashboard by recursing on the type list and calling 'makeSection' on each type.
+    makeDashboard :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO SomeView
+
+    includedJobTables :: [Text]
+
+    -- | Renders the index page, which is the view returned from 'makeDashboard'.
+    indexPage :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
+
+    listJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Text -> IO ()
+    listJob' :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Bool -> IO ()
+
+    -- | Renders the detail view page. Rescurses on the type list to find a type with the
+    -- same table name as the "tableName" query parameter.
+    viewJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Text -> UUID -> IO ()
+    viewJob' :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Bool -> IO ()
+
+    -- | If performed in a POST request, creates a new job depending on the "tableName" query parameter.
+    -- If performed in a GET request, renders the new job from depending on said parameter.
+    newJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Text -> IO ()
+    newJob' :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Bool -> IO ()
+
+    -- | Deletes a job from the database.
+    deleteJob :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Text -> UUID -> IO ()
+    deleteJob' :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Bool -> IO ()
+
+-- If no types are passed, try to get all tables dynamically and render them as BaseJobs
+instance JobsDashboard '[] where
+
+    -- | Invoked at the end of recursion
+    makeDashboard = pure (SomeView EmptyView)
+
+    includedJobTables = []
+
+    indexPage = do
+        tableNames <- getAllTableNames
+        tables <- mapM buildBaseJobTable tableNames
+        render $ SomeView tables
+        where
+            getAllTableNames = map extractText <$> sqlQuery
+                "SELECT table_name FROM information_schema.tables WHERE table_name LIKE '%_jobs'" ()
+
+    listJob = error "listJob: Requested job type not in JobsDashboard Type"
+    listJob' _ = do
+        let page = fromMaybe 1 $ param "page"
+            table = param "tableName"
+        numberOfPages <- numberOfPagesForTable table 25
+        jobs <- queryBaseJobsFromTablePaginated table (page - 1) 25
+        render $ HtmlView $ renderBaseJobTablePaginated table jobs page numberOfPages
+        render $ EmptyView
+
+    viewJob = error "viewJob: Requested job type not in JobsDashboard Type"
+    viewJob' _ = do
+        baseJob <- queryBaseJob (param "tableName") (param "id")
+        render $ HtmlView $ renderBaseJobDetailView baseJob
+
+    newJob = error "newJob: Requested job type not in JobsDashboard Type"
+    newJob' _ = do
+        if requestMethod request == methodPost
+            then do
+                insertJob
+                setSuccessMessage (columnNameToFieldLabel (param "tableName") <> " job started.")
+                redirectTo ListJobsAction
+            else render $ HtmlView $ renderNewBaseJobForm (param "tableName")
+        where insertJob = sqlExec (PG.Query $ "INSERT into " <> param "tableName" <> " DEFAULT VALUES") ()
+
+    deleteJob = error "deleteJob: Requested job type not in JobsDashboard Type"
+    deleteJob' _ = do
+        let id    :: UUID = param "id"
+            table :: Text = param "tableName"
+        delete id table
+        setSuccessMessage (columnNameToFieldLabel table <> " record deleted.")
+        redirectTo ListJobsAction
+
+        where delete id table = sqlExec (PG.Query $ cs $ "DELETE FROM " <> table <> " WHERE id = ?") (Only id)
+
+
+-- | Defines the default implementation for a dashboard of a list of job types.
+-- We know the current job is a 'DisplayableJob', and we can recurse on the rest of the list to build the rest of the dashboard.
+-- You probably don't want to provide custom implementations for these. Read the documentation for each of the functions if
+-- you'd like to know how to customize the behavior. They mostly rely on the functions from 'DisplayableJob'.
+instance {-# OVERLAPPABLE #-} (DisplayableJob job, JobsDashboard rest) => JobsDashboard (job:rest) where
+
+    -- | Recusively create a list of views that are concatenated together as 'SomeView's to build the dashboard.
+    -- To customize, override 'makeSection' for each job.
+    makeDashboard = do
+        section <- makeSection @job
+        restSections <- SomeView <$> makeDashboard @rest
+        pure $ SomeView (section : [restSections])
+
+    -- | Recursively build list of included table names
+    includedJobTables = tableName @job : includedJobTables @rest
+
+    -- | Build the dashboard and render it.
+    indexPage = do
+        dashboardIncluded <- makeDashboard @(job:rest)
+        notIncluded <- getNotIncludedTableNames (includedJobTables @(job:rest))
+        baseJobTables <- mapM buildBaseJobTable notIncluded
+        render $ dashboardIncluded : baseJobTables
+
+    listJob table = do
+        let page = fromMaybe 1 $ param "page"
+        numberOfPages <- numberOfPagesForTable table 25
+        page <- makePageView @job page numberOfPages
+        render page
+
+    listJob' isFirstTime = do
+        let table = param "tableName"
+
+        when isFirstTime $ do
+            notIncluded <- getNotIncludedTableNames (includedJobTables @(job:rest))
+            when (table `elem` notIncluded) (listJob' @'[] False)
+
+        if tableName @job == table
+            then listJob @(job:rest) table
+            else listJob' @rest False
+
+    -- | View the detail page for the job with a given uuid.
+    viewJob _ uuid = do
+        let id :: Id job = unsafeCoerce uuid
+        j <- fetch id
+        view <- makeDetailView @job j
+        render view
+    -- | For a given "tableName" parameter, try and recurse over the list of types
+    -- in order to find a type with the some table name as the parameter.
+    -- If one is found, attempt to construct an ID from the "id" parameter,
+    -- and render a page using the type's implementation of 'makeDetailView'.
+    -- If you want to customize the page, override that function instead.
+    viewJob' isFirstTime = do
+        let table = param "tableName"
+
+        when isFirstTime $ do
+            notIncluded <- getNotIncludedTableNames (includedJobTables @(job:rest))
+            when (table `elem` notIncluded) (viewJob' @'[] False)
+
+        if tableName @job == table
+            then viewJob @(job:rest) table (param "id")
+            else viewJob' @rest False
+
+    -- For POST, create a new job using the job's implementation of 'createNewJob'.
+    -- To include other request data and parameters, override that function, not this one.
+    -- If it's a GET request, render a new job form with the job's implementation of 'makeNewJobView'.
+    -- For customizing this form, override 'makeNewJobView'.
+    newJob tableName = do
+        if requestMethod request == methodPost
+            then do
+                createNewJob @job
+                setSuccessMessage (columnNameToFieldLabel tableName <> " job started.")
+                redirectTo ListJobsAction
+            else do
+                view <- makeNewJobView @job
+                render view
+
+    -- | For a given "tableName" parameter, try and recurse over the list of types
+    -- in order to find a type with the some table name as the parameter.
+    -- If such a type is found, call newJob.
+    newJob' isFirstTime = do
+        let table = param "tableName"
+
+        when isFirstTime $ do
+            notIncluded <- getNotIncludedTableNames (includedJobTables @(job:rest))
+            when (table `elem` notIncluded) (newJob' @'[] False)
+
+        if tableName @job == table
+            then newJob @(job:rest) table
+            else newJob' @rest False
+
+    -- | Delete job in 'table' with ID 'uuid'.
+    deleteJob table uuid = do
+        let id :: Id job = unsafeCoerce uuid
+        j <- fetch id
+        deleteRecord j
+        setSuccessMessage (columnNameToFieldLabel table <> " record deleted.")
+        redirectTo ListJobsAction
+
+    -- | For a given "tableName" parameter, try and recurse over the list of types
+    -- in order to find a type with the some table name as the parameter.
+    -- If one is found, delete the record with the given id.
+    deleteJob' isFirstTime = do
+        let table = param "tableName"
+
+        when isFirstTime $ do
+            notIncluded <- getNotIncludedTableNames (includedJobTables @(job:rest))
+            when (table `elem` notIncluded) (deleteJob' @'[] False)
+
+        if tableName @job == table
+            then deleteJob @(job:rest) table (param "id")
+            else deleteJob' @rest False
+
+
+extractText = \(Only t) -> t
+getNotIncludedTableNames includedNames = map extractText <$> sqlQuery
+    "SELECT table_name FROM information_schema.tables WHERE table_name LIKE '%_jobs' AND table_name NOT IN ?"
+    (Only $ In $ includedNames)
+buildBaseJobTable :: (?modelContext :: ModelContext, ?context :: ControllerContext) => Text -> IO SomeView
+buildBaseJobTable tableName = do
+    baseJobs <- sqlQuery (PG.Query $ cs $ queryString) (Only tableName)
+    baseJobs
+        |> renderBaseJobTable tableName
+        |> HtmlView
+        |> SomeView
+        |> pure
+
+    where
+        queryString = "SELECT ?, id, status, updated_at, created_at, last_error FROM "
+            <> tableName
+            <> " ORDER BY created_at DESC LIMIT 10"
+
 
 buildBaseJob :: forall job. (DisplayableJob job) => job -> BaseJob
 buildBaseJob job = BaseJob
     (tableName @job)
-    (unsafeCoerce $ get #id job)
+    (unsafeCoerce $ get #id job) -- model Id type -> UUID. Pls don't use integer IDs for your jobs :)
     (get #status job)
     (get #updatedAt job)
     (get #createdAt job)
@@ -384,9 +368,25 @@ queryBaseJob table id = do
         [table, tshow id]
     pure job
 
+queryBaseJobsFromTablePaginated :: _ => Text -> Int -> Int -> IO [BaseJob]
+queryBaseJobsFromTablePaginated table page pageSize =
+    sqlQuery
+        (PG.Query $ cs $ "select ?, id, status, updated_at, created_at, last_error from " <> table <> " OFFSET " <> tshow (page * pageSize) <> " LIMIT " <> tshow pageSize)
+        (Only table)
+
+numberOfPagesForTable :: _ => Text -> Int -> IO Int
+numberOfPagesForTable table pageSize = do
+    (Only totalRecords : _) <- sqlQuery
+        (PG.Query $ cs $ "SELECT COUNT(*) FROM " <> table)
+        ()
+    pure $ case totalRecords `quotRem` pageSize of
+        (pages, 0) -> pages
+        (pages, _) -> pages + 1
+
 instance (JobsDashboard jobs, AuthenticationMethod authType) => Controller (JobsDashboardController authType jobs) where
     beforeAction = authenticate @authType
     action ListJobsAction   = autoRefresh $ indexPage @jobs
+    action ListJobAction'   = autoRefresh $ listJob' @jobs True
     action ViewJobAction'   = autoRefresh $ viewJob' @jobs True
     action CreateJobAction' = newJob' @jobs True
     action DeleteJobAction' = deleteJob' @jobs True

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE GADTs #-}
 
 {-|

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE GADTs #-}
 
+{-|
+Module: IHP.Job.Dashboard
+Description:  Auto-generate a dashboard for job types
+Author: Zac Wood (GitHub @zacwood9)
+-}
 module IHP.Job.Dashboard (
     JobsDashboard(..),
     DisplayableJob(..),
@@ -29,51 +34,98 @@ import qualified IHP.Log as Log
 import Network.Wai (requestMethod)
 import Network.HTTP.Types.Method (methodGet, methodPost)
 
+-- | Defines controller actions for acting on a dashboard made of some list of types.
+-- Later functions and typeclasses introduce constraints on the types in this list,
+-- so you'll get a compile error if you try and include a type that is not a job.
 data JobsDashboardController (jobs :: [*])
     = AllJobsAction
     | ViewJobAction
     | CreateJobAction
     deriving (Show, Eq, Data)
 
+-- | Defines implementations for actions for acting on a dashboard made of some list of types.
+-- This is included to allow these actions to recurse on the types, isn't possible in an IHP Controller
+-- action implementation.
+--
+-- Later functions and typeclasses introduce constraints on the types in this list,
+-- so you'll get a compile error if you try and include a type that is not a job.
 class JobsDashboard (jobs :: [*]) where
+    -- | Creates the entire dashboard by recursing on the type list and calling 'makeSection' on each type.
     makeDashboard :: (?modelContext :: ModelContext) => IO SomeView
+
+    -- | Renders the index page, which is the view returned from 'makeDashboard'.
     indexPage :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+
+    -- | Renders the detail view page. Rescurses on the type list to find a type with the
+    -- same table name as the "tableName" query parameter.
     viewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+
+    -- | If performed in a POST request, creates a new job depending on the "tableName" query parameter.
+    -- If performed in a GET request, renders the new job from depending on said parameter.
     newJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
 
+-- | The only function that should ever be invoked for this class is 'makeDashboard'
+-- which ends the recursion the build the index view. If other cases are reached,
+-- that means the type passed in "tableName" was not found and thus an error is thrown.
 instance JobsDashboard '[] where
     makeDashboard = pure (SomeView EmptyView)
     indexPage = error "No Index implemented for empty jobs list"
     viewJob = error "viewJob: Requested job type not in JobsDashboard Type"
     newJob = error "newJob: Requested job type not in JobsDashboard Type"
 
-data SomeView = forall a. (View a) => SomeView a
+-- | Provides a type-erased view. This allows us to specify a view as a return type without needed
+-- to know exactly what type the view will be, which in turn allows for custom implmentations of
+-- almost all the view functions in this module. Go GADTs!
+data SomeView where
+    SomeView :: forall a. (View a) => a -> SomeView
+
+-- | Since the only constructor for 'SomeView' requires that it is passed a 'View', we can use
+-- that to implement a 'View' instance for 'SomeView'
 instance View SomeView where
     html (SomeView a) = let ?view = a in IHP.ViewPrelude.html a
 
+-- | Define how to render a list of views as a view. Just concatenate them together!
 instance (View a) => View [a] where
     html [] = [hsx||]
     html (x:xs) =
+        -- need to nest let's here in order to satisfy the implicit ?view parameter for 'html'.
+        -- ?view needs to be the type of the view being rendered, so set it before each render
+        -- here we render single view
         let ?view = x in
             let current = IHP.ViewPrelude.html x in
+                -- now rendering a list view
                 let ?view = xs in
                     let rest = IHP.ViewPrelude.html xs in
                         [hsx|{current}{rest}|]
 
+-- | A view containing no data. Used occasionally as a default implementation for some functions.
 data EmptyView = EmptyView
 instance View EmptyView where
     html _ = [hsx||]
 
+-- | Defines the default implementation for a dashboard of a list of job types.
+-- We know the current job is a 'DisplayableJob', and we can recurse on the rest of the list to build the rest of the dashboard.
+-- You probably don't want to provide custom implementations for these. Read the documentation for each of the functions if
+-- you'd like to know how to customize the behavior. They mostly rely on the functions from 'DisplayableJob'.
 instance {-# OVERLAPPABLE #-} (DisplayableJob job, JobsDashboard rest) => JobsDashboard (job:rest) where
+
+    -- | Recusively create a list of views that are concatenated together as 'SomeView's to build the dashboard.
+    -- To customize, override 'makeSection' for each job.
     makeDashboard = do
         section <- makeSection @job
         restSections <- SomeView <$> makeDashboard @rest
         pure $ SomeView (section : [restSections])
 
+    -- | Build the dashboard and render it.
     indexPage = do
         dashboard <- makeDashboard @(job:rest)
         render dashboard
 
+    -- | For a given "tableName" parameter, try and recurse over the list of types
+    -- in order to find a type with the some table name as the parameter.
+    -- If one is found, attempt to construct an ID from the "id" parameter,
+    -- and render a page using the type's implementation of 'makeDetailView'.
+    -- If you want to customize the page, override that function instead.
     viewJob = do
         let table = param "tableName"
         if tableName @job == table
@@ -84,6 +136,13 @@ instance {-# OVERLAPPABLE #-} (DisplayableJob job, JobsDashboard rest) => JobsDa
                 render view
             else do
                 viewJob @rest
+
+    -- | For a given "tableName" parameter, try and recurse over the list of types
+    -- in order to find a type with the some table name as the parameter.
+    -- If one is found, and the request is POST, create a new job using the job's implementation of 'createNewJob'.
+    -- To include other request data and parameters, override that function, not this one.
+    -- If it's a GET request, render a new job form with the job's implementation of 'makeNewJobView'.
+    -- For customizing this form, override 'makeNewJobView'.
     newJob = do
         let table = param "tableName"
         if tableName @job == table
@@ -98,6 +157,11 @@ instance {-# OVERLAPPABLE #-} (DisplayableJob job, JobsDashboard rest) => JobsDa
             else do
                 newJob @rest
 
+-- | The crazy list of type constraints for this class defines everything needed for a generic "Job".
+-- All jobs created through the IHP dev IDE will automatically satisfy these constraints and thus be able to
+-- be used as a 'DisplayableJob'.
+-- To customize the dashboard behavior for each job, you should provide a custom implementation of 'DisplayableJob'
+-- for your job type. Your custom implementations will then be used instead of the defaults.
 class ( job ~ GetModelByTableName (GetTableName job)
     , FilterPrimaryKey (GetTableName job)
     , FromRow job
@@ -116,15 +180,27 @@ class ( job ~ GetModelByTableName (GetTableName job)
     , Eq job
     , Typeable job) => DisplayableJob job where
 
+    -- | How this job's section should be displayed in the dashboard. By default it's displayed as a table,
+    -- but this can be any arbitrary view! Make some cool graphs :)
     makeSection :: (?modelContext :: ModelContext) => IO SomeView
 
+    -- | The content of the page that will be displayed for a detail view of this job.
+    -- By default, the ID, Status, Created/Updated at times, and last error are displayed.
+    -- Can be defined as any arbitrary view.
     makeDetailView :: (?modelContext :: ModelContext) => job -> IO SomeView
     makeDetailView job = do
         pure $ SomeView $ GenericShowView job
 
+    -- | The content of the page that will be displayed for the "new job" form of this job.
+    -- By default, only the submit button is rendered. For additonal form data, define your own implementation.
+    -- See 'GenericNewJobView' for a guide on how it can look.look
+    -- Can be defined as any arbitrary view, but it should be a form.
     makeNewJobView :: (?modelContext :: ModelContext) => IO SomeView
     makeNewJobView = pure (SomeView $ GenericNewJobView @job)
 
+    -- | The action run to create and insert a new value of this job into the database.
+    -- By default, create an empty record and insert it.
+    -- To add more data, define your own implementation.
     createNewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
     createNewJob = do
         newRecord @job |> create
@@ -132,10 +208,13 @@ class ( job ~ GetModelByTableName (GetTableName job)
 
 
 
-data TableView = forall a. (TableViewable a) => TableView [a]
-instance View TableView where
+data TableView a = TableView [a]
+
+-- A TableView is only a View if it's contents are TableViewable.
+instance forall a. (TableViewable a) => View (TableView a) where
     html (TableView rows) = renderTable rows
 
+-- | Creates a form with a single small button that links to the Create Job form for some 'DisplayableJob;.
 newJobFormForTableHeader :: forall job. (DisplayableJob job) => Html
 newJobFormForTableHeader =
         let
@@ -147,10 +226,14 @@ newJobFormForTableHeader =
             </form>
         |]
 
+-- | Defines a set of necessary functions to display some data 'a' in a table format given a list of '[a]'.
 class TableViewable a where
     tableTitle :: Text
+
+    -- | Headers that describe each column in the table
     tableHeaders :: [Text]
 
+    -- | Optional HTML that will be placed in the top right of the table. Used for a "create new" button.
     createNewForm :: Html
     createNewForm = [hsx||]
 
@@ -184,6 +267,8 @@ class TableViewable a where
     |]
         where renderHeader field = [hsx|<th>{field}</th>|]
 
+-- | The crazy list of type constraints for this instance defines everything needed for a generic "Job".
+-- Given all the constraints are satisfied, we can define how this job type can be used to display in a table format.
 instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
     , FilterPrimaryKey (GetTableName job)
     , FromRow job
@@ -205,15 +290,7 @@ instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
 
     tableTitle = tableName @job
     tableHeaders = ["ID", "Updated at", "Status", ""]
-    createNewForm =
-        let
-            t = tableName @job
-            link :: Text = "/jobs/CreateJob?tableName=" <> t
-        in [hsx|
-            <form action={link}>
-                <button type="submit" class="btn btn-primary btn-sm">+ New Job</button>
-            </form>
-        |]
+    createNewForm = newJobFormForTableHeader @job
     renderTableRow job =
         let
             table = tableName @job
@@ -227,6 +304,8 @@ instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
             </tr>
         |]
 
+-- | Given a generic job that is able to be displayed in a table through the 'TableViewable' constraint,
+-- define the functions needed for a 'DisplayableJob'.
 instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
     , FilterPrimaryKey (GetTableName job)
     , FromRow job
@@ -252,16 +331,32 @@ instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
         pure $ SomeView (TableView jobs)
 
 
+-- | Often, jobs are related to some model type. These relations are modeled through the type system.
+-- For example, the type 'Include "userId" UpdateUserJob' models an 'UpdateUserJob' type that can access
+-- the 'User' it belongs to through the 'userId' field.
+-- For some reason, GHC doesn't allow us to create implementations of type family applications, so the following doesn't work:
+--
+-- > instance DisplayableJob (Include "userId" UpdateUserJob) where
+--
+-- However, if we wrap this in a concrete type, it works fine. That's what this wrapper is for.
+-- To get the same behavior as above, just define
+--
+-- > instance DisplayableJob (IncludeWrapper "userId" UpdateUserJob) where
+--
+-- and wrap the values as so:
+--
+-- > jobsWithUsers <- query @UpdateUserJob
+-- >    |> fetch
+-- >    >>= mapM (fetchRelated #userId)
+-- >    >>= pure . map (IncludeWrapper @"userId" @UpdateUserJob)
 newtype IncludeWrapper (id :: Symbol) job = IncludeWrapper (Include id job)
 
--- CREATE TYPE JOB_STATUS AS ENUM ('job_status_not_started', 'job_status_running', 'job_status_failed', 'job_status_succeeded', 'job_status_retry');
 statusToBadge :: JobStatus -> Html
 statusToBadge JobStatusSucceeded = [hsx|<span class="badge badge-success">Succeeded</span>|]
 statusToBadge JobStatusFailed = [hsx|<span class="badge badge-danger">Failed</span>|]
 statusToBadge JobStatusRunning = [hsx|<span class="badge badge-info">Running</span>|]
 statusToBadge _ = [hsx|<span class="badge badge-secondary">Other</span>|]
 
- -- CONTROLLER
 instance (JobsDashboard jobs) => Controller (JobsDashboardController jobs) where
     action AllJobsAction = autoRefresh $ do
         indexPage @(jobs)
@@ -272,6 +367,8 @@ instance (JobsDashboard jobs) => Controller (JobsDashboardController jobs) where
     action CreateJobAction = autoRefresh $ do
         newJob @jobs
 
+-- | We can't always access the type of our job in order to use type application syntax for 'tableName'.
+-- This is just a convinence function for those cases.
 getTableName :: forall job. (DisplayableJob job) => job -> Text
 getTableName _ = tableName @job
 
@@ -282,7 +379,7 @@ instance (DisplayableJob job) => View (GenericShowView job) where
             table = getTableName job
         in [hsx|
             <br>
-            <h5>Viewing Job {get #id job} in {table}</h5>
+                <h5>Viewing Job {get #id job} in {table}</h5>
             <br>
             <table class="table">
                 <tbody>
@@ -315,7 +412,7 @@ instance (DisplayableJob job) => View (GenericNewJobView job) where
             table = tableName @job
         in [hsx|
             <br>
-            <h5>New Job: {table}</h5>
+                <h5>New Job: {table}</h5>
             <br>
             <form action="/jobs/CreateJob" method="POST">
                 <input type="hidden" id="tableName" name="tableName" value={table}>

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -21,7 +21,6 @@ module IHP.Job.Dashboard (
 ) where
 
 import IHP.Prelude
-import Generated.Types
 import IHP.ViewPrelude (Html, View, hsx, html)
 import IHP.ModelSupport
 import IHP.ControllerPrelude

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -143,7 +143,23 @@ class JobsDashboard (jobs :: [*]) where
 instance JobsDashboard '[] where
 
     -- | Invoked at the end of recursion
-    makeDashboard = pure (SomeView EmptyView)
+    makeDashboard = pure $ SomeView $ HtmlView [hsx|
+        <script>
+            function initPopover() {
+                $('[data-toggle="popover"]').popover({ trigger: 'hover click' })
+            }
+            $(document).on('ready turbolinks:load', initPopover);
+            $(initPopover);
+        </script>
+        <style>
+        .popover-body {
+            background-color: #01313f;
+            color: rgb(147, 161, 161);
+            font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+            font-size: 11px;
+        }
+        </style>
+    |]
 
     includedJobTables = []
 

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -1,0 +1,283 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE GADTs #-}
+
+module IHP.Job.Dashboard (
+    JobsDashboard(..),
+    DisplayableJob(..),
+    JobsDashboardController(..),
+    IncludeWrapper(..),
+    SomeView(..),
+    EmptyView(..),
+    TableViewable(..),
+    TableView(..),
+    getTableName,
+    statusToBadge,
+) where
+
+import IHP.Prelude
+import Generated.Types
+import IHP.ViewPrelude (Html, View, hsx, html)
+import IHP.ModelSupport
+import IHP.ControllerPrelude
+import Unsafe.Coerce
+import IHP.RouterPrelude hiding (get, tshow, error, map)
+import qualified Database.PostgreSQL.Simple as PG
+import qualified Database.PostgreSQL.Simple.Types as PG
+import qualified Database.PostgreSQL.Simple.FromField as PG
+
+data JobsDashboardController (jobs :: [*])
+    = AllJobsAction
+    | ViewJobAction
+    | CreateJobAction
+    deriving (Show, Eq, Data)
+
+class JobsDashboard (jobs :: [*]) where
+    makeDashboard :: (?modelContext :: ModelContext) => IO SomeView
+    indexPage :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    viewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    newJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+
+instance JobsDashboard '[] where
+    makeDashboard = pure (SomeView EmptyView)
+    indexPage = error "No Index implemented for empty jobs list"
+    viewJob = error "viewJob: Requested job type not in JobsDashboard Type"
+    newJob = error "newJob: Requested job type not in JobsDashboard Type"
+
+data SomeView = forall a. (View a) => SomeView a
+instance View SomeView where
+    html (SomeView a) = let ?view = a in IHP.ViewPrelude.html a
+
+instance (View a) => View [a] where
+    html [] = [hsx||]
+    html (x:xs) =
+        let ?view = x in
+            let current = IHP.ViewPrelude.html x in
+                let ?view = xs in
+                    let rest = IHP.ViewPrelude.html xs in
+                        [hsx|{current}{rest}|]
+
+data EmptyView = EmptyView
+instance View EmptyView where
+    html _ = [hsx||]
+
+instance {-# OVERLAPPABLE #-} (DisplayableJob job, JobsDashboard rest) => JobsDashboard (job:rest) where
+    makeDashboard = do
+        section <- makeSection @job
+        restSections <- SomeView <$> makeDashboard @rest
+        pure $ SomeView (section : [restSections])
+
+    indexPage = do
+        dashboard <- makeDashboard @(job:rest)
+        render dashboard
+
+    viewJob = do
+        let table = param "tableName"
+        if tableName @job == table
+            then do
+                let id :: Id job = unsafeCoerce (param "id" :: UUID) -- TODO: safe cast?
+                j <- fetch id
+                view <- makeDetailView @job j
+                render view
+            else do
+                viewJob @rest
+    newJob = do
+        let table = param "tableName"
+        if tableName @job == table
+            then do
+                createNewJob @job
+                redirectToPath "/jobs/ListJobs"
+            else do
+                newJob @rest
+
+class ( job ~ GetModelByTableName (GetTableName job)
+    , FilterPrimaryKey (GetTableName job)
+    , FromRow job
+    , Show (PrimaryKey (GetTableName job))
+    , PG.FromField (PrimaryKey (GetTableName job))
+    , KnownSymbol (GetTableName job)
+    , HasField "id" job (Id job)
+    , HasField "status" job JobStatus
+    , HasField "updatedAt" job UTCTime
+    , HasField "createdAt" job UTCTime
+    , HasField "lastError" job (Maybe Text)
+    , CanUpdate job
+    , CanCreate job
+    , Record job
+    , Show job
+    , Eq job
+    , Typeable job
+    ) => DisplayableJob job where
+
+    makeSection :: (?modelContext :: ModelContext) => IO SomeView
+
+    makeDetailView :: (?modelContext :: ModelContext) => job -> IO SomeView
+    makeDetailView job = do
+        pure $ SomeView $ GenericShowView job
+
+    createNewJob :: (?context::ControllerContext, ?modelContext::ModelContext) => IO ()
+    createNewJob = do
+        newRecord @job |> create
+        pure ()
+
+
+
+data TableView = forall a. (TableViewable a) => TableView [a]
+instance View TableView where
+    html (TableView rows) = renderTable rows
+
+
+class TableViewable a where
+    tableTitle :: Text
+    tableHeaders :: [Text]
+    renderTableRow :: a -> Html
+
+    renderTable :: [a] -> Html
+    renderTable rows =
+        let
+            title = tableTitle @a
+            headers = tableHeaders @a
+            renderRow = renderTableRow @a
+        in [hsx|
+        <div>
+            <h3>Job type: {title}</h3>
+            <table class="table table-sm">
+                <thead>
+                    <tr>
+                        {forEach headers renderHeader}
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {forEach rows renderRow}
+                </tbody>
+            </table>
+        </div>
+    |]
+        where renderHeader field = [hsx|<th>{field}</th>|]
+
+instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
+    , FilterPrimaryKey (GetTableName job)
+    , FromRow job
+    , Show (PrimaryKey (GetTableName job))
+    , PG.FromField (PrimaryKey (GetTableName job))
+    , KnownSymbol (GetTableName job)
+    , HasField "id" job (Id job)
+    , HasField "status" job JobStatus
+    , HasField "updatedAt" job UTCTime
+    , HasField "createdAt" job UTCTime
+    , HasField "lastError" job (Maybe Text)
+    , CanUpdate job
+    , CanCreate job
+    , Record job
+    , Show job
+    , Eq job
+    , Typeable job
+    ) => TableViewable job where
+
+    tableTitle = tableName @job
+    tableHeaders = ["ID", "Updated at", "Status", ""]
+    renderTableRow job =
+        let
+            table = tableName @job
+            linkToView :: Text = "/jobs/ViewJob?tableName=" <> table <> "&id=" <> tshow (get #id job)
+        in [hsx|
+            <tr>
+                <td>{get #id job}</td>
+                <td>{get #updatedAt job}</td>
+                <td>{statusToBadge $ get #status job}</td>
+                <td><a href={linkToView} class="text-primary">Show</a></td>
+            </tr>
+        |]
+
+instance {-# OVERLAPPABLE #-} (job ~ GetModelByTableName (GetTableName job)
+    , FilterPrimaryKey (GetTableName job)
+    , FromRow job
+    , Show (PrimaryKey (GetTableName job))
+    , PG.FromField (PrimaryKey (GetTableName job))
+    , KnownSymbol (GetTableName job)
+    , HasField "id" job (Id job)
+    , HasField "status" job JobStatus
+    , HasField "updatedAt" job UTCTime
+    , HasField "createdAt" job UTCTime
+    , HasField "lastError" job (Maybe Text)
+    , CanUpdate job
+    , CanCreate job
+    , Record job
+    , Show job
+    , Eq job
+    , Typeable job
+    , TableViewable job
+    ) => DisplayableJob job where
+    makeSection :: (?modelContext :: ModelContext) => IO SomeView
+    makeSection = do
+        jobs <- query @job |> fetch
+        pure $ SomeView (TableView jobs)
+
+
+newtype IncludeWrapper (id :: Symbol) job = IncludeWrapper (Include id job)
+
+-- CREATE TYPE JOB_STATUS AS ENUM ('job_status_not_started', 'job_status_running', 'job_status_failed', 'job_status_succeeded', 'job_status_retry');
+statusToBadge :: JobStatus -> Html
+statusToBadge JobStatusSucceeded = [hsx|<span class="badge badge-success">Succeeded</span>|]
+statusToBadge JobStatusFailed = [hsx|<span class="badge badge-danger">Failed</span>|]
+statusToBadge JobStatusRunning = [hsx|<span class="badge badge-info">Running</span>|]
+statusToBadge _ = [hsx|<span class="badge badge-secondary">Other</span>|]
+
+ -- CONTROLLER
+instance (JobsDashboard jobs) => Controller (JobsDashboardController jobs) where
+    action AllJobsAction = autoRefresh $ do
+        indexPage @(jobs)
+
+    action ViewJobAction = autoRefresh $ do
+        viewJob @(jobs)
+
+    action CreateJobAction = autoRefresh $ do
+        newJob @jobs
+
+data GenericShowView = forall job. (DisplayableJob job) => GenericShowView job
+
+-- VIEW
+getTableName :: forall job. (DisplayableJob job) => job -> Text
+getTableName _ = tableName @job
+
+instance View GenericShowView where
+    html (GenericShowView job) =
+        let
+            table = getTableName job
+        in [hsx|
+            <br>
+            <h5>Viewing Job {get #id job} in {table}</h5>
+            <br>
+            <table class="table">
+                <tbody>
+                    <tr>
+                        <th>Updated At</th>
+                        <td>{get #updatedAt job}</td>
+                    </tr>
+                    <tr>
+                        <th>Created At</th>
+                        <td>{get #createdAt job}</td>
+                    </tr>
+                    <tr>
+                        <th>Last Error</th>
+                        <td>{fromMaybe "No error" (get #lastError job)}</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <form action="/jobs/CreateJob" method="POST">
+                <input type="hidden" id="tableName" name="tableName" value={table}>
+                <button type="submit" class="btn btn-primary">Run again</button>
+            </form>
+        |]
+
+
+instance HasPath (JobsDashboardController jobs) where
+    pathTo _ = error "HasPath not supported for JobsDashboardController."
+
+instance CanRoute (JobsDashboardController jobs) where
+    parseRoute' = do
+        (string "/jobs/ListJobs" <* endOfInput >> pure AllJobsAction)
+        <|> (string "/jobs/ViewJob" <* endOfInput >> pure ViewJobAction)
+        <|> (string "/jobs/CreateJob" <* endOfInput >> pure CreateJobAction)
+

--- a/IHP/Job/Dashboard/Auth.hs
+++ b/IHP/Job/Dashboard/Auth.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE GADTs #-}
 
 {-|
 Module: IHP.Job.Dashboard.Auth

--- a/IHP/Job/Dashboard/Auth.hs
+++ b/IHP/Job/Dashboard/Auth.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GADTs #-}
+
+{-|
+Module: IHP.Job.Dashboard.Auth
+Description:  Authentication for Job dashboard
+-}
+module IHP.Job.Dashboard.Auth (
+    AuthenticationMethod(..),
+    NoAuth(..),
+    BasicAuth(..),
+    BasicAuthStatic(..),
+) where
+
+import IHP.Prelude
+import GHC.TypeLits
+import IHP.ControllerPrelude
+import System.Environment (lookupEnv)
+
+-- | Defines one method, 'authenticate', called before every action. Use to authenticate user.
+--
+-- Three implementations are provided:
+-- - 'NoAuth' : No authentication
+-- - 'BasicAuth' : HTTP Basic Auth using environment variables
+-- - 'BasicAuthStatic' : HTTP Basic Auth using static values
+--
+-- Define your own implementation to use custom authentication for production.
+class AuthenticationMethod a where
+    authenticate :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
+
+-- | Don't use any authentication for jobs.
+data NoAuth
+
+-- | Authenticate using HTTP Basic Authentication by looking up username/password values
+-- in environment variables given as type-level strings.
+data BasicAuth (userEnv :: Symbol) (passEnv :: Symbol)
+
+-- | Authenticate using HTTP Basic Authentication using username/password given as type level strings.
+-- Meant for development only!
+data BasicAuthStatic (user :: Symbol) (pass :: Symbol)
+
+instance AuthenticationMethod NoAuth where
+    authenticate = pure ()
+
+instance (KnownSymbol userEnv, KnownSymbol passEnv) => AuthenticationMethod (BasicAuth userEnv passEnv) where
+    authenticate = do
+        creds <- (,) <$> lookupEnv (symbolVal $ Proxy @userEnv) <*> lookupEnv (symbolVal $ Proxy @passEnv)
+        case creds of
+            (Just user, Just pass) -> basicAuth (cs user) (cs pass) "jobs"
+            _ -> error "Did not find HTTP Basic Auth credentials for Jobs Dashboard."
+
+instance (KnownSymbol user, KnownSymbol pass) => AuthenticationMethod (BasicAuthStatic user pass) where
+    authenticate = basicAuth (cs $ symbolVal $ Proxy @user) (cs $ symbolVal $ Proxy @pass) "jobs"
+

--- a/IHP/Job/Dashboard/Types.hs
+++ b/IHP/Job/Dashboard/Types.hs
@@ -34,12 +34,22 @@ data BaseJob = BaseJob {
 } deriving (Show)
 
 class TableViewable a where
+    -- | Human readable title displayed on the table
     tableTitle :: Text
+
+    -- | Database table backing the view
     modelTableName :: Text
+
     tableHeaders :: [Text]
     renderTableRow :: a -> Html
+
+    -- | Link used in the table to send user to new job form
     newJobLink :: Html
+
+    -- | Gets records for displaying in the dashboard index page
     getIndex :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO [a]
+
+    -- | Gets paginated records for displaying in the list page
     getPage :: (?context :: ControllerContext, ?modelContext :: ModelContext) => Int -> Int -> IO [a]
 
 instance FromRow BaseJob where

--- a/IHP/Job/Dashboard/Types.hs
+++ b/IHP/Job/Dashboard/Types.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE GADTs #-}
-
 {-|
 Module: IHP.Job.Dashboard.Types
 Description:  Types for Job dashboard

--- a/IHP/Job/Dashboard/Types.hs
+++ b/IHP/Job/Dashboard/Types.hs
@@ -2,9 +2,11 @@
 Module: IHP.Job.Dashboard.Types
 Description:  Types for Job dashboard
 -}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 module IHP.Job.Dashboard.Types (
     BaseJob(..),
     JobsDashboardController(..),
+    TableViewable(..),
 ) where
 
 import IHP.Prelude
@@ -14,6 +16,7 @@ import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 import qualified Database.PostgreSQL.Simple.FromField as PG
 import qualified Database.PostgreSQL.Simple.ToField as PG
+import IHP.ViewPrelude (Html, View, hsx, html, timeAgo, columnNameToFieldLabel, JobStatus(..))
 import IHP.RouterPrelude hiding (get, tshow, error, map, putStrLn, elem)
 import Database.PostgreSQL.Simple.FromRow (FromRow(..), field)
 import IHP.Job.Queue () -- get FromField definition for JobStatus
@@ -29,6 +32,15 @@ data BaseJob = BaseJob {
   , lastError :: Maybe Text
 } deriving (Show)
 
+class TableViewable a where
+    tableTitle :: Text
+    modelTableName :: Text
+    tableHeaders :: [Text]
+    renderTableRow :: a -> Html
+    getPage :: (?modelContext :: ModelContext) => Int -> Int -> IO [a]
+    getIndex :: (?modelContext :: ModelContext) => IO [a]
+    newJobLink :: Html
+
 instance FromRow BaseJob where
     fromRow = BaseJob <$> field <*> field <*> field <*> field <*> field <*> field
 
@@ -37,13 +49,14 @@ instance FromRow BaseJob where
 -- so you'll get a compile error if you try and include a type that is not a job.
 data JobsDashboardController authType (jobs :: [*])
     = ListJobsAction
-
+    | ListJobAction { jobTableName :: Text, page :: Int }
     -- These actions are used for 'pathTo'. Need  to pass the parameters explicity to know how to build the path
     | ViewJobAction { jobTableName :: Text, jobId :: UUID }
     | CreateJobAction { jobTableName :: Text }
     | DeleteJobAction { jobTableName :: Text, jobId :: UUID }
 
     -- These actions are used for interal routing. Parameters are extracted dynamically in the action based on types
+    | ListJobAction'
     | ViewJobAction'
     | CreateJobAction'
     | DeleteJobAction'
@@ -51,7 +64,8 @@ data JobsDashboardController authType (jobs :: [*])
 
 
 instance HasPath (JobsDashboardController authType jobs) where
-    pathTo ListJobsAction         = "/jobs/ListJobs"
+    pathTo ListJobsAction = "/jobs/ListJobs"
+    pathTo ListJobAction   { .. } = "/jobs/ListJob?tableName=" <> jobTableName <> "&page=" <> tshow page
     pathTo ViewJobAction   { .. } = "/jobs/ViewJob?tableName=" <> jobTableName <> "&id=" <> tshow jobId
     pathTo CreateJobAction { .. } = "/jobs/CreateJob?tableName=" <> jobTableName
     pathTo DeleteJobAction { .. } = "/jobs/DeleteJob?tableName=" <> jobTableName <> "&id=" <> tshow jobId
@@ -62,6 +76,7 @@ instance CanRoute (JobsDashboardController authType jobs) where
         (string "/jobs" <* endOfInput >> pure ListJobsAction)
         <|> (string "/jobs/" <* endOfInput >> pure ListJobsAction)
         <|> (string "/jobs/ListJobs" <* endOfInput >> pure ListJobsAction)
+        <|> (string "/jobs/ListJob" <* endOfInput >> pure ListJobAction')
         <|> (string "/jobs/ViewJob" <* endOfInput >> pure ViewJobAction')
         <|> (string "/jobs/CreateJob" <* endOfInput >> pure CreateJobAction')
         <|> (string "/jobs/DeleteJob" <* endOfInput >> pure DeleteJobAction')

--- a/IHP/Job/Dashboard/Types.hs
+++ b/IHP/Job/Dashboard/Types.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GADTs #-}
+
+{-|
+Module: IHP.Job.Dashboard.Types
+Description:  Types for Job dashboard
+-}
+module IHP.Job.Dashboard.Types (
+    BaseJob(..),
+    JobsDashboardController(..),
+) where
+
+import IHP.Prelude
+import IHP.ControllerPrelude
+import GHC.TypeLits
+import qualified Database.PostgreSQL.Simple as PG
+import qualified Database.PostgreSQL.Simple.Types as PG
+import qualified Database.PostgreSQL.Simple.FromField as PG
+import qualified Database.PostgreSQL.Simple.ToField as PG
+import IHP.RouterPrelude hiding (get, tshow, error, map, putStrLn, elem)
+import Database.PostgreSQL.Simple.FromRow (FromRow(..), field)
+import IHP.Job.Queue () -- get FromField definition for JobStatus
+
+import IHP.Job.Dashboard.Auth
+
+data BaseJob = BaseJob {
+    table :: Text
+  , id :: UUID
+  , status :: JobStatus
+  , updatedAt :: UTCTime
+  , createdAt :: UTCTime
+  , lastError :: Maybe Text
+} deriving (Show)
+
+instance FromRow BaseJob where
+    fromRow = BaseJob <$> field <*> field <*> field <*> field <*> field <*> field
+
+-- | Defines controller actions for acting on a dashboard made of some list of types.
+-- Later functions and typeclasses introduce constraints on the types in this list,
+-- so you'll get a compile error if you try and include a type that is not a job.
+data JobsDashboardController authType (jobs :: [*])
+    = ListJobsAction
+
+    -- These actions are used for 'pathTo'. Need  to pass the parameters explicity to know how to build the path
+    | ViewJobAction { jobTableName :: Text, jobId :: UUID }
+    | CreateJobAction { jobTableName :: Text }
+    | DeleteJobAction { jobTableName :: Text, jobId :: UUID }
+
+    -- These actions are used for interal routing. Parameters are extracted dynamically in the action based on types
+    | ViewJobAction'
+    | CreateJobAction'
+    | DeleteJobAction'
+    deriving (Show, Eq, Data)
+
+
+instance HasPath (JobsDashboardController authType jobs) where
+    pathTo ListJobsAction         = "/jobs/ListJobs"
+    pathTo ViewJobAction   { .. } = "/jobs/ViewJob?tableName=" <> jobTableName <> "&id=" <> tshow jobId
+    pathTo CreateJobAction { .. } = "/jobs/CreateJob?tableName=" <> jobTableName
+    pathTo DeleteJobAction { .. } = "/jobs/DeleteJob?tableName=" <> jobTableName <> "&id=" <> tshow jobId
+    pathTo _ = error "pathTo for internal JobsDashboard functions not supported. Use non-backtick action and pass necessary parameters to use pathTo."
+
+instance CanRoute (JobsDashboardController authType jobs) where
+    parseRoute' = do
+        (string "/jobs" <* endOfInput >> pure ListJobsAction)
+        <|> (string "/jobs/" <* endOfInput >> pure ListJobsAction)
+        <|> (string "/jobs/ListJobs" <* endOfInput >> pure ListJobsAction)
+        <|> (string "/jobs/ViewJob" <* endOfInput >> pure ViewJobAction')
+        <|> (string "/jobs/CreateJob" <* endOfInput >> pure CreateJobAction')
+        <|> (string "/jobs/DeleteJob" <* endOfInput >> pure DeleteJobAction')
+

--- a/IHP/Job/Dashboard/Utils.hs
+++ b/IHP/Job/Dashboard/Utils.hs
@@ -1,0 +1,18 @@
+module IHP.Job.Dashboard.Utils where
+
+import IHP.Prelude
+import IHP.ModelSupport
+import qualified Database.PostgreSQL.Simple as PG
+import qualified Database.PostgreSQL.Simple.Types as PG
+import qualified Database.PostgreSQL.Simple.FromField as PG
+import qualified Database.PostgreSQL.Simple.ToField as PG
+
+numberOfPagesForTable :: _ => Text -> Int -> IO Int
+numberOfPagesForTable table pageSize = do
+    (PG.Only totalRecords : _) <- sqlQuery
+        (PG.Query $ cs $ "SELECT COUNT(*) FROM " <> table)
+        ()
+    pure $ case totalRecords `quotRem` pageSize of
+        (pages, 0) -> pages
+        (pages, _) -> pages + 1
+

--- a/IHP/Job/Dashboard/View.hs
+++ b/IHP/Job/Dashboard/View.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE GADTs #-}
 
 {-|

--- a/IHP/Job/Dashboard/View.hs
+++ b/IHP/Job/Dashboard/View.hs
@@ -54,7 +54,6 @@ newtype HtmlView = HtmlView Html
 instance View HtmlView where
     html (HtmlView html) = [hsx|{html}|]
 
--- renderStatus :: forall job. (HasField "status" JobStatus job, HasField "lastError" (Maybe Text) job) => job -> Html
 renderStatus job = case get #status job of
     JobStatusNotStarted -> [hsx|<span class="badge badge-secondary">Not Started</span>|]
     JobStatusRunning -> [hsx|<span class="badge badge-primary">Running</span>|]

--- a/IHP/Job/Dashboard/View.hs
+++ b/IHP/Job/Dashboard/View.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GADTs #-}
+
+{-|
+Module: IHP.Job.Dashboard.View
+Description:  Views for Job dashboard
+-}
+module IHP.Job.Dashboard.View where
+
+import IHP.Prelude
+import IHP.ViewPrelude (Html, View, hsx, html, timeAgo, columnNameToFieldLabel, JobStatus(..))
+import IHP.Job.Dashboard.Types
+
+-- | Provides a type-erased view. This allows us to specify a view as a return type without needed
+-- to know exactly what type the view will be, which in turn allows for custom implmentations of
+-- almost all the view functions in this module. Go GADTs!
+data SomeView where
+    SomeView :: forall a. (View a) => a -> SomeView
+
+-- | Since the only constructor for 'SomeView' requires that it is passed a 'View', we can use
+-- that to implement a 'View' instance for 'SomeView'
+instance View SomeView where
+    html (SomeView a) = let ?view = a in IHP.ViewPrelude.html a
+
+-- | Define how to render a list of views as a view. Just concatenate them together!
+instance (View a) => View [a] where
+    html [] = [hsx||]
+    html (x:xs) =
+        -- need to nest let's here in order to satisfy the implicit ?view parameter for 'html'.
+        -- ?view needs to be the type of the view being rendered, so set it before each render
+        -- here we render single view
+        let ?view = x in
+            let current = IHP.ViewPrelude.html x in
+                -- now rendering a list view
+                let ?view = xs in
+                    let rest = IHP.ViewPrelude.html xs in
+                        [hsx|{current}{rest}|]
+
+-- | A view containing no data. Used occasionally as a default implementation for some functions.
+data EmptyView = EmptyView
+instance View EmptyView where
+    html _ = [hsx||]
+
+-- | A view constructed from some HTML.
+newtype HtmlView = HtmlView Html
+instance View HtmlView where
+    html (HtmlView html) = [hsx|{html}|]
+
+-- | Defines a set of necessary functions to display some data 'a' in a table format given a list of '[a]'.
+class TableViewable a where
+    tableTitle :: Text
+
+    -- | Headers that describe each column in the table
+    tableHeaders :: [Text]
+
+    -- | Optional HTML that will be placed in the top right of the table. Used for a "create new" button.
+    createNewForm :: Html
+    createNewForm = [hsx||]
+
+    renderTableRow :: a -> Html
+
+    renderTable :: [a] -> Html
+    renderTable rows =
+        let
+            title = tableTitle @a
+            headers = tableHeaders @a
+            renderRow = renderTableRow @a
+            newForm = createNewForm @a
+        in [hsx|
+        <div>
+            <div class="d-flex justify-content-between align-items-center">
+                <h3>{title}</h3>
+                {newForm}
+            </div>
+            <table class="table table-sm table-hover">
+                <thead>
+                    <tr>
+                        {forEach headers renderHeader}
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {forEach rows renderRow}
+                </tbody>
+            </table>
+        </div>
+    |]
+        where renderHeader field = [hsx|<th>{field}</th>|]
+
+data TableView a = TableView [a]
+
+-- A TableView is only a View if it's contents are TableViewable.
+instance forall a. (TableViewable a) => View (TableView a) where
+    html (TableView rows) = renderTable rows
+
+statusToBadge :: JobStatus -> Html
+statusToBadge JobStatusNotStarted= [hsx|<span class="badge badge-info">Not Started</span>|]
+statusToBadge JobStatusRunning = [hsx|<span class="badge badge-info">Running</span>|]
+statusToBadge JobStatusSucceeded = [hsx|<span class="badge badge-success">Succeeded</span>|]
+statusToBadge JobStatusFailed = [hsx|<span class="badge badge-danger">Failed</span>|]
+statusToBadge JobStatusRetry = [hsx|<span class="badge badge-info">Retrying</span>|]
+
+renderBaseJobTableRow :: BaseJob -> Html
+renderBaseJobTableRow job = let
+        btnStyle :: Text = "outline: none !important; padding: 0; border: 0; vertical-align: baseline;"
+    in [hsx|
+        <tr>
+            <td>{get #id job}</td>
+            <td>{get #updatedAt job}</td>
+            <td>{statusToBadge $ get #status job}</td>
+            <td><a href={ViewJobAction (get #table job) (get #id job)} class="text-primary">Show</a></td>
+            <td>
+                <form action={CreateJobAction (get #table job)} method="POST">
+                    <button type="submit" style={btnStyle} class="btn btn-link text-secondary">Retry</button>
+                </form>
+            </td>
+        </tr>
+    |]
+
+renderBaseJobTable :: Text -> [BaseJob] -> Html
+renderBaseJobTable table rows =
+    let
+        headers :: [Text] = ["ID", "Updated At", "Status", "", ""]
+    in [hsx|
+    <div>
+        <div class="d-flex justify-content-between align-items-center">
+            <h3>{table |> columnNameToFieldLabel}</h3>
+            {renderNewBaseJobLink table}
+        </div>
+        <table class="table table-sm table-hover">
+            <thead>
+                <tr>
+                    {forEach headers renderHeader}
+                </tr>
+            </thead>
+
+            <tbody>
+                {forEach rows renderBaseJobTableRow}
+            </tbody>
+        </table>
+    </div>
+|]
+    where renderHeader field = [hsx|<th>{field}</th>|]
+
+renderNewBaseJobLink :: Text -> Html
+renderNewBaseJobLink table =
+    let
+        link = "/jobs/CreateJob?tableName=" <> table
+    in [hsx|
+        <form action={link}>
+            <button type="submit" class="btn btn-primary btn-sm">+ New Job</button>
+        </form>
+    |]
+
+renderNewBaseJobForm :: Text -> Html
+renderNewBaseJobForm table = [hsx|
+    <br>
+        <h5>New Job: {table}</h5>
+    <br>
+    <form action="/jobs/CreateJob" method="POST">
+        <input type="hidden" id="tableName" name="tableName" value={table}>
+        <button type="submit" class="btn btn-primary">New Job</button>
+    </form>
+|]
+
+renderBaseJobDetailView :: BaseJob -> Html
+renderBaseJobDetailView job = let table = get #table job in [hsx|
+    <br>
+        <h5>Viewing Job {get #id job} in {table}</h5>
+    <br>
+    <table class="table">
+        <tbody>
+            <tr>
+                <th>Updated At</th>
+                <td>{get #updatedAt job}</td>
+            </tr>
+            <tr>
+                <th>Created At</th>
+                <td>{get #createdAt job |> timeAgo}</td>
+            </tr>
+            <tr>
+                <th>Status</th>
+                <td>{statusToBadge (get #status job)}</td>
+            </tr>
+            <tr>
+                <th>Last Error</th>
+                <td>{fromMaybe "No error" (get #lastError job)}</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="d-flex flex-row">
+        <form class="mr-2" action="/jobs/DeleteJob" method="POST">
+            <input type="hidden" id="tableName" name="tableName" value={table}>
+            <input type="hidden" id="id" name="id" value={tshow $ get #id job}>
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+        <form action="/jobs/CreateJob" method="POST">
+            <input type="hidden" id="tableName" name="tableName" value={table}>
+            <button type="submit" class="btn btn-primary">Run again</button>
+        </form>
+    </div>
+|]
+
+

--- a/IHP/Job/Types.hs
+++ b/IHP/Job/Types.hs
@@ -23,7 +23,7 @@ class Worker application where
 data JobWorkerArgs = JobWorkerArgs
     { allJobs :: IORef [Async.Async ()]
     , workerId :: UUID
-    , modelContext :: ModelContext 
+    , modelContext :: ModelContext
     , frameworkConfig :: FrameworkConfig }
 
 newtype JobWorker = JobWorker (JobWorkerArgs -> IO (Async.Async ()))

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -223,6 +223,9 @@ library
         , IHP.Job.Runner
         , IHP.Job.Types
         , IHP.Job.Dashboard
+        , IHP.Job.Dashboard.Types
+        , IHP.Job.Dashboard.Auth
+        , IHP.Job.Dashboard.View
         , IHP.PageTitle.ControllerFunctions
         , IHP.PageTitle.Types
         , IHP.PageTitle.ViewFunctions

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -222,6 +222,7 @@ library
         , IHP.Job.Queue
         , IHP.Job.Runner
         , IHP.Job.Types
+        , IHP.Job.Dashboard
         , IHP.PageTitle.ControllerFunctions
         , IHP.PageTitle.Types
         , IHP.PageTitle.ViewFunctions

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -226,6 +226,7 @@ library
         , IHP.Job.Dashboard.Types
         , IHP.Job.Dashboard.Auth
         , IHP.Job.Dashboard.View
+        , IHP.Job.Dashboard.Utils
         , IHP.PageTitle.ControllerFunctions
         , IHP.PageTitle.Types
         , IHP.PageTitle.ViewFunctions


### PR DESCRIPTION
Jobs share lots in common. By default, in order to provide an interface for viewing and running jobs, IHP users would have to create separate controllers, views, and actions for each job type individually  which is error prone and just not fun. The goal of this job dashboard to use leverage Haskell's type programming and the similar type characteristics of jobs to produce a customizable dashboard for interacting with an IHP application's jobs.

In the future I could imagine this being extended to allow for scheduling of jobs and other nice features.

See included documentation for details https://github.com/digitallyinduced/ihp/pull/832/files#diff-b046ff406e82435d7978bf6566eab8772b94e3b8092a3d8c389d173a0ebfbe9dR94

TODO
- [x] Limit views shown on index page
- [x] Add paginated view page for each job type