### PR TITLE
ProjectGenerator: Make <nixpkgs> a param.

### DIFF
--- a/ProjectGenerator/default.nix
+++ b/ProjectGenerator/default.nix
@@ -1,4 +1,5 @@
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 
 stdenv.mkDerivation rec {
   name = "ihp-new";


### PR DESCRIPTION
Turned ProjectGenerator/default.nix into a function by adding a param "pkgs" that defaults to <nixpkgs>
If nothing is passed in this should behave the same, but now the file can be imported  using the nix builtin "import".