### PR TITLE
Fix small typo in documentation

### DIFF
--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -334,7 +334,7 @@ Preloading with InstantClick on hover will only happen with links that
 We provide two custom events
 
 -   `ihp:load` that will trigger when `DOMContentLoaded` or `turbolinks:load`
--   `ihp:load` that will fire on `beforeunload` and before [morphdom patches the page](#TurboLinks)
+-   `ihp:unload` that will fire on `beforeunload` and before [morphdom patches the page](#TurboLinks)
 
 ```javascript
 document.addEventListener('ihp:load', () => {


### PR DESCRIPTION
I believe this should be `unload`