### PR TITLE
Show SQL errors inline instead of separate crash page

### DIFF
--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -270,7 +270,7 @@ Or `distinctOn #tableField` to fetch distinct records based on the `#tableField`
 ```haskell
 do
     users <- query @User
-        |> distinctBy #fullName
+        |> distinctOn #fullName
         |> fetch
 ```
 

--- a/IHP/IDE/Data/Controller.hs
+++ b/IHP/IDE/Data/Controller.hs
@@ -48,7 +48,7 @@ instance Controller DataController where
         queryResult :: Either PG.SqlError [[DynamicField]] <- if isQuery queryText then
                 (PG.query_ connection query <&> Right) `catch` (pure . Left)
             else
-                PG.execute_ connection query >> pure (Right []) `catch` (pure . Left)
+                (PG.execute_ connection query >> pure (Right [])) `catch` (pure . Left)
 
         PG.close connection
         render ShowQueryView { .. }

--- a/IHP/IDE/Data/Controller.hs
+++ b/IHP/IDE/Data/Controller.hs
@@ -17,8 +17,8 @@ import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 import qualified Data.Text as T
 import qualified Data.ByteString.Builder
-
 import qualified Data.ByteString.Char8 as BS
+import Data.Functor ((<&>))
 
 instance Controller DataController where
     action ShowDatabaseAction = do
@@ -41,9 +41,15 @@ instance Controller DataController where
 
     action ShowQueryAction = do
         connection <- connectToAppDb
-        let query = (param @Text "query")
-        when (query == "") $ redirectTo ShowDatabaseAction
-        rows :: [[DynamicField]] <- if isQuery query then PG.query_ connection (fromString (cs query)) else PG.execute_ connection (fromString (cs query)) >> return []
+        let queryText = param @Text "query"
+        when (queryText == "") $ redirectTo ShowDatabaseAction
+        let query = fromString $ cs queryText
+
+        queryResult :: Either PG.SqlError [[DynamicField]] <- if isQuery queryText then
+                (PG.query_ connection query <&> Right) `catch` (pure . Left)
+            else
+                PG.execute_ connection query >> pure (Right []) `catch` (pure . Left)
+
         PG.close connection
         render ShowQueryView { .. }
 

--- a/IHP/IDE/Data/View/ShowQuery.hs
+++ b/IHP/IDE/Data/View/ShowQuery.hs
@@ -53,6 +53,6 @@ instance View ShowQueryView where
             columnNames rows = maybe [] (map (get #fieldName)) (head rows)
 
             showIfNotEmpty :: Text -> ByteString -> Html
-            showIfNotEmpty title text = case text of
+            showIfNotEmpty title = \case
                 "" -> mempty
-                _ -> [hsx|<div><strong>{title}:</strong> {text}</div>|]
+                text -> [hsx|<div><strong>{title}:</strong> {text}</div>|]

--- a/IHP/IDE/Data/View/ShowQuery.hs
+++ b/IHP/IDE/Data/View/ShowQuery.hs
@@ -2,7 +2,6 @@ module IHP.IDE.Data.View.ShowQuery where
 
 import IHP.ViewPrelude
 import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.ToolServer.Types
 import IHP.IDE.ToolServer.Layout
 import IHP.IDE.SchemaDesigner.View.Layout
 import IHP.IDE.ToolServer.Types

--- a/lib/IHP/static/IDE/ihp-schemadesigner.js
+++ b/lib/IHP/static/IDE/ihp-schemadesigner.js
@@ -194,11 +194,13 @@ document.addEventListener('turbolinks:load', initTooltip);
 function initQueryAce() {
     var editorEl = document.getElementById('queryInput');
     if (!editorEl) return;
-    ace.edit(editorEl).destroy();
-    var editor;
+    var editor = ace.edit(editorEl);
+    var existingValue = editor.getValue();
+    editor.destroy();
     function initAce() {
         ace.require("ace/ext/language_tools");
         editor = ace.edit(editorEl);
+        editor.setValue(existingValue, 1);
         editor.setTheme("ace/theme/solarized_dark");
         editor.session.setMode("ace/mode/sql");
         editor.setShowPrintMargin(false);


### PR DESCRIPTION
Two small changes I feel like might be nice:
- The SQL query written in the Ace input now persists between pages and won't reset after hitting `Enter`
- SQL errors are shown inline in a bootstrap alert box (see screenshot below) instead of going to a different page

![image](https://user-images.githubusercontent.com/9722062/122689805-695ea300-d1f3-11eb-9e78-621e0287e403.png)
