### PR TITLE
feat: use frameworkConfig context in Job

### DIFF
--- a/IHP/Job/Runner.hs
+++ b/IHP/Job/Runner.hs
@@ -28,8 +28,9 @@ runJobWorkers jobWorkers = do
     let oneSecond = 1000000
 
     putStrLn ("Starting worker " <> tshow workerId)
+    let ?frameworkConfig = ?context
 
-    let jobWorkerArgs = JobWorkerArgs { allJobs, workerId, modelContext = ?modelContext, frameworkConfig = ?context}
+    let jobWorkerArgs = JobWorkerArgs { allJobs, workerId, modelContext = ?modelContext, frameworkConfig = ?frameworkConfig}
 
     threadId <- Concurrent.myThreadId
     exitSignalsCount <- newIORef 0
@@ -103,8 +104,9 @@ jobWorkerFetchAndRunLoop :: forall job.
     , Show job
     ) => JobWorkerArgs -> IO (Async.Async ())
 jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
-    let ?context = frameworkConfig
+    let ?frameworkConfig = frameworkConfig
     let ?modelContext = modelContext
+
 
     -- This loop schedules all jobs that are in the queue.
     -- It will be initally be called when first starting up this job worker

--- a/IHP/Job/Types.hs
+++ b/IHP/Job/Types.hs
@@ -1,30 +1,31 @@
 module IHP.Job.Types
-( Job (..)
-, JobWorkerArgs (..)
-, JobWorker (..)
-, JobStatus (..)
-, Worker (..)
-)
+  ( Job (..),
+    JobWorkerArgs (..),
+    JobWorker (..),
+    JobStatus (..),
+    Worker (..),
+  )
 where
 
-import IHP.Prelude
-import IHP.FrameworkConfig
 import qualified Control.Concurrent.Async as Async
+import IHP.FrameworkConfig
+import IHP.Prelude
 
 class Job job where
-    perform :: (?modelContext :: ModelContext, ?context :: FrameworkConfig) => job -> IO ()
+  perform :: (?modelContext :: ModelContext, ?frameworkConfig :: FrameworkConfig) => job -> IO ()
 
-    maxAttempts :: (?job :: job) => Int
-    maxAttempts = 10
+  maxAttempts :: (?job :: job) => Int
+  maxAttempts = 10
 
 class Worker application where
-    workers :: application -> [JobWorker]
+  workers :: application -> [JobWorker]
 
 data JobWorkerArgs = JobWorkerArgs
-    { allJobs :: IORef [Async.Async ()]
-    , workerId :: UUID
-    , modelContext :: ModelContext
-    , frameworkConfig :: FrameworkConfig }
+  { allJobs :: IORef [Async.Async ()],
+    workerId :: UUID,
+    modelContext :: ModelContext,
+    frameworkConfig :: FrameworkConfig
+  }
 
 newtype JobWorker = JobWorker (JobWorkerArgs -> IO (Async.Async ()))
 
@@ -32,9 +33,9 @@ newtype JobWorker = JobWorker (JobWorkerArgs -> IO (Async.Async ()))
 --
 -- > CREATE TYPE JOB_STATUS AS ENUM ('job_status_not_started', 'job_status_running', 'job_status_failed', 'job_status_succeeded', 'job_status_retry');
 data JobStatus
-    = JobStatusNotStarted
-    | JobStatusRunning
-    | JobStatusFailed
-    | JobStatusSucceeded
-    | JobStatusRetry
-    deriving (Eq, Show, Read, Enum)
+  = JobStatusNotStarted
+  | JobStatusRunning
+  | JobStatusFailed
+  | JobStatusSucceeded
+  | JobStatusRetry
+  deriving (Eq, Show, Read, Enum)


### PR DESCRIPTION
a function with a constraint like so : `:: (?frameworkConfig :: FrameworkConfig) => ...` can't be called in Jobs like in Controllers because the constraint in the `perform` function is  

```
perform :: (?modelContext :: ModelContext, ?context :: FrameworkConfig) => job -> IO ()
```
This PR replaces the signature with : 
```
perform :: (?modelContext :: ModelContext, ?frameworkConfig :: FrameworkConfig) => job -> IO ()
```

PS : formatting problem, I didn't find a way to respect yours, sorry about that.