### PR TITLE
Disable nonmoving-gc as a possible solution to #799

### DIFF
--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -81,7 +81,7 @@ PROD_GHC_OPTIONS+= -fspec-constr-keen
 PROD_GHC_OPTIONS+= -fspecialise-aggressively
 PROD_GHC_OPTIONS+= -fstatic-argument-transformation
 PROD_GHC_OPTIONS+= -fmax-worker-args=200
-PROD_GHC_OPTIONS+= -with-rtsopts="-A512m -n4m -N --nonmoving-gc"
+PROD_GHC_OPTIONS+= -with-rtsopts="-A512m -n4m -N"
 
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
Currently the non moving gc causes server crashes in production, https://github.com/digitallyinduced/ihp/issues/799