### PR TITLE
potential mod for create form actions to helpers.js 

### DIFF
--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -187,7 +187,9 @@ window.submitForm = function (form, possibleClickedButton) {
             );
             transitionToNewPage(request.response);
             Turbolinks.clearCache();
-            history.pushState({ turbolinks: true }, '', request.responseURL);
+            if (request.responseURL !== form.action) {
+                history.pushState({ turbolinks: true }, '', request.responseURL);
+            };
             var turbolinkLoadEvent = new CustomEvent('turbolinks:load');
             document.dispatchEvent(turbolinkLoadEvent);
         } else {


### PR DESCRIPTION
This PR would make the behaviour for a failed Form request the same with and without Turbolinks. The pattern is that if a   `Left branch` failed form submission leads to a `render SomeView {..}` the form creation action and controller URL will match. In this case we likely do not want the url to update to the target for the form creation because on a user manual browser refresh this will trigger a `GET` request to the Create action which leads to a `400` error (those endpoints require `POST` by IHP convention). This PR catches the url equality and doesn't update the local url so a refresh triggers the page reload.

Tested [here](https://github.com/Montmorency/ihp-create-action). 