### PR TITLE
Add local mail testing with MailHog instructions

### DIFF
--- a/Guide/mail.markdown
+++ b/Guide/mail.markdown
@@ -111,13 +111,13 @@ config = do
         }
 ```
 
-### Local (For Deubgging)
+### Local (For Debugging)
 
 A convinient way to see sent mails is to use a local mail testing such as [MailHog](https://github.com/mailhog/MailHog). This service will catch all outgoing emails, and show their HTML to you - which is handy while developing. 
 
 1. Make sure `sendmail` is locally installed and configured.
 2. Install MailHog.
-3. Enter the followning Config.
+3. Enter the following Config.
 4. Start MailHog and open the link at http://0.0.0.0:8025/
 5. Send an email via your application, and see it in MailHog.
 


### PR DESCRIPTION
Maybe it's better to include MailHog (or similar) as part of the IHP installation? Anyway, until then - here's the manual way.

Slightly off topic. When a mail is sent, under http://localhost:8001/AppLogs there's no mention of it. I assume it should be added [here](https://github.com/digitallyinduced/ihp/blob/18f104da69c526ff9e8ad3a6cdaedc6d39afb38c/IHP/Mail.hs#L41) - but not sure how.