### PR TITLE
Labeled Query Results

### DIFF
--- a/IHP/Fetch.hs
+++ b/IHP/Fetch.hs
@@ -92,10 +92,10 @@ instance (model ~ GetModelByTableName table, KnownSymbol table) => Fetchable (No
     fetchOne :: (?modelContext :: ModelContext) => (PG.FromRow model, KnownSymbol (GetTableName model)) => NoJoinQueryBuilderWrapper table -> IO model
     fetchOne = commonFetchOne
 
-instance (model ~ GetModelByTableName table, KnownSymbol table, FromField value, KnownSymbol foreignTable, foreignTable ~ GetTableName foreignModel, KnownSymbol columnName, Gen.Generic value, HasField columnName foreignModel value, HasQueryBuilder (IndexedQueryBuilderWrapper foreignModel columnName value) NoJoins) => Fetchable (IndexedQueryBuilderWrapper foreignModel columnName value table) model where
-    type instance FetchResult (IndexedQueryBuilderWrapper foreignModel columnName value table) model = [IndexedData value model]
+instance (model ~ GetModelByTableName table, KnownSymbol table, FromField value, KnownSymbol foreignTable, foreignModel ~ GetModelByTableName foreignTable, KnownSymbol columnName, HasField columnName foreignModel value, HasQueryBuilder (IndexedQueryBuilderWrapper foreignTable columnName value) NoJoins) => Fetchable (IndexedQueryBuilderWrapper foreignTable columnName value table) model where
+    type instance FetchResult (IndexedQueryBuilderWrapper foreignTable columnName value table) model = [IndexedData value model]
     {-# INLINE fetch #-}
-    fetch :: (KnownSymbol (GetTableName model), PG.FromRow model, FromField value, KnownSymbol foreignTable, foreignTable ~ GetTableName foreignModel, KnownSymbol columnName, HasField columnName foreignModel value, HasQueryBuilder (IndexedQueryBuilderWrapper foreignModel columnName value) NoJoins, Gen.Generic value, ?modelContext :: ModelContext) => IndexedQueryBuilderWrapper foreignModel columnName value table -> IO [IndexedData value model]
+    fetch :: (KnownSymbol (GetTableName model), PG.FromRow model, ?modelContext :: ModelContext) => IndexedQueryBuilderWrapper foreignTable columnName value table -> IO [IndexedData value model]
     fetch !queryBuilderProvider = do
         let !(theQuery, theParameters) = queryBuilderProvider
                 |> toSQL
@@ -103,11 +103,11 @@ instance (model ~ GetModelByTableName table, KnownSymbol table, FromField value,
         sqlQuery @_ @(IndexedData value model) (Query $ cs theQuery) theParameters
 
     {-# INLINE fetchOneOrNothing #-}
-    fetchOneOrNothing :: (?modelContext :: ModelContext) => (PG.FromRow model, KnownSymbol (GetTableName model), KnownSymbol foreignTable, foreignTable ~ GetTableName foreignModel, KnownSymbol columnName, HasField columnName foreignModel value, HasQueryBuilder (IndexedQueryBuilderWrapper foreignModel columnName value) NoJoins) => IndexedQueryBuilderWrapper foreignModel columnName value table -> IO (Maybe model)
+    fetchOneOrNothing :: (?modelContext :: ModelContext) => (PG.FromRow model, KnownSymbol (GetTableName model), KnownSymbol foreignTable, foreignModel ~ GetModelByTableName foreignTable, KnownSymbol columnName, HasField columnName foreignModel value, HasQueryBuilder (IndexedQueryBuilderWrapper foreignTable columnName value) NoJoins) => IndexedQueryBuilderWrapper foreignTable columnName value table -> IO (Maybe model)
     fetchOneOrNothing = commonFetchOneOrNothing
 
     {-# INLINE fetchOne #-}
-    fetchOne :: (?modelContext :: ModelContext) => (PG.FromRow model, KnownSymbol (GetTableName model), KnownSymbol foreignTable, foreignTable ~ GetTableName foreignModel, KnownSymbol columnName, HasField columnName foreignModel value, HasQueryBuilder (IndexedQueryBuilderWrapper foreignModel columnName value) NoJoins) => IndexedQueryBuilderWrapper foreignModel columnName value table -> IO model
+    fetchOne :: (?modelContext :: ModelContext) => (PG.FromRow model, KnownSymbol (GetTableName model), KnownSymbol foreignTable, foreignModel ~ GetModelByTableName foreignTable, KnownSymbol columnName, HasField columnName foreignModel value, HasQueryBuilder (IndexedQueryBuilderWrapper foreignTable columnName value) NoJoins) => IndexedQueryBuilderWrapper foreignTable columnName value table -> IO model
     fetchOne = commonFetchOne
 
 

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -260,10 +260,10 @@ instance Newtype.Newtype (Id' model) where
     pack = Id
     unpack (Id uuid) = uuid
 
-data IndexedData a b = IndexedData { index :: a, content :: b }
-    deriving (Generic)
+data IndexedData a b = IndexedData { indexValue :: a, contentValue :: b }
+    deriving (Show)
 
-instance (FromField index, Generic index, PG.FromRow a) => PGFR.FromRow (IndexedData index a) where
+instance (FromField index, PG.FromRow a) => PGFR.FromRow (IndexedData index a) where
     fromRow = IndexedData <$> PGFR.field <*> PGFR.fromRow
 
 -- | Sometimes you have a hardcoded UUID value which represents some record id. This instance allows you

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -27,6 +27,7 @@ import Unsafe.Coerce
 import Data.UUID
 import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
+import qualified Database.PostgreSQL.Simple.FromRow as PGFR
 import GHC.Records
 import GHC.OverloadedLabels
 import GHC.TypeLits
@@ -258,6 +259,12 @@ instance Newtype.Newtype (Id' model) where
     type O (Id' model) = PrimaryKey model
     pack = Id
     unpack (Id uuid) = uuid
+
+data IndexedData a b = IndexedData { index :: a, content :: b }
+    deriving (Generic)
+
+instance (FromField index, Generic index, PG.FromRow a) => PGFR.FromRow (IndexedData index a) where
+    fromRow = IndexedData <$> PGFR.field <*> PGFR.fromRow
 
 -- | Sometimes you have a hardcoded UUID value which represents some record id. This instance allows you
 -- to write the Id like a string:

--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -774,13 +774,15 @@ innerJoin (name, name') queryBuilderProvider = injectQueryBuilder $ JoinQueryBui
 --
 --
 -- __Example:__ Fetch a list of all comments, each paired with the id of the post it belongs to.
--- > postLabeledComments <- query @Comment
--- >                            |> innerJoin @Post (#postId, #id)
--- >                            |> labelResults @Post #id
--- >                            |> fetch
--- > -- SELECT posts.id, comments.* FROM comments INNER JOIN posts ON comments.postId = posts.id 
+-- labeledTags <-
+--   query @Tag
+--      |> innerJoin @Tagging (#id, #tagId)
+--      |> innerJoinThirdTable @Post @Tagging (#id, #postId)
+--      |> labelResults @Post #id
+--      |> fetch
+---- > -- SELECT posts.id, tags.* FROM comments INNER JOIN taggings ON tags.id = taggings.tagId INNER JOIN posts ON posts.id = taggings.postId 
 -- 
--- postLabeledComments is a list of type ['LabeledData' (Id' "posts") Comment] such that "LabeledData postId comment" is contained in that list if "comment" is a comment to the post with id postId.
+-- postLabeledTags is a list of type ['LabeledData' (Id' "posts") Tag] such that "LabeledData postId comment" is contained in that list if "comment" is a comment to the post with id postId.
 --
 labelResults :: forall foreignModel baseModel foreignTable baseTable name value queryBuilderProvider joinRegister.
                 (

--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -770,19 +770,20 @@ innerJoin (name, name') queryBuilderProvider = injectQueryBuilder $ JoinQueryBui
         rightJoinColumn = (Text.encodeUtf8 . fieldNameToColumnName) (symbolToText @name')
 {-# INLINE innerJoin #-}
 
--- | Index the values from a table with values of a field from a table joined by 'innerJoin' or 'innerJoinThirdTable'. Useful to get, e.g., the comments to a set of posts in such a way that the assignment of comments to posts.
+-- | Index the values from a table with values of a field from a table joined by 'innerJoin' or 'innerJoinThirdTable'. Useful to get, e.g., the tags to a set of posts in such a way that the assignment of tags to posts is preserved.
 --
 --
 -- __Example:__ Fetch a list of all comments, each paired with the id of the post it belongs to.
--- labeledTags <-
---   query @Tag
---      |> innerJoin @Tagging (#id, #tagId)
---      |> innerJoinThirdTable @Post @Tagging (#id, #postId)
---      |> labelResults @Post #id
---      |> fetch
----- > -- SELECT posts.id, tags.* FROM comments INNER JOIN taggings ON tags.id = taggings.tagId INNER JOIN posts ON posts.id = taggings.postId 
+--
+-- > labeledTags <-
+-- >  query @Tag
+-- >     |> innerJoin @Tagging (#id, #tagId)
+-- >     |> innerJoinThirdTable @Post @Tagging (#id, #postId)
+-- >     |> labelResults @Post #id
+-- >     |> fetch
+-- > -- SELECT posts.id, tags.* FROM comments INNER JOIN taggings ON tags.id = taggings.tagId INNER JOIN posts ON posts.id = taggings.postId 
 -- 
--- postLabeledTags is a list of type ['LabeledData' (Id' "posts") Tag] such that "LabeledData postId comment" is contained in that list if "comment" is a comment to the post with id postId.
+-- labeledTags is then a list of type ['LabeledData' (Id' "posts") Tag] such that "LabeledData postId tag" is contained in that list if "tag" is a tag of the post with id postId.
 --
 labelResults :: forall foreignModel baseModel foreignTable baseTable name value queryBuilderProvider joinRegister.
                 (

--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -373,7 +373,7 @@ toSQL' sqlQuery@SQLQuery { selectFrom, distinctClause, distinctOnClause, orderBy
         joinClause = buildJoinClause $ reverse $ joins sqlQuery
         buildJoinClause :: [Join] -> Maybe ByteString
         buildJoinClause [] = Nothing
-        buildJoinClause (j:js) = Just $ "INNER JOIN " <> table j <> " ON " <> tableJoinColumn j <> " = " <>table j <> "." <> otherJoinColumn j <> maybe "" (" " <>) (buildJoinClause js)
+        buildJoinClause (joinClause:joinClauses) = Just $ "INNER JOIN " <> table joinClause <> " ON " <> tableJoinColumn joinClause <> " = " <>table joinClause <> "." <> otherJoinColumn joinClause <> maybe "" (" " <>) (buildJoinClause joinClauses)
 
 
 {-# INLINE toSQL' #-}

--- a/Test/QueryBuilderSpec.hs
+++ b/Test/QueryBuilderSpec.hs
@@ -24,6 +24,24 @@ data Post = Post
 type instance GetTableName Post = "posts"
 type instance GetModelByTableName "posts" = Post
 
+data Tag = Tag
+        { id :: UUID
+        , tagText :: Text
+        }
+
+type instance GetTableName Tag = "tags"
+type instance GetModelByTableName "tags" = Tag 
+
+data Tagging = Tagging 
+        { id :: UUID
+        , postId :: UUID
+        , tagId :: UUID
+        }
+
+
+type instance GetTableName Tagging = "taggings"
+type instance GetModelByTableName "taggings" = Tagging
+
 data User = User
     { id :: UUID,
       name :: Text
@@ -194,10 +212,11 @@ tests = do
 
         describe "labelResults" do
             it "should provide a query with index field" do
-                let theQuery = query @Post
-                        |> innerJoin @User (#createdBy, #id)
-                        |> labelResults @User #id
-                (toSQL theQuery) `shouldBe` ("SELECT users.id, posts.* FROM posts INNER JOIN users ON posts.created_by = users.id", [])
+                let theQuery = query @Tag
+                        |> innerJoin @Tagging (#id, #tagId)
+                        |> innerJoinThirdTable @Post @Tagging (#id, #postId)
+                        |> labelResults @Post #id
+                (toSQL theQuery) `shouldBe` ("SELECT posts.id, tags.* FROM tags INNER JOIN taggings ON tags.id = taggings.tag_id INNER JOIN posts ON taggings.post_id = posts.id", [])
 
 
 

--- a/Test/QueryBuilderSpec.hs
+++ b/Test/QueryBuilderSpec.hs
@@ -192,11 +192,11 @@ tests = do
                 (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts INNER JOIN users ON posts.created_by = users.id INNER JOIN favorite_title ON posts.title = favorite_title.title WHERE users.name != ?", [Escape "Tom"])
 
 
-        describe "indexResults" do
+        describe "labelResults" do
             it "should provide a query with index field" do
                 let theQuery = query @Post
                         |> innerJoin @User (#createdBy, #id)
-                        |> indexResults @User #id
+                        |> labelResults @User #id
                 (toSQL theQuery) `shouldBe` ("SELECT users.id, posts.* FROM posts INNER JOIN users ON posts.created_by = users.id", [])
 
 

--- a/Test/QueryBuilderSpec.hs
+++ b/Test/QueryBuilderSpec.hs
@@ -185,6 +185,14 @@ tests = do
                 (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts INNER JOIN users ON posts.created_by = users.id INNER JOIN favorite_title ON posts.title = favorite_title.title WHERE users.name != ?", [Escape "Tom"])
 
 
+        describe "indexResults" do
+            it "should provide a query with index field" do
+                let theQuery = query @Post
+                        |> innerJoin @User (#createdBy, #id)
+                        |> indexResults @User #id
+                (toSQL theQuery) `shouldBe` ("SELECT users.id, posts.* FROM posts INNER JOIN users ON posts.created_by = users.id", [])
+
+
 
         describe "orderBy" do
             describe "orderByAsc" do


### PR DESCRIPTION
I added a function labelResults to the QueryBuilder interface that allows for labelling the results of a query with the values of corresponding values of a joined table. This can be used, for instance, to query all comments and obtain them labeled with the ids of the posts they belong to.

```haskell
labeledComments <-
   query @Comment
      |> innerJoin @Post (#postId, #id)
      |> labelResults @Post #id
      |> fetch
```
This piece of code will provide in labeledComments a list of type [LabeledData (Id' "posts") Comment]. With filters or comprehension, the comments can thus be sorted accordings to the posts they belong to.

This approach would seem to be much more flexible than the current approach using fetchRelated. For instance, it works seamlessly with many-to-one relations:

```haskell
labeledComments <-
   query @Tag
      |> innerJoin @Tagging (#id, #tagId)
      |> innerJoinThirdTable @Post @Tagging (#id, #postId)
      |> labelResults @Post #id
      |> fetch
```
In addition, it reduces the number of SQL request, since the fetchRelated-approach (if I see this correctly) requires making a separate SQL request for each post in order to preserve the association between Post and comment (or tag).