### PR TITLE
Tailwind 3 support

### DIFF
--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -66,12 +66,10 @@ module.exports = {
     content: [
         "../Web/View/**/*.hs",
     ],
-    options: {
-        safelist: [
-        // Add here custom class names. Since we're using TW's jit (Just-In-
-        // Time), `safelist` must be full class names, and not regex.
-        ],
-    },
+    safelist: [
+        // Add custom class names.
+        // https://tailwindcss.com/docs/content-configuration#safelisting-classes
+    ],
     plugins: [
         require('@tailwindcss/forms'),
     ],

--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -63,17 +63,15 @@ module.exports = {
         extend: {
         },
     },
-    purge: {
-        content: [
-            "../Web/View/**/*.hs",
-        ],
+    content: [
+        "../Web/View/**/*.hs",
+    ],
     options: {
         safelist: [
         // Add here custom class names. Since we're using TW's jit (Just-In-
         // Time), `safelist` must be full class names, and not regex.
         ],
     },
-  },
     plugins: [
         require('@tailwindcss/forms'),
     ],


### PR DESCRIPTION
When creating a new IHP project and installing Tailwind, Tailwind 3 will be installed.

There is a slight difference in the configuration file, where the `contents` and `options` are now moved up in the hierarchy and the tailwind cli throws an error if using the old structure.

Other than that, there aren't any incompatability issues with Tailwind 3 as I am following this guide with this modification in two fresh projects now :+1: 

CC @amitaibu 