### PR TITLE
Typo on ContentType in CanSelect form docs.

### DIFF
--- a/Guide/form.markdown
+++ b/Guide/form.markdown
@@ -549,7 +549,7 @@ view to generate the list of select fields:
     {selectField #contentType allContentTypes}
 |]
     where
-      allContentTypes = allEnumValues @ContentTypes
+      allContentTypes = allEnumValues @ContentType
 ```
 
 ### Select Inputs with Integers


### PR DESCRIPTION
Accidentally pluralized data type. Could be confusing for someone following docs. 