### PR TITLE
Fix Tailwind script that fails in new versions

### DIFF
--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -116,7 +116,7 @@ We need to add a new build command for starting a tailwind build process to our 
 
 ```makefile
 tailwind-dev:
-    ls tailwind/*.css|NODE_ENV=development entr npx tailwindcss build tailwind/app.css -o static/app.css -c tailwind/tailwind.config.js
+    ls tailwind/*.css|NODE_ENV=development entr npx tailwindcss build -i tailwind/app.css -o static/app.css -c tailwind/tailwind.config.js
 ```
 
 **Make requires tab characters instead of 4 spaces in the second line. Make sure you're using a tab character when pasting this into the file**
@@ -128,7 +128,7 @@ For production builds we also need a new make target:
 ```makefile
 static/app.css:
     NODE_ENV=production npm ci
-    NODE_ENV=production npx tailwindcss build tailwind/app.css -o static/app.css -c tailwind/tailwind.config.js
+    NODE_ENV=production npx tailwindcss build -i tailwind/app.css -o static/app.css -c tailwind/tailwind.config.js
 ```
 
 **Make requires tab characters instead of 4 spaces in the second line. Make sure you're using a tab character when pasting this into the file**

--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -128,7 +128,7 @@ For production builds we also need a new make target:
 ```makefile
 static/app.css:
     NODE_ENV=production npm ci
-    NODE_ENV=production npx tailwindcss build -i tailwind/app.css -o static/app.css -c tailwind/tailwind.config.js
+    NODE_ENV=production npx tailwindcss build -i tailwind/app.css -o static/app.css -c tailwind/tailwind.config.js --minify
 ```
 
 **Make requires tab characters instead of 4 spaces in the second line. Make sure you're using a tab character when pasting this into the file**


### PR DESCRIPTION
In the new versions, Tailwind complains and does not accept the build script unless it's provided with the `-i` flag before the input  argument.

Also added the `--minify` flag for the production build for a bit smaller css bundle.