### PR TITLE
Added transactions to DataSync

### DIFF
--- a/IHP/DataSync/Types.hs
+++ b/IHP/DataSync/Types.hs
@@ -6,17 +6,21 @@ import IHP.QueryBuilder
 import IHP.DataSync.DynamicQuery
 import Data.HashMap.Strict (HashMap)
 import qualified IHP.PGListener as PGListener
+import qualified Database.PostgreSQL.Simple as PG
 
 data DataSyncMessage
-    = DataSyncQuery { query :: !DynamicSQLQuery, requestId :: !Int }
+    = DataSyncQuery { query :: !DynamicSQLQuery, requestId :: !Int, transactionId :: !(Maybe UUID) }
     | CreateDataSubscription { query :: !DynamicSQLQuery, requestId :: !Int }
     | DeleteDataSubscription { subscriptionId :: !UUID, requestId :: !Int }
-    | CreateRecordMessage { table :: !Text, record :: !(HashMap Text Value), requestId :: !Int }
-    | CreateRecordsMessage { table :: !Text, records :: ![HashMap Text Value], requestId :: !Int }
-    | UpdateRecordMessage { table :: !Text, id :: !UUID, patch :: !(HashMap Text Value), requestId :: !Int }
-    | UpdateRecordsMessage { table :: !Text, ids :: ![UUID], patch :: !(HashMap Text Value), requestId :: !Int }
-    | DeleteRecordMessage { table :: !Text, id :: !UUID, requestId :: !Int }
-    | DeleteRecordsMessage { table :: !Text, ids :: ![UUID], requestId :: !Int }
+    | CreateRecordMessage { table :: !Text, record :: !(HashMap Text Value), requestId :: !Int, transactionId :: !(Maybe UUID) }
+    | CreateRecordsMessage { table :: !Text, records :: ![HashMap Text Value], requestId :: !Int, transactionId :: !(Maybe UUID) }
+    | UpdateRecordMessage { table :: !Text, id :: !UUID, patch :: !(HashMap Text Value), requestId :: !Int, transactionId :: !(Maybe UUID) }
+    | UpdateRecordsMessage { table :: !Text, ids :: ![UUID], patch :: !(HashMap Text Value), requestId :: !Int, transactionId :: !(Maybe UUID) }
+    | DeleteRecordMessage { table :: !Text, id :: !UUID, requestId :: !Int, transactionId :: !(Maybe UUID) }
+    | DeleteRecordsMessage { table :: !Text, ids :: ![UUID], requestId :: !Int, transactionId :: !(Maybe UUID) }
+    | StartTransaction { requestId :: !Int }
+    | RollbackTransaction { requestId :: !Int, id :: !UUID }
+    | CommitTransaction { requestId :: !Int, id :: !UUID }
     deriving (Eq, Show)
 
 data DataSyncResponse
@@ -34,9 +38,21 @@ data DataSyncResponse
     | DidUpdateRecords { requestId :: !Int, records :: ![[Field]] } -- ^ Response to 'UpdateRecordsMessage'
     | DidDeleteRecord { requestId :: !Int }
     | DidDeleteRecords { requestId :: !Int }
+    | DidStartTransaction { requestId :: !Int, transactionId :: !UUID }
+    | DidRollbackTransaction { requestId :: !Int, transactionId :: !UUID }
+    | DidCommitTransaction { requestId :: !Int, transactionId :: !UUID }
 
 data Subscription = Subscription { id :: !UUID, channelSubscription :: !PGListener.Subscription }
+data DataSyncTransaction
+    = DataSyncTransaction
+    { id :: !UUID
+    , connection :: !PG.Connection
+    , releaseConnection :: IO ()
+    }
 
 data DataSyncController
     = DataSyncController
-    | DataSyncReady { subscriptions :: !(HashMap UUID Subscription) }
+    | DataSyncReady
+        { subscriptions :: !(HashMap UUID Subscription)
+        , transactions :: !(HashMap UUID DataSyncTransaction)
+        }

--- a/lib/IHP/DataSync/ihp-datasync.js
+++ b/lib/IHP/DataSync/ihp-datasync.js
@@ -130,6 +130,13 @@ class DataSyncController {
         this.eventListeners[event].push(callback);
     }
 
+    removeEventListener(event, callback) {
+        const index = this.eventListeners[event].indexOf(callback);
+        if (index > -1) {
+            this.eventListeners[event].splice(index, 1);
+        }
+    }
+
     retryToReconnect() {
         if (this.connection) {
             return;
@@ -332,7 +339,7 @@ function initIHPBackend({ host }) {
     DataSyncController.ihpBackendHost = host;
 }
 
-export async function createRecord(table, record) {
+export async function createRecord(table, record, options = {}) {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to createRecord(${JSON.stringify(table)}, ${JSON.stringify(record, null, 4)})`);
     }
@@ -340,7 +347,8 @@ export async function createRecord(table, record) {
         throw new Error(`Record needs to be an object, you passed ${JSON.stringify(record)} in a call to createRecord(${JSON.stringify(table)}, ${JSON.stringify(record, null, 4)})`);
     }
 
-    const request = { tag: 'CreateRecordMessage', table, record };
+    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const request = { tag: 'CreateRecordMessage', table, record, transactionId };
     
     try {
         const response = await DataSyncController.getInstance().sendMessage(request);
@@ -354,7 +362,7 @@ export async function createRecord(table, record) {
     }
 }
 
-export async function updateRecord(table, id, patch) {
+export async function updateRecord(table, id, patch, options = {}) {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to updateRecord(${JSON.stringify(table)}, ${JSON.stringify(id)}, ${JSON.stringify(patch, null, 4)})`);
     }
@@ -365,7 +373,8 @@ export async function updateRecord(table, id, patch) {
         throw new Error(`Patch needs to be an object, you passed ${JSON.stringify(patch)} in a call to updateRecord(${JSON.stringify(table)}, ${JSON.stringify(id)}, ${JSON.stringify(patch, null, 4)})`);
     }
 
-    const request = { tag: 'UpdateRecordMessage', table, id, patch };
+    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const request = { tag: 'UpdateRecordMessage', table, id, patch, transactionId };
 
     try {
         const response = await DataSyncController.getInstance().sendMessage(request);
@@ -376,7 +385,7 @@ export async function updateRecord(table, id, patch) {
     }
 }
 
-export async function updateRecords(table, ids, patch) {
+export async function updateRecords(table, ids, patch, options = {}) {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to updateRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)}, ${JSON.stringify(patch, null, 4)})`);
     }
@@ -387,7 +396,8 @@ export async function updateRecords(table, ids, patch) {
         throw new Error(`Patch needs to be an object, you passed ${JSON.stringify(patch)} in a call to updateRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)}, ${JSON.stringify(patch, null, 4)})`);
     }
 
-    const request = { tag: 'UpdateRecordsMessage', table, ids, patch };
+    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const request = { tag: 'UpdateRecordsMessage', table, ids, patch, transactionId };
 
     try {
         const response = await DataSyncController.getInstance().sendMessage(request);
@@ -398,7 +408,7 @@ export async function updateRecords(table, ids, patch) {
     }
 }
 
-export async function deleteRecord(table, id) {
+export async function deleteRecord(table, id, options = {}) {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to deleteRecord(${JSON.stringify(table)}, ${JSON.stringify(id)})`);
     }
@@ -406,7 +416,8 @@ export async function deleteRecord(table, id) {
         throw new Error(`ID needs to be an UUID, you passed ${JSON.stringify(id)} in a call to deleteRecord(${JSON.stringify(table)}, ${JSON.stringify(id)})`);
     }
 
-    const request = { tag: 'DeleteRecordMessage', table, id };
+    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const request = { tag: 'DeleteRecordMessage', table, id, transactionId };
 
     try {
         const response = await DataSyncController.getInstance().sendMessage(request);
@@ -417,7 +428,7 @@ export async function deleteRecord(table, id) {
     }
 }
 
-export async function deleteRecords(table, ids) {
+export async function deleteRecords(table, ids, options = {}) {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to deleteRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)})`);
     }
@@ -425,7 +436,8 @@ export async function deleteRecords(table, ids) {
         throw new Error(`IDs needs to be an array, you passed ${JSON.stringify(ids)} in a call to deleteRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)})`);
     }
 
-    const request = { tag: 'DeleteRecordsMessage', table, ids };
+    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const request = { tag: 'DeleteRecordsMessage', table, ids, transactionId };
 
     try {
         const response = await DataSyncController.getInstance().sendMessage(request);
@@ -436,7 +448,7 @@ export async function deleteRecords(table, ids) {
     }
 }
 
-export async function createRecords(table, records) {
+export async function createRecords(table, records, options = {}) {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to createRecords(${JSON.stringify(table)}, ${JSON.stringify(records, null, 4)})`);
     }
@@ -444,7 +456,8 @@ export async function createRecords(table, records) {
         throw new Error(`Records need to be an array, you passed ${JSON.stringify(records)} in a call to createRecords(${JSON.stringify(table)}, ${JSON.stringify(records, null, 4)})`);
     }
     
-    const request = { tag: 'CreateRecordsMessage', table, records };
+    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const request = { tag: 'CreateRecordsMessage', table, records, transactionId };
     
     try {
         const response = await DataSyncController.getInstance().sendMessage(request);

--- a/lib/IHP/DataSync/ihp-querybuilder.js
+++ b/lib/IHP/DataSync/ihp-querybuilder.js
@@ -27,6 +27,7 @@ class QueryBuilder {
             limit: null,
             offset: null
         };
+        this.transactionId = null;
     }
 
     filterWhere(field, value) {
@@ -73,8 +74,11 @@ class QueryBuilder {
     }
 
     async fetch() {
-        // return fetch('/Query').then(response => response.json());
-        const { result } = await DataSyncController.getInstance().sendMessage({ tag: 'DataSyncQuery', query: this.query });
+        const { result } = await DataSyncController.getInstance().sendMessage({
+                tag: 'DataSyncQuery',
+                query: this.query,
+                transactionId: this.transactionId
+            });
         return result;
     }
 

--- a/lib/IHP/DataSync/index.js
+++ b/lib/IHP/DataSync/index.js
@@ -1,10 +1,14 @@
 import { QueryBuilder, query, ihpBackendUrl, fetchAuthenticated } from './ihp-querybuilder.js';
-import { DataSyncController, DataSubscription, initIHPBackend, createRecord, updateRecord, deleteRecord, createRecords } from './ihp-datasync.js';
+import { DataSyncController, DataSubscription, initIHPBackend, createRecord, createRecords, updateRecord, updateRecords, deleteRecord, deleteRecords } from './ihp-datasync.js';
+import { Transaction, withTransaction } from './transaction.js';
 
 export {
     /* ihp-querybuilder.js */
     QueryBuilder, query, ihpBackendUrl, fetchAuthenticated,
 
     /* ihp-datasync.js */
-    DataSyncController, DataSubscription, initIHPBackend, createRecord, updateRecord, deleteRecord, createRecords
+    DataSyncController, DataSubscription, initIHPBackend, createRecord, createRecords, updateRecord, updateRecords, deleteRecord, deleteRecords,
+
+    /* transaction.js */
+    Transaction, withTransaction
 };

--- a/lib/IHP/DataSync/transaction.js
+++ b/lib/IHP/DataSync/transaction.js
@@ -1,0 +1,94 @@
+import { DataSyncController, createRecord, createRecords, updateRecord, updateRecords, deleteRecord, deleteRecords } from "./ihp-datasync.js";
+import { query } from "./ihp-querybuilder.js";
+
+export class Transaction {
+    constructor() {
+        this.transactionId = null;
+        this.onClose = this.onClose.bind(this);
+        this.dataSyncController = DataSyncController.getInstance();
+    }
+
+    async start() {
+        const { transactionId } = await this.dataSyncController.sendMessage({ tag: 'StartTransaction' });
+
+        this.transactionId = transactionId;
+
+        this.dataSyncController.addEventListener('close', this.onClose);
+    }
+
+    async commit() {
+        if (this.transactionId === null) {
+            throw new Error('You need to call `.start()` before you can commit the transaction');
+        }
+        
+        await this.dataSyncController.sendMessage({ tag: 'CommitTransaction', id: this.transactionId });
+    }
+
+    async rollback() {
+        if (this.transactionId === null) {
+            throw new Error('You need to call `.start()` before you can rollback the transaction');
+        }
+        
+        await this.dataSyncController.sendMessage({ tag: 'RollbackTransaction', id: this.transactionId });
+    }
+
+    onClose() {
+        this.transactionId = null;
+        this.dataSyncController.removeEventListener('close', this.onClose);
+    }
+    
+    getIdOrFail() {
+        if (this.transactionId === null) {
+            throw new Error('You need to call `.start()` before you can use this transaction');
+        }
+
+        return this.transactionId;
+    }
+
+    buildOptions() {
+        return { transactionId: this.getIdOrFail() };
+    }
+
+    query(table) {
+        const tableQuery = query(table);
+        tableQuery.transactionId = this.getIdOrFail();
+        return tableQuery;
+    }
+
+    createRecord(table, record) {
+        return createRecord(table, record, this.buildOptions());
+    }
+
+    createRecords(table, records) {
+        return createRecords(table, records, this.buildOptions());
+    }
+
+    updateRecord(table, id, patch) {
+        return updateRecord(table, id, patch, this.buildOptions());
+    }
+
+    updateRecords(table, ids, patch) {
+        return updateRecords(table, ids, patch, this.buildOptions());
+    }
+
+    deleteRecord(table, id) {
+        return deleteRecord(table, id, this.buildOptions());
+    }
+
+    deleteRecords(table, ids) {
+        return deleteRecords(table, ids, this.buildOptions());
+    }
+}
+
+export async function withTransaction(callback) {
+    const transaction = new Transaction();
+    await transaction.start();
+    try {
+        const result = await callback(transaction);
+        await transaction.commit();
+        return result;
+    } catch (exception) {
+        await transaction.rollback();
+        throw exception;
+    }
+}


### PR DESCRIPTION
This adds a new high-level `withTransaction` function and a lower-level `Transaction` object to deal with postgres transactions from DataSync.

The following operations can be used from within a transaction:
- createRecord, createRecords
- updateRecord, updateRecords
- deleteRecord, deleteRecords
- query

Example Usage:

```javascript
    const addTask = async () => {
        console.log('length before transaction', (await query('tasks').fetch()).length); // => 0

        await withTransaction(async transaction => {
            await transaction.createRecord('tasks', { title: 'hello world', userId: getCurrentUserId() })
            
            console.log('length outside of transaction', (await query('tasks').fetch()).length); // => 0
            console.log('length in transaction', (await transaction.query('tasks').fetch()).length); // => 1

        })
        console.log('length after transaction', (await query('tasks').fetch()).length); // => 1
    }
```