### PR TITLE
link api docs in guide

### DIFF
--- a/Guide/assets.markdown
+++ b/Guide/assets.markdown
@@ -15,7 +15,7 @@ To avoid this problem, web applications typically append a hash to the url of yo
 <script src="/app.js?v=19319eb"></script>
 ```
 
-IHP provides an `assetPath` view helper to automatically add these hashes:
+IHP provides an [`assetPath`](https://ihp.digitallyinduced.com/api-docs/IHP-Assets-ViewFunctions.html#v:assetPath) view helper to automatically add these hashes:
 
 ```haskell
 [hsx|

--- a/Guide/authentication.markdown
+++ b/Guide/authentication.markdown
@@ -54,7 +54,7 @@ instance HasNewSessionUrl User where
 type instance CurrentUserRecord = User
 ```
 
-The `instance HasNewSessionUrl User` tells the auth module where to redirect a user in case the user tries to access a action that requires login. The definition of `CurrentUserRecord` tells the auth system to use our `User` type within the login system.
+The `instance HasNewSessionUrl User` tells the auth module where to redirect a user in case the user tries to access a action that requires login. The definition of [`CurrentUserRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Types.html#t:CurrentUserRecord) tells the auth system to use our `User` type within the login system.
 
 We also need to add the type definitions for the `SessionsController`:
 
@@ -134,7 +134,7 @@ import IHP.LoginSupport.Middleware
 import Web.Controller.Sessions
 ```
 
-We then need to mount our session controller by adding `parseRoute @SessionController`:
+We then need to mount our session controller by adding [`parseRoute @SessionController`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:parseRoute):
 
 ```haskell
 instance FrontController WebApplication where
@@ -154,7 +154,7 @@ instance InitControllerContext WebApplication where
         initAutoRefresh
 ```
 
-We need to extend this function with a `initAuthentication @User` like this:
+We need to extend this function with a [`initAuthentication @User`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Middleware.html#v:initAuthentication) like this:
 
 ```haskell
 instance InitControllerContext WebApplication where
@@ -164,7 +164,7 @@ instance InitControllerContext WebApplication where
         initAuthentication @User
 ```
 
-This will fetch the user from the database when a `userId` is given in the session. The fetched user record is saved to the special `?context` variable and is used by all the helper functions like `currentUser`.
+This will fetch the user from the database when a `userId` is given in the session. The fetched user record is saved to the special `?context` variable and is used by all the helper functions like [`currentUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:currentUser).
 
 
 ## Trying out the login
@@ -177,7 +177,7 @@ After you have completed the above steps, you can open the login at `/NewSession
 
 ## Accessing the current user
 
-Inside your actions you can then use `currentUser` to get access to the current logged in user:
+Inside your actions you can then use [`currentUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:currentUser) to get access to the current logged in user:
 
 ```haskell
 action MyAction = do
@@ -185,9 +185,9 @@ action MyAction = do
     renderPlain text
 ```
 
-In case the user is logged out, an exception will be thrown when accessing `currentUser` and the browser will automatically be redirected to the `NewSessionAction`.
+In case the user is logged out, an exception will be thrown when accessing [`currentUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:currentUser) and the browser will automatically be redirected to the `NewSessionAction`.
 
-You can use `currentUserOrNothing` to manually deal with the not-logged-in case:
+You can use [`currentUserOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:currentUserOrNothing) to manually deal with the not-logged-in case:
 
 ```haskell
 action MyAction = do
@@ -198,9 +198,9 @@ action MyAction = do
         Nothing -> renderPlain "Please login first"
 ```
 
-Additionally you can use `currentUserId` as a shortcut for `currentUser |> get #id`.
+Additionally you can use [`currentUserId`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:currentUserId) as a shortcut for `currentUser |> get #id`.
 
-You can also access the user using `currentUser` inside your views:
+You can also access the user using [`currentUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:currentUser) inside your views:
 
 ```html
 [hsx|
@@ -210,7 +210,7 @@ You can also access the user using `currentUser` inside your views:
 
 ## Performing actions on login
 
-The sessioncontroller has a convenient `beforeLogin` which is run on login after the user is authenticated, but before the target page is rendered. This can be useful for updating last login time, number of logins or aborting the login when the user is blocked. Add code for it in your `Web/Controller/Sessions.hs`. To update number of logins (requires `logins` integer field in `Users` table):
+The sessioncontroller has a convenient [`beforeLogin`](https://ihp.digitallyinduced.com/api-docs/IHP-AuthSupport-Controller-Sessions.html#v:beforeLogin) which is run on login after the user is authenticated, but before the target page is rendered. This can be useful for updating last login time, number of logins or aborting the login when the user is blocked. Add code for it in your `Web/Controller/Sessions.hs`. To update number of logins (requires `logins` integer field in `Users` table):
 
 ```haskell
 instance Sessions.SessionsControllerConfig User where
@@ -223,7 +223,7 @@ updateLoginHistory user = do
     pure ()
 ```
 
-To block login (requires `isConfirmed`boolean field in `Users` table):
+To block login (requires `isConfirmed` boolean field in `Users` table):
 
 ```haskell
 instance Sessions.SessionsControllerConfig User where

--- a/Guide/authorization.markdown
+++ b/Guide/authorization.markdown
@@ -6,7 +6,7 @@
 
 ## Restricting an action to logged-in users
 
-To restrict an action to a logged-in user, use `ensureIsUser`:
+To restrict an action to a logged-in user, use [`ensureIsUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:ensureIsUser):
 
 ```haskell
 action PostsAction = do
@@ -17,7 +17,7 @@ action PostsAction = do
 
 When someone is trying to access the `PostsAction` but is not logged-in, the browser will be redirected to the login page. After the login succeeded, the user will be redirected back to the `PostsAction`.
 
-It's common to restrict all actions inside a controller to logged-in users only. Place the `ensureIsUser` inside the `beforeAction` hook to automatically apply it to all actions:
+It's common to restrict all actions inside a controller to logged-in users only. Place the [`ensureIsUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:ensureIsUser) inside the [`beforeAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:beforeAction) hook to automatically apply it to all actions:
 
 ```haskell
 instance Controller PostsController where
@@ -36,7 +36,7 @@ In this case `PostsAction` and `ShowPostAction` are only accessible to logged-in
 
 ## Restricting an action to logged-in admins
 
-To restrict an action to a logged-in admin, use `ensureIsAdmin` instead of `ensureIsUser`. If you get
+To restrict an action to a logged-in admin, use [`ensureIsAdmin`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:beforeAction) instead of [`ensureIsUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:ensureIsUser). If you get
 
 ```
 error:
@@ -57,7 +57,7 @@ instance Controller UserController where
 
 ## Checking for Permissions
 
-You can use `accessDeniedUnless` to allow certain things only for specific users. For example, to restrict a `ShowPostAction` only to the user who a post belongs to, use this:
+You can use [`accessDeniedUnless`](https://ihp.digitallyinduced.com/api-docs/IHP-AuthSupport-Authorization.html#v:accessDeniedUnless) to allow certain things only for specific users. For example, to restrict a `ShowPostAction` only to the user who a post belongs to, use this:
 
 ```haskell
     action ShowPostAction { postId } = do

--- a/Guide/auto-refresh.markdown
+++ b/Guide/auto-refresh.markdown
@@ -18,7 +18,7 @@ Auto Refresh offers a way to re-render views of your application when the underl
 
 It's good to have a general understanding of how IHP Auto Refresh works.
 
-Auto Refresh first has to be activated for an action by calling `autoRefresh`. Once activated the framework will automatically track all tables your action is using e.g. in `SELECT * FROM ...` queries. Once the action sends a response IHP will start watching for any kind of `INSERT`, `UPDATE` or `DELETE` statement to all the tables used by your action.
+Auto Refresh first has to be activated for an action by calling [`autoRefresh`](https://ihp.digitallyinduced.com/api-docs/IHP-AutoRefresh.html#v:autoRefresh). Once activated the framework will automatically track all tables your action is using e.g. in `SELECT * FROM ...` queries. Once the action sends a response IHP will start watching for any kind of `INSERT`, `UPDATE` or `DELETE` statement to all the tables used by your action.
 
 When the page is rendered a small JavaScript function will connect back to the IHP server using a WebSocket connection.
 
@@ -37,7 +37,7 @@ action ShowProjectAction { projectId } = do
     render ShowView { .. }
 ```
 
-To enable auto refresh we have to add `autoRefresh` in front of the `do`:
+To enable auto refresh we have to add [`autoRefresh`](https://ihp.digitallyinduced.com/api-docs/IHP-AutoRefresh.html#v:autoRefresh) in front of the `do`:
 
 ```haskell
 action ShowProjectAction { projectId } = autoRefresh do
@@ -106,7 +106,7 @@ action StatsAction = autoRefresh do
     pure StatsView { ..}
 ```
 
-When using this custom query with `sqlQuery`, Auto Refresh is not aware that we're reading from the `companies` table. In this case we need to help out Auto Refresh by calling `trackTableRead`:
+When using this custom query with [`sqlQuery`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:sqlQuery), Auto Refresh is not aware that we're reading from the `companies` table. In this case we need to help out Auto Refresh by calling [`trackTableRead`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:trackTableRead):
 
 
 ```haskell
@@ -118,4 +118,4 @@ action StatsAction = autoRefresh do
     pure StatsView { ..}
 ```
 
-The `trackTableRead` marks the table as accessed for Auto Refresh and leads to the table being watched.
+The [`trackTableRead`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:trackTableRead) marks the table as accessed for Auto Refresh and leads to the table being watched.

--- a/Guide/controller.markdown
+++ b/Guide/controller.markdown
@@ -26,9 +26,9 @@ data PostsController
     deriving (Eq, Show, Data)
 ```
 
-This defines a type `PostsController` with a data constructor `ShowPostAction { postId :: !(Id Post) }`. The argument `postId` will later be filled with the `postId` parameter of the request URL. This is done automatically by the IHP router. IHP also requires the controller to have `Eq`, `Show` and `Data` instances. Therefore we derive them here.
+This defines a type `PostsController` with a data constructor `ShowPostAction { postId :: !(Id Post) }`. The argument `postId` will later be filled with the `postId` parameter of the request URL. This is done automatically by the IHP router. IHP also requires the controller to have [`Eq`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Eq), [`Show`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Show) and [`Data`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Data) instances. Therefore we derive them here.
 
-After we have defined the "interface" for our controller, we need to implement the actual request handling logic. IHP expects to find this inside the `action` function of the [`Controller`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:Controller) instance. We can define this instance in `Web/Controller/Posts.hs`:
+After we have defined the "interface" for our controller, we need to implement the actual request handling logic. IHP expects to find this inside the [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:action) function of the [`Controller`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:Controller) instance. We can define this instance in `Web/Controller/Posts.hs`:
 
 ```haskell
 module Web.Controller.Posts where
@@ -39,11 +39,11 @@ instance Controller PostsController where
     action ShowPostAction { postId } = renderPlain "Hello World"
 ```
 
-This implementation for `ShowPostAction` responds with a simple plain text message. The `action` implementation is usually a big pattern match over all possible actions of a controller.
+This implementation for `ShowPostAction` responds with a simple plain text message. The [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:action) implementation is usually a big pattern match over all possible actions of a controller.
 
 ## Reading Query and Body Parameters
 
-Inside the action, you can access request parameters using the `param` function. A parameter can either be a URL parameter like `?paramName=paramValue` (_this is also called a query parameter_), or given as a form field like `<form><input name="paramName" value="paramValue"/></form>` (_in that case we're talking about a body parameter_). The `param` function will work with query and body parameters, so you don't have to worry about that (in case a query and body parameter is set with the same name, the body parameter will take priority).
+Inside the action, you can access request parameters using the [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param) function. A parameter can either be a URL parameter like `?paramName=paramValue` (_this is also called a query parameter_), or given as a form field like `<form><input name="paramName" value="paramValue"/></form>` (_in that case we're talking about a body parameter_). The [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param) function will work with query and body parameters, so you don't have to worry about that (in case a query and body parameter is set with the same name, the body parameter will take priority).
 
 Given a request like `GET /UsersAction?maxItems=50`, you can access the `maxItems` like this:
 
@@ -61,7 +61,7 @@ An alternative request to that action can use a form for passing the `maxItems`:
 </form>
 ```
 
-The value is automatically transformed to an `Int`. This parsing works out of the box for Ids, UUID, Bools, Timestamps, etc. Here are some more examples:
+The value is automatically transformed to an [`Int`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Int). This parsing works out of the box for [Ids](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Id), [UUID](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:UUID), [Bools](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Bool), [Timestamps](https://ihp.digitallyinduced.com/api-docs/IHP-RouterPrelude.html#t:UTCTime), etc. Here are some more examples:
 
 ```haskell
 action ExampleAction = do
@@ -74,7 +74,7 @@ action ExampleAction = do
 
 In case there is a problem parsing the request parameter, an error will be triggered.
 
-When the parameter is optional, use `paramOrDefault`:
+When the parameter is optional, use [`paramOrDefault`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:paramOrDefault):
 
 ```haskell
 action UsersAction = do
@@ -83,7 +83,7 @@ action UsersAction = do
 
 When this action is called without the `maxItems` parameter being set (or when invalid), it will fall back to the default value `50`.
 
-There is also `paramOrNothing` which will return `Nothing` when the parameter is missing and `Just theValue` otherwise.
+There is also [`paramOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:paramOrNothing) which will return [`Nothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) when the parameter is missing and [`Just theValue`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) otherwise.
 
 ### Multiple Params With Same Name (Checkboxes)
 
@@ -97,7 +97,7 @@ When working with checkboxes sometimes there are multiple values for a given par
 <input name="ingredients" type="checkbox" value="egg" /> Egg
 ```
 
-When both checkboxes for Milk and Egg are checked, the usual way of calling `param @Text "ingredients"` will only return the first ingredient `"Milk"`. To access all the checked `ingredients` use `paramList`:
+When both checkboxes for Milk and Egg are checked, the usual way of calling [`param @Text "ingredients"`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param) will only return the first ingredient `"Milk"`. To access all the checked `ingredients` use [`paramList`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:paramList):
 
 ```haskell
 action BuildFood = do
@@ -106,7 +106,7 @@ action BuildFood = do
 
 When this action is called with both checkboxes checked `ingredients` will be set to `["milk", "egg"]`. When no checkbox is checked it will return an empty list.
 
-Similar to `param` this works out of the box for Ids, UUID, Bools, Timestamps, etc.
+Similar to [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param) this works out of the box for [Ids](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Id), [UUID](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:UUID), [Bools](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Bool), [Timestamps](https://ihp.digitallyinduced.com/api-docs/IHP-RouterPrelude.html#t:UTCTime), etc.
 
 ### Passing Data from the Action to the View
 
@@ -159,26 +159,26 @@ This will render `Hello World, Unnamed!` when the `ExampleAction` is called with
 
 ### Accessing the FrameworkConfig inside Controllers and Views.
 
-The config defined in `Config/Config.hs` is available through the implicit parameter `context`, a `ConfigProvider` that is available in controllers.
+The config defined in `Config/Config.hs` is available through the implicit parameter `context`, a [`ConfigProvider`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#t:ConfigProvider) that is available in controllers.
 
-There are helpers that use this implicit parameter, e.g. `isDevelopment/isProduction`:
+There are helpers that use this implicit parameter, e.g. [`isDevelopment`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#v:isDevelopment)/[`isProduction`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#v:isProduction):
 
 ```haskell
 action MyAction = do
     when isDevelopment (putStrLn "Running in dev mode")
 ```
 
-or you can use the function `getFrameworkConfig` if you need to access the config yourself.
+or you can use the function [`getFrameworkConfig`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#v:getFrameworkConfig) if you need to access the config yourself.
 
 ### Advanced: Working with Custom Types
 
-Rarely you might want to work with a custom scalar value which is not yet supported with `param`. Define a custom `ParamReader` instance to be able to use the `param` functions with your custom value type. [For that, take a look at the existing instances of `ParamReader`.](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#t:ParamReader)
+Rarely you might want to work with a custom scalar value which is not yet supported with [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param). Define a custom [`ParamReader`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#t:ParamReader) instance to be able to use the [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param) functions with your custom value type. [For that, take a look at the existing instances of `ParamReader`.](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#t:ParamReader)
 
 ### Records
 
-When working with records, use `fill` instead of `param`. Fill automatically deals with validation failure when e.g. a field value needs to be an integer, but the submitted value is not numeric.
+When working with records, use [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill) instead of [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param). [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill) automatically deals with validation failure when e.g. a field value needs to be an integer, but the submitted value is not numeric.
 
-Here is an example of using `fill`:
+Here is an example of using [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill):
 
 ```haskell
 action CreatePostAction = do
@@ -195,7 +195,7 @@ action CreatePostAction = do
 
 ## Lifecycle
 
-The Controller instance provides a `beforeAction` function, which is called before the `action` function is called. Common request handling logic like authentication is often placed inside `beforeAction` to protect all actions of the controller against unprotected access.
+The Controller instance provides a [`beforeAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:beforeAction) function, which is called before the [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:action) function is called. Common request handling logic like authentication is often placed inside [`beforeAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:beforeAction) to protect all actions of the controller against unprotected access.
 
 Here is an example to illustrate the lifecycle:
 
@@ -221,13 +221,13 @@ instance Controller PostsController where
 
 ## Accessing the Current Action
 
-Inside the `beforeAction` and `action` you can access the current action using the special `?theAction` variable. That is useful when writing controller helpers, because the variable is passed implicitly.
+Inside the [`beforeAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:beforeAction) and [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:action) you can access the current action using the special `?theAction` variable. That is useful when writing controller helpers, because the variable is passed implicitly.
 
 ## Accessing the Current Request
 
-IHP uses the Haskell WAI standard for dealing with HTTP requests and responses. You can get access to the Wai Request data structure by using `request`:
+IHP uses the Haskell WAI standard for dealing with HTTP requests and responses. You can get access to the Wai Request data structure by using [`request`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:request):
 
-Take a look at [the Wai documentation](https://hackage.haskell.org/package/wai-3.2.2.1/docs/Network-Wai.html) to see what you can do with the Wai `Request`:
+Take a look at [the Wai documentation](https://hackage.haskell.org/package/wai-3.2.2.1/docs/Network-Wai.html) to see what you can do with the Wai [`Request`](https://hackage.haskell.org/package/wai-3.2.2.1/docs/Network-Wai.html#t:Request):
 
 ```haskell
 action ExampleAction = do
@@ -253,7 +253,7 @@ action ExampleAction = do
 
 ### Request Headers
 
-Use `getHeader` to access a request header:
+Use [`getHeader`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:getHeader) to access a request header:
 
 ```haskell
 action ExampleAction = do
@@ -266,7 +266,7 @@ to `Just "the user agent value"`.
 
 The lookup for the header in the request is case insensitive.
 
-Use `setHeader` to set a request header:
+Use [`setHeader`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:setHeader) to set a request header:
 
 ```haskell
 action ExampleAction = do
@@ -277,17 +277,17 @@ action ExampleAction = do
 
 ### Rendering Views
 
-Inside a controller, you have several ways of sending a response. The most common way is to use the `render` function with a `View` data structure, like this:
+Inside a controller, you have several ways of sending a response. The most common way is to use the [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:render) function with a [`View`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#t:View) data structure, like this:
 
 ```
 render ShowPostView { .. }
 ```
 
-The `render` function automatically picks the right response format based on the `Accept` header of the browser. It will try to send an HTML response when HTML is requested, and will also try to send a JSON response when a JSON response is expected. A [`406 Not Acceptable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) will be send when the `render` function cannot fulfill the requested `Accept` formats.
+The [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:render) function automatically picks the right response format based on the `Accept` header of the browser. It will try to send an HTML response when HTML is requested, and will also try to send a JSON response when a JSON response is expected. A [`406 Not Acceptable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) will be send when the [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:render) function cannot fulfill the requested `Accept` formats.
 
 ### Rendering Plain Text
 
-Call `renderPlain` to send a simple plain text response:
+Call [`renderPlain`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderPlain) to send a simple plain text response:
 
 ```haskell
 action ExampleAction = do
@@ -298,18 +298,18 @@ action ExampleAction = do
 
 Usually, you want to render your HTML using a view. See `Rendering Views` for details.
 
-Sometimes you want to render HTML without using views, e.g. doing it inline in the action. Call `respondHtml` for that:
+Sometimes you want to render HTML without using views, e.g. doing it inline in the action. Call [`respondHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:respondHtml) for that:
 
 ```haskell
 action ExampleAction = do
     respondHtml [hsx|<div>Hello World</div>|]
 ```
 
-You will need to import `hsx` into your controller: `import IHP.ViewPrelude (hsx)`.
+You will need to import [`hsx`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx) into your controller: [`import IHP.ViewPrelude (hsx)`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx).
 
 ### Rendering a Static File
 
-Use `renderFile path contentType` to respond with a static file:
+Use [`renderFile path contentType`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderFile) to respond with a static file:
 
 ```haskell
 action ExampleAction = do
@@ -318,7 +318,7 @@ action ExampleAction = do
 
 ### Rendering a Not Found Message
 
-Use `renderNotFound` to render a generic not found message, e.g. when an entity cannot be found:
+Use [`renderNotFound`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderNotFound) to render a generic not found message, e.g. when an entity cannot be found:
 
 ```haskell
 action ExampleAction = do
@@ -329,20 +329,20 @@ action ExampleAction = do
 
 ### Redirect to an Action
 
-Use `redirectTo` to redirect to an action:
+Use [`redirectTo`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectTo) to redirect to an action:
 
 ```haskell
 action ExampleAction = do
     redirectTo ShowPostAction { postId = ... }
 ```
 
-When you need to pass a custom query parameter, you cannot use the `redirectTo` function. See `Redirect to a Path` for that.
+When you need to pass a custom query parameter, you cannot use the [`redirectTo`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectTo) function. See `Redirect to a Path` for that.
 
-The redirect will use HTTP status code `302`. The `baseUrl` in `Config/Config.hs` will be used. In development mode, the `baseUrl` might not be specified in `Config/Config.hs`. Then it will be set to localhost by default.
+The redirect will use HTTP status code `302`. The [`baseUrl`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#t:FrameworkConfig) in `Config/Config.hs` will be used. In development mode, the [`baseUrl`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#t:FrameworkConfig) might not be specified in `Config/Config.hs`. Then it will be set to localhost by default.
 
 ### Redirect to a Path
 
-Use `redirectToPath` when you want to redirect to a path on the same domain:
+Use [`redirectToPath`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectToPath) when you want to redirect to a path on the same domain:
 
 ```haskell
 action ExampleAction = do
@@ -358,7 +358,7 @@ action ExampleAction = do
 
 ### Redirect to a URL
 
-Use `redirectToUrl` to redirect to some external URL:
+Use [`redirectToUrl`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectToUrl) to redirect to some external URL:
 
 ```haskell
 action ExampleAction = do
@@ -377,7 +377,7 @@ action ExampleAction = do
     putStrLn "This line here is not reachable"
 ```
 
-The `putStrLn` will never be called because the `redirectTo` already stops execution.
+The [`putStrLn`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:putStrLn) will never be called because the [`redirectTo`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectTo) already stops execution.
 
 When you have created a [`Response`](https://hackage.haskell.org/package/wai-3.2.2.1/docs/Network-Wai.html#t:Response) manually, you can use [`respondAndExit`](https://ihp.digitallyinduced.com/api-docs/src/IHP.ControllerSupport.html#respondAndExit) to send your response and stop action execution.
 
@@ -393,7 +393,7 @@ Actions have access to the Request Context via the controller context:
 let requestContext = get #requestContext ?context
 ```
 
-The Request Context provides access to the Wai request as well as information like the request query and post parameters and the uploaded files. It's usually used by other functions to provide high-level functionality. E.g. the `getHeader` function uses the Request Context to access the request headers.
+The Request Context provides access to the Wai request as well as information like the request query and post parameters and the uploaded files. It's usually used by other functions to provide high-level functionality. E.g. the [`getHeader`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:getHeader) function uses the Request Context to access the request headers.
 
 ## File Uploads
 

--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -88,7 +88,7 @@ When dumping the database into the `Fixtures.sql` first and then rebuilding the 
 
 ### Model Context
 
-In a pure functional programming language like Haskell, we need to pass the database connection to all functions which need to access the database. We use an implicit parameter `?modelContext :: ModelContext` to pass around the database connection without always specifying it. The `ModelContext` data structure is basically just a wrapper around the actual database connection.
+In a pure functional programming language like Haskell, we need to pass the database connection to all functions which need to access the database. We use an implicit parameter `?modelContext :: ModelContext` to pass around the database connection without always specifying it. The [`ModelContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#t:ModelContext) data structure is basically just a wrapper around the actual database connection.
 
 An implicit parameter is a parameter which is automatically passed to certain functions, it just needs to be available in the current scope.
 
@@ -134,7 +134,7 @@ In the Schema Designer, you can take a look at the generated Haskell code by rig
 
 ### Querying Records
 
-You can retrieve all records of a table using `query`
+You can retrieve all records of a table using [`query`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:query)
 
 ```haskell
 do
@@ -147,7 +147,7 @@ This will run a `SELECT * FROM users` query and put a list of `User` structures.
 
 ### Fetching a single record
 
-When you have the id of a record, you can also use `fetch` to get it from the database:
+When you have the id of a record, you can also use [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) to get it from the database:
 
 ```haskell
 do
@@ -158,11 +158,11 @@ do
 
 This will run the SQL query `SELECT * FROM users WHERE id = ... LIMIT 1`.
 
-`fetch` knows a single entity will be returned for the id, so instead of a list of users, a single user will be returned. In case the entity is not found, an exception is thrown. Use `fetchOrNothing` to get `Nothing` instead of an exception when no result is found
+[`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) knows a single entity will be returned for the id, so instead of a list of users, a single user will be returned. In case the entity is not found, an exception is thrown. Use [`fetchOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOneOrNothing) to get `Nothing` instead of an exception when no result is found
 
 ### Fetching a list of ids
 
-When have you a list of ids of a single record type, you can also just `fetch` them:
+When have you a list of ids of a single record type, you can also just [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) them:
 
 ```haskell
 do
@@ -196,7 +196,7 @@ action ShowTask { taskId } = do
             Nothing -> pure Nothing
 ```
 
-This contains a lot of boilerplate for wrapping and unwrapping the `Maybe` value. Therefore you can just call `fetchOneOrNothing` directly on the `Maybe (Id User)` value:
+This contains a lot of boilerplate for wrapping and unwrapping the [`Maybe`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) value. Therefore you can just call [`fetchOneOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOneOrNothing) directly on the `Maybe (Id User)` value:
 
 ```haskell
 action ShowTask { taskId } = do
@@ -206,7 +206,7 @@ action ShowTask { taskId } = do
 
 ### Fetching `n` records (LIMIT)
 
-Use `limit` to query only up to `n` records from a table:
+Use [`limit`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:limit) to query only up to `n` records from a table:
 
 ```haskell
 do
@@ -218,7 +218,7 @@ do
 
 This will run a `SELECT * FROM users ORDER BY firstname LIMIT 10` query and will return the first 10 users ordered by their `firstname`.
 
-When you are only interested in the first result you can also use `fetchOne` as a shortcut for `|> limit 1`:
+When you are only interested in the first result you can also use [`fetchOne`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOne) as a shortcut for [`|> limit 1`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:limit):
 
 ```haskell
 do
@@ -229,7 +229,7 @@ do
 
 ### Skipping `n` records (OFFSET)
 
-Use `offset` to skip `n` records from a table:
+Use [`offset`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:offset) to skip `n` records from a table:
 
 ```haskell
 do
@@ -239,11 +239,11 @@ do
         |> fetch
 ```
 
-This is most often used together with `limit` to implement paging.
+This is most often used together with [`limit`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:limit) to implement paging.
 
 ### Counting records (COUNT queries)
 
-You can use `fetchCount` instead of `fetch` to get the count of records matching the query:
+You can use [`fetchCount`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchCount) instead of [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) to get the count of records matching the query:
 
 ```haskell
 do
@@ -256,7 +256,7 @@ do
 
 ### Fetching distinct records
 
-Use `distinct` to fetch distinct records.
+Use [`distinct`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:distinct) to fetch distinct records.
 
 ```haskell
 do
@@ -265,7 +265,7 @@ do
         |> fetch
 ```
 
-Or `distinctOn #tableField` to fetch distinct records based on the `#tableField` value.
+Or [`distinctOn #tableField`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:distinctOn) to fetch distinct records based on the `#tableField` value.
 
 ```haskell
 do
@@ -278,7 +278,7 @@ do
 
 The IHP query builder is designed to be able to easily express many basic sql queries. When your application is growing you will typically hit a point where a complex SQL query cannot be easily expressed with the IHP query builder. In that case it's recommended to use handwritten SQL to access your data.
 
-Use the function `sqlQuery` to run a raw SQL query:
+Use the function [`sqlQuery`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:sqlQuery) to run a raw SQL query:
 
 ```haskell
 do
@@ -294,7 +294,7 @@ do
 
 ### Scalar Results
 
-The `sqlQuery` function always returns a list of rows as the result. When the result of your query is a single value (such as an integer or string) use `sqlQueryScalar`:
+The [`sqlQuery`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:sqlQuery) function always returns a list of rows as the result. When the result of your query is a single value (such as an integer or string) use [`sqlQueryScalar`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:sqlQueryScalar):
 
 ```haskell
 do
@@ -433,13 +433,13 @@ query =
     |]
 ```
 
-`Row` is the data type used to hold the result of the query. The use of `trackTableRead` enables the query to play nicely with Auto Refresh.
+`Row` is the data type used to hold the result of the query. The use of [`trackTableRead`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:trackTableRead) enables the query to play nicely with Auto Refresh.
 
 ## Create
 
 ### Creating a single record
 
-To insert a record into the database, call `newRecord` to get an empty record value:
+To insert a record into the database, call [`newRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#t:Record) to get an empty record value:
 
 ```haskell
 do
@@ -447,9 +447,9 @@ do
     -- user = User { id = 0000-0000-0000-0000, firstname = "", lastname = "" }
 ```
 
-The `newRecord` function does not insert the record, it just returns a new empty data structure we can fill with values and then insert into the database.
+The [`newRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#t:Record) function does not insert the record, it just returns a new empty data structure we can fill with values and then insert into the database.
 
-We can use `set` to fill in attributes:
+We can use [`set`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:set) to fill in attributes:
 
 ```haskell
 do
@@ -460,7 +460,7 @@ do
     -- user = User { id = 0000-0000-0000-0000, firstname = "Max", lastname = "Mustermann" }
 ```
 
-We use `createRecord` to insert the above record into the `users` table:
+We use [`createRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:set) to insert the above record into the `users` table:
 
 ```haskell
 do
@@ -488,7 +488,7 @@ do
 
 ### Creating many records
 
-You can use `createMany` to insert multiple records with a single `INSERT` statement:
+You can use [`createMany`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createMany) to insert multiple records with a single `INSERT` statement:
 
 ```haskell
 do
@@ -505,7 +505,7 @@ INSERT INTO users (id, firstname, lastname)
 
 ## Update
 
-The function `updateRecord` runs an `UPDATE` query for a specific record:
+The function [`updateRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#t:CanUpdate) runs an `UPDATE` query for a specific record:
 
 ```haskell
 do
@@ -527,7 +527,7 @@ The `UPDATE` query will only update columns that have been changed using `|> set
 
 ### Deleting a single record
 
-Use `deleteRecord` to run a simple `DELETE` query:
+Use [`deleteRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:deleteRecord) to run a simple `DELETE` query:
 
 ```haskell
 do
@@ -543,7 +543,7 @@ DELETE FROM users WHERE id = "cf633b17-c409-4df5-a2fc-8c3b3d6c2ea7"
 
 ### Deleting many records
 
-Use `deleteRecords` to run a `DELETE` query for multiple records:
+Use [`deleteRecords`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:deleteRecords) to run a `DELETE` query for multiple records:
 
 ```haskell
 do
@@ -559,7 +559,7 @@ DELETE FROM users WHERE id IN (...)
 
 ### Deleting all records
 
-Use `deleteAll` to run a `DELETE` query for all rows in a table:
+Use [`deleteAll`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:deleteAll) to run a `DELETE` query for all rows in a table:
 
 ```haskell
 do
@@ -629,7 +629,7 @@ You can use `fill` even with custom enums:
                     redirectTo PostsAction
 ```
 
-In your views, use `inputValue` to get a textual representation for your enum which works with `fill`:
+In your views, use [`inputValue`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#t:InputValue) to get a textual representation for your enum which works with [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill):
 
 ```html
 [hsx|
@@ -728,7 +728,7 @@ IHP currently has support for the following postgres column types:
 
 ## Transactions
 
-You can use the `withTransaction` function to wrap your database operations in a postgres database transaction:
+You can use the [`withTransaction`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:withTransaction) function to wrap your database operations in a postgres database transaction:
 
 ```haskell
 withTransaction do
@@ -746,11 +746,11 @@ withTransaction do
 In this example, when the creation of the User fails, the creation of the company will be rolled back. So that no
 incomplete data is left in the database when there's an error.
 
-The `withTransaction` function will automatically commit after it succesfully executed the passed do-block. When any exception is thrown, it will automatically rollback.
+The [`withTransaction`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:withTransaction) function will automatically commit after it succesfully executed the passed do-block. When any exception is thrown, it will automatically rollback.
 
 ### Common Pitfalls
 
-Keep in mind that some IHP functions like `redirectTo` or `render` throw a `ResponseException`. So code like below will not work as expected:
+Keep in mind that some IHP functions like [`redirectTo`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectTo) or [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:render) throw a [`ResponseException`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:ResponseException). So code like below will not work as expected:
 
 ```haskell
 action CreateUserAction = do
@@ -759,7 +759,7 @@ action CreateUserAction = do
         redirectTo NewSessionAction
 ```
 
-The `redirectTo` throws a `ResponseException` and will cause a rollback. This code should be structured like this:
+The [`redirectTo`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectTo) throws a [`ResponseException`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:ResponseException) and will cause a rollback. This code should be structured like this:
 
 ```haskell
 action CreateUserAction = do

--- a/Guide/deployment.markdown
+++ b/Guide/deployment.markdown
@@ -371,7 +371,7 @@ CSS_FILES += static/startpage.css # The second import of app.css
 
 We need to update the `Layout.hs` to only load `prod.css` and `prod.js` when running in production. 
 
-For that we use `isDevelopment` and `isProduction` to conditionally load different files. Change your `Web/View/Layout.hs` to look like this:
+For that we use [`isDevelopment`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#v:isDevelopment) and [`isProduction`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#v:isProduction) to conditionally load different files. Change your `Web/View/Layout.hs` to look like this:
 
 ```haskell
 stylesheets :: Html

--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -22,7 +22,7 @@ Open your `Config/Config.hs` and import `import IHP.FileStorage.Config`:
 import IHP.FileStorage.Config
 ```
 
-Then add a call to `initStaticDirStorage`:
+Then add a call to [`initStaticDirStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Config.html#v:initStaticDirStorage):
 
 ```haskell
 module Config where
@@ -48,7 +48,7 @@ Open your `Config/Config.hs` and import `import IHP.FileStorage.Config`:
 import IHP.FileStorage.Config
 ```
 
-Then add a call to `initS3Storage`:
+Then add a call to [`initS3Storage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Config.html#v:initS3Storage):
 
 ```haskell
 module Config where
@@ -93,7 +93,7 @@ Open your `Config/Config.hs` and import `import IHP.FileStorage.Config`:
 import IHP.FileStorage.Config
 ```
 
-Then add a call to `initMinioStorage`:
+Then add a call to [`initMinioStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Config.html#v:initMinioStorage):
 
 ```haskell
 module Config where
@@ -144,7 +144,7 @@ CREATE TABLE companies (
 );
 ```
 
-You can use the `uploadToStorage` function to save a user upload to the storage:
+You can use the [`uploadToStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorage) function to save a user upload to the storage:
 
 ```haskell
 action UpdateCompanyAction { companyId } = do
@@ -159,9 +159,9 @@ action UpdateCompanyAction { companyId } = do
                 redirectTo EditCompanyAction { .. }
 ```
 
-The call to `uploadToStorage #logoUrl` will upload the file provided by the user. It will be saved as `companies/<some uuid>` on the configured storage. The the file url will be written to the `logoUrl` attribute.
+The call to [`uploadToStorage #logoUrl`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorage) will upload the file provided by the user. It will be saved as `companies/<some uuid>` on the configured storage. The the file url will be written to the `logoUrl` attribute.
 
-After calling `uploadToStorage` inside a action, you typically need to use `>>=` instead of `|>`:
+After calling [`uploadToStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorage) inside a action, you typically need to use [`>>=`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:-62--62--61-) instead of [`|>`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:-124--62-):
 
 ```haskell
 -- Bad, will cause a type error:
@@ -181,7 +181,7 @@ company
 
 #### Form
 
-To submit a file upload, add a `{fileField #logoUrl}` to the form that calls the action:
+To submit a file upload, add a [`{fileField #logoUrl}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:fileField) to the form that calls the action:
 
 ```haskell
 renderForm :: Company -> Html
@@ -196,7 +196,7 @@ renderForm company = formFor company [hsx|
 
 ##### Custom File Field
 
-If you need to more customization on the file field which the `fileField` helper doesn't allow, you can also use a handwritten file input:
+If you need to more customization on the file field which the [`fileField`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:fileField) helper doesn't allow, you can also use a handwritten file input:
 
 ```haskell
 renderForm :: Company -> Html
@@ -214,7 +214,7 @@ renderForm company = formFor company [hsx|
 |]
 ```
 
-It's important that `<input>` has `name="logoUrl` attribute, as that's where `uploadToStorage #logoUrl` expects to find the file.
+It's important that `<input>` has `name="logoUrl` attribute, as that's where [`uploadToStorage #logoUrl`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorage) expects to find the file.
 
 ##### Inline Preview
 
@@ -244,7 +244,7 @@ renderForm company = formFor company [hsx|
 
 When dealing with images, we can use the imagemagick tool to e.g. resize the image and strip metadata:
 
-This accepts any kind of image file compatible with ImageMagick, converts it to a 512x512 PNG and strip all meta data we use `uploadToStorageWithOptions` together with `applyImageMagick`:
+This accepts any kind of image file compatible with ImageMagick, converts it to a 512x512 PNG and strip all meta data we use [`uploadToStorageWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorageWithOptions) together with [`applyImageMagick`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Preprocessor-ImageMagick.html#v:applyImageMagick):
 
 ```haskell
 action UpdateCompanyAction { companyId } = do
@@ -264,7 +264,7 @@ action UpdateCompanyAction { companyId } = do
 
 #### Installing ImageMagick
 
-The `applyImageMagick` function requires `imagemagick` to be installed. You can install it by adding `imagemagick` to the `otherDeps` of your `default.nix`:
+The [`applyImageMagick`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Preprocessor-ImageMagick.html#v:applyImageMagick) function requires `imagemagick` to be installed. You can install it by adding `imagemagick` to the `otherDeps` of your `default.nix`:
 
 ```nix
         otherDeps = p: with p; [
@@ -289,7 +289,7 @@ The browser uses the [`Content-Disposition`](https://developer.mozilla.org/en-US
 
 By default no `Content-Disposition` header is set.
 
-If you use the S3 Storage you can use the `contentDispositionAttachmentAndFileName` function to mark a file as an attachment and use its original provided file name as the downloaded file name:
+If you use the S3 Storage you can use the [`contentDispositionAttachmentAndFileName`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:contentDispositionAttachmentAndFileName) function to mark a file as an attachment and use its original provided file name as the downloaded file name:
 
 ```haskell
 let uploadAttachment = uploadToStorageWithOptions $ def
@@ -326,7 +326,7 @@ record
 
 The above methods always require a record like `company` to store the files.
 
-Use `storeFile` to save uploads without a model:
+Use [`storeFile`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:storeFile) to save uploads without a model:
 
 ```haskell
 action UpdateLogoAction = do
@@ -337,9 +337,9 @@ action UpdateLogoAction = do
     let url = get #url storedFile
 ```
 
-This will upload the provided `<input type="file" name="logo"/>` to the `logos` directory. The `storeFile` function returns `StoredFile` structure. We use `get #url` to read the url where the file was saved to.
+This will upload the provided `<input type="file" name="logo"/>` to the `logos` directory. The [`storeFile`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:storeFile) function returns [`StoredFile`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Types.html#t:StoredFile) structure. We use `get #url` to read the url where the file was saved to.
 
-There's also a `storeFileWithOptions` to pass additional configuration:
+There's also a [`storeFileWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:storeFileWithOptions) to pass additional configuration:
 
 ```haskell
 let file = fileOrNothing "file"
@@ -393,7 +393,7 @@ let url :: Text = get #url signedUrl
 let expiredAt :: UTCTime = get #expiredAt signedUrl
 ```
 
-If the `StaticDirStorage` is used, a unsigned normal URL will be returned, as these files are public anyways.
+If the [`StaticDirStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Types.html#t:FileStorage) is used, a unsigned normal URL will be returned, as these files are public anyways.
 
 The signed url is valid for 7 days.
 

--- a/Guide/form.markdown
+++ b/Guide/form.markdown
@@ -14,7 +14,7 @@ Unless javascript helpers have been deactivated, your form will be submitted usi
 
 ## Simple Forms
 
-Forms usually begin with a `formFor` expression. This is how a simple form can look like:
+Forms usually begin with a [`formFor`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor) expression. This is how a simple form can look like:
 
 ```haskell
 renderForm :: Post -> Html
@@ -51,21 +51,19 @@ All inputs have auto-generated class names and ids for styling. Also, all `name`
 
 IHP has the most commonly-used form controls built in. In general the form control helpers just need to be passed the field name. Here is a list of all built-in form control helpers:
 
-```haskell
-{textField #title}
-{textareaField #body}
-{colorField #brandColor}
-{emailField #email}
-{dateField #dueAt}
-{passwordField #password}
-{dateTimeField #createdAt}
-{numberField #quantity}
-{hiddenField #projectId}
-{checkboxField #termsAccepted}
-{selectField #projectId allProjects}
-{fileFile #profilePicture}
-{submitButton}
-```
+- [`{textField #title}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textField)
+- [`{textareaField #body}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textareaField)
+- [`{colorField #brandColor}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:colorField)
+- [`{emailField #email}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:emailField)
+- [`{dateField #dueAt}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:dateField)
+- [`{passwordField #password}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:passwordField)
+- [`{dateTimeField #createdAt}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:dateTimeField)
+- [`{numberField #quantity}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:numberField)
+- [`{hiddenField #projectId}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:hiddenField)
+- [`{checkboxField #termsAccepted}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:checkboxField)
+- [`{selectField #projectId allProjects}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:selectField)
+- [`{fileFile #profilePicture}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:fileField)
+- [`{submitButton}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:submitButton)
 
 A form control is always filled with the value of the given field when rendering. For example, given a post
 
@@ -73,7 +71,7 @@ A form control is always filled with the value of the given field when rendering
 let post = Post { ..., title = "Hello World" }
 ```
 
-Rendering `{textField #title}`, the input value will be set like
+Rendering [`{textField #title}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textField), the input value will be set like
 
 ```html
 <input ... value="Hello World" />
@@ -90,7 +88,7 @@ let post = Post { ..., title = "" }
     |> validateField #title nonEmpty
 ```
 
-Rendering `{textField #title}`, the input will have the css class `is-invalid` and an element with the error message will be rendered below the input:
+Rendering [`{textField #title}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textField), the input will have the css class `is-invalid` and an element with the error message will be rendered below the input:
 
 ```html
 <div class="form-group" id="form-group-post_title">
@@ -108,7 +106,7 @@ Rendering `{textField #title}`, the input will have the css class `is-invalid` a
 
 ## Forms Are Also HSX
 
-It's important to understand that while the form helpers like `{textField #title}` are called by `formFor`, you can still use HSX there. So you can just add any kind of HSX code inside your form:
+It's important to understand that while the form helpers like [`{textField #title}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textField) are called by [`formFor`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor), you can still use HSX there. So you can just add any kind of HSX code inside your form:
 
 ```haskell
 renderForm :: Post -> Html
@@ -136,7 +134,7 @@ Inside the HSX block of a form, you have access to the special `?formContext` va
 
 ## Customizing Inputs
 
-The return values of the form control helpers are usually a value of type [FormField](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#t:FormField). The `FormField` value is automatically rendered as HTML when used inside an HSX expression. Before this rendering happens, you can specify options to customize the rendering.
+The return values of the form control helpers are usually a value of type [FormField](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#t:FormField). The [`FormField`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField) value is automatically rendered as HTML when used inside an HSX expression. Before this rendering happens, you can specify options to customize the rendering.
 
 ### Help Texts
 
@@ -159,7 +157,7 @@ This will render like:
 
 ### Custom Field Label Text
 
-By default, the field name will be used as a label text. The camel case field name will be made more human-readable of course, so `contactName` will turn to `Contact Name`, etc. Sometimes you want to change this auto-generated input label to something custom. Use `fieldLabel` for that, like this:
+By default, the field name will be used as a label text. The camel case field name will be made more human-readable of course, so `contactName` will turn to `Contact Name`, etc. Sometimes you want to change this auto-generated input label to something custom. Use [`fieldLabel`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField) for that, like this:
 
 ```haskell
 {(textField #title) { fieldLabel = "Post Title"} }
@@ -176,7 +174,7 @@ This will render like:
 
 ### Custom CSS Classes
 
-You can add custom CSS classes to the input and label for better styling. Set `fieldClass` for adding a class to the input element and `labelClass` for the label element:
+You can add custom CSS classes to the input and label for better styling. Set [`fieldClass`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField) for adding a class to the input element and [`labelClass`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField) for the label element:
 
 ```haskell
 {(textField #title) { fieldClass="title-input", labelClass = "title-label" } }
@@ -398,7 +396,7 @@ This will render like:
 
 #### Don't render `<label>`
 
-You can specify `disableLabel` to stop the label element from being generated:
+You can specify [`disableLabel`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField) to stop the label element from being generated:
 
 ```haskell
 {(textField #title) { disableLabel = True }
@@ -420,7 +418,7 @@ Will render as:
 
 #### Don't render `<div class="form-group">`
 
-You can specify `disableGroup` to stop the outer `<div class="form-group">` element from being generated:
+You can specify [`disableGroup`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField) to stop the outer `<div class="form-group">` element from being generated:
 
 ```haskell
 {(textField #title) { disableGroup = True }
@@ -441,17 +439,17 @@ Will render as:
 
 #### Don't show validation error message
 
-You can specify `disableValidationResult` to stop the validation error message being shown when the validation failed:
+You can specify [`disableValidationResult`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField) to stop the validation error message being shown when the validation failed:
 
 ```haskell
 {(textField #title) { disableValidationResult = True }
 ```
 
-This works out of the box for most Haskell data types. When you are working with a custom data type, e.g. a custom enum value, you need to add a `InputValue MyDataType` implementation. We will cover this later in this Guide.
+This works out of the box for most Haskell data types. When you are working with a custom data type, e.g. a custom enum value, you need to add a [`InputValue MyDataType`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#t:InputValue) implementation. We will cover this later in this Guide.
 
 ### Standalone Validation Errors
 
-If you're using a custom widget for a form field, you might still want to show IHP's validation errors. Use `validationResult #someField` to render a standalone validation error:
+If you're using a custom widget for a form field, you might still want to show IHP's validation errors. Use [`validationResult #someField`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:validationResult) to render a standalone validation error:
 
 ```haskell
 formFor user [hsx|
@@ -466,17 +464,17 @@ formFor user [hsx|
 |]
 ```
 
-The `{validationResult #email}` will render like this when the validation failed:
+The [`{validationResult #email}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:validationResult) will render like this when the validation failed:
 
 ```html
 <div class="invalid-feedback">is not a valid email</div>
 ```
 
-If there's no validation failure on the given field, the `validationResult` will not render anything.
+If there's no validation failure on the given field, the [`validationResult`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:validationResult) will not render anything.
 
 #### Standalone Validation Errors Without Styling
 
-If you need more control over the styling of your validation error, you can use `validationResultMaybe #someField`. This function will return `Just "some error"` when there's a validation failure on that field or `Nothing` if the field passed validation.
+If you need more control over the styling of your validation error, you can use [`validationResultMaybe #someField`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:validationResultMaybe). This function will return `Just "some error"` when there's a validation failure on that field or `Nothing` if the field passed validation.
 
 You can use this to write custom error messages in your form:
 
@@ -516,7 +514,7 @@ action NewInviteAction = do
 
 Select inputs require you to pass a list of possible values to select.
 
-You can use the `selectField` helper for select inputs:
+You can use the [`selectField`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:selectField) helper for select inputs:
 
 ```haskell
 formFor project [hsx|
@@ -526,7 +524,7 @@ formFor project [hsx|
 
 In the example above the variable `users` contains all the possible option values for the select.
 
-You also need to define a instance `CanSelect User`:
+You also need to define a instance [`CanSelect User`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#t:CanSelect):
 
 ```haskell
 instance CanSelect User where
@@ -562,7 +560,7 @@ If you want a certain value to be preselected, set the value in the controller. 
 
 ### Select Inputs with Nullable Value
 
-Sometimes we want to allow the user to specifically make a choice of missing/none. To have our user-dropdown from the previous example allow this we need to adjust the `CanSelect` instance.
+Sometimes we want to allow the user to specifically make a choice of missing/none. To have our user-dropdown from the previous example allow this we need to adjust the [`CanSelect`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#t:CanSelect) instance.
 
 ```haskell
 instance CanSelect (Maybe User) where
@@ -591,7 +589,7 @@ Given an enum like this:
 CREATE TYPE CONTENT_TYPE AS ENUM ('video', 'article', 'audio');
 ```
 
-We need to define a `CanSelect ContentType` like this:
+We need to define a [`CanSelect ContentType`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#t:CanSelect) like this:
 
 ```haskell
 instance CanSelect ContentType where
@@ -604,7 +602,7 @@ instance CanSelect ContentType where
     -- You can also use the following shortcut: selectLabel = tshow
 ```
 
-The helper function `allEnumValues @ContentType` can then be used in your 
+The helper function [`allEnumValues @ContentType`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:allEnumValues) can then be used in your 
 view to generate the list of select fields:
 
 ```haskell
@@ -631,7 +629,7 @@ formFor subscription [hsx|
         -- Quick reminder: [1..10] is just a shortcut for [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] in haskell :)
 ```
 
-You also need a `CanSelect` instance like this:
+You also need a [`CanSelect`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#t:CanSelect) instance like this:
 
 
 ```haskell
@@ -645,9 +643,9 @@ instance CanSelect Int where
 
 ### Custom Form Action / Form URLs
 
-The URL where the form is going to be submitted to is specified in HTML using the form's `action` attribute. When using `formFor` the `action` attribute is automatically set to the expected path.
+The URL where the form is going to be submitted to is specified in HTML using the form's `action` attribute. When using [`formFor`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor) the `action` attribute is automatically set to the expected path.
 
-E.g. given the below `formFor` code, the `action` is set to `/CreatePost` or `/UpdatePost`:
+E.g. given the below [`formFor`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor) code, the `action` is set to `/CreatePost` or `/UpdatePost`:
 
 ```haskell
 renderForm :: Post -> Html
@@ -658,21 +656,21 @@ renderForm post = formFor post [hsx|
 |]
 ```
 
-To override the auto-generated `action` attribute use the `formFor'` function:
+To override the auto-generated `action` attribute use the [`formFor'`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor-39-) function:
 
 ```haskell
 renderForm :: Post -> Html
 renderForm post = formFor' post "/my-custom-endpoint" [hsx||]
 ```
 
-If you pass an action to that, you need to wrap it with `pathTo`:
+If you pass an action to that, you need to wrap it with [`pathTo`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo):
 
 ```haskell
 renderForm :: Post -> Html
 renderForm post = formFor' post (pathTo CreateDraftAction) [hsx||]
 ```
 
-If you want to combine this with other customizations, you can also specify a custom path using `formForWithOptions`:
+If you want to combine this with other customizations, you can also specify a custom path using [`formForWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formForWithOptions):
 
 ```haskell
 renderForm :: Post -> Html
@@ -694,7 +692,7 @@ By default forms have the CSS class `new-form` or `edit-form`, depending on if t
 <form class="edit-form">
 ```
 
-You can override the form class using `formForWithOptions`:
+You can override the form class using [`formForWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formForWithOptions):
 
 ```haskell
 renderForm :: Post -> Html
@@ -712,7 +710,7 @@ The generated HTML will look like this:
 <form class="custom-form-class">
 ```
 
-If you want to append your own classes while keeping the default `new-form` and `edit-form` classes, use `modify`:
+If you want to append your own classes while keeping the default `new-form` and `edit-form` classes, use [`modify`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:modify):
 
 ```haskell
 options :: FormContext Post -> FormContext Post
@@ -723,7 +721,7 @@ options formContext =
 
 ### Custom Form Id
 
-By default forms don't have an id. You can set a `<form id="">` attribute using `formForWithOptions`:
+By default forms don't have an id. You can set a `<form id="">` attribute using [`formForWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formForWithOptions):
 
 ```haskell
 renderForm :: Post -> Html
@@ -743,7 +741,7 @@ The generated HTML will look like this:
 
 ### Custom Form Attributes
 
-You can specifiy custom HTML attributes using `formForWithOptions`.
+You can specifiy custom HTML attributes using [`formForWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formForWithOptions).
 
 ```haskell
 renderForm :: Post -> Html
@@ -770,7 +768,7 @@ Your form will be submitted using AJAX and TurboLinks instead of browser-based f
 
 Sometimes this behavior is problematic. For example when the successful form submissions redirects to page that starts a Single Page App. Usually you want to have a clean page refresh here to avoid troubles with the JavaScript.
 
-Set `disableJavascriptSubmission` to `True` to use normal browser-based form submission:
+Set [`disableJavascriptSubmission`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormContext) to `True` to use normal browser-based form submission:
 
 ```haskell
 renderForm :: Post -> Html
@@ -782,7 +780,7 @@ options formContext =
     |> set #disableJavascriptSubmission True
 ```
 
-There's also a shortcut called `formForWithoutJavascript` for this:
+There's also a shortcut called [`formForWithoutJavascript`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formForWithoutJavascript) for this:
 
 ```haskell
 renderForm :: Post -> Html
@@ -823,7 +821,7 @@ An action that can deal with an arbitrary amount of fields can look like this:
             (invalidPosts, validPosts) -> render NewView { posts }
 ```
 
-The `NewView` needs to be changed as well to deal with an arbitrary amount of posts. For these cases we cannot use `formFor`, but we'll handle the job of `formFor` manually:
+The `NewView` needs to be changed as well to deal with an arbitrary amount of posts. For these cases we cannot use `formFor`, but we'll handle the job of [`formFor`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor) manually:
 
 ```haskell
 module Web.View.Posts.New where

--- a/Guide/helpful-tips.markdown
+++ b/Guide/helpful-tips.markdown
@@ -125,9 +125,9 @@ In general the `\case ...` can be expanded to `\value -> case value of ...`.
 
 [Learn more about lambda cases here.](https://typeclasses.com/ghc/lambda-case)
 
-### The Pipe operator `|>`
+### The Pipe operator [`|>`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:-124--62-)
 
-In IHP code bases you find lot's of usage of the `|>` operator. We usually call it the `pipe operator`.
+In IHP code bases you find lot's of usage of the [`|>`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:-124--62-) operator. We usually call it the `pipe operator`.
 
 The operator allows you to write code like this:
 

--- a/Guide/hsx.markdown
+++ b/Guide/hsx.markdown
@@ -295,8 +295,8 @@ In these cases you can use [`preEscapedToHtml`](https://ihp.digitallyinduced.com
 
 Be careful when using [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) as it can easily introduce security issues.
 
-The `preEscapedToHtml` function can also be used to output HTML code that is not supported by HSX:
-The [`preEscapedToHtml`]() function can also be used to output HTML code that is not supported by HSX:
+The [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) function can also be used to output HTML code that is not supported by HSX:
+The [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) function can also be used to output HTML code that is not supported by HSX:
 
 ```html
 {"<!--[if IE]> Internet Explorer Conditional Comments <![endif]-->" |> preEscapedToHtml}

--- a/Guide/hsx.markdown
+++ b/Guide/hsx.markdown
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-HSX can be written pretty much like normal HTML. You can write an HSX expression inside your Haskell code by wrapping it with `[hsx|YOUR HSX CODE|]`. HSX expressions are just a syntax for [BlazeHtml](https://jaspervdj.be/blaze/) and thus are automatically escaped as described in the blaze documentation.
+HSX can be written pretty much like normal HTML. You can write an HSX expression inside your Haskell code by wrapping it with [`[hsx|YOUR HSX CODE|]`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx). HSX expressions are just a syntax for [BlazeHtml](https://jaspervdj.be/blaze/) and thus are automatically escaped as described in the blaze documentation.
 
 Because the HSX is parsed, you will get a syntax error when you type in invalid HTML.
 
@@ -23,7 +23,7 @@ in
 
 **If the variable is another HSX expression, a blaze HTML element, a text or string**: it is just included as you would expect.
 
-**If the variable is any other custom Haskell data structure**: it will first be converted to a string representation by calling `show` on it. You can add a custom `ToHtml` (import it from `IHP.HSX.ToHtml`) instance, to customize rendering a data structure.
+**If the variable is any other custom Haskell data structure**: it will first be converted to a string representation by calling [`show`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:show) on it. You can add a custom [`ToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-ToHtml.html#t:ToHtml) (import it from `IHP.HSX.ToHtml`) instance, to customize rendering a data structure.
 
 You can also write more complex code like:
 
@@ -224,7 +224,7 @@ If you use HTML entities, such as `&nbsp;` for a non-breaking space, you will no
 
 ### Dealing with Maybe Values
 
-When dealing with `Maybe` values you sometimes want to conditionally render something. E.g. in react to render a tag with JSX you would do it like this:
+When dealing with [`Maybe`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) values you sometimes want to conditionally render something. E.g. in react to render a tag with JSX you would do it like this:
 
 ```html
 <p>Hi {user.name}</p>
@@ -255,8 +255,7 @@ renderCountry = case get #country user of
     Nothing -> [hsx||]
 ```
 
-That code doesn't feel right. It's better to deal with the problem at create time of the `User` record already. Use  `
-emptyValueToNothing` to transform an empty `Just ""` to `Nothing` before inserting it into the db:
+That code doesn't feel right. It's better to deal with the problem at create time of the `User` record already. Use  [`emptyValueToNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:emptyValueToNothing) to transform an empty `Just ""` to `Nothing` before inserting it into the db:
 
 ```haskell
 action CreateUserAction = do
@@ -283,7 +282,7 @@ Let's say we have variable `myVariable = "<script>alert(1)</script>"`. This is h
 
 Sometimes you want to insert some actual HTML code to your HSX using a variable. E.g. when your app is rendering markdown, the generated HTML by the markdown library should not be escaped, the markdown library typically already takes care of that.
 
-In these cases you can use `preEscapedToHtml` to mark a text as already escaped:
+In these cases you can use [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) to mark a text as already escaped:
 
 ```html
 <div>{markdownHtml |> preEscapedToHtml}</div>
@@ -294,9 +293,10 @@ In these cases you can use `preEscapedToHtml` to mark a text as already escaped:
 <div><p>hello</p></div>
 ```
 
-Be careful when using `preEscapedToHtml` as it can easily introduce security issues.
+Be careful when using [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) as it can easily introduce security issues.
 
 The `preEscapedToHtml` function can also be used to output HTML code that is not supported by HSX:
+The [`preEscapedToHtml`]() function can also be used to output HTML code that is not supported by HSX:
 
 ```html
 {"<!--[if IE]> Internet Explorer Conditional Comments <![endif]-->" |> preEscapedToHtml}

--- a/Guide/jobs.markdown
+++ b/Guide/jobs.markdown
@@ -68,7 +68,7 @@ Every job has two options you can configure:
 
 #### Attempts
 
-When a job fails, it is automatically retried up to 10 times, or until it succeeds. If you want to configure this number, you can set `maxAttempts` to a custom value, like in this example:
+When a job fails, it is automatically retried up to 10 times, or until it succeeds. If you want to configure this number, you can set [`maxAttempts`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Types.html#v:maxAttempts) to a custom value, like in this example:
 
 ```haskell
 instance Job EmailCustomersJob where
@@ -83,7 +83,7 @@ instance Job EmailCustomersJob where
 
 #### Timeout
 
-Sometimes you might want a job to stop if its runtime exceeds some threshold. For that case, there's a `timeoutInMicroseconds` option which you can set for you job. The default is no timeout. If you want your job to time out after some time, set it to a `Just Int` value, like in the following example, which causes the job to time out after one minute:
+Sometimes you might want a job to stop if its runtime exceeds some threshold. For that case, there's a [`timeoutInMicroseconds`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Types.html#v:timeoutInMicroseconds) option which you can set for you job. The default is no timeout. If you want your job to time out after some time, set it to a `Just Int` value, like in the following example, which causes the job to time out after one minute:
 
 ```haskell
 instance Job EmailCustomersJob where
@@ -96,7 +96,7 @@ instance Job EmailCustomersJob where
     timeoutInMicroseconds = Just $ 1000000 * 60
 ```
 
-A timed out job will be retried, just as if it failed. If you want to prevent that, set its `maxAttempts` to `0`, as shown above.
+A timed out job will be retried, just as if it failed. If you want to prevent that, set its [`maxAttempts`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Types.html#v:maxAttempts) to `0`, as shown above.
 
 ### Scheduling jobs with cron
 
@@ -146,7 +146,7 @@ type MyJobDashboard = JobsDashboardController
 
 With the empty list type `'[]`, the job dashboard will render a default dashboard for all the tables in the database ending in `_jobs`. See below for a guide on adding custom dashboards for your job types.
 
-To add the dashboard to your application, you need to add a `parseRoute` call to this type.
+To add the dashboard to your application, you need to add a [`parseRoute`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:parseRoute) call to this type.
 
 ```haskell
 type MyJobDashboard = JobsDashboardController
@@ -165,13 +165,13 @@ This will mount a jobs dashboard under `/jobs/`.
 
 ### Authentication
 
-The second type parameter to `JobsDashboardController` is a type that defines how users should be authenticated when visiting any of the jobs pages.
+The second type parameter to [`JobsDashboardController`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard-Types.html#t:JobsDashboardController) is a type that defines how users should be authenticated when visiting any of the jobs pages.
 IHP provides three types for common use cases.
 - `NoAuth`: No authentication
 - `BasicAuth`: HTTP Basic Auth using environment variables
 - `BasicAuthStatic`: HTTP Basic Auth using static values
 
-To use your own authentication, create an empty type and define an instance of `AuthenticationMethod` for it. Example:
+To use your own authentication, create an empty type and define an instance of [`AuthenticationMethod`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard-Auth.html#t:AuthenticationMethod) for it. Example:
 
 ```haskell
 data CustomAuth
@@ -190,11 +190,11 @@ type MyJobDashboard = JobsDashboardController
 
 ### Jobs to include
 
-The third type parameter to `JobsDashboardController` is a list of job types that the dashboard will display using their custom `DisplayableJob` implementations. See the documentation for `IHP.Job.Dashboard` for details.
+The third type parameter to [`JobsDashboardController`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard-Types.html#t:JobsDashboardController) is a list of job types that the dashboard will display using their custom [`DisplayableJob`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard.html#t:DisplayableJob) implementations. See the documentation for [`IHP.Job.Dashboard`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard.html) for details.
 
 ### Customize views
 
-Most views in the dashboard can be customized by providing a custom implementation of `DisplayableJob` for your job type.
+Most views in the dashboard can be customized by providing a custom implementation of [`DisplayableJob`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard.html#t:DisplayableJob) for your job type.
 These methods can be overriden to allow for custom behavior:
 
 ```haskell
@@ -233,7 +233,7 @@ To add more data, define your own implementation. See the case study below for a
 
 ### TableViewable
 
-The jobs dashboard provides a `TableViewable` type class that makes it easier to customize the appearance of jobs in the dashboard.
+The jobs dashboard provides a [`TableViewable`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard-Types.html#t:TableViewable) type class that makes it easier to customize the appearance of jobs in the dashboard.
 The typeclass defines behavior for how the type should be rendered as a table.
 
 ```haskell
@@ -307,8 +307,8 @@ instance TableViewable (IncludeWrapper "bandId" InitialScrapeJob) where
 
 ```
 
-Note the use of `IncludeWrapper` instead of the normal `Include`. This gets around an unfortunate limitation in Haskell's type system.
-This instance is then used by a custom `DisplayableJob` instance that uses some helpers from `IHP.Job.Dashboard.View` that render the dashboard section and list pages using any `TableViewable` instance.
+Note the use of [`IncludeWrapper`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard-Types.html#t:IncludeWrapper) instead of the normal [`Include`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard-Types.html#t:IncludeWrapper). This gets around an unfortunate limitation in Haskell's type system.
+This instance is then used by a custom [`DisplayableJob`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard.html#t:DisplayableJob) instance that uses some helpers from `IHP.Job.Dashboard.View` that render the dashboard section and list pages using any [`TableViewable`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard-Types.html#t:TableViewable) instance.
 
 ```haskell
 instance DisplayableJob InitialScrapeJob where

--- a/Guide/logging.markdown
+++ b/Guide/logging.markdown
@@ -15,14 +15,14 @@ If you need to know exact ordering it's recommended you rely on the timestamp.
 IHP logging uses log levels to determine which messages should be printed.
 This way, you can log messages to help in development without flooding production logs.
 
-The available log levels are `debug`, `info`, `warn`, `error`, `fatal`, and `unknown`.
+The available log levels are [`debug`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:debug), [`info`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:info), [`warn`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:warn), [`error`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:error), [`fatal`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:fatal), and [`unknown`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:unknown).
 In development, the default log level is debug. In production, the default log level is info.
 Log messages will only be output if their log level is greater than or equal to the logger's configured log level.
 
 ### Sending messages
 
 In any controller or model code, you can log a message at a given log level by simply calling
-`Log.debug`, `Log.info`, or any of the other available log levels.
+[`Log.debug`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:debug), [`Log.info`](https://ihp.digitallyinduced.com/api-docs/IHP-Log.html#v:info), or any of the other available log levels.
 
 Example:
 ```haskell
@@ -51,7 +51,7 @@ import qualified IHP.Log as Log
 import IHP.Log.Types
 ```
 
-Using the `newLogger` function, create a logger with the desired options. For example, here is a logger that formats
+Using the [`newLogger`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#v:newLogger) function, create a logger with the desired options. For example, here is a logger that formats
 logs with a timestamp at the `Debug` log level:
 
 ```haskell
@@ -62,7 +62,7 @@ logger <- liftIO $ newLogger def {
 option logger
 ```
 
-The available configuration options can be found in the `LoggerSettings` record.
+The available configuration options can be found in the [`LoggerSettings`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:LoggerSettings) record.
 
 ```haskell
 data LoggerSettings = LoggerSettings {
@@ -75,7 +75,7 @@ data LoggerSettings = LoggerSettings {
 
 #### Configuring log level
 
-Set `level` to one of the available constructors for the `LogLevel` type:
+Set [`level`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:LoggerSettings) to one of the available constructors for the [`LogLevel`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:LogLevel) type:
 
 ```haskell
 data LogLevel
@@ -91,13 +91,13 @@ data LogLevel
 
 IHP ships with four available log formats.
 
-- `defaultFormatter` simply prints the log message with a newline.
+- [`defaultFormatter`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#v:defaultFormatter) simply prints the log message with a newline.
   - `Server started`
-- `withTimeFormatter` prepends a timestamp.
+- [`withTimeFormatter`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#v:withTimeFormatter) prepends a timestamp.
   - `[28-Jan-2021 10:07:58] Server started`
-- `withLevelFormatter` prepends the message's log level
+- [`withLevelFormatter`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#v:withLevelFormatter) prepends the message's log level
   - `[INFO] Server started`
-- `withTimeAndLevelFormatter` prepends both a timestamp and log level.
+- [`withTimeAndLevelFormatter`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#v:withTimeAndLevelFormatter) prepends both a timestamp and log level.
   - `[INFO] [28-Jan-2021 10:07:58] Server started`
 
 You can also define your own formatter. Since a LogFormatter is just a type alias:
@@ -142,9 +142,9 @@ data LogDestination
 ##### Logging to a file
 
 When logging to a file, it is common to rotate the file logged to in order to prevent
-the log file from getting too big. IHP allows for this in three ways, through the `RotateSettings` record.
+the log file from getting too big. IHP allows for this in three ways, through the [`RotateSettings`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:RotateSettings) record.
 
-- `NoRotate` never rotates the file, meaning the log file can become arbitrarily large.
+- [`NoRotate`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:RotateSettings) never rotates the file, meaning the log file can become arbitrarily large.
   Use with caution. The following example will log all messages to a file at `Log/production.log`.
 
 ```haskell
@@ -153,7 +153,7 @@ newLogger def {
 }
 ```
 
-- `SizeRotate` rotates the file after reaching a specified size (in bytes).
+- [`SizeRotate`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:RotateSettings) rotates the file after reaching a specified size (in bytes).
   The following example will log all messages to a file at `Log/production.log`,
   and rotate the file once it reaches 4 megabytes in size. It will
   keep 7 log files before overwriting the first file.
@@ -164,7 +164,7 @@ newLogger def {
 }
 ```
 
-- `TimedRotate` rotates the file based on a time format string and a function which compares two times formatted by said format string. It also passes the rotated log's file path to a function, which can be used to compress old logs as in this example which rotates once per day:
+- [`TimedRotate`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:RotateSettings) rotates the file based on a time format string and a function which compares two times formatted by said format string. It also passes the rotated log's file path to a function, which can be used to compress old logs as in this example which rotates once per day:
 
 ```haskell
 let
@@ -184,7 +184,7 @@ in
 
 #### Configuring timestamp format
 
-`timeFormat` expects a time format string as defined [here](https://man7.org/linux/man-pages/man3/strptime.3.html).
+[`timeFormat`](https://ihp.digitallyinduced.com/api-docs/IHP-Log-Types.html#t:TimeFormat) expects a time format string as defined [here](https://man7.org/linux/man-pages/man3/strptime.3.html).
 
 Example:
 

--- a/Guide/mail.markdown
+++ b/Guide/mail.markdown
@@ -79,7 +79,7 @@ Last we need to change the email text a little bit. The mail supports HSX so thi
 
 ## Sending Mails
 
-From inside a controller or script, an email can be sent by using `sendMail`:
+From inside a controller or script, an email can be sent by using [`sendMail`](https://ihp.digitallyinduced.com/api-docs/IHP-Mail.html#v:sendMail):
 
 ```haskell
 action MyAction = do
@@ -146,7 +146,7 @@ config = do
 
 ## Email Attachments
 
-You can add file attachments by adding a `attachments` statement:
+You can add file attachments by adding a [`attachments`](https://ihp.digitallyinduced.com/api-docs/IHP-Mail.html#v:attachments) statement:
 
 ```haskell
 module Web.Mail.Users.Confirmation where

--- a/Guide/modal.markdown
+++ b/Guide/modal.markdown
@@ -14,7 +14,7 @@ IHP provides support to render [Bootstrap 4 Modals](https://getbootstrap.com/doc
 
 Before we can build our modal, we have to make sure that your current application layout has modal rendering enabled.
 
-Open your `Web/View/Layout.hs` and add a `{modal}` just before the closing `</body>` tag:
+Open your `Web/View/Layout.hs` and add a [`{modal}`](https://ihp.digitallyinduced.com/api-docs/IHP-Modal-ViewFunctions.html#v:modal) just before the closing `</body>` tag:
 
 ```haskell
 defaultLayout :: Html -> Html
@@ -26,7 +26,7 @@ defaultLayout inner = H.docTypeHtml ! A.lang "en" $ [hsx|
 |]
 ```
 
-In case there is a `{modal}` already you can skip this step. Don't add the `{modal}` twice.
+In case there is a [`{modal}`](https://ihp.digitallyinduced.com/api-docs/IHP-Modal-ViewFunctions.html#v:modal) already you can skip this step. Don't add the [`{modal}`](https://ihp.digitallyinduced.com/api-docs/IHP-Modal-ViewFunctions.html#v:modal) twice.
 
 ## Rendering Modal Views
 
@@ -48,7 +48,7 @@ action NewProjectAction = do
     render NewView { .. }
 ```
 
-We need to call `setModal NewView { .. }` to turn the `NewView` into a modal. We also need to call `jumpToAction ProjectsAction` to render the `NewView` on top of the `ProjectsView` which is going to be rendered by the `ProjectsAction`:
+We need to call [`setModal NewView { .. }`](https://ihp.digitallyinduced.com/api-docs/IHP-Modal-ControllerFunctions.html#v:setModal) to turn the `NewView` into a modal. We also need to call [`jumpToAction ProjectsAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:jumpToAction) to render the `NewView` on top of the `ProjectsView` which is going to be rendered by the `ProjectsAction`:
 
 ```haskell
 action NewProjectAction = do
@@ -62,7 +62,7 @@ Let's take a look at `/NewPost`, it now looks like this:
 
 ![](images/modal/modal-2.png)
 
-The `NewView` is now rendered inside the `ProjectsView` (it's rendered where the `{modal}` is placed). Next, we're going to add the modal styling.
+The `NewView` is now rendered inside the `ProjectsView` (it's rendered where the [`{modal}`](https://ihp.digitallyinduced.com/api-docs/IHP-Modal-ViewFunctions.html#v:modal) is placed). Next, we're going to add the modal styling.
 
 ## Modal Styling
 
@@ -89,7 +89,7 @@ instance View NewView where
     |]
 ```
 
-We're going to use `renderModal` inside the `html NewView { .. }` definition to turn this into a bootstrap-styled Modal view:
+We're going to use [`renderModal`](https://ihp.digitallyinduced.com/api-docs/IHP-Modal-ViewFunctions.html#v:renderModal) inside the `html NewView { .. }` definition to turn this into a bootstrap-styled Modal view:
 
 ```haskell
 module Web.View.Projects.New where
@@ -112,7 +112,7 @@ After that our `/NewProject` view looks like this:
 
 ![](images/modal/modal.png)
 
-The call to `renderModal Modal { .. }` returns the HTML code for the bootstrap modal. You can think of it as a template function where `modalTitle`, `modalCloseUrl`, etc. just fill in the placeholder variables for the modal.
+The call to [`renderModal Modal { .. }`](https://ihp.digitallyinduced.com/api-docs/IHP-Modal-ViewFunctions.html#v:renderModal) returns the HTML code for the bootstrap modal. You can think of it as a template function where `modalTitle`, `modalCloseUrl`, etc. just fill in the placeholder variables for the modal.
 
 
 ## Common Issues
@@ -121,7 +121,7 @@ The call to `renderModal Modal { .. }` returns the HTML code for the bootstrap m
 
 This error comes up when you try to render a modal on top of another controllers action.
 
-To fix this error you need to add an import statement to the file where `jumpToAction` is called:
+To fix this error you need to add an import statement to the file where [`jumpToAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:jumpToAction) is called:
 
 ```haskell
 import Web.Controller.Projects () -- <----- ADD THIS LINE

--- a/Guide/oauth.markdown
+++ b/Guide/oauth.markdown
@@ -383,7 +383,7 @@ import IHP.ViewPrelude
 import IHP.OAuth.Github.Types  -- <---- ADD THIS
 ```
 
-This ensures that we can write `pathTo NewSessionWithGithubAction` and similiar calls without always manually needing to add import statements.
+This ensures that we can write [`pathTo NewSessionWithGithubAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo) and similiar calls without always manually needing to add import statements.
 
 
 ### Config

--- a/Guide/querybuilder.markdown
+++ b/Guide/querybuilder.markdown
@@ -11,7 +11,7 @@ The QueryBuilder module allows you to compose database queries in a type-safe wa
 ## Creating a new query
 
 To query the database for some records, you first need to build a query.
-You can just use the `query` function for that.
+You can just use the [`query`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:query) function for that.
 
 ```haskell
 let myQueryBuilder = query
@@ -25,11 +25,11 @@ let myProjectQueryBuilder = query @Project
 
 ## Running a query
 
-You can run a query using `fetch`, `fetchOneOrNothing` or `fetchOne`:
+You can run a query using [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch), [`fetchOneOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOneOrNothing) or [`fetchOne`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOne):
 
-### many rows: `fetch`
+### many rows: [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch)
 
-To run a query which will return many rows use `fetch`:
+To run a query which will return many rows use [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch):
 
 ```haskell
 example :: IO [Project]
@@ -39,9 +39,9 @@ example = do
     pure projects
 ```
 
-### maybe single row: `fetchOneOrNothing`
+### maybe single row: [`fetchOneOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOneOrNothing)
 
-To run a query which will maybe return a single row use `fetchOneOrNothing`:
+To run a query which will maybe return a single row use [`fetchOneOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOneOrNothing):
 
 ```haskell
 example :: IO (Maybe Project)
@@ -51,9 +51,9 @@ example = do
     pure project
 ```
 
-### single row: `fetchOne`
+### single row: [`fetchOne`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOne)
 
-To run a query which will return a single row and **throw an error if no record is found** use `fetchOne`:
+To run a query which will return a single row and **throw an error if no record is found** use [`fetchOne`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOne):
 
 ```haskell
 example :: IO Project
@@ -65,7 +65,7 @@ example = do
 
 ## Where Conditions
 
-To specify `WHERE` conditions, you can use `filterWhere`:
+To specify `WHERE` conditions, you can use [`filterWhere`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhere):
 
 ```haskell
 projectsByUser :: UserId -> IO [Project]
@@ -78,7 +78,7 @@ projectsByUser userId = do
     pure projects
 ```
 
-Use `filterWhereNot` to negate a condition:
+Use [`filterWhereNot`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhereNot) to negate a condition:
 
 ```haskell
 projectsByUser :: UserId -> IO [Project]
@@ -90,7 +90,7 @@ projectsByUser userId = do
     pure otherProjects
 ```
 
-There's a case insensitive variant of `filterWhere` called `filterWhereCaseInsensitive`:
+There's a case insensitive variant of [`filterWhere`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhere) called [`filterWhereCaseInsensitive`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhereCaseInsensitive):
 
 ```haskell
 userByEmail :: Text -> IO (Maybe User)
@@ -102,7 +102,7 @@ userByEmail email = do
     pure user
 ```
 
-You can also use the more general `filterWhereSql`:
+You can also use the more general [`filterWhereSql`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhereSql):
 
 ```haskell
 retiredEmployees :: IO [Employee]
@@ -114,11 +114,11 @@ retiredEmployees = do
     pure employees
 ```
 
-Several other filter-functions for generating `WHERE` clauses exist, such as `filterWhereIn` and `filterWhereNotIn` which take lists of items. Read more about these in the [API docs on QueryBuilder](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html)
+Several other filter-functions for generating `WHERE` clauses exist, such as [`filterWhereIn`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhereIn) and [`filterWhereNotIn`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhereNotIn) which take lists of items. Read more about these in the [API docs on QueryBuilder](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html)
 
 ## Order By
 
-You can just use `orderBy #field`:
+You can just use [`orderBy #field`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:orderBy):
 
 ```haskell
 projects <- query @Project
@@ -127,7 +127,7 @@ projects <- query @Project
 -- Query: `SELECT * FROM projects ORDER BY created_at`
 ```
 
-Nested `orderBy`s work as expected:
+Nested [`orderBy`s](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:orderBy) work as expected:
 
 ```haskell
 projects <- query @Employee
@@ -188,7 +188,7 @@ let projects :: QueryBuilder Project = queryUnion teamProjects personalProjects
 
 ## Shortcuts
 
-### `findBy #field value`
+### [`findBy #field value`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:findBy)
 
 Just a shortcut for `filterWhere (#field, value) |> fetchOne`
 
@@ -199,7 +199,7 @@ project <- query @Project |> filterWhere (#userId, userId) |> fetchOne
 project <- query @Project |> findBy #userId userId
 ```
 
-### `findMaybeBy #field value`
+### [`findMaybeBy #field value`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:findMaybeBy)
 
 Just a shortcut for `filterWhere (#field, value) |> fetchOneOrNothing`
 
@@ -210,7 +210,7 @@ project <- query @Project |> filterWhere (#userId, userId) |> fetchOneOrNothing
 project <- query @Project |> findMaybeBy #userId userId
 ```
 
-### `findManyBy #field value`
+### [`findManyBy #field value`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:findManyBy)
 
 Just a shortcut for `filterWhere (#field, value) |> fetch`
 
@@ -223,14 +223,14 @@ projects <- query @Project |> findManyBy #userId userId
 
 ## `projectId |> fetch`
 
-Ids also have `fetch` implementations, that way you can just run:
+Ids also have [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) implementations, that way you can just run:
 
 ```haskell
 let projectId :: ProjectId = ...
 project <- projectId |> fetch
 ```
 
-For convenience there is also a `fetch` implementation for `Maybe SomeId`:
+For convenience there is also a [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) implementation for `Maybe SomeId`:
 
 ```haskell
 let assignedUserId :: Maybe UserId = project |> get #assignedUserId

--- a/Guide/recipes.markdown
+++ b/Guide/recipes.markdown
@@ -33,7 +33,7 @@ instance Controller StaticController where
     action AboutAction = render AboutView
 ```
 
-We can now customize the routing in `Web.Routes` by first deleting the `instance AutoRoute StaticController` statement to delete the auto generated routing configuration and append:
+We can now customize the routing in `Web.Routes` by first deleting the [`instance AutoRoute StaticController`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:AutoRoute) statement to delete the auto generated routing configuration and append:
 
 ```haskell
 instance HasPath StaticController where
@@ -50,7 +50,7 @@ Now the terms can be reached at `/terms` instead of `/Terms`. The about is at `/
 
 ## Uploading a user profile picture
 
-You can easily upload a user profile picture using `uploadImageWithOptions` inside your `UpdateUserAction`:
+You can easily upload a user profile picture using [`uploadImageWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-FileUpload.html#v:uploadImageWithOptions) inside your `UpdateUserAction`:
 
 ```haskell
 action UpdateUserAction { userId } = do
@@ -206,9 +206,9 @@ The `DeleteSessionAction` expects a `HTTP DELETE` request, which is set by JavaS
 
 ## Making a dynamic Login/Logout button
 
-Depending on the `Maybe User` type in the [ControllerContext](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html), by using `fromFrozenContext` we can tell if no user logged in when the `Maybe User` is `Nothing`, and confirm someone is logged in if the `Maybe User` is a `Just user`. Here is an example of a navbar, which has a dynamic Login/Logout button. You can define this in your View/Layout to reuse this in your Views.
+Depending on the `Maybe User` type in the [ControllerContext](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html), by using [`fromFrozenContext`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html#v:fromFrozenContext) we can tell if no user logged in when the `Maybe User` is `Nothing`, and confirm someone is logged in if the `Maybe User` is a `Just user`. Here is an example of a navbar, which has a dynamic Login/Logout button. You can define this in your View/Layout to reuse this in your Views.
 
-> The `@` syntax from `fromFrozenContext @(Maybe User)` is just syntax sugar for `let maybeUser :: Maybe User = fromFrozenContext`
+> The `@` syntax from [`fromFrozenContext @(Maybe User)`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html#v:fromFrozenContext) is just syntax sugar for `let maybeUser :: Maybe User = fromFrozenContext`
 
 ```haskell
 navbar :: Html
@@ -243,7 +243,7 @@ Protip: If the `Maybe User` is a `Just user` you can use the user object to run 
 
 ## Making an HTTP request
 
-To make an HTTP request, you need `Wreq`. You need to add it to your Haskell dependencies in the `default.nix` file, like here:
+To make an HTTP request, you need [`Wreq`](https://hackage.haskell.org/package/wreq). You need to add it to your Haskell dependencies in the `default.nix` file, like here:
 
 ```bash
 ...
@@ -290,7 +290,7 @@ To confirm before a link is fired add an `onclick` to the link.
 
 ## How to generate a random string
 
-To generate a random string which can be used as a secure token or hash use `generateAuthenticationToken`:
+To generate a random string which can be used as a secure token or hash use [`generateAuthenticationToken`](https://hackage.haskell.org/package/wreq):
 
 ```haskell
 import IHP.AuthSupport.Authentication -- Not needed if you're inside a IHP controller
@@ -381,7 +381,7 @@ Given a enum defined in the `Schema.sql` like this:
 CREATE TYPE colors AS ENUM ('yellow', 'red', 'blue');
 ```
 
-you can call `allEnumValues` to get a list of all the colors:
+you can call [`allEnumValues`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:allEnumValues) to get a list of all the colors:
 
 ```haskell
 let allColors = allEnumValues @Color
@@ -413,7 +413,7 @@ page <- LBS.readFile "static/404.html"
 respondAndExit $ responseLBS status404 [(hContentType, "text/html")] page
 ```
 
-Now you can use your customNotFoundResponse:
+Now you can use your `customNotFoundResponse`:
 
 ```haskell
 action WelcomeAction  = do

--- a/Guide/relationships.markdown
+++ b/Guide/relationships.markdown
@@ -57,9 +57,9 @@ In the view we can just access the comments like this:
 
 The `post |> get #comments` returns a list of the comments belonging to the post.
 
-The type of `post` is `Include "comments" Post` instead of the usual `Post`. This way the state of a fetched nested resource is tracked at the type level.
+The type of `post` is [`Include "comments" Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) instead of the usual `Post`. This way the state of a fetched nested resource is tracked at the type level.
 
-It is possible to have multiple nested resources. For example, if Post had a list of comments and tags related to it, it can be defined as `Include "comments" (Include "tags" Post)` or with the more convinient way as `Include' ["comments", "tags"] Post`.
+It is possible to have multiple nested resources. For example, if Post had a list of comments and tags related to it, it can be defined as [`Include "comments" (Include "tags" Post)`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) or with the more convinient way as [`Include' ["comments", "tags"] Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include-39-).
 
 Note that for the above example, it is expected that the query will change as-well:
 
@@ -73,7 +73,7 @@ post <- fetch postId
 
 ### Order by
 
-When we want to order the relationship in a certain way, we can just apply our commonly used `orderBy` function:
+When we want to order the relationship in a certain way, we can just apply our commonly used [`orderBy`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:orderBy) function:
 
 ```haskell
 let postId :: Id Post = ...
@@ -83,7 +83,7 @@ post <- fetch postId
     >>= fetchRelated #comments
 ```
 
-This works because the `comments` field of a `Post` is just a `QueryBuilder` before we call `fetchRelated`.
+This works because the `comments` field of a `Post` is just a [`QueryBuilder`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#t:QueryBuilder) before we call [`fetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated).
 
 This query builder is equivalent to:
 
@@ -91,19 +91,19 @@ This query builder is equivalent to:
 query @Comment |> filterWhere (#postId, get #id post)
 ```
 
-The call to `>>= pure . modify #comments (orderByDesc #createdAt)` just appends a `|> orderByDesc #createdAt` like this:
+The call to `>>= pure . modify #comments (orderByDesc #createdAt)` just appends a [`|> orderByDesc #createdAt`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:orderByDesc) like this:
 
 ```haskell
 query @Comment |> filterWhere (#postId, get #id post) |> orderByDesc #createdAt
 ```
 
-Then the `fetchRelated` basically just executes this query builder and puts the result back into the `comments` field of the `post` record.
+Then the [`fetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated) basically just executes this query builder and puts the result back into the `comments` field of the `post` record.
 
 ### Multiple Records
 
 #### Fetching all Posts with their Comments (One-to-many)
 
-When we want to fetch all the comments for a list of posts, we can use `collectionFetchRelated`:
+When we want to fetch all the comments for a list of posts, we can use [`collectionFetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:collectionFetchRelated):
 
 ```haskell
 posts <- query @Post
@@ -111,7 +111,7 @@ posts <- query @Post
     >>= collectionFetchRelated #comments
 ```
 
-This will query all posts with all their comments. The type of `posts` is `[Include "comments" Post]`.
+This will query all posts with all their comments. The type of `posts` is [`[Include "comments" Post]`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include).
 
 The above Haskell code will trigger the following two SQL queries to be executed:
 
@@ -152,7 +152,7 @@ comments <- query @Comment
     >>= collectionFetchRelated #postId
 ```
 
-This will query all comments and their respective posts. The type of `comments` is `[Include "postId" Comment]`.
+This will query all comments and their respective posts. The type of `comments` is [`[Include "postId" Comment]`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include).
 
 The Haskell code will trigger the following two SQL queries:
 
@@ -182,7 +182,7 @@ renderComment comment = [hsx|
 
 ### Order With Multiple Records
 
-If you want to sort the results after fetching multiple records with `collectionFetchRelated`
+If you want to sort the results after fetching multiple records with [`collectionFetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:collectionFetchRelated)
 
 ```haskell
 posts <-
@@ -194,7 +194,7 @@ posts <-
 
 ## Belongs To Relationships
 
-Given a specific comment, we can fetch the post this comment belongs to. Like other relationships this is also using `fetchRelated`:
+Given a specific comment, we can fetch the post this comment belongs to. Like other relationships this is also using [`fetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated):
 
 ```haskell
 let comment :: Id Comment = ...
@@ -220,7 +220,7 @@ In the view we can just access the comments like this:
 |]
 ```
 
-The type of `comment` is `Include "postId" Comment` instead of the usual `Comment`. This way the state of a fetched nested resource is tracked at the type level.
+The type of `comment` is [`Include "postId" Comment`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated) instead of the usual `Comment`. This way the state of a fetched nested resource is tracked at the type level.
 
 ## Delete Behavior
 
@@ -251,11 +251,11 @@ query @Posts
         |> filterWhereJoinedTable @Department (#number, 5)
 ```
 
-`innerJoin` is used to join the `users` table (for type `User`) to the primary table `posts` (for type `Posts`) on the columns `posts.author_id` and `users.id`. Type checks ascertain that both tables actually have the pertinent columns.
+[`innerJoin`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:innerJoin) is used to join the `users` table (for type `User`) to the primary table `posts` (for type `Posts`) on the columns `posts.author_id` and `users.id`. Type checks ascertain that both tables actually have the pertinent columns.
 
-The function `innerJoinThirdTable` is used to join a third table on a column of some previously joined table. In the example, the table is `departments` and it is joined on `departments.id = users.department_id`. Again, the type system ascertains that the columns actually exist on the pertinent tables. It is furthermore ascertained that the table associated with the second type `User` has been joined before.
+The function [`innerJoinThirdTable`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:innerJoinThirdTable) is used to join a third table on a column of some previously joined table. In the example, the table is `departments` and it is joined on `departments.id = users.department_id`. Again, the type system ascertains that the columns actually exist on the pertinent tables. It is furthermore ascertained that the table associated with the second type `User` has been joined before.
 
-To add `WHERE` clauses involving a joined table, there is a family of functions of functions named like the ordinary filter functions, but suffixed with "JoinedTable". Where the normal filter functions use columns from the primary table, the tabel that the JoinedTable-functions operate on is specified by the type they are called with. In the example, the `filterWhereJoinedTable` filters all rows where `department.number` equals 5.
+To add `WHERE` clauses involving a joined table, there is a family of functions of functions named like the ordinary filter functions, but suffixed with "JoinedTable". Where the normal filter functions use columns from the primary table, the tabel that the JoinedTable-functions operate on is specified by the type they are called with. In the example, the [`filterWhereJoinedTable`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:filterWhereJoinedTable) filters all rows where `department.number` equals 5.
 
 ### Many-to-many relationships and labeled results
 

--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -6,7 +6,7 @@
 
 ## Routing Basics
 
-In your project routes are defined in the `Web/Routes.hs`. In addition to defining that route, it also has to be added in `Web/FrontController.hs` to be picked up by the routing system.
+In your project, routes are defined in the `Web/Routes.hs`. In addition to defining that route, it also has to be added in `Web/FrontController.hs` to be picked up by the routing system.
 
 The simplest way to define a route is by using `AutoRoute`, which automatically maps each controller action to an URL. For a `PostsController`, the definition in `Web/Routes.hs` will look like this:
 

--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -8,7 +8,7 @@
 
 In your project, routes are defined in the `Web/Routes.hs`. In addition to defining that route, it also has to be added in `Web/FrontController.hs` to be picked up by the routing system.
 
-The simplest way to define a route is by using `AutoRoute`, which automatically maps each controller action to an URL. For a `PostsController`, the definition in `Web/Routes.hs` will look like this:
+The simplest way to define a route is by using [`AutoRoute`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:AutoRoute), which automatically maps each controller action to an URL. For a `PostsController`, the definition in `Web/Routes.hs` will look like this:
 
 ```haskell
 instance AutoRoute PostsController
@@ -28,7 +28,7 @@ Now you can open e.g. `/Posts` to access the `PostsAction`.
 
 ## Changing the Start Page / Home Page
 
-You can define a custom start page action using the `startPage` function like this:
+You can define a custom start page action using the [`startPage`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:startPage) function like this:
 
 ```haskell
 instance FrontController WebApplication where
@@ -38,18 +38,18 @@ instance FrontController WebApplication where
         ]
 ```
 
-In a new IHP project, you usually have a `startPage WelcomeAction` defined. Make sure to remove this line. Otherwise, you will still see the default IHP welcome page.
+In a new IHP project, you usually have a [`startPage WelcomeAction`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:startPage) defined. Make sure to remove this line. Otherwise, you will still see the default IHP welcome page.
 
 ## URL Generation
 
-Use `pathTo` to generate a path to a given action:
+Use [`pathTo`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo) to generate a path to a given action:
 
 ```haskell
 pathTo ShowPostAction { postId = "adddfb12-da34-44ef-a743-797e54ce3786" }
 -- /ShowPost?postId=adddfb12-da34-44ef-a743-797e54ce3786
 ```
 
-To generate a full URL, use `urlTo`:
+To generate a full URL, use [`urlTo`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:urlTo):
 
 ```haskell
 urlTo NewUserAction
@@ -138,7 +138,7 @@ pathTo (MyController [1,2,3]) ==> "/Default?listParam=1,2,3"
 ## For Integer ID types
 
 AutoRoute needs some help if your model does not use UUID as the id type and uses an integer based type instead. To get this to work, add the following to the
-`AutoRoute` instance declarations for each controller that needs to parse an integer ID type as an argument:
+[`AutoRoute`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:AutoRoute) instance declarations for each controller that needs to parse an integer ID type as an argument:
 
 ```haskell
 instance AutoRoute TestController where
@@ -157,7 +157,7 @@ Show_Action   => GET, HEAD
 otherwise     => GET, POST, HEAD
 ```
 
-If you need more strong rules, consider using the other routing APIs available or overriding the `allowedMethodsForAction` like this:
+If you need more strong rules, consider using the other routing APIs available or overriding the [`allowedMethodsForAction`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:allowedMethodsForAction) like this:
 
 ```haskell
 instance AutoRoute HelloWorldController where
@@ -172,7 +172,7 @@ This prefixing has special handling for the `Web` module so that all controllers
 
 ## Custom Routing
 
-Sometimes you have special needs for your routing. For this case, IHP provides a lower-level routing API on which `AutoRoute` is built.
+Sometimes you have special needs for your routing. For this case, IHP provides a lower-level routing API on which [`AutoRoute`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:AutoRoute) is built.
 
 Let's say we have a controller like this:
 
@@ -180,14 +180,14 @@ Let's say we have a controller like this:
 data PostsController = ShowAllMyPostsAction
 ```
 
-We want requests to `/posts` to map to `ShowAllMyPostsAction`. For that we need to add a `CanRoute` instance:
+We want requests to `/posts` to map to `ShowAllMyPostsAction`. For that we need to add a [`CanRoute`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:CanRoute) instance:
 
 ```haskell
 instance CanRoute PostsController where
     parseRoute' = string "/posts" <* endOfInput >> pure ShowAllMyPostsAction
 ```
 
-The `parseRoute'` function is a parser that reads an URL and returns an action of type `PostsController`. The router uses [attoparsec](https://hackage.haskell.org/package/attoparsec). See below for examples on how to use this for building beautiful URLs.
+The [`parseRoute'`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:parseRoute-39-) function is a parser that reads an URL and returns an action of type `PostsController`. The router uses [attoparsec](https://hackage.haskell.org/package/attoparsec). See below for examples on how to use this for building beautiful URLs.
 
 Next to the routing itself, we also need to implement the URL generation:
 
@@ -236,7 +236,7 @@ action ShowPostAction { postId, slug } = do
 
 This expects the `posts` table to have a field `slug :: Text`.
 
-Now we define our `CanRoute` instance like this:
+Now we define our [`CanRoute`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:CanRoute) instance like this:
 
 ```haskell
 instance CanRoute PostsController where
@@ -247,7 +247,7 @@ instance CanRoute PostsController where
         postById <|> postBySlug
 ```
 
-Additionally we also have to implement the `HasPath` instance:
+Additionally we also have to implement the [`HasPath`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:HasPath) instance:
 
 ```haskell
 instance HasPath PostsController where

--- a/Guide/server-side-components.markdown
+++ b/Guide/server-side-components.markdown
@@ -8,7 +8,7 @@
 
 IHP Server-Side Components provide a toolkit for building interactive client-side functionality without needing to write too much javascript.
 
-A Server-Side Component consist of a state object, a set of actions and a `render` function.
+A Server-Side Component consist of a state object, a set of actions and a [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:render) function.
 
 The typical lifecycle is like this:
 1. The component is rendered based as part of a view
@@ -70,17 +70,18 @@ instance Component Counter CounterController where
 instance SetField "value" Counter Int where setField value' counter = counter { value = value' }
 ```
 
-You can see that the `Counter` component has a state object with a number `data Counter = Counter { value :: !Int }`. It has two actions `IncrementCounterAction` and `SetCounterValue`. The `initialState = Counter { value = 0 }` means that the counter starts at 0.
+You can see that the `Counter` component has a state object with a number `data Counter = Counter { value :: !Int }`. It has two actions `IncrementCounterAction` and `SetCounterValue`. The [`initialState = Counter { value = 0 }`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:initialState) means that the counter starts at 0.
 
-Inside the `render` function you can see how server-side actions are triggered from the client-side:
+Inside the [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:render) function you can see how server-side actions are triggered from the client-side:
 
 ```html
 <button onclick="callServerAction('IncrementCounterAction')">Plus One</button>
 ```
 
 When the `callServerAction('IncrementCounterAction')` is called, it will trigger the `action state IncrementCounterAction = do` haskell block to be called on the server.
+When the `callServerAction('IncrementCounterAction')` is called, it will trigger the [`action state IncrementCounterAction = do`]() haskell block to be called on the server.
 
-You can see that the `action` handler get's passed the current state and will return a new state based on the action and the current state.
+You can see that the [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:action) handler get's passed the current state and will return a new state based on the action and the current state.
 
 ### FrontController
 
@@ -93,7 +94,7 @@ import IHP.ServerSideComponent.RouterFunctions
 import Web.Component.Counter
 ```
 
-Inside the `instance FrontController WebApplication` add a `routeComponent @Counter`:
+Inside the `instance FrontController WebApplication` add a [`routeComponent @Counter`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-RouterFunctions.html#v:routeComponent):
 
 ```haskell
 
@@ -131,7 +132,7 @@ instance View WelcomeView where
             counter = component @Counter
 ```
 
-If you wonder why we're using the `where` instead of writing `{component @Counter}`: Currently the at-symbol `@` is not supported in HSX expressions.
+If you wonder why we're using the `where` instead of writing [`{component @Counter}`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-ViewFunctions.html#v:component): Currently the at-symbol `@` is not supported in HSX expressions.
 
 We also need to load the `ihp-ssc.js` from our `Layout.hs`. Open the `Web/View/Layout.hs` and add `<script src="/vendor/ihp-ssc.js"></script>` inside your `scripts` section:
 
@@ -170,9 +171,9 @@ To call the `SetSearchQuery` action with a specific `searchQuery` value, we can 
 
 ### Fetching from the Database
 
-You can use the typical IHP database operations like `query @Post` or `createRecord` from your actions.
+You can use the typical IHP database operations like [`query @Post`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:query) or [`createRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) from your actions.
 
-To fill the inital data you can use the `componentDidMount` lifecycle function:
+To fill the inital data you can use the [`componentDidMount`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) lifecycle function:
 
 ```haskell
 data PostsTable = PostsTable
@@ -197,9 +198,9 @@ instance Component PostsTable PostsTableController where
     |]
 ```
 
-The `componentDidMount` get's passed the initial state and returns a new state. It's called right after the first render once the client has wired up the WebSocket connection.
+The [`componentDidMount`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) get's passed the initial state and returns a new state. It's called right after the first render once the client has wired up the WebSocket connection.
 
-When the `posts` field is set to `Nothing` we know that the data is still being fetched. In that case we render a loading spinner inside our `render` function.
+When the `posts` field is set to `Nothing` we know that the data is still being fetched. In that case we render a loading spinner inside our [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:render) function.
 
 ### HTML Diffing & Patching
 

--- a/Guide/session.markdown
+++ b/Guide/session.markdown
@@ -16,18 +16,18 @@ The session works by storing the data inside a cryptographically signed and encr
 
 ### Writing
 
-In your controller action, use `setSession` to store a value:
+In your controller action, use [`setSession`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Session.html#v:setSession) to store a value:
 
 ```haskell
 action SessionExampleAction = do
     setSession "userEmail" "hi@digitallyinduced.com"
 ```
 
-Right now, `setSession` only accepts `Text` values. Other types like `Int` have to be converted to `Text` using `tshow theIntValue`.
+Right now, [`setSession`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Session.html#v:setSession) only accepts `Text` values. Other types like `Int` have to be converted to `Text` using [`tshow theIntValue`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:tshow).
 
 ### Reading
 
-You can use `getSession` to retrieve a value:
+You can use [`getSession`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Session.html#v:getSession) to retrieve a value:
 
 ```haskell
 action SessionExampleAction = do
@@ -36,7 +36,7 @@ action SessionExampleAction = do
 
 `userEmail` is set to `Just "hi@digitallyinduced.com"` when the value has been set before. Otherwise, it will be `Nothing`.
 
-For convenience you can use `getSessionInt` to retrieve the value as a `Maybe Int`, and `getSessionUUID` to retrieve the value as a `Maybe UUID`:
+For convenience you can use [`getSessionInt`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Session.html#v:getSessionInt) to retrieve the value as a `Maybe Int`, and [`getSessionUUID`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Session.html#v:getSessionUUID) to retrieve the value as a `Maybe UUID`:
 
 ```haskell
 action SessionExampleAction = do
@@ -46,7 +46,7 @@ action SessionExampleAction = do
 
 ### Deleting
 
-Use `deleteSession` to remove a value from the session:
+Use [`deleteSession`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Session.html#v:deleteSession) to remove a value from the session:
 
 ```haskell
 action LogoutAction = do
@@ -63,7 +63,7 @@ In the following view you can see a success flash message `Post created`:
 
 ### Setting a Message
 
-Use `setSuccessMessage` to set a success message:
+Use [`setSuccessMessage`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMessages-ControllerFunctions.html#v:setSuccessMessage) to set a success message:
 
 ```haskell
 action CreatePostAction = do
@@ -72,7 +72,7 @@ action CreatePostAction = do
     redirectTo ShowPostAction { .. }
 ```
 
-Use `setErrorMessage` to set a failure message:
+Use [`setErrorMessage`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMessages-ControllerFunctions.html#v:setErrorMessage) to set a failure message:
 
 ```haskell
 action CreatePostAction = do
@@ -87,9 +87,9 @@ In both cases, the messages are stored inside the session. The message value is 
 
 ### Rendering a Message
 
-You have to make sure that `{renderFlashMessages}` is displayed somewhere in your layout or view, otherwise, the flash message is not visible.
+You have to make sure that [`{renderFlashMessages}`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMessages-ViewFunctions.html#v:renderFlashMessages) is displayed somewhere in your layout or view, otherwise, the flash message is not visible.
 
-Here is an example of a layout calling `renderFlashMessages`:
+Here is an example of a layout calling [`renderFlashMessages`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMessages-ViewFunctions.html#v:renderFlashMessages):
 
 ```haskell
 defaultLayout :: Html -> Html
@@ -111,7 +111,7 @@ The rendered HTML looks like this:
 <div class="alert alert-danger">{errorMessage}</div>
 ```
 
-To display the Flash Messages in a custom way, you can always access them using `let flashMessages :: [FlashMessage] = fromFrozenContext` in your views. This returns a list of `FlashMessage`. You can also take a look at the [`renderFlashMessages`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMessages-ViewFunctions.html#v:renderFlashMessages) implementation and copy the code into your view, and then make customizations.
+To display the Flash Messages in a custom way, you can always access them using `let flashMessages :: [FlashMessage] = fromFrozenContext` in your views. This returns a list of [`FlashMessage`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMessages-Types.html#t:FlashMessage). You can also take a look at the [`renderFlashMessages`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMessages-ViewFunctions.html#v:renderFlashMessages) implementation and copy the code into your view, and then make customizations.
 
 ## Session Cookie
 

--- a/Guide/testing.markdown
+++ b/Guide/testing.markdown
@@ -8,7 +8,7 @@ This section provides some guidelines for testing your IHP applications.
 
 ## Setup
 
-Start by creating a new module for your tests (perhaps for an individual controller, something like `test/Web/Controller/SomeControllerSpec.hs`), then import the IHP testing mock framework and [Hspec](http://hspec.github.io/) (a Haskell testing library). You will also need to import your project's `Main` module (this is usually where a project's `InitControllerContext` instance is defined). Your imports will likely look something like this:
+Start by creating a new module for your tests (perhaps for an individual controller, something like `test/Web/Controller/SomeControllerSpec.hs`), then import the IHP testing mock framework and [Hspec](http://hspec.github.io/) (a Haskell testing library). You will also need to import your project's `Main` module (this is usually where a project's [`InitControllerContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:InitControllerContext) instance is defined). Your imports will likely look something like this:
 
 ```haskell
 module ExampleSpec where
@@ -26,7 +26,7 @@ import           Main ()
 ```
 
 ## Writing a test module
-The `IHP.Test.Mocking` module has functions to mock `ModelContext`, `RequestContext` and `ApplicationContext`. These contexts are created with the `mockContext` function, which requires a `ConfigBuilder` and an IHP application as inputs. This function should be called before the tests start:
+The `IHP.Test.Mocking` module has functions to mock [`ModelContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#t:ModelContext), [`RequestContext`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-RequestContext.html#t:RequestContext) and [`ApplicationContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ApplicationContext.html#t:ApplicationContext). These contexts are created with the [`mockContext`](https://ihp.digitallyinduced.com/api-docs/IHP-Test-Mocking.html#v:mockContext) function, which requires a [`ConfigBuilder`](https://ihp.digitallyinduced.com/api-docs/IHP-FrameworkConfig.html#t:ConfigBuilder) and an IHP application as inputs. This function should be called before the tests start:
 
 ```haskell
 -- a function like this probably already exists in your Config module:
@@ -38,7 +38,7 @@ spec = beforeAll (makeConfig >>= mockContext WebApplication) do
   ...
 ```
 
-In order to execute database queries and run controller actions, the implicit context paramaters must be bound in the testing environment using `withContext`. Here is an example test to check there are no users in the database:
+In order to execute database queries and run controller actions, the implicit context paramaters must be bound in the testing environment using [`withContext`](https://ihp.digitallyinduced.com/api-docs/IHP-Test-Mocking.html#v:withContext). Here is an example test to check there are no users in the database:
 
 ```haskell
   describe "User controller" $ do
@@ -64,7 +64,7 @@ It is also possible to check the HTTP status of a controller response and respon
       mockActionStatus CreateUserAction `shouldReturn` status200
 ```
 
-## Runing a test
+## Running a test
 To execute a single test spec, load the test module into GHCI and run `hspec spec` (make sure your database server is running).
 
 ## Next steps

--- a/Guide/validation.markdown
+++ b/Guide/validation.markdown
@@ -53,7 +53,7 @@ Now let's add some validation.
 
 ### Adding Validation Logic
 
-To make sure that the `title` and `body` are not empty, we can `validateField ... nonEmpty` like this:
+To make sure that the `title` and `body` are not empty, we can [`validateField ... nonEmpty`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:validateField) like this:
 
 ```haskell
     action CreatePostAction = do
@@ -84,41 +84,39 @@ record
 
 Here is a list of the most common validators:
 
-```haskell
--- works with Text fields
-|> validateField #name nonEmpty
-|> validateField #email isEmail
-|> validateField #phoneNumber isPhoneNumber
+Works with Text fields:
+- [`|> validateField #name nonEmpty`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:nonEmpty)
+- [`|> validateField #email isEmail`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:isEmail)
+- [`|> validateField #phoneNumber isPhoneNumber`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:isPhoneNumber)
 
--- works with ints
-|> validateField #rating (isInRange (1, 10))
-```
+Works with ints:
+- [`|> validateField #rating (isInRange (1, 10))`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:isInRange)
 
 You can find [the full list of built-in validators in the API Documentation](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html).
 
 ### Fill Validation
 
-When using `fill`, like `|> fill @'["title", "body"]`, any error parsing the input is also added as a validation error.
+When using [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill), like `|> fill @'["title", "body"]`, any error parsing the input is also added as a validation error.
 
-E.g. when `fill` fills in an integer attribute, but the string `"hello"` is submitted, an error will be added to the record and the record is not valid anymore. The record attribute will then keep its old value (before applying `fill`) and later re-render in the error case of `ifValid`. This applies to all arguments read via `fill`. It's very helpful when dealing with strings expected in a certain format, like date times.
+E.g. when [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill) fills in an integer attribute, but the string `"hello"` is submitted, an error will be added to the record and the record is not valid anymore. The record attribute will then keep its old value (before applying [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill)) and later re-render in the error case of [`ifValid`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:ifValid). This applies to all arguments read via [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill). It's very helpful when dealing with strings expected in a certain format, like date times.
 
 As IHP is never putting raw strings into the records, without previously parsing them, it does not provide validators like Rails's `:only_integer`.
 
 ### Rendering Errors
 
-When a post with an empty title is now submitted to this action, an error message will be written into the record. The call to `|> ifValid` will see that there is an error, and then run the `Left post -> render NewView { post } `, which displays the form to the user again. The form will be rendered, and errors will automatically pop up next to the form field.
+When a post with an empty title is now submitted to this action, an error message will be written into the record. The call to [`|> ifValid`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:ifValid) will see that there is an error, and then run the `Left post -> render NewView { post } `, which displays the form to the user again. The form will be rendered, and errors will automatically pop up next to the form field.
 
-The default form helpers like `{textField #title}` automatically render the error message below the field. Here is how this looks:
+The default form helpers like [`{textField #title}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textField) automatically render the error message below the field. Here is how this looks:
 
 ![Validation Error Message Below Title Input](images/first-project/title_non_empty.png)
 
 ### Validating An Email Is Unique
 
-For example, when dealing with users, you usually want to make sure that an email is only used once for a single user. You can use `|> validateIsUnique #email` to validate that an email is unique for a given record.
+For example, when dealing with users, you usually want to make sure that an email is only used once for a single user. You can use [`|> validateIsUnique #email`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateIsUnique.html#v:validateIsUnique) to validate that an email is unique for a given record.
 
 This function queries the database and checks whether there exists a record with the same email value. The function ignores the current entity of course.
 
-This function does IO, so any further arrows have to be `>>=`, like this:
+This function does IO, so any further arrows have to be [`>>=`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:-62--62--61-), like this:
 
 ```haskell
 action CreateUserAction = do
@@ -135,7 +133,7 @@ action CreateUserAction = do
 
 #### Case Insensitive Uniqueness
 
-Usually emails like `someone@example.com` and `Someone@example.com` belong to the same person. You can use `validateIsUniqueCaseInsensitive` to ignore the case when checking for uniqueness:
+Usually emails like `someone@example.com` and `Someone@example.com` belong to the same person. You can use [`validateIsUniqueCaseInsensitive`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateIsUnique.html#v:validateIsUniqueCaseInsensitive) to ignore the case when checking for uniqueness:
 
 
 ```haskell
@@ -205,7 +203,7 @@ user |> validateField #age isAge`
 
 ### Checking If A Record Is Valid
 
-Use `ifValid` to check for validity of a record:
+Use [`ifValid`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:ifValid) to check for validity of a record:
 
 ```haskell
 post |> ifValid \case
@@ -229,7 +227,7 @@ putStrLn message
 
 ### Customizing Error Messages
 
-#### Use `withCustomErrorMessage` to customize the error message when validation failed:
+#### Use [`withCustomErrorMessage`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:withCustomErrorMessage) to customize the error message when validation failed:
 
 ```haskell
 user
@@ -237,9 +235,9 @@ user
     |> validateField #firstname (nonEmpty |> withCustomErrorMessage "Please enter your firstname")
 ```
 
-In this example, when the `nonEmpty` adds an error to the user, the message `Please enter your firstname` will be used instead of the default `This field cannot be empty`.
+In this example, when the [`nonEmpty`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:nonEmpty) adds an error to the user, the message `Please enter your firstname` will be used instead of the default `This field cannot be empty`.
 
-#### Use `withCustomErrorMessageIO` to customize the error message when using IO functions:
+#### Use [`withCustomErrorMessageIO`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateIsUnique.html#v:withCustomErrorMessageIO) to customize the error message when using IO functions:
 
 ```haskell
 user
@@ -250,13 +248,13 @@ user
         Right user -> ...
 ```
 
-In this example, when the `validateIsUnique` function adds an error to the user, the message `Email Has Already Been Used` will be used instead of the default `This is already in use`.
+In this example, when the [`validateIsUnique`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateIsUnique.html#v:validateIsUnique) function adds an error to the user, the message `Email Has Already Been Used` will be used instead of the default `This is already in use`.
 
 ## Internals
 
 IHP's validation is built with a few small operations.
 
-### `validateField`
+### [`validateField`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:validateField)
 
 The primary operation is `validateField #field validationFunction record`.
 
@@ -266,7 +264,7 @@ This function does the following thing:
 2. Apply the `validationFunction` to the field value
 3. When the validator returns errors, store the errors inside the `meta` attribute of the record.
 
-The `validateField` function expects the `record` to have a field `meta :: MetaBag`. This `meta` field is used to store validation errors.
+The [`validateField`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:validateField) function expects the `record` to have a field `meta :: MetaBag`. This `meta` field is used to store validation errors.
 
 Let's say we have an example data type `Post`:
 
@@ -274,7 +272,7 @@ Let's say we have an example data type `Post`:
 data Post = Post { title :: Text, meta :: MetaBag }
 ```
 
-A call to `validateField` will result in the following:
+A call to [`validateField`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:validateField) will result in the following:
 
 ```haskell
 let post = Post { title = "" , meta = def } -- def stands for default :)
@@ -292,7 +290,7 @@ post |> validateField #title nonEmpty
 -- }
 ```
 
-As you can see, the errors are tracked inside the `MetaBag`. When you apply another `validateField` to the record, the errors will be appended to the `annotations` list.
+As you can see, the errors are tracked inside the `MetaBag`. When you apply another [`validateField`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:validateField) to the record, the errors will be appended to the `annotations` list.
 
 ### Validation Functions
 
@@ -306,7 +304,7 @@ isColor text | ("#" `isPrefixOf` text) && (length text == 7) = Success
 isColor text = Failure "is not a valid color"
 ```
 
-Calling `isColor "#ffffff"` will return `Success`. Calling `isColor "something bad"` will result in `Failure "is not a valid color"`.
+Calling [`isColor "#ffffff"`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:isColor) will return `Success`. Calling [`isColor "something bad"`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:isColor) will result in `Failure "is not a valid color"`.
 
 It might be useful to take a look at the definition of some more validation functions to see how it works. [You can find them in the API Docs](https://ihp.digitallyinduced.com/api-docs/src/IHP.ValidationSupport.ValidateField.html#isColor).
 
@@ -325,7 +323,7 @@ This record now has a validation error attached to its title.
 
 #### Attaching Errors with HTML
 
-If you try to use HTML code within `attachFailure`, the HTML code will be escaped and not rendered as expected:
+If you try to use HTML code within [`attachFailure`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-Types.html#v:attachFailure), the HTML code will be escaped and not rendered as expected:
 
 ```haskell
 post
@@ -333,7 +331,7 @@ post
     -- Link will not be clickable as the HTML is escaped
 ```
 
-Use `attachFailureHtml` instead:
+Use [`attachFailureHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-Types.html#v:attachFailureHtml) instead:
 
 ```haskell
 post
@@ -343,7 +341,7 @@ post
 
 ### Retrieving The First Error Message For A Field
 
-You can also access an error for a specific field using `getValidationFailure`:
+You can also access an error for a specific field using [`getValidationFailure`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-Types.html#v:getValidationFailure):
 
 ```haskell
 post

--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -10,9 +10,9 @@ IHP views are usually represented as HTML, but can also be represented as JSON o
 
 The HTML templating is implemented on top of the well-known blaze-html Haskell library. To quickly build HTML views, IHP supports a JSX-like syntax called HSX. HSX is type-checked and compiled to Haskell code at compile-time.
 
-The controller provides the view with a key-value map called `ControllerContext`. The `ControllerContext` provides the view information it might need to render, without always explicitly passing it. This is usually used to pass e.g. the current HTTP request, logged-in user, flash messages, the layout, etc..
+The controller provides the view with a key-value map called [`ControllerContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:ControllerContext). The [`ControllerContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:ControllerContext) provides the view information it might need to render, without always explicitly passing it. This is usually used to pass e.g. the current HTTP request, logged-in user, flash messages, the layout, etc..
 
-Usually, a view consists of a data structure and a `View` instance. E.g. like this:
+Usually, a view consists of a data structure and a [`View`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#t:View) instance. E.g. like this:
 
 ```haskell
 data ExampleView = ExampleView { optionA :: Text, optionB :: Bool }
@@ -56,7 +56,7 @@ module Web.View.Layout (defaultLayout, appLayout) where
 
 ### Using a layout inside a single view
 
-To use the layout inside a view, call `setLayout` from the `beforeRender`:
+To use the layout inside a view, call [`setLayout`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Layout.html#v:setLayout) from the [`beforeRender`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:beforeRender):
 
 ```haskell
 instance View MyView where
@@ -66,7 +66,7 @@ instance View MyView where
 
 ### Using a layout for a complete controller
 
-When all views of a controller use a custom layout place the `setLayout` call in the `beforeAction` of the controller:
+When all views of a controller use a custom layout place the [`setLayout`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Layout.html#v:setLayout) call in the [`beforeAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:beforeAction) of the controller:
 
 ```haskell
 instance Controller MyController where
@@ -79,7 +79,7 @@ instance Controller MyController where
 
 ### Changing the default layout
 
-You can change the default layout of your application by updating `initContext` in `Web.FrontController`.
+You can change the default layout of your application by updating [`initContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:initContext) in `Web.FrontController`.
 
 ```haskell
 instance InitControllerContext WebApplication where
@@ -89,7 +89,7 @@ instance InitControllerContext WebApplication where
 
 ### Disabling the Layout for a View
 
-You can disable the layout for a specific view by overriding the `beforeRender` function like this:
+You can disable the layout for a specific view by overriding the [`beforeRender`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:beforeRender) function like this:
 
 ```haskell
 instance View MyView where
@@ -139,7 +139,7 @@ initCompanyContext =
         Nothing -> pure ()
 ```
 
-The `initContext` is called on every request, just before the action is executed. The `initCompanyContext` fetches the current user's company and then calls `putContext company` to store it inside the controller context.
+The [`initContext`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:initContext) is called on every request, just before the action is executed. The `initCompanyContext` fetches the current user's company and then calls [`putContext company`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html#v:putContext) to store it inside the controller context.
 
 Next we'll read the company from the `Layout.hs`
 
@@ -166,9 +166,9 @@ company :: (?context :: ControllerContext) => Company
 company = fromFrozenContext
 ```
 
-Here the company is read by using the `fromFrozenContext` function.
+Here the company is read by using the [`fromFrozenContext`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html#v:fromFrozenContext) function.
 
-You might wonder: How does `fromFrozenContext` know that I want the company? The context is a key-value map, where the key's are the type of the object. Using the `company :: Company` type annotation the `fromFrozenContext` knows we want to read the value with the key `Company`.
+You might wonder: How does [`fromFrozenContext`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html#v:fromFrozenContext) know that I want the company? The context is a key-value map, where the key's are the type of the object. Using the `company :: Company` type annotation the [`fromFrozenContext`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Context.html#v:fromFrozenContext) knows we want to read the value with the key `Company`.
 
 Now the `company` variable can be used to read the current user's company across the layout and also in all views (you need to add `company` to the export list of the Layout module for that). If the `company` value is used somewhere during rendering while the user is not logged it will raise a runtime error.
 
@@ -176,7 +176,7 @@ Now the `company` variable can be used to read the current user's company across
 
 ### Accessing the Request
 
-Use `theRequest` to access the current [WAI request](https://hackage.haskell.org/package/wai-3.2.2.1/docs/Network-Wai.html).
+Use [`theRequest`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:theRequest) to access the current [WAI request](https://hackage.haskell.org/package/wai-3.2.2.1/docs/Network-Wai.html).
 
 ### Highlighting the current active link
 
@@ -222,7 +222,7 @@ By default, a message `Are you sure you want to delete this?` is shown as a simp
 
 #### Setting the Page Title
 
-You can override the default page title by calling `setTitle` inside the `beforeRender` function of your view:
+You can override the default page title by calling [`setTitle`](https://ihp.digitallyinduced.com/api-docs/IHP-PageHead-ControllerFunctions.html#v:setTitle) inside the [`beforeRender`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:beforeRender) function of your view:
 
 ```haskell
 instance View MyView where
@@ -232,7 +232,7 @@ instance View MyView where
     -- ...
 ```
 
-You can also call `setTitle` from the controller action if needed:
+You can also call [`setTitle`](https://ihp.digitallyinduced.com/api-docs/IHP-PageHead-ControllerFunctions.html#v:setTitle) from the controller action if needed:
 
 ```haskell
 module Web.Controller.Posts where
@@ -247,7 +247,7 @@ instance Controller PostsController where
         render ShowView { .. }
 ```
 
-If the page title is not changed as expected, make sure that your `Layout.hs` is using `pageTitleDefault`:
+If the page title is not changed as expected, make sure that your `Layout.hs` is using [`pageTitleDefault`](https://ihp.digitallyinduced.com/api-docs/IHP-PageHead-ViewFunctions.html#v:pageTitleOrDefault):
 
 ```html
 WRONG:
@@ -280,7 +280,7 @@ To dynamically manage meta tags like `<meta property="og:description" content="d
 </head>
 ```
 
-You can set the values for these meta tags from the `beforeRender` function within your view:
+You can set the values for these meta tags from the [`beforeRender`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:beforeRender) function within your view:
 
 
 ```haskell
@@ -348,7 +348,7 @@ document.addEventListener('ihp:unload', () => {
 
 ## JSON
 
-Views that are rendered by calling the `render` function can also respond with JSON.
+Views that are rendered by calling the [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:render) function can also respond with JSON.
 
 Let's say we have a normal HTML view that renders all posts for our blog app:
 
@@ -377,7 +377,7 @@ instance View IndexView where
     |]
 ```
 
-We can add a JSON output for all blog posts by adding a `json` function to this:
+We can add a JSON output for all blog posts by adding a [`json`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:json) function to this:
 
 ```haskell
 import Data.Aeson -- <--- Add this import at the top of the file
@@ -390,9 +390,9 @@ instance View IndexView where
     json IndexView { .. } = toJSON posts -- <---- The new json render function
 ```
 
-In the above code, our `json` function has access to all arguments passed to the view. Here we call `toJSON`, which is provided by the [aeson](https://hackage.haskell.org/package/aeson) Haskell library. This simply encodes all the `posts` given to this view as JSON.
+In the above code, our [`json`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:json) function has access to all arguments passed to the view. Here we call [`toJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:toJSON), which is provided by the [aeson](https://hackage.haskell.org/package/aeson) Haskell library. This simply encodes all the `posts` given to this view as JSON.
 
-Additionally we need to define a `ToJSON` instance which describes how the `Post` record is going to be transformed to JSON. We need to add this to our view:
+Additionally we need to define a [`ToJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#t:ToJSON) instance which describes how the `Post` record is going to be transformed to JSON. We need to add this to our view:
 
 ```haskell
 instance ToJSON Post where
@@ -460,7 +460,7 @@ When you open the `PostsAction` at `/Posts` in your browser you will still get t
 
 #### JavaScript
 
-From JavaScript you can get the JSON using `fetch`:
+From JavaScript you can get the JSON using [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch):
 
 ```javascript
 const response = await fetch('http://localhost:8000/Posts', {
@@ -471,7 +471,7 @@ const json = await response.json();
 
 #### curl
 
-You can use `curl` to check out the new JSON response from the terminal:
+You can use [`curl`](https://curl.se/) to check out the new JSON response from the terminal:
 
 ```bash
 curl http://localhost:8000/Posts -H 'Accept: application/json'
@@ -481,7 +481,7 @@ curl http://localhost:8000/Posts -H 'Accept: application/json'
 
 ### Advanced: Rendering JSON directly from actions
 
-When you are building an API and your action is only responding with JSON (so no HTML is expected), you can respond with your JSON directly from the controller using `renderJson`:
+When you are building an API and your action is only responding with JSON (so no HTML is expected), you can respond with your JSON directly from the controller using [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson):
 
 ```haskell
 instance Controller PostsController where
@@ -498,6 +498,6 @@ instance ToJSON Post where
         ]
 ```
 
-In this example, no content negotiation takes place as the `renderJson` is used instead of the normal `render` function.
+In this example, no content negotiation takes place as the [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) is used instead of the normal `render` function.
 
-The `ToJSON` instances have to be defined somewhere, so it's usually placed inside the controller file. This often makes the file harder to read. We recommend not using `renderJson` most times and instead stick with a separate view file as described in the section above. Using `renderJson` makes sense only when the controller is very small or you already have a predefined `ToJSON` instance which is not defined in your controller.
+The [`ToJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#t:ToJSON) instances have to be defined somewhere, so it's usually placed inside the controller file. This often makes the file harder to read. We recommend not using [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) most times and instead stick with a separate view file as described in the section above. Using [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) makes sense only when the controller is very small or you already have a predefined [`ToJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#t:ToJSON) instance which is not defined in your controller.

--- a/Guide/websockets.markdown
+++ b/Guide/websockets.markdown
@@ -10,7 +10,7 @@ IHP has first class support for WebSockets.
 
 **When you only want to use WebSockets to update the UI:** Check out [Auto Refresh](https://ihp.digitallyinduced.com/Guide/auto-refresh.html). The Auto Refresh API provides a high-level approach for pushing HTML/UI updates from the server-side build on top of WebSockets.
 
-The entry points for your WebSocket servers are similiar to the typical IHP controllers, and are also stored in the `Web/Controller/` directory. Similiar to normal IHP controllers, the WebSocket servers are also added to the `FrontController` later on.
+The entry points for your WebSocket servers are similiar to the typical IHP controllers, and are also stored in the `Web/Controller/` directory. Similiar to normal IHP controllers, the WebSocket servers are also added to the [`FrontController`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:FrontController) later on.
 
 ## Creating a WebSocket Controlller
 
@@ -59,7 +59,7 @@ instance FrontController WebApplication where
         ]
 ```
 
-As you can see, the WebSocket controller is using `webSocketApp` instead of the usual `parseRoute` function.
+As you can see, the WebSocket controller is using [`webSocketApp`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:webSocketApp) instead of the usual [`parseRoute`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:parseRoute) function.
 
 Our `HelloWorldController` can now be accessed at `ws://localhost:8000/HelloWorldController`.
 
@@ -105,7 +105,7 @@ instance WSApp HelloWorldController where
         sendTextData ("Hello " <> name <> "!")
 ```
 
-The `receiveData` function is used to read data sent by the `JS` side of our code. The `receiveData` function waits until the client is sending us some data before it continues running the `run` function.
+The [`receiveData`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:receiveData) function is used to read data sent by the `JS` side of our code. The [`receiveData`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:receiveData) function waits until the client is sending us some data before it continues running the [`run`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:run) function.
 
 On the JS side we now need to send our name like this:
 
@@ -122,11 +122,11 @@ helloWorldController.onmessage = function (event) {
 };
 ```
 
-Once the connection is ready, this will ask for the users name and will then send it over the wire. On the server the call of `receiveData` will then return the name we entered and the server will send back the greeting.
+Once the connection is ready, this will ask for the users name and will then send it over the wire. On the server the call of [`receiveData`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:receiveData) will then return the name we entered and the server will send back the greeting.
 
 ### Receiving Other Data Types
 
-The `receiveData` function can also deal with other types such as `Int` or `UUID`. You can use it like that: 
+The [`receiveData`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:receiveData) function can also deal with other types such as `Int` or `UUID`. You can use it like that: 
 
 ```haskell
 myInt  :: Int  <- receiveData
@@ -150,7 +150,7 @@ data HelloWorldController
 
 The `WaitForName` now reflects the state before the names has been entered, and the `NameEntered { name = ".." }` keeps track of the entered name.
 
-We need to update the controlller to reflect our new data structure. First we need to make `WaitForName` the start state. For that we need to update the `initialState` in `Web/Controller/HelloWorld.hs`:
+We need to update the controlller to reflect our new data structure. First we need to make `WaitForName` the start state. For that we need to update the [`initialState`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:initialState) in `Web/Controller/HelloWorld.hs`:
 
 ```haskell
     initialState = WaitForName
@@ -167,9 +167,9 @@ Next we're going to update our `run` function to update the state after it got t
         sendTextData ("Hello " <> name <> "!")
 ```
 
-The `setState NameEntered { name }` changes the state from `WaitForName` to `NameEntered`.
+The [`setState NameEntered { name }`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:setState) changes the state from `WaitForName` to `NameEntered`.
 
-To do something when the connection is closed, we're using the `onClose` lifecycle event:
+To do something when the connection is closed, we're using the [`onClose`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:onClose) lifecycle event:
 
 ```haskell
 module Web.Controller.HelloWorld where
@@ -193,18 +193,18 @@ instance WSApp HelloWorldController where
                 putStrLn message
 ```
 
-You can see that we can access the state using `state <- getState`.
+You can see that we can access the state using [`state <- getState`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:getState).
 
 Now whenever the connection is closed, it will print out the message inside the terminal where the IHP server is running.
 
-**Good to know:** The connection is automatically closed when the `run` function has finished. Therefore it's normal that the `... has left!` message is directly printed after you entered the name. To keep it running until the browser windows is closed, add a `forever receiveDataMessage` to the end of the `run`.
+**Good to know:** The connection is automatically closed when the [`run`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:run) function has finished. Therefore it's normal that the `... has left!` message is directly printed after you entered the name. To keep it running until the browser windows is closed, add a [`forever receiveDataMessage`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:receiveDataMessage) to the end of the [`run`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:run).
 
-As you've seen above the primitive state operations are `setState` and `getState`. Using these two operations together with a good data structure is a very powerful way to manage your stateful WebSocket connections.
+As you've seen above the primitive state operations are [`setState`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:setState) and [`getState`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:getState). Using these two operations together with a good data structure is a very powerful way to manage your stateful WebSocket connections.
 
 
 ## Accessing the current user
 
-When the user is logged in, you can use the normal auth functions like `currentUser` inside the WebSocket controller as well:
+When the user is logged in, you can use the normal auth functions like [`currentUser`](https://ihp.digitallyinduced.com/api-docs/IHP-LoginSupport-Helper-Controller.html#v:currentUser) inside the WebSocket controller as well:
 
 ```haskell
 module Web.Controller.HelloWorld where
@@ -221,7 +221,7 @@ instance WSApp HelloWorldController where
 
 ### Receiving Custom Data Types
 
-You can write a custom decoder for `receiveData` by writing an instance of `WebSocketsData` for your data type. Here's an example for how the `UUID` decoder is implemented:
+You can write a custom decoder for [`receiveData`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:receiveData) by writing an instance of `WebSocketsData` for your data type. Here's an example for how the `UUID` decoder is implemented:
 
 ```haskell
 import qualified Network.WebSockets as WS
@@ -253,9 +253,9 @@ In this example the WebSocket server will be available at `/my-ws`.
 
 ### Ping
 
-By default the server will ping the browser every 30 seconds to make sure that the connection is still alive. You can run custom code whenever the ping has finished by overriding the `onPing` function.
+By default the server will ping the browser every 30 seconds to make sure that the connection is still alive. You can run custom code whenever the ping has finished by overriding the [`onPing`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:onPing) function.
 
-Here's an example of how `AutoRefresh` uses `onPing` to keep Auto Refresh Sessions from being closed:
+Here's an example of how [`AutoRefresh`](/auto-refresh.html) uses [`onPing`](https://ihp.digitallyinduced.com/api-docs/IHP-WebSocket.html#v:onPing) to keep Auto Refresh Sessions from being closed:
 
 ```haskell
     onPing = do

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -220,7 +220,7 @@ The preview will show you all the files which are going to be created or modifie
 
 ![](images/first-project/code_gen_3_posts.png)
 
-After the files have been created as in the preview, your controller is ready to be used. Open your browser at [http://localhost:8000/Posts](http://localhost:8000/Posts) to try out the new controller. The generator did all the initial work we need to get our usual [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) (Created, Read, Update, Delete) actions going.
+After the files have been created as in the preview, your controller is ready to be used. Open your browser at [http://localhost:8000/Posts](http://localhost:8000/Posts) to try out the new controller. The generator did all the initial work we need to get our usual [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) (Create, Read, Update, Delete) actions going.
 
 Here's how the new `/Posts` page looks like:
 

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -72,9 +72,9 @@ Start the development server by running the following in the `blog` directory:
 Your application is starting now. The development server will automatically launch the built-in IDE.
 The server can be stopped by pressing CTRL+C.
 
-By default, your app is available at `http://localhost:8000` and your development tooling is at `http://localhost:8001`.
+By default, your app is available at [`http://localhost:8000`](http://localhost:8000) and your development tooling is at [`http://localhost:8001`](http://localhost:8001).
 
-The development server automatically picks other ports when they are already in use by some other server. For example, it would pick `http://localhost:8001` and `http://localhost:8002` if port 8000 is used.
+The development server automatically picks other ports when they are already in use by some other server. For example, it would pick [`http://localhost:8001`](http://localhost:8001) and [`http://localhost:8002`](http://localhost:8002) if port 8000 is used.
 
 In the background, the built-in development server starts a PostgreSQL database connected to your application. Don't worry about manually setting up the database. It also runs a WebSocket server to power live reloads on file saves inside your app.
 
@@ -83,7 +83,7 @@ The very first time you start this might take a while, and in rare cases may eve
 
 ### Hello Haskell World
 
-Open http://localhost:8000 and you will see this:
+Open [`http://localhost:8000`](http://localhost:8000) and you will see this:
 
 ![It's working screen](images/first-project/its-working.png)
 

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -282,11 +282,11 @@ In the header we just see some imports. Controllers always import a special `Web
 instance Controller PostsController where
 ```
 
-The controller logic is specified by implementing an instance of the `Controller` type-class.
+The controller logic is specified by implementing an instance of the [`Controller`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:Controller) type-class.
 
 #### Index Action
 
-This is where the interesting part begins. As we will see below, the controller implementation is just an `action` function, pattern matching over our `data PostsController` structure we defined in `Web/Types.hs`.
+This is where the interesting part begins. As we will see below, the controller implementation is just an [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:action) function, pattern matching over our `data PostsController` structure we defined in `Web/Types.hs`.
 
 ```haskell
     action PostsAction = do
@@ -304,7 +304,7 @@ This is the index action. It's called when opening `/Posts`. First, it fetches a
         render NewView { .. }
 ```
 
-This is our endpoint for `/NewPost`. It just creates an empty new post and then passes it to the `NewView`. The `newRecord` is giving us an empty `Post` model. It's equivalent to manually writing `Post { id = Default, title = "", body = "" }`.
+This is our endpoint for `/NewPost`. It just creates an empty new post and then passes it to the `NewView`. The [`newRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:newRecord) is giving us an empty `Post` model. It's equivalent to manually writing `Post { id = Default, title = "", body = "" }`.
 
 #### Show Action
 
@@ -314,7 +314,7 @@ This is our endpoint for `/NewPost`. It just creates an empty new post and then 
         render ShowView { .. }
 ```
 
-This is our show action at `/ShowPost?postId=postId`. Here we pattern match on the `postId` field of `ShowPostAction` to get the post id of the given request. Then we just call `fetch` on that `postId` which gives us the specific `Post` record. Finally, we just pass that post to the view.
+This is our show action at `/ShowPost?postId=postId`. Here we pattern match on the `postId` field of `ShowPostAction` to get the post id of the given request. Then we just call [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) on that `postId` which gives us the specific `Post` record. Finally, we just pass that post to the view.
 
 #### Edit Action
 
@@ -343,13 +343,13 @@ Our `/EditPost?postId=postId` action. It's pretty much the same as in the `actio
 
 This action deals with update requests for a specific post. As usual, we pattern match on the `postId` and fetch it.
 
-The interesting part is `buildPost`. It is a helper function defined later in the controller: `buildPost = fill @["title", "body"]`. The `fill` call inside `buildPost` reads the `title` and `body` attributes from the browser request and fills them into the `post` record. The `buildPost` is also the place for validation logic.
+The interesting part is `buildPost`. It is a helper function defined later in the controller: `buildPost = fill @["title", "body"]`. The [`fill`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:fill) call inside `buildPost` reads the `title` and `body` attributes from the browser request and fills them into the `post` record. The `buildPost` is also the place for validation logic.
 
 `ifValid` returns `Either Post Post`. `Left post` means that e.g. the `title` or `body` did not pass validation. `Right post` means that all parameters could be set on `post` without any errors.
 
 In the error case (`Left post ->`) we just re-render the `EditView`. The `EditView` then tells the user about validation errors.
 
-In the success case (`Right post ->`) we save the updated post to the database (with `updateRecord`). Then we set a success message and redirect the user back to the edit view.
+In the success case (`Right post ->`) we save the updated post to the database (with [`updateRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:updateRecord)). Then we set a success message and redirect the user back to the edit view.
 
 #### Create Action
 
@@ -368,7 +368,7 @@ In the success case (`Right post ->`) we save the updated post to the database (
 
 Our create action, dealing with `POST /CreatePost` requests.
 
-It's pretty much like the update action. When the validation succeeded, it saves the record to the database using `createRecord`.
+It's pretty much like the update action. When the validation succeeded, it saves the record to the database using [`createRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord).
 
 #### Delete Action
 
@@ -380,7 +380,7 @@ It's pretty much like the update action. When the validation succeeded, it saves
         redirectTo PostsAction
 ```
 
-The last action is dealing with `DELETE /DeletePost?postId=postId` requests. It's pretty much like the other actions, we just call `deleteRecord` here.
+The last action is dealing with `DELETE /DeletePost?postId=postId` requests. It's pretty much like the other actions, we just call [`deleteRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:deleteRecord) here.
 
 #### Routes
 
@@ -418,7 +418,7 @@ instance View ShowView where
     |]
 ```
 
-We can see that `ShowView` is just a data definition. There is also a `View ShowView` instance. The HTML-like syntax inside the `html` function is `hsx` code. It's similar to React's [JSX](https://reactjs.org/docs/introducing-jsx.html). You can write HTML code as usual there. Everything inside the `[hsx|...|]` block is also type-checked and converted to Haskell code at compile-time.
+We can see that `ShowView` is just a data definition. There is also a `View ShowView` instance. The HTML-like syntax inside the [`html`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:html) function is [`hsx`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx) code. It's similar to React's [JSX](https://reactjs.org/docs/introducing-jsx.html). You can write HTML code as usual there. Everything inside the [`[hsx|...|]`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx) block is also type-checked and converted to Haskell code at compile-time.
 
 Now that we have a rough overview of all the parts belonging to our `Post`, it's time to do some coding ourselves.
 
@@ -548,7 +548,7 @@ In general, the workflow for making database schema changes locally is: Make cha
 
 You can open [http://localhost:8000/Posts](http://localhost:8000/Posts) again. The error is gone now.
 
-Now we can order the posts by our new `created_at` field. Open `Web/Controller/Posts.hs` and add `orderByDesc #createdAt` like this inside the `action PostsAction`:
+Now we can order the posts by our new `created_at` field. Open `Web/Controller/Posts.hs` and add [`orderByDesc #createdAt`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:orderByDesc) like this inside the `action PostsAction`:
 
 ```haskell
 action PostsAction = do
@@ -572,7 +572,7 @@ Let's also show the creation time in the `ShowView` in `Web/View/Posts/Show.hs`.
 <div>{get #body post}</div>
 ```
 
-Open the view to check that it's working. If everything is fine, you will see something like `5 minutes ago` below the title. The `timeAgo` helper uses a bit of JavaScript to automatically display the given timestamp in the current time zone and in a relative format. In case you want to show the absolute time (like `10.6.2019, 15:58`), just use `dateTime` instead of `timeAgo`.
+Open the view to check that it's working. If everything is fine, you will see something like `5 minutes ago` below the title. The [`timeAgo`](https://ihp.digitallyinduced.com/api-docs/IHP-View-TimeAgo.html#v:timeAgo) helper uses a bit of JavaScript to automatically display the given timestamp in the current time zone and in a relative format. In case you want to show the absolute time (like `10.6.2019, 15:58`), just use [`dateTime`](https://ihp.digitallyinduced.com/api-docs/IHP-View-TimeAgo.html#v:dateTime) instead of [`timeAgo`](https://ihp.digitallyinduced.com/api-docs/IHP-View-TimeAgo.html#v:timeAgod).
 
 ![Schema Designer created at view](images/first-project/created_at_view.png)
 
@@ -582,7 +582,7 @@ Right now our posts can only be plain text. Let's make it more powerful by addin
 
 #### Adding a Markdown Library
 
-To deal with Markdown, instead of implementing a custom Markdown parser, let's just use an existing package. There's the excellent `mmark` package we can use.
+To deal with Markdown, instead of implementing a custom Markdown parser, let's just use an existing package. There's the excellent [`mmark`](https://hackage.haskell.org/package/mmark) package we can use.
 
 To install this package, open the `default.nix` file and append `mmark` to the `haskellDeps` list. The file will now look like this:
 
@@ -616,7 +616,7 @@ Stop the development server by pressing CTRL+C. Then update the local developmen
 
 #### Markdown Rendering
 
-Now that we have `mmark` installed, we need to integrate it into our `ShowView`. First, we need to import it: add the following line to the top of `Web/View/Posts/Show.hs`:
+Now that we have [`mmark`](https://hackage.haskell.org/package/mmark) installed, we need to integrate it into our `ShowView`. First, we need to import it: add the following line to the top of `Web/View/Posts/Show.hs`:
 
 ```haskell
 import qualified Text.MMark as MMark
@@ -630,13 +630,13 @@ Add the following to the bottom of the show view:
 renderMarkdown text = text
 ```
 
-This function now does nothing except return its input text. Our Markdown package provides two functions, `MMark.parse` and `MMark.render` to deal with the Markdown. Let's first deal with parsing:
+This function now does nothing except return its input text. Our Markdown package provides two functions, [`MMark.parse`](https://hackage.haskell.org/package/mmark-0.0.7.3/docs/Text-MMark.html#v:parse) and [`MMark.render`](https://hackage.haskell.org/package/mmark-0.0.7.3/docs/Text-MMark.html#v:render) to deal with the Markdown. Let's first deal with parsing:
 
 ```haskell
 renderMarkdown text = text |> MMark.parse ""
 ```
 
-The empty string we pass to `MMark.parse` is usually the file name of the `.markdown` file. As we don't have any Markdown file, we just pass an empty string.
+The empty string we pass to [`MMark.parse`](https://hackage.haskell.org/package/mmark-0.0.7.3/docs/Text-MMark.html#v:parse) is usually the file name of the `.markdown` file. As we don't have any Markdown file, we just pass an empty string.
 
 Now open the web app and take a look at a blog post. You will see something like this:
 
@@ -644,7 +644,7 @@ Now open the web app and take a look at a blog post. You will see something like
 Right MMark {..}
 ```
 
-This is the parsed representation of the Markdown. Of course, that's not very helpful. We also have to connect it with `MMark.render` to get HTML code for our Markdown. Replace the `renderMarkdown` with the following code:
+This is the parsed representation of the Markdown. Of course, that's not very helpful. We also have to connect it with [`MMark.render`](https://hackage.haskell.org/package/mmark-0.0.7.3/docs/Text-MMark.html#v:render) to get HTML code for our Markdown. Replace the `renderMarkdown` with the following code:
 
 ```haskell
 renderMarkdown text =
@@ -659,7 +659,7 @@ The `show` view will now show real formatted text, as we would have expected.
 
 Let's also quickly update our form. Right now we have a one-line text field there. We can replace it with a text area to support multi-line text.
 
-Open `Web/View/Posts/Edit.hs` and change `{textField #body}` to `{textareaField #body}`. We can also add a short hint that the text area supports Markdown: Replace `{textareaField #body}` with `{(textareaField #body) { helpText = "You can use Markdown here"} }`.
+Open `Web/View/Posts/Edit.hs` and change [`{textField #body}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textField) to [`{textareaField #body}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textareaField). We can also add a short hint that the text area supports Markdown: Replace [`{textareaField #body}`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:textareaField) with [`{(textareaField #body) { helpText = "You can use Markdown here"} }`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Types.html#t:FormField).
 
 ```haskell
 renderForm :: Post -> Html
@@ -690,7 +690,7 @@ isMarkdown text =
         Right _ -> Success
 ```
 
-We can use the validator by adding a new `validateField #body isMarkdown` line to the `buildPost` function:
+We can use the validator by adding a new [`validateField #body isMarkdown`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateField.html#v:validateField) line to the `buildPost` function:
 
 ```haskell
 buildPost post = post
@@ -946,7 +946,7 @@ Inside the `Show.hs` we need to update the type signature to tell our action wha
 data ShowView = ShowView { post :: Post }
 ```
 
-Add an `Include "comments"` like this:
+Add an [`Include "comments"`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) like this:
 
 ```haskell
 data ShowView = ShowView { post :: Include "comments" Post }
@@ -954,20 +954,20 @@ data ShowView = ShowView { post :: Include "comments" Post }
 
 This specifies that our view requires a post and should also include its comments. This will trigger a type error to be shown in the browser because our `ShowPostAction` is not passing the comments yet.
 
-To fix this, open `Web/Controller/Posts.hs` and take a look at the `ShowPostAction`. Right now we have a `fetch` call:
+To fix this, open `Web/Controller/Posts.hs` and take a look at the `ShowPostAction`. Right now we have a [`fetch`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetch) call:
 
 ```haskell
 post <- fetch postId
 ```
 
-We need to extend our fetch to also include comments. We can use `fetchRelated` for this:
+We need to extend our fetch to also include comments. We can use [`fetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated) for this:
 
 ```haskell
 post <- fetch postId
     >>= fetchRelated #comments
 ```
 
-The type of `post` has changed from `Post` to `Include "comments" Post`. In general, when you're dealing with has-many relationships, use `Include "relatedRecords"` and `fetchRelated` to specify and fetch data according to your needs.
+The type of `post` has changed from `Post` to [`Include "comments" Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include). In general, when you're dealing with has-many relationships, use [`Include "relatedRecords"`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) and [`fetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated) to specify and fetch data according to your needs.
 
 The type error is fixed now. When opening the Show View of a post, you will see that the comments are displayed. When you take a look at the [`Logs` in the Dev tools](http://localhost:8001/AppLogs) you can see, that when opening a Post, two SQL queries will be fired:
 
@@ -1032,7 +1032,7 @@ To the following:
         render ShowView { .. }
 ```
 
-The `modify #comments (orderByDesc #createdAt)` basically just does a `|> orderByDesc #createdAt` to the query builder inside the `#comments` field. Then it just writes it back to the field. The `fetchRelated #comments` will then use the query builder stored inside `#comments` to fetch the comments, thus using the `ORDER BY` we added to the query.
+The [`modify #comments (orderByDesc #createdAt)`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:modify) basically just does a [`|> orderByDesc #createdAt`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:orderByDesc) to the query builder inside the `#comments` field. Then it just writes it back to the field. The [`fetchRelated #comments`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated) will then use the query builder stored inside `#comments` to fetch the comments, thus using the `ORDER BY` we added to the query.
 
 That's it already. Taking a look at our post, we can see that the newest comment is shown first now.
 


### PR DESCRIPTION
Every mention of an IHP function that I could find is now linked to the corresponding documentation. I changed the formatting where it made sense. Functions in code blocks are not linked, as that doesn't work due to markdown limitations. (It would be pretty cool though...)