### PR TITLE
Add `overflow-x` to code in an error message

### DIFF
--- a/IHP/ErrorController.hs
+++ b/IHP/ErrorController.hs
@@ -562,6 +562,7 @@ renderError errorTitle view = H.docTypeHtml ! A.lang "en" $ [hsx|
 
         .ihp-error-code {
             padding: 1rem;
+            overflow-x: auto;
         }
 
         .ihp-error-inline-code {


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/125707/150601597-c1e11ebd-2427-464c-8fed-5962126577f2.png)


## After

![image](https://user-images.githubusercontent.com/125707/150601567-ec8958af-dfde-4def-a706-6d24600c93c0.png)

