### PR TITLE
Small fix in the JS example in views doc

### DIFF
--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -312,7 +312,8 @@ From JavaScript you can get the JSON using `fetch`:
 ```javascript
 const response = await fetch('http://localhost:8000/Posts', {
     headers: { Accept: 'application/json' },
-}).then((response) => response.json());
+});
+const json = await response.json();
 ```
 
 #### curl


### PR DESCRIPTION
This MR introduces a small fix in the views documentation. The example code was mixing `async/await` and `then` method chaining. 

The MR changes the example to use only the `async/await` approach for readability improvement.