### PR TITLE
Fix job dashboard retry

### DIFF
--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -207,13 +207,13 @@ instance JobsDashboard '[] where
         redirectTo ListJobsAction
 
         where delete id table = sqlExec (PG.Query $ cs $ "DELETE FROM " <> table <> " WHERE id = ?") (Only id)
-    
+
     retryJob = error "retryJob: Requested job type not in JobsDashboard Type"
     retryJob' = do
         let id    :: UUID = param "id"
             table :: Text = param "tableName"
         retryJobById table id
-        setSuccessMessage (columnNameToFieldLabel table <> " record deleted.")
+        setSuccessMessage (columnNameToFieldLabel table <> " record marked as 'retry'.")
         redirectTo ListJobsAction
 
         where retryJobById table id = sqlExec ("UPDATE ? SET status = 'job_status_retry' WHERE id = ?") (PG.Identifier table, id)

--- a/IHP/Job/Dashboard/View.hs
+++ b/IHP/Job/Dashboard/View.hs
@@ -212,8 +212,9 @@ renderBaseJobDetailView job = let table = get #table job in [hsx|
             <input type="hidden" id="id" name="id" value={tshow $ get #id job}>
             <button type="submit" class="btn btn-danger">Delete</button>
         </form>
-        <form action="/jobs/CreateJob" method="POST">
+        <form action="/jobs/RetryJob" method="POST">
             <input type="hidden" id="tableName" name="tableName" value={table}>
+            <input type="hidden" id="id" name="id" value={tshow $ get #id job}>
             <button type="submit" class="btn btn-primary">Run again</button>
         </form>
     </div>


### PR DESCRIPTION
In a last [commit](https://github.com/digitallyinduced/ihp/commit/272565698c56dcfeb56b474e3d8e493c6a4b5394) the "retry" button on the job list view has been fixed, but not on the Job's detail page. There was also a wrong success message (talking about "job record deleted") which this PR also addresses.