### PR TITLE
job timeouts

### DIFF
--- a/IHP/Job/Queue.hs
+++ b/IHP/Job/Queue.hs
@@ -131,60 +131,60 @@ jobDidFail job exception = do
 
 -- | Called by jobDidFail. Sets the job status to 'JobStatusFailed' or 'JobStatusRetry' (if more attempts are possible) and resets 'lockedBy'
 jobDidFail' :: forall job.
-  ( job ~ GetModelByTableName (GetTableName job)
-  , SetField "lockedBy" job (Maybe UUID)
-  , SetField "status" job JobStatus
-  , SetField "updatedAt" job UTCTime
-  , HasField "attemptsCount" job Int
-  , SetField "lastError" job (Maybe Text)
-  , Job job
-  , CanUpdate job
-  , Show job
-  , ?modelContext :: ModelContext
-  ) => job -> Text -> IO ()
+    ( job ~ GetModelByTableName (GetTableName job)
+    , SetField "lockedBy" job (Maybe UUID)
+    , SetField "status" job JobStatus
+    , SetField "updatedAt" job UTCTime
+    , HasField "attemptsCount" job Int
+    , SetField "lastError" job (Maybe Text)
+    , Job job
+    , CanUpdate job
+    , Show job
+    , ?modelContext :: ModelContext
+    ) => job -> Text -> IO ()
 jobDidFail' job lastExceptionMessage = do
-  updatedAt <- getCurrentTime
+    updatedAt <- getCurrentTime
 
-  let ?job = job
-  let canRetry = get #attemptsCount job < maxAttempts
-  let status = if canRetry then JobStatusRetry else JobStatusFailed
-  job
-    |> set #status status
-    |> set #lockedBy Nothing
-    |> set #updatedAt updatedAt
-    |> set #lastError (Just lastExceptionMessage)
-    |> updateRecord
+    let ?job = job
+    let canRetry = get #attemptsCount job < maxAttempts
+    let status = if canRetry then JobStatusRetry else JobStatusFailed
+    job
+        |> set #status status
+        |> set #lockedBy Nothing
+        |> set #updatedAt updatedAt
+        |> set #lastError (Just lastExceptionMessage)
+        |> updateRecord
 
-  pure ()
+    pure ()
 
 jobDidTimeout :: forall job.
-  ( job ~ GetModelByTableName (GetTableName job)
-  , SetField "lockedBy" job (Maybe UUID)
-  , SetField "status" job JobStatus
-  , SetField "updatedAt" job UTCTime
-  , HasField "attemptsCount" job Int
-  , SetField "lastError" job (Maybe Text)
-  , Job job
-  , CanUpdate job
-  , Show job
-  , ?modelContext :: ModelContext
-  ) => job -> IO ()
+    ( job ~ GetModelByTableName (GetTableName job)
+    , SetField "lockedBy" job (Maybe UUID)
+    , SetField "status" job JobStatus
+    , SetField "updatedAt" job UTCTime
+    , HasField "attemptsCount" job Int
+    , SetField "lastError" job (Maybe Text)
+    , Job job
+    , CanUpdate job
+    , Show job
+    , ?modelContext :: ModelContext
+    ) => job -> IO ()
 jobDidTimeout job = do
-  updatedAt <- getCurrentTime
+    updatedAt <- getCurrentTime
 
-  putStrLn "Job timed out"
+    putStrLn "Job timed out"
 
-  let ?job = job
-  let canRetry = get #attemptsCount job < maxAttempts
-  let status = if canRetry then JobStatusRetry else JobStatusTimedOut
-  job
-    |> set #status status
-    |> set #lockedBy Nothing
-    |> set #updatedAt updatedAt
-    |> set #lastError (Just "Timeout reached")
-    |> updateRecord
+    let ?job = job
+    let canRetry = get #attemptsCount job < maxAttempts
+    let status = if canRetry then JobStatusRetry else JobStatusTimedOut
+    job
+        |> set #status status
+        |> set #lockedBy Nothing
+        |> set #updatedAt updatedAt
+        |> set #lastError (Just "Timeout reached")
+        |> updateRecord
 
-  pure ()
+    pure ()
   
 
 -- | Called when a job succeeded. Sets the job status to 'JobStatusSucceded' and resets 'lockedBy'

--- a/IHP/Job/Runner.hs
+++ b/IHP/Job/Runner.hs
@@ -108,6 +108,9 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
     let ?context = frameworkConfig
     let ?modelContext = modelContext
 
+    runningJobs <- Queue.fetchRunningJobs @job
+    mapM_ (Queue.jobDidFail' job "Job was running at startup") runningJobs
+
     -- This loop schedules all jobs that are in the queue.
     -- It will be initally be called when first starting up this job worker
     -- and after that it will be called when something has been inserted into the queue (or changed to retry)

--- a/IHP/Job/Types.hs
+++ b/IHP/Job/Types.hs
@@ -17,6 +17,9 @@ class Job job where
     maxAttempts :: (?job :: job) => Int
     maxAttempts = 10
 
+    timeoutInMicroseconds :: (?job :: job) => Maybe Int
+    timeoutInMicroseconds = Nothing
+
 class Worker application where
     workers :: application -> [JobWorker]
 
@@ -35,6 +38,7 @@ data JobStatus
     = JobStatusNotStarted
     | JobStatusRunning
     | JobStatusFailed
+    | JobStatusTimedOut
     | JobStatusSucceeded
     | JobStatusRetry
     deriving (Eq, Show, Read, Enum)

--- a/IHP/Job/Types.hs
+++ b/IHP/Job/Types.hs
@@ -29,7 +29,7 @@ data JobWorkerArgs = JobWorkerArgs
     , modelContext :: ModelContext
     , frameworkConfig :: FrameworkConfig }
 
-newtype JobWorker = JobWorker (JobWorkerArgs -> IO (Async.Async ()))
+data JobWorker = JobWorker (JobWorkerArgs -> (Text, IO ())) (JobWorkerArgs -> IO (Async.Async ()))
 
 -- | Mapping for @JOB_STATUS@. The DDL statement for this can be found in IHPSchema.sql:
 --

--- a/lib/IHP/IHPSchema.sql
+++ b/lib/IHP/IHPSchema.sql
@@ -2,4 +2,4 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- Used by IHP.Job
-CREATE TYPE JOB_STATUS AS ENUM ('job_status_not_started', 'job_status_running', 'job_status_failed', 'job_status_succeeded', 'job_status_retry');
+CREATE TYPE JOB_STATUS AS ENUM ('job_status_not_started', 'job_status_running', 'job_status_failed', 'job_status_timed_out', 'job_status_succeeded', 'job_status_retry');


### PR DESCRIPTION
Adds an optional timeoutInMicroseconds.

Also automatically sets jobs that are set to "running" on startup to "failed" with a custom message, as that's more appropriate than setting them to time out as we talked about before.