### PR TITLE
Add CustomMiddleware option for user-provided WAI middleware

### DIFF
--- a/Guide/config.markdown
+++ b/Guide/config.markdown
@@ -128,4 +128,27 @@ instance EnvVarReader RequestLogger.IPAddrSource where
     envStringToValue "FromHeader" = Right RequestLogger.FromHeader
     envStringToValue "FromSocket" = Right RequestLogger.FromSocket
     envStringToValue otherwise    = Left "Expected 'FromHeader' or 'FromSocket'"
-````
+```
+
+### Custom Middleware
+
+IHP provides an "escape-hatch" from the framework with the `CustomMiddleware` option.
+This can be used to run any WAI middleware after IHP's middleware stack, allowing for possibilities
+such as embedding a Servant or Yesod app into an IHP app, adding GZIP compression, or any other
+number of possibilities. See [wai-extra](https://hackage.haskell.org/package/wai-extra) for examples
+of WAI middleware that could be added.
+
+The following example sets up a custom middleware that infers the real IP using `X-Forwarded-For`
+and adds a custom header for every request.
+
+```haskell
+module Config where
+
+import Network.Wai.Middleware.AddHeaders (addHeaders)
+import Network.Wai.Middleware.RealIp (realIp)
+
+config :: ConfigBuilder
+config = do
+    option $ CustomMiddleware $ addHeaders [("X-My-Header", "Custom WAI Middleware!")] . realIp
+```
+

--- a/IHP/FrameworkConfig.hs
+++ b/IHP/FrameworkConfig.hs
@@ -71,6 +71,8 @@ newtype RLSAuthenticatedRole = RLSAuthenticatedRole Text
 
 newtype AssetVersion = AssetVersion Text
 
+newtype CustomMiddleware = CustomMiddleware Middleware
+
 -- | Puts an option into the current configuration
 --
 -- In case an option already exists with the same type, it will not be overriden:
@@ -154,6 +156,8 @@ ihpDefaultConfig = do
     option $ RLSAuthenticatedRole rlsAuthenticatedRole
 
     initAssetVersion
+    
+    option $ CustomMiddleware id
 
 {-# INLINABLE ihpDefaultConfig #-}
 
@@ -273,6 +277,7 @@ buildFrameworkConfig appConfig = do
             (IdeBaseUrl ideBaseUrl) <- findOption @IdeBaseUrl
             (RLSAuthenticatedRole rlsAuthenticatedRole) <- findOption @RLSAuthenticatedRole
             (AssetVersion assetVersion) <- findOption @AssetVersion
+            customMiddleware <- findOption @CustomMiddleware
 
             appConfig <- State.get
 
@@ -432,6 +437,9 @@ data FrameworkConfig = FrameworkConfig
     -- string @"dev"@.
     --
     , assetVersion :: !Text
+
+    -- | User provided WAI middleware that is run after IHP's middleware stack.
+    , customMiddleware :: !CustomMiddleware
 }
 
 class ConfigProvider a where

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -59,15 +59,17 @@ run configBuilder = do
             staticMiddleware <- initStaticMiddleware frameworkConfig
             let corsMiddleware = initCorsMiddleware frameworkConfig
             let requestLoggerMiddleware = get #requestLoggerMiddleware frameworkConfig
+            let CustomMiddleware customMiddleware = get #customMiddleware frameworkConfig
 
-            withBackgroundWorkers pgListener frameworkConfig $
-                   runServer frameworkConfig $
-                        staticMiddleware $
-                            corsMiddleware $
-                                sessionMiddleware $
-                                        requestLoggerMiddleware $
-                                                methodOverridePost $
-                                                    application
+            withBackgroundWorkers pgListener frameworkConfig 
+                . runServer frameworkConfig
+                . customMiddleware
+                . staticMiddleware
+                . corsMiddleware
+                . sessionMiddleware
+                . requestLoggerMiddleware
+                . methodOverridePost 
+                $ application
 
 {-# INLINABLE run #-}
 


### PR DESCRIPTION
The PR adds a `CustomMiddleware` option to `FrameworkConfig`.  By providing a middleware here the user can run any arbitrary WAI middleware, providing a real "escape-hatch" for IHP.  It would even be possible, for example, to combine a Servant app or Yesod app with an IHP app using this option. Further examples are provided in the docs.