### PR TITLE
refuse to build union query if one of the queries contains joins

### DIFF
--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -340,7 +340,7 @@ buildQuery queryBuilderProvider = buildQueryHelper $ getQueryBuilder queryBuilde
                 let
                     firstQuery = buildQueryHelper firstQueryBuilder
                     secondQuery = buildQueryHelper secondQueryBuilder
-                    isSimpleQuery query = null (orderByClause query) && isNothing (limitClause query) && isNothing (offsetClause query)
+                    isSimpleQuery query = null (orderByClause query) && isNothing (limitClause query) && isNothing (offsetClause query) && null (joins query)
                     isSimpleUnion = isSimpleQuery firstQuery && isSimpleQuery secondQuery
                     unionWhere =
                         case (whereCondition firstQuery, whereCondition secondQuery) of


### PR DESCRIPTION
'Fix' for git@github.com:digitallyinduced/ihp.git #1034: join queries need to be regarded as complex queries.