### PR TITLE
Makes sure to alway update input and textarea in Server-Side Components

### DIFF
--- a/lib/IHP/static/vendor/ihp-ssc.js
+++ b/lib/IHP/static/vendor/ihp-ssc.js
@@ -97,8 +97,13 @@ function replaceNode(component, nodeOperation) {
     }
 }
 
+const inputTagnames = ["INPUT", "TEXTAREA"];
+
 function evaluateAttributeOperation(domNode, op) {
-    if (op.type === 'UpdateAttribute' || op.type === 'AddAttribute') {
+    if (op.type === "UpdateAttribute" && inputTagnames.includes(domNode.tagName)) {
+        domNode.value = op.attributeValue;
+    } 
+    else if (op.type === 'UpdateAttribute' || op.type === 'AddAttribute') {
         domNode.setAttribute(op.attributeName, op.attributeValue);
     } else if (op.type === 'DeleteAttribute') {
         domNode.removeAttribute(op.attributeName);


### PR DESCRIPTION
Bug case: Testing the Counter Example in the IHP docs Server-Side Components using Firefox

1. If you click the increment button, both the input value and the text will change.
2. If you change the input value directly, both the input value and the text will change.
3. If you after these steps click the increment button again, the input value will not change accordingly

`domNode.setAttribute` does not update the input element after it has been dirtied. We must therefore mutate the `domNode.value` to make it work.

Not sure if this will also apply to other form tags as well, will probably do some more testing on this another day :)