### PR TITLE
Use standard `renderPagination` in list page for Jobs Dashboard

### DIFF
--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -185,7 +185,6 @@ instance JobsDashboard '[] where
         jobs <- queryBaseJobsFromTablePaginated table (page - 1) pageSize
         let pagination = Pagination { currentPage = page, totalItems, pageSize, window = windowSize options }
         render $ HtmlView $ renderBaseJobTablePaginated table jobs pagination
-        render $ EmptyView
 
     viewJob = error "viewJob: Requested job type not in JobsDashboard Type"
     viewJob' _ = do

--- a/IHP/Job/Dashboard/Utils.hs
+++ b/IHP/Job/Dashboard/Utils.hs
@@ -13,8 +13,4 @@ numberOfPagesForTable table pageSize = do
         (pages, _) -> pages + 1
 
 totalRecordsForTable :: (?modelContext :: ModelContext) => Text -> IO Int
-totalRecordsForTable table = do
-    (PG.Only totalRecords : _) <- sqlQuery
-        (PG.Query $ cs $ "SELECT COUNT(*) FROM " <> table)
-        ()
-    pure totalRecords
+totalRecordsForTable table = sqlQueryScalar (PG.Query $ cs $ "SELECT COUNT(*) FROM " <> table) ()

--- a/IHP/Job/Dashboard/Utils.hs
+++ b/IHP/Job/Dashboard/Utils.hs
@@ -7,10 +7,14 @@ import qualified Database.PostgreSQL.Simple.Types as PG
 
 numberOfPagesForTable :: (?modelContext::ModelContext) => Text -> Int -> IO Int
 numberOfPagesForTable table pageSize = do
-    (PG.Only totalRecords : _) <- sqlQuery
-        (PG.Query $ cs $ "SELECT COUNT(*) FROM " <> table)
-        ()
+    totalRecords <- totalRecordsForTable table
     pure $ case totalRecords `quotRem` pageSize of
         (pages, 0) -> pages
         (pages, _) -> pages + 1
 
+totalRecordsForTable :: (?modelContext::ModelContext) => Text -> IO Int
+totalRecordsForTable table = do
+    (PG.Only totalRecords : _) <- sqlQuery
+        (PG.Query $ cs $ "SELECT COUNT(*) FROM " <> table)
+        ()
+    pure totalRecords

--- a/IHP/Job/Dashboard/Utils.hs
+++ b/IHP/Job/Dashboard/Utils.hs
@@ -12,7 +12,7 @@ numberOfPagesForTable table pageSize = do
         (pages, 0) -> pages
         (pages, _) -> pages + 1
 
-totalRecordsForTable :: (?modelContext::ModelContext) => Text -> IO Int
+totalRecordsForTable :: (?modelContext :: ModelContext) => Text -> IO Int
 totalRecordsForTable table = do
     (PG.Only totalRecords : _) <- sqlQuery
         (PG.Query $ cs $ "SELECT COUNT(*) FROM " <> table)

--- a/IHP/Job/Dashboard/View.hs
+++ b/IHP/Job/Dashboard/View.hs
@@ -12,6 +12,8 @@ import IHP.ViewPrelude (JobStatus(..), ControllerContext, Html, View, hsx, html,
 import qualified Data.List as List
 import IHP.Job.Dashboard.Types
 import IHP.Job.Dashboard.Utils
+import IHP.Pagination.Types
+import IHP.Pagination.ViewFunctions
 import qualified IHP.Log as Log
 
 -- | Provides a type-erased view. This allows us to specify a view as a return type without needed
@@ -87,8 +89,8 @@ renderBaseJobTable table rows =
 |]
     where renderHeader field = [hsx|<th>{field}</th>|]
 
-renderBaseJobTablePaginated :: Text -> [BaseJob] -> Int -> Int -> Html
-renderBaseJobTablePaginated table jobs page totalPages =
+renderBaseJobTablePaginated :: Text -> [BaseJob] -> Pagination -> Html
+renderBaseJobTablePaginated table jobs pagination =
     let
         headers :: [Text] = ["ID", "Updated At", "Status", "", ""]
         lastJobIndex = (List.length jobs) - 1
@@ -111,37 +113,10 @@ renderBaseJobTablePaginated table jobs page totalPages =
                     </tbody>
                 </table>
             </div>
-            <nav aria-label="Page navigation example">
-                <ul class="pagination justify-content-end">
-                    {renderPrev}
-                    {when (totalPages /= 1) renderDest}
-                    {renderNext}
-                </ul>
-            </nav>
+            {renderPagination pagination}
         |]
     where
         renderHeader field = [hsx|<th>{field}</th>|]
-        renderDest = [hsx|<li class="page-item active"><a class="page-link" href={ListJobAction table page}>{page}</a></li>|]
-        renderPrev
-            | page == 1 = [hsx||]
-            | otherwise = [hsx|
-                <li class="page-item">
-                    <a class="page-link" href={ListJobAction table (page - 1)} aria-label="Previous">
-                        <span aria-hidden="true">&laquo;</span>
-                        <span class="sr-only">Previous</span>
-                    </a>
-                </li>
-        |]
-        renderNext
-            | page == totalPages || totalPages == 0 = [hsx||]
-            | otherwise = [hsx|
-                <li class="page-item">
-                    <a class="page-link" href={ListJobAction table (page + 1)} aria-label="Next">
-                        <span aria-hidden="true">&raquo;</span>
-                        <span class="sr-only">Next</span>
-                    </a>
-                </li>
-            |]
 
 renderBaseJobTableRow :: BaseJob -> Html
 renderBaseJobTableRow job = [hsx|


### PR DESCRIPTION
Addresses #1198

# Test Plan

I tested locally by creating 65 job instances in a sample project and checking that the pagination renders as expected for various page and window sizes:

<img width="979" alt="Screen Shot 2021-12-28 at 2 35 54 PM" src="https://user-images.githubusercontent.com/136982/147601096-67547713-c681-4a3c-871a-27ce6a6e417b.png">

## Cases

* No pagination is rendered when all items fit on a single page.
* Only the necessary number of pages are listed when `window size > total pages`.
* Only the specified number of items are rendered per page when selecting the "items per page" dropdown.
* Clicking on an arbitrary page number navigates to that page.
* Clicking on the "previous" and "next" arrows navigates to the associated pages.

# QueryBuilder / Limitations

There's still redundancy with `IHP.Pagination.ControllerFunctions.paginateWithOptions`.

I tried to use that function but couldn't figure out how to initialize a `QueryBuilder` with a `Text`-valued table name. This isn't possible, right? Since the static types from the application aren't accessible to the IHP library.

I'm wondering if it makes sense to duplicate the validation logic here? In particular, the logic to constrain the page size.