### PR TITLE
Add prefixes for alpine.js support

### DIFF
--- a/IHP/HSX/Parser.hs
+++ b/IHP/HSX/Parser.hs
@@ -178,8 +178,12 @@ hsxAttributeName = do
         isValidAttributeName name =
             "data-" `Text.isPrefixOf` name
             || "aria-" `Text.isPrefixOf` name
+            -- Prefix for HTMX support
             || "hx-" `Text.isPrefixOf` name
-            || "hx-" `Text.isPrefixOf` name
+            -- Prefixes for Alpine.js support
+            || "x-" `Text.isPrefixOf` name
+            || "@" `Text.isPrefixOf` name
+            || ":" `Text.isPrefixOf` name
             || name `Set.member` attributes
 
         rawAttribute = takeWhile1P Nothing (\c -> Char.isAlphaNum c || c == '-')


### PR DESCRIPTION
These seems to be all the prefixes needed to fully support alpine.js according to the [documentation](https://alpinejs.dev/start-here). All the other special syntax is inside strings.

Example 
```html
<div x-data="{ count: 0 }">
    <button x-on:click="count++">Increment</button>
 
    <span x-text="count"></span>
</div>
```