### PR TITLE
Make query builder use Table API to access the table name

### DIFF
--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -48,6 +48,7 @@ import Data.Dynamic
 import Data.Scientific
 import GHC.Stack
 import qualified Numeric
+import qualified Data.Text.Encoding as Text
 
 -- | Provides the db connection and some IHP-specific db configuration
 data ModelContext = ModelContext
@@ -533,7 +534,7 @@ class
     -- "users"
     --
     tableNameByteString :: ByteString
-    tableNameByteString = symbolToByteString @(GetTableName record)
+    tableNameByteString = Text.encodeUtf8 (tableName @record)
     {-# INLINE tableNameByteString #-}
 
     -- | Returns the list of column names for a given model

--- a/IHP/Pagination/ControllerFunctions.hs
+++ b/IHP/Pagination/ControllerFunctions.hs
@@ -23,7 +23,7 @@ import IHP.QueryBuilder
     ( HasQueryBuilder, filterWhereILike, limit, offset )
 import IHP.Fetch (fetchCount)
 
-import IHP.ModelSupport (GetModelByTableName, sqlQuery, sqlQueryScalar)
+import IHP.ModelSupport (GetModelByTableName, sqlQuery, sqlQueryScalar, Table)
 
 import Database.PostgreSQL.Simple.ToField (toField, Action)
 import Database.PostgreSQL.Simple.Types (Query(Query))
@@ -131,7 +131,9 @@ filterList :: forall name table model queryBuilderProvider joinRegister .
     , HasField name model Text
     , model ~ GetModelByTableName table
     , KnownSymbol table
-    , HasQueryBuilder queryBuilderProvider joinRegister) =>
+    , HasQueryBuilder queryBuilderProvider joinRegister
+    , Table model
+    ) =>
     Proxy name
     -> queryBuilderProvider table
     -> queryBuilderProvider table

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -621,7 +621,7 @@ compileTableInstance :: (?schema :: Schema) => CreateTable -> Text
 compileTableInstance table@(CreateTable { name, columns, constraints }) = cs [i|
 instance #{instanceHead} where
     tableName = \"#{name}\"
-    tableNameByteString = \"#{name}\"
+    tableNameByteString = Data.Text.Encoding.encodeUtf8 \"#{name}\"
     columnNames = #{columnNames}
     primaryKeyCondition #{pattern} = #{condition}
     {-# INLINABLE primaryKeyCondition #-}

--- a/Test/SchemaCompilerSpec.hs
+++ b/Test/SchemaCompilerSpec.hs
@@ -211,7 +211,7 @@ tests = do
                     instance Default (Id' "users") where def = Id def
                     instance () => Table (User' ) where
                         tableName = "users"
-                        tableNameByteString = "users"
+                        tableNameByteString = Data.Text.Encoding.encodeUtf8 "users"
                         columnNames = ["id","ids","electricity_unit_price"]
                         primaryKeyCondition User { id } = [("id", toField id)]
                         {-# INLINABLE primaryKeyCondition #-}
@@ -270,7 +270,7 @@ tests = do
                     instance Default (Id' "users") where def = Id def
                     instance () => Table (User' ) where
                         tableName = "users"
-                        tableNameByteString = "users"
+                        tableNameByteString = Data.Text.Encoding.encodeUtf8 "users"
                         columnNames = ["id","ids","electricity_unit_price"]
                         primaryKeyCondition User { id } = [("id", toField id)]
                         {-# INLINABLE primaryKeyCondition #-}


### PR DESCRIPTION
This allows for easier building custom data records that use an existing table