### PR TITLE
Allow scheduling jobs at a specific time with runAt

### DIFF
--- a/IHP/Job/Runner.hs
+++ b/IHP/Job/Runner.hs
@@ -78,6 +78,7 @@ worker :: forall job.
     , SetField "lockedBy" job (Maybe UUID)
     , SetField "status" job JobStatus
     , SetField "updatedAt" job UTCTime
+    , HasField "runAt" job UTCTime
     , HasField "attemptsCount" job Int
     , SetField "lastError" job (Maybe Text)
     , Job job
@@ -134,6 +135,6 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
     startLoop
 
     -- Start a job when a new job is added to the table or when it's set to retry
-    watcher <- Queue.watchForJob (tableName @job) startLoop
+    watcher <- Queue.watchForJob (tableName @job) (queuePollInterval @job) startLoop
 
     pure watcher

--- a/IHP/Job/Types.hs
+++ b/IHP/Job/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 module IHP.Job.Types
 ( Job (..)
 , JobWorkerArgs (..)
@@ -19,6 +20,13 @@ class Job job where
 
     timeoutInMicroseconds :: (?job :: job) => Maybe Int
     timeoutInMicroseconds = Nothing
+
+    -- | While jobs are typically fetch using pg_notiy, we have to poll the queue table
+    -- periodically to catch jobs with a @run_at@ in the future
+    --
+    -- By default we only poll every minute
+    queuePollInterval :: Int
+    queuePollInterval = 60 * 1000000
 
 class Worker application where
     workers :: application -> [JobWorker]

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -97,6 +97,7 @@ common shared-properties
             , conduit-extra
             , wai-cors
             , lens
+            , random
     default-extensions:
         OverloadedStrings
         , NoImplicitPrelude

--- a/ihp.nix
+++ b/ihp.nix
@@ -58,6 +58,7 @@
 , temporary
 , wai-cors
 , lens
+, random
 }:
 mkDerivation {
   pname = "ihp";
@@ -122,6 +123,7 @@ mkDerivation {
     temporary
     wai-cors
     lens
+    random
   ];
   license = lib.licenses.mit;
   postInstall = ''

--- a/shell.nix
+++ b/shell.nix
@@ -60,6 +60,7 @@ let
         minio-hs
         temporary
         wai-cors
+        random
 
         # Development Specific Tools (not in ihp.nix)
         mmark-cli


### PR DESCRIPTION
The job queue table's now have a `run_at` column. Jobs are only executed after the specified time.

This requires a migration for all userland job queues, to add the missing run_at column. The default value for existing jobs can be the created_at column.

The job runner is now also polling the job queue at regular intervals as otherwise scheduled jobs will not be picked up when there's no activity on the job queue table.