### PR TITLE
customNotFoundResponse in Guide/recipes.markdown gets a better typean…

### DIFF
--- a/Guide/recipes.markdown
+++ b/Guide/recipes.markdown
@@ -407,7 +407,7 @@ with a 404:
 ```haskell
 import qualified Data.ByteString.Lazy as LBS
 
-customNotFoundResponse :: IO ()
+customNotFoundResponse :: (?context :: ControllerContext) => IO () 
 customNotFoundResponse = do
 page <- LBS.readFile "static/404.html"
 respondAndExit $ responseLBS status404 [(hContentType, "text/html")] page


### PR DESCRIPTION
customNotFoundResponse in Guide/recipes.markdown gets a better typeannotation - known to work for versions from ihp 0.11 up to 0.15