### PR TITLE
Minify Production CSS

### DIFF
--- a/IHP/Modal/ViewFunctions.hs
+++ b/IHP/Modal/ViewFunctions.hs
@@ -13,7 +13,7 @@ import Text.Blaze.Html5 (Html, preEscapedText)
 
 renderModal modal = renderModal' modal True
 renderModal' Modal { .. } show = [hsx|
-        <div class={modalClassName} id="modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true" style={displayStyle} onclick="if (event.target.id === 'modal') document.getElementById('modal-backdrop').click()">
+        <div class={modalClassName} id="modal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true" style={displayStyle} onclick="if (event.target.id === 'modal') document.getElementById('modal-backdrop').click()">
             {modalInner}
         </div>
         <a id="modal-backdrop" href={modalCloseUrl} class={backdropClassName} style={displayStyle}/>
@@ -44,7 +44,7 @@ renderModal' Modal { .. } show = [hsx|
 renderModalHeader :: Text -> Text -> Html
 renderModalHeader title closeUrl = [hsx|
     <div class="modal-header">
-      <h5 class="modal-title" id="exampleModalLabel">{title}</h5>
+      <h5 class="modal-title" id="modal-title">{title}</h5>
       <a href={closeUrl} class="btn-link close" data-dismiss="modal" aria-label="Close">
         <span aria-hidden="true">{preEscapedText "&times;"}</span>
       </a>

--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -155,7 +155,7 @@ static/prod.js: $(JS_FILES) ## Builds the production js bundle
 	awk -v RS='\0' '{print "(function (window, document, undefined) {"; print; print "\n})(window, document);";}' $(JS_FILES) > $@
 
 static/prod.css: $(CSS_FILES) ## Builds the production css bundle
-	cat $(CSS_FILES) > $@
+	cat $(CSS_FILES) | sed -r ':a; s%(.*)/\*.*\*/%\1%; ta; /\/\*/ !b; N; ba' | tr -d '\t' | tr -d ' ' | tr -d '\n' | tr -s ' ' ' ' > $@
 
 print-ghc-options: ## Prints all used ghc options. Useful for scripting
 	@echo ${GHC_OPTIONS}


### PR DESCRIPTION
This doesn't really do real minification like renaming variable names to one letter, but it removes all spaces/tabs/new lines, and is pretty good.
Taken from here: https://mohammadthalif.wordpress.com/2016/07/25/how-to-minify-css-using-simple-bash-commands/