### PR TITLE
Postgres Extensions in Dev Environment.

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -5,6 +5,7 @@
 , projectPath ? ./.
 , withHoogle ? false
 , additionalNixpkgsOptions ? {}
+, postgresExtensions ? (p: [])
 , optimized ? false
 }:
 
@@ -16,7 +17,8 @@ let
       then ghc.ghcWithHoogle
       else ghc.ghcWithPackages)
         (p: builtins.concatLists [ [p.haskell-language-server] (haskellDeps p) ] );
-    allNativePackages = builtins.concatLists [ (otherDeps pkgs) [pkgs.postgresql pkgs.makeWrapper] (if pkgs.stdenv.isDarwin then [] else []) ];
+    allNativePackages = builtins.concatLists [ (otherDeps pkgs)
+    [(pkgs.postgresql_13.withPackages postgresExtensions) pkgs.makeWrapper] (if pkgs.stdenv.isDarwin then [] else []) ];
 
     appBinary = if optimized
       then "build/bin/RunOptimizedProdServer"


### PR DESCRIPTION
A small change to `IHP/NixSupport/default.nix` allows for developer to customize the extensions available to postgres. E.g. in their `app/default.nix` they can add the line:
```
import "{$ihp}/NixSupport/default.nix" {
        ihp = ihp;
        postgresExtensions = (p: [ p.postgis ]);
```
to enable postgis for geographic db tools in posgresql.