### PR TITLE
SSC: use unescaping

### DIFF
--- a/lib/IHP/static/vendor/ihp-ssc.js
+++ b/lib/IHP/static/vendor/ihp-ssc.js
@@ -43,6 +43,12 @@ function initalizeSSC(component) {
     };
 }
 
+// Unescapes a HTML-encoded string.
+function htmlDecode(input) {
+    var doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent;
+}
+
 function evaluatePatch(component, nodeOperations) {
     for (var nodeOperation of nodeOperations) {
         nodeOperation.domNode = resolvePathToNode(component, nodeOperation.path);
@@ -71,10 +77,11 @@ function createNode(component, nodeOperation) {
 }
 
 function updateTextContent(component, nodeOperation) {
-    if (nodeOperation.domNode.textContent === nodeOperation.textContent) {
+    var decodedContent = htmlDecode(nodeOperation.textContent)
+    if (nodeOperation.domNode.textContent === decodedContent) {
         return;
     }
-    nodeOperation.domNode.textContent = nodeOperation.textContent;
+    nodeOperation.domNode.textContent = decodedContent;
 }
 
 function updateNode(component, nodeOperation) {
@@ -100,11 +107,14 @@ function replaceNode(component, nodeOperation) {
 const inputTagnames = ["INPUT", "TEXTAREA"];
 
 function evaluateAttributeOperation(domNode, op) {
+    // HtmlDiff passes attribute values as raw values — that is, if the attribute value is a single quote mark it'll be
+    // represented in HTML as "&quot;" and therefore we'll get "&quot;". We have to unescape those values before using
+    // 'setAttribute' or 'x.value = y'.
     if (op.type === "UpdateAttribute" && inputTagnames.includes(domNode.tagName)) {
-        domNode.value = op.attributeValue;
-    } 
+        domNode.value = htmlDecode(op.attributeValue);
+    }   
     else if (op.type === 'UpdateAttribute' || op.type === 'AddAttribute') {
-        domNode.setAttribute(op.attributeName, op.attributeValue);
+        domNode.setAttribute(op.attributeName, htmlDecode(op.attributeValue));
     } else if (op.type === 'DeleteAttribute') {
         domNode.removeAttribute(op.attributeName);
     } else {


### PR DESCRIPTION
IHP's HTML parser outputs HTML-escaped strings but ihp-ssc.js does not unescape them when inserting them into DOM. This means SSC is mostly broken for any text containing chars like `"`, especially for `<input>`s.