### PR TITLE
add setIfJust which ignores updates on Nothing

### DIFF
--- a/IHP/HaskellSupport.hs
+++ b/IHP/HaskellSupport.hs
@@ -12,7 +12,7 @@ module IHP.HaskellSupport
 , get
 , set
 , setJust
-, setIfJust
+, setMaybe
 , ifOrEmpty
 , modify
 , modifyJust
@@ -115,9 +115,9 @@ instance forall name name'. (KnownSymbol name, name' ~ name) => IsLabel name (Pr
 -- | Returns the field value for a field name
 --
 -- __Example:__
--- 
+--
 -- > data Project = Project { name :: Text, isPublic :: Bool }
--- > 
+-- >
 -- > let project = Project { name = "Hello World", isPublic = False }
 --
 -- >>> get #name project
@@ -132,9 +132,9 @@ get _ record = Record.getField @name record
 -- | Sets a field of a record and returns the new record.
 --
 -- __Example:__
--- 
+--
 -- > data Project = Project { name :: Text, isPublic :: Bool }
--- > 
+-- >
 -- > let project = Project { name = "Hello World", isPublic = False }
 --
 -- >>> set #name "New Name" project
@@ -156,25 +156,25 @@ set name value record = setField @name value record
 -- >
 -- > let project = Project { name = Nothing }
 --
--- >>> setIfJust #name (Just "New Name") project
+-- >>> setMaybe #name (Just "New Name") project
 -- Project { name = Just "New Name" }
 --
--- >>> setIfJust #name Nothing project
+-- >>> setMaybe #name Nothing project
 -- Project { name = Just "New Name" } -- previous value is kept
 --
-setIfJust :: forall model name value. (KnownSymbol name, SetField name model (Maybe value)) => Proxy name -> Maybe value -> model -> model
-setIfJust name value record = case value of
+setMaybe :: forall model name value. (KnownSymbol name, SetField name model (Maybe value)) => Proxy name -> Maybe value -> model -> model
+setMaybe name value record = case value of
     Just value -> setField @name (Just value) record
     Nothing    -> record
-{-# INLINE setIfJust #-}
+{-# INLINE setMaybe #-}
 
 
 -- | Like 'set' but wraps the value with a 'Just'. Useful when you want to set a 'Maybe' field
 --
 -- __Example:__
--- 
+--
 -- > data Project = Project { name :: Maybe Text }
--- > 
+-- >
 -- > let project = Project { name = Nothing }
 --
 -- >>> setJust #name "New Name" project
@@ -208,9 +208,9 @@ modifyJust _ updateFunction model = case Record.getField @name model of
 -- | Plus @1@ on record field.
 --
 -- __Example:__
--- 
+--
 -- > data Project = Project { name :: Text, followersCount :: Int }
--- > 
+-- >
 -- > let project = Project { name = "Hello World", followersCount = 0 }
 --
 -- >>> project |> incrementField #followersCount
@@ -222,9 +222,9 @@ incrementField _ model = let value = Record.getField @name model in setField @na
 -- | Minus @1@ on a record field.
 --
 -- __Example:__
--- 
+--
 -- > data Project = Project { name :: Text, followersCount :: Int }
--- > 
+-- >
 -- > let project = Project { name = "Hello World", followersCount = 1337 }
 --
 -- >>> project |> decrementField #followersCount
@@ -282,7 +282,7 @@ forEach elements function = forM_ elements function
 --
 -- > printUser :: (Int, User) -> IO ()
 -- > printUser (index, user) = putStrLn (tshow index <> ": " <> tshow user)
--- > 
+-- >
 -- > forEachWithIndex users printUser
 --
 -- __Example:__ Within HSX

--- a/Test/HaskellSupportSpec.hs
+++ b/Test/HaskellSupportSpec.hs
@@ -14,7 +14,7 @@ tests = do
             it "should deal with empty input" do
                 stripTags "" `shouldBe` ""
 
-            it "should strip html tags and return the plain text" do 
+            it "should strip html tags and return the plain text" do
                 stripTags "This is <b>Bold</b>" `shouldBe` "This is Bold"
 
         describe "copyFields" do
@@ -30,13 +30,31 @@ tests = do
             it "should return all enum values" do
                 (allEnumValues @Color) `shouldBe` [Yellow, Red, Blue]
 
+        describe "setIfJust" do
+            it "should set a Just value" do
+                let c = RecordC { field = Nothing }
+                let c' = c |> setIfJust #field (Just 1)
+
+                c' `shouldBe` RecordC { field = Just 1 }
+
+            it "should not set a Nothing value" do
+                let c = RecordC { field = Just 1 }
+                let c' = c |> setIfJust #field Nothing
+
+                c' `shouldBe` RecordC { field = Just 1 }
+
+
 data RecordA = RecordA { fieldA :: Int, fieldB :: Text } deriving (Eq, Show)
-data RecordB = RecordB { fieldA :: Int, fieldB :: Text} deriving (Eq, Show)
+data RecordB = RecordB { fieldA :: Int, fieldB :: Text } deriving (Eq, Show)
+data RecordC = RecordC { field :: Maybe Int } deriving (Eq, Show)
 
 instance SetField "fieldA" RecordB Int where
     setField value record = record { fieldA = value }
 
 instance SetField "fieldB" RecordB Text where
     setField value record = record { fieldB = value }
+
+instance SetField "field" RecordC (Maybe Int) where
+    setField value record = record { field = value }
 
 data Color = Yellow | Red | Blue deriving (Enum, Show, Eq)

--- a/Test/HaskellSupportSpec.hs
+++ b/Test/HaskellSupportSpec.hs
@@ -30,16 +30,16 @@ tests = do
             it "should return all enum values" do
                 (allEnumValues @Color) `shouldBe` [Yellow, Red, Blue]
 
-        describe "setIfJust" do
+        describe "setMaybe" do
             it "should set a Just value" do
                 let c = RecordC { field = Nothing }
-                let c' = c |> setIfJust #field (Just 1)
+                let c' = c |> setMaybe #field (Just 1)
 
                 c' `shouldBe` RecordC { field = Just 1 }
 
             it "should not set a Nothing value" do
                 let c = RecordC { field = Just 1 }
-                let c' = c |> setIfJust #field Nothing
+                let c' = c |> setMaybe #field Nothing
 
                 c' `shouldBe` RecordC { field = Just 1 }
 


### PR DESCRIPTION
This adds a function `setIfJust` which is similar to `set` but which takes a `Mabye value` and updates the record if the value is `Just`, and doesn't change it if it's `Nothing`.