### PR TITLE
compile equations for MatchesOp added.

### DIFF
--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -94,6 +94,8 @@ compileOperator (LikeOp CaseSensitive) = "LIKE"
 compileOperator (LikeOp CaseInsensitive) = "ILIKE"
 compileOperator (NotLikeOp CaseSensitive) = "NOT LIKE"
 compileOperator (NotLikeOp CaseInsensitive) = "NOT ILIKE"
+compileOperator (MatchesOp CaseSensitive) = " ~ "
+compileOperator (MatchesOp CaseInsensitive) = " ~* "
 compileOperator SqlOp = ""
 {-# INLINE compileOperator #-}
 


### PR DESCRIPTION
Apparently the compile equations for MatchesOp were missing, so I added them.