### PR TITLE
Added Trailing slash for additional apps in IDE

### DIFF
--- a/IHP/IDE/ToolServer/Layout.hs
+++ b/IHP/IDE/ToolServer/Layout.hs
@@ -88,7 +88,7 @@ toolServerLayout inner = H.docTypeHtml ! A.lang "en" $ [hsx|
 
         appNavItem :: Text -> Html
         appNavItem "Web" = navItem "APP" fileIcon (appUrl <> "/") False
-        appNavItem name = navItem (toUpper name) fileIcon (appUrl <> "/" <> (toLower name)) False
+        appNavItem name = navItem (toUpper name) fileIcon (appUrl <> "/" <> (toLower name) <> "/") False
 
         navItem :: Text -> Html -> Text -> Bool -> Html
         navItem label icon action active = [hsx|


### PR DESCRIPTION
Very small PR. To route to autogenerated Apps like ADMIN (localhost:8000/admin/). Previously link broken ((localhost:8000/admin) in IDE without a trailing slash, similar for other autogenerated applications.