### PR TITLE
Table prefix column names

### DIFF
--- a/IHP/Pagination/ControllerFunctions.hs
+++ b/IHP/Pagination/ControllerFunctions.hs
@@ -114,7 +114,7 @@ paginateWithOptions options q =
 -- >        |> filterList #email
 -- >    user <- userQ |> fetch
 -- >    render IndexView { .. }
-filterList :: forall name table model . (?context::ControllerContext, KnownSymbol name, HasField name model Text, model ~ GetModelByTableName table) =>
+filterList :: forall name table model . (?context::ControllerContext, KnownSymbol table, KnownSymbol name, HasField name model Text, model ~ GetModelByTableName table) =>
     Proxy name
     -> QueryBuilder table
     -> QueryBuilder table

--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -468,10 +468,10 @@ class FilterPrimaryKey table where
 -- For case-insensitive versions of these operators, see 'filterWhereILike' and 'filterWhereIMatches'.
 --
 -- When your condition is too complex, use a raw sql query with 'IHP.ModelSupport.sqlQuery'.
-filterWhere :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol name, ToField value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhere :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhere (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value), applyLeft = Nothing, applyRight = Nothing }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhere #-}
 
@@ -501,10 +501,10 @@ filterWhereJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder F
 -- >     |> fetch
 -- > -- SELECT * FROM projects WHERE user_id != '23d5ea33-b28e-4f0a-99b3-77a3564a2546'
 --
-filterWhereNot :: forall name table model value. (KnownSymbol name, ToField value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereNot :: forall name table model value. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereNot (name, value) queryBuilder = FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, negateFilterOperator (toEqOrIsOperator value), toField value), applyLeft = Nothing, applyRight = Nothing }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
 {-# INLINE filterWhereNot #-}
 
 -- | Like 'filterWhereNotJoinedTable' but negates the condition.
@@ -534,7 +534,7 @@ filterWhereNotJoinedTable (name, value) queryBuilderProvider = injectQueryBuilde
 --
 -- For negation use 'filterWhereNotIn'
 --
-filterWhereIn :: forall name table model value queryBuilderProvider (joinRegister :: *). (KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, EqOrIsOperator value) => (Proxy name, [value]) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereIn :: forall name table model value queryBuilderProvider (joinRegister :: *). (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, EqOrIsOperator value) => (Proxy name, [value]) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhereIn (name, value) queryBuilderProvider =
         case head nullValues of
             Nothing -> injectQueryBuilder whereInQuery -- All values non null
@@ -556,7 +556,7 @@ filterWhereIn (name, value) queryBuilderProvider =
 
         whereInQuery = FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, InOp, toField (In nonNullValues)), applyLeft = Nothing, applyRight = Nothing }
 
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhereIn #-}
 
@@ -589,7 +589,7 @@ filterWhereInJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder
 --
 -- The inclusive version of this function is called 'filterWhereIn'.
 --
-filterWhereNotIn :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, EqOrIsOperator value) => (Proxy name, [value]) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereNotIn :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, EqOrIsOperator value) => (Proxy name, [value]) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhereNotIn (_, []) queryBuilder = queryBuilder -- Handle empty case by ignoring query part: `WHERE x NOT IN ()`
 filterWhereNotIn (name, value) queryBuilderProvider =
         case head nullValues of
@@ -606,7 +606,7 @@ filterWhereNotIn (name, value) queryBuilderProvider =
 
         whereNotInQuery = FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, NotInOp, toField (In nonNullValues)), applyLeft = Nothing, applyRight = Nothing }
 
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhereNotIn #-}
 
@@ -636,10 +636,10 @@ filterWhereNotInJoinedTable (name, value) queryBuilderProvider = injectQueryBuil
 -- >     |> filterWhereLike (#title, "%" <> searchTerm <> "%")
 -- >     |> fetch
 -- > -- SELECT * FROM articles WHERE title LIKE '%..%'
-filterWhereLike :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereLike :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhereLike (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, LikeOp CaseSensitive, toField value), applyLeft = Nothing, applyRight = Nothing }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhereLike #-}
 
@@ -668,10 +668,10 @@ filterWhereLikeJoinedTable (name, value) queryBuilderProvider = injectQueryBuild
 -- >     |> filterWhereILike (#title, "%" <> searchTerm <> "%")
 -- >     |> fetch
 -- > -- SELECT * FROM articles WHERE title ILIKE '%..%'
-filterWhereILike :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereILike :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhereILike (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, LikeOp CaseInsensitive, toField value), applyLeft = Nothing, applyRight = Nothing }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhereILike #-}
 
@@ -700,10 +700,10 @@ filterWhereILikeJoinedTable (name, value) queryBuilderProvider = injectQueryBuil
 -- >     |> filterWhereMatches (#name, "^(M(rs|r|iss)|Dr|Sir). ")
 -- >     |> fetch
 -- > -- SELECT * FROM articles WHERE title ~ '^(M(rs|r|iss)|Dr|Sir). '
-filterWhereMatches :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol name, ToField value, HasField name model value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereMatches :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhereMatches (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, MatchesOp CaseSensitive, toField value), applyLeft = Nothing, applyRight = Nothing }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhereMatches #-}
 
@@ -753,10 +753,10 @@ filterWhereIMatchesJoinedTable (name, value) queryBuilderProvider = injectQueryB
 -- >     |> fetch
 -- > -- SELECT * FROM projects WHERE started_at < current_timestamp - interval '1 day'
 --
-filterWhereSql :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, ByteString) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereSql :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, ByteString) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhereSql (name, sqlCondition) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, SqlOp, Plain (Builder.byteString sqlCondition)), applyLeft = Nothing, applyRight = Nothing }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhereSql #-}
 
@@ -773,10 +773,10 @@ filterWhereSql (name, sqlCondition) queryBuilderProvider = injectQueryBuilder Fi
 --
 -- >>> CREATE UNIQUE INDEX users_email_index ON users ((LOWER(email)));
 --
-filterWhereCaseInsensitive :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol name, ToField value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereCaseInsensitive :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
 filterWhereCaseInsensitive (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value), applyLeft = Just "LOWER", applyRight = Just "LOWER" }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE filterWhereCaseInsensitive #-}
 
@@ -875,10 +875,10 @@ innerJoinThirdTable (name, name') queryBuilderProvider = injectQueryBuilder $ Jo
 -- >     |> orderBy #createdAt -- >     |> limit 10
 -- >     |> fetch
 -- > -- SELECT * FROM books LIMIT 10 ORDER BY created_at ASC
-orderByAsc :: forall name model table value queryBuilderProvider joinRegister. (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
+orderByAsc :: forall name model table value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
 orderByAsc !name queryBuilderProvider = injectQueryBuilder OrderByQueryBuilder { queryBuilder, queryOrderByClause = OrderByClause { orderByColumn = columnName, orderByDirection = Asc } }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE orderByAsc #-}
 
@@ -893,15 +893,15 @@ orderByAsc !name queryBuilderProvider = injectQueryBuilder OrderByQueryBuilder {
 -- >     |> limit 10
 -- >     |> fetch
 -- > -- SELECT * FROM projects LIMIT 10 ORDER BY created_at DESC
-orderByDesc :: forall name model table value queryBuilderProvider joinRegister. (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
+orderByDesc :: forall name model table value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
 orderByDesc !name queryBuilderProvider = injectQueryBuilder OrderByQueryBuilder { queryBuilder, queryOrderByClause = OrderByClause { orderByColumn = columnName, orderByDirection = Desc } }
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
 {-# INLINE orderByDesc #-}
 
 -- | Alias for 'orderByAsc'
-orderBy :: (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
+orderBy :: (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
 orderBy !name = orderByAsc name
 {-# INLINE orderBy #-}
 
@@ -998,10 +998,10 @@ distinct = injectQueryBuilder . DistinctQueryBuilder . getQueryBuilder
 -- >     |> distinctOn #categoryId
 -- >     |> fetch
 -- > -- SELECT DISTINCT ON (category_id) * FROM books
-distinctOn :: forall name model value table queryBuilderProvider joinRegister. (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
+distinctOn :: forall name model value table queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister) => Proxy name -> queryBuilderProvider table -> queryBuilderProvider table
 distinctOn !name queryBuilderProvider = injectQueryBuilder DistinctOnQueryBuilder { distinctOnColumn = columnName, queryBuilder = getQueryBuilder queryBuilderProvider}
     where
-        columnName = Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
+        columnName = Text.encodeUtf8 (symbolToText @table) <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
 {-# INLINE distinctOn #-}
 
 

--- a/Test/QueryBuilderSpec.hs
+++ b/Test/QueryBuilderSpec.hs
@@ -73,26 +73,26 @@ tests = do
                 let theQuery = query @Post
                         |> filterWhere (#title, "Test" :: Text)
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE title = ?", [Escape "Test"])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.title = ?", [Escape "Test"])
 
             it "should use a IS operator for checking null" do
                 let theQuery = query @Post
                         |> filterWhere (#externalUrl, Nothing)
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE external_url IS ?", [Plain "null"])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.external_url IS ?", [Plain "null"])
 
         describe "filterWhereNot" do
             it "should produce a SQL with a WHERE NOT condition" do
                 let theQuery = query @Post
                         |> filterWhereNot (#title, "Test" :: Text)
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE title != ?", [Escape "Test"])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.title != ?", [Escape "Test"])
 
             it "should use a IS NOT operator for checking null" do
                 let theQuery = query @Post
                         |> filterWhereNot (#externalUrl, Nothing)
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE external_url IS NOT ?", [Plain "null"])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.external_url IS NOT ?", [Plain "null"])
 
         describe "filterWhereIn" do
             it "should produce a SQL with a WHERE condition" do
@@ -100,7 +100,7 @@ tests = do
                 let theQuery = query @Post
                         |> filterWhereIn (#title, theValues)
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE title IN ?", [Many [Plain "(", Escape "first", Plain ",", Escape "second", Plain ")"]])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.title IN ?", [Many [Plain "(", Escape "first", Plain ",", Escape "second", Plain ")"]])
 
             describe "with Maybe / NULL values" do
                 it "should handle [Just .., Nothing]" do
@@ -108,21 +108,21 @@ tests = do
                     let theQuery = query @Post
                             |> filterWhereIn (#categoryId, theValues)
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE (category_id IN ?) OR (category_id IS ?)", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"], Plain "null"])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE (posts.category_id IN ?) OR (posts.category_id IS ?)", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"], Plain "null"])
 
                 it "should handle [Just ..]" do
                     let theValues :: [Maybe UUID] = ["44dcf2cf-a79d-4caf-a2ea-427838ba3574"]
                     let theQuery = query @Post
                             |> filterWhereIn (#categoryId, theValues)
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE category_id IN ?", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"]])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.category_id IN ?", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"]])
 
                 it "should handle [Nothing]" do
                     let theValues :: [Maybe UUID] = [Nothing]
                     let theQuery = query @Post
                             |> filterWhereIn (#categoryId, theValues)
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE category_id IS ?", [Plain "null"])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.category_id IS ?", [Plain "null"])
 
 
         describe "filterWhereInJoinedTable" do
@@ -141,7 +141,7 @@ tests = do
                 let theQuery = query @Post
                         |> filterWhereNotIn (#title, theValues)
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE title NOT IN ?", [Many [Plain "(", Escape "first", Plain ",", Escape "second", Plain ")"]])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.title NOT IN ?", [Many [Plain "(", Escape "first", Plain ",", Escape "second", Plain ")"]])
 
             it "ignore an empty value list as this causes the query to always return nothing" do
                 let theValues :: [Text] = []
@@ -156,21 +156,21 @@ tests = do
                     let theQuery = query @Post
                             |> filterWhereNotIn (#categoryId, theValues)
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE (category_id NOT IN ?) AND (category_id IS NOT ?)", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"], Plain "null"])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE (posts.category_id NOT IN ?) AND (posts.category_id IS NOT ?)", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"], Plain "null"])
 
                 it "should handle [Just ..]" do
                     let theValues :: [Maybe UUID] = ["44dcf2cf-a79d-4caf-a2ea-427838ba3574"]
                     let theQuery = query @Post
                             |> filterWhereNotIn (#categoryId, theValues)
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE category_id NOT IN ?", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"]])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.category_id NOT IN ?", [Many [Plain "(", Plain "'44dcf2cf-a79d-4caf-a2ea-427838ba3574'", Plain ")"]])
 
                 it "should handle [Nothing]" do
                     let theValues :: [Maybe UUID] = [Nothing]
                     let theQuery = query @Post
                             |> filterWhereNotIn (#categoryId, theValues)
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE category_id IS NOT ?", [Plain "null"])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.category_id IS NOT ?", [Plain "null"])
 
         describe "filterWhereNotInJoinedTable" do
             it "should produce a SQL with a WHERE condition" do
@@ -194,7 +194,7 @@ tests = do
                 let searchTerm = "good"
                 let theQuery = query @Post
                      |> filterWhereILike (#title, "%" <> searchTerm <> "%")
-                (toSQL theQuery `shouldBe` ("SELECT posts.* FROM posts WHERE title ILIKE ?", [Escape "%good%"]))
+                (toSQL theQuery `shouldBe` ("SELECT posts.* FROM posts WHERE posts.title ILIKE ?", [Escape "%good%"]))
 
         describe "filterWhereILikeJoinedTable" do
             it "should produce a SQL with a WHERE condition" do
@@ -210,14 +210,14 @@ tests = do
                 let theQuery = query @Post
                         |> filterWhereSql (#createdAt, "< current_timestamp - interval '1 day'")
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE created_at  ?", [Plain "< current_timestamp - interval '1 day'"])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE posts.created_at  ?", [Plain "< current_timestamp - interval '1 day'"])
 
         describe "filterWhereCaseInsensitive" do
             it "should produce a SQL with a WHERE LOWER() condition" do
                 let theQuery = query @Post
                         |> filterWhereCaseInsensitive (#title, "Test" :: Text)
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE LOWER(title) = LOWER(?)", [Escape "Test"])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE LOWER(posts.title) = LOWER(?)", [Escape "Test"])
 
         describe "innerJoin" do
             it "should provide an inner join sql query" do
@@ -272,28 +272,28 @@ tests = do
                     let theQuery = query @Post
                             |> orderByAsc #createdAt
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY created_at", [])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY posts.created_at", [])
                 
                 it "should accumulate multiple ORDER BY's" do
                     let theQuery = query @Post
                             |> orderByAsc #createdAt
                             |> orderByAsc #title
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY created_at,title", [])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY posts.created_at,posts.title", [])
             
             describe "orderByDesc" do
                 it "should add a ORDER BY DESC" do
                     let theQuery = query @Post
                             |> orderByDesc #createdAt
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY created_at DESC", [])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY posts.created_at DESC", [])
                 
                 it "should accumulate multiple ORDER BY's" do
                     let theQuery = query @Post
                             |> orderByDesc #createdAt
                             |> orderByDesc #title
 
-                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY created_at DESC,title DESC", [])
+                    (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts ORDER BY posts.created_at DESC,posts.title DESC", [])
         
         describe "limit" do
             it "should add a LIMIT" do
@@ -317,7 +317,7 @@ tests = do
                             (filterWhere (#public, True))
 
 
-                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE (created_by = ?) OR (public = ?)", [Plain "'fe41a985-36a3-4f14-b13c-c166977dc7e8'", Plain "true"])
+                (toSQL theQuery) `shouldBe` ("SELECT posts.* FROM posts WHERE (posts.created_by = ?) OR (posts.public = ?)", [Plain "'fe41a985-36a3-4f14-b13c-c166977dc7e8'", Plain "true"])
 
         describe "distinct" do
             it "should add a DISTINCT" do
@@ -331,7 +331,7 @@ tests = do
                 let theQuery = query @Post
                         |> distinctOn #title
 
-                (toSQL theQuery) `shouldBe` ("SELECT DISTINCT ON (title) posts.* FROM posts", [])
+                (toSQL theQuery) `shouldBe` ("SELECT DISTINCT ON (posts.title) posts.* FROM posts", [])
 
         describe "Complex Queries" do
             it "should allow a query with limit and offset" do
@@ -355,7 +355,7 @@ tests = do
                         |> limit 10
 
                 (toSQL theQuery) `shouldBe` (
-                        "SELECT posts.* FROM posts WHERE (((title = ?) AND (public = ?)) AND (external_url IS ?)) OR (created_by = ?) ORDER BY created_at,title LIMIT 10",
+                        "SELECT posts.* FROM posts WHERE (((posts.title = ?) AND (posts.public = ?)) AND (posts.external_url IS ?)) OR (posts.created_by = ?) ORDER BY posts.created_at,posts.title LIMIT 10",
                         [ Escape "test"
                         , Plain "true"
                         , Plain "null"


### PR DESCRIPTION
Fix for #1035: so far, only the filter functions for joined tables prefixed the column names with the table names. In the present case, this resulted in the column name "id" becoming ambiguous, being a columns in both joined tables.
All the filter functions now prefix the column name with the table name to rule out such ambiguities.