### PR TITLE
Codegen app.js

### DIFF
--- a/IHP/IDE/CodeGen/ApplicationGenerator.hs
+++ b/IHP/IDE/CodeGen/ApplicationGenerator.hs
@@ -117,6 +117,7 @@ generateGenericApplication applicationName =
                 <> "        <script src={assetPath \"/vendor/turbolinksMorphdom.js\"}></script>\n"
                 <> "        <script src={assetPath \"/helpers.js\"}></script>\n"
                 <> "        <script src={assetPath \"/ihp-auto-refresh.js\"}></script>\n"
+                <> "        <script src={\"/app.js\"}></script>\n"
                 <> "    |]\n"
                 <> "\n"
                 <> "devScripts :: Html\n"

--- a/IHP/IDE/CodeGen/ApplicationGenerator.hs
+++ b/IHP/IDE/CodeGen/ApplicationGenerator.hs
@@ -117,7 +117,7 @@ generateGenericApplication applicationName =
                 <> "        <script src={assetPath \"/vendor/turbolinksMorphdom.js\"}></script>\n"
                 <> "        <script src={assetPath \"/helpers.js\"}></script>\n"
                 <> "        <script src={assetPath \"/ihp-auto-refresh.js\"}></script>\n"
-                <> "        <script src={\"/app.js\"}></script>\n"
+                <> "        <script src={assetPath \"/app.js\"}></script>\n"
                 <> "    |]\n"
                 <> "\n"
                 <> "devScripts :: Html\n"

--- a/ihp.nix
+++ b/ihp.nix
@@ -137,7 +137,7 @@ mkDerivation {
 
   # For faster builds when hacking on IHP:
   # Uncommenting will build without optimizations
-   configureFlags = [ "--flag FastBuild" ];
+  # configureFlags = [ "--flag FastBuild" ];
   # Uncommenting will not generate documentation
-   doHaddock = false;
+  # doHaddock = false;
 }

--- a/ihp.nix
+++ b/ihp.nix
@@ -137,7 +137,7 @@ mkDerivation {
 
   # For faster builds when hacking on IHP:
   # Uncommenting will build without optimizations
-  # configureFlags = [ "--flag FastBuild" ];
+   configureFlags = [ "--flag FastBuild" ];
   # Uncommenting will not generate documentation
-  # doHaddock = false;
+   doHaddock = false;
 }


### PR DESCRIPTION
Suggestion that if `app.js` is shipped with ihp-boilerplate might make sense to have it in the CodeGen as well. E.g. a developer who opens a test project and starts playing with customizing `app.js`  but changes aren't getting picked up in starter project. Also attaching new cache buster to this automatically makes sure production app.js changes are picked up straight away.