### PR TITLE
Added tsvector based fulltext search for DataSync

### DIFF
--- a/IHP/DataSync/Controller.hs
+++ b/IHP/DataSync/Controller.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 module IHP.DataSync.Controller where
 
-import IHP.ControllerPrelude
+import IHP.ControllerPrelude hiding (OrderByClause)
 import qualified Control.Exception as Exception
 import qualified IHP.Log as Log
 import qualified Data.Aeson as Aeson
@@ -353,13 +353,6 @@ changesToValue :: [ChangeNotifications.Change] -> Value
 changesToValue changes = object (map changeToPair changes)
     where
         changeToPair ChangeNotifications.Change { col, new } = (columnNameToFieldName col) .= new
-
-queryFieldNamesToColumnNames :: SQLQuery -> SQLQuery
-queryFieldNamesToColumnNames sqlQuery = sqlQuery
-        |> modify #orderByClause (map convertOrderByClause)
-    where
-        convertOrderByClause OrderByClause { orderByColumn, orderByDirection } = OrderByClause { orderByColumn = cs (fieldNameToColumnName (cs orderByColumn)), orderByDirection }
-
 
 runInModelContextWithTransaction :: (?state :: IORef DataSyncController, _) => ((?modelContext :: ModelContext) => IO result) -> Maybe UUID -> IO result
 runInModelContextWithTransaction function (Just transactionId) = do

--- a/IHP/DataSync/REST/Controller.hs
+++ b/IHP/DataSync/REST/Controller.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 module IHP.DataSync.REST.Controller where
 
-import IHP.ControllerPrelude
+import IHP.ControllerPrelude hiding (OrderByClause)
 import IHP.DataSync.REST.Types
 import Data.Aeson
 import Data.Aeson.TH

--- a/lib/IHP/DataSync/ihp-querybuilder.js
+++ b/lib/IHP/DataSync/ihp-querybuilder.js
@@ -341,6 +341,34 @@ class QueryBuilder {
     filterWhereGreaterThanOrEqual() {
 	return this.whereGreaterThanOrEqual.apply(this, Array.from(arguments))
     }
+    
+    whereTextSearchStartsWith(field, value) {
+        let normalized = value.trim().split(' ').map(s => s.trim()).filter(v => v.length > 0).join('&');
+        if (normalized.length > 0) {
+            normalized +=  ':*';
+        }
+        const expression = {
+                tag: 'InfixOperatorExpression',
+                left: {
+                    tag: 'ColumnExpression',
+                    field,
+                },
+                op: 'OpTSMatch',
+                right: {
+                    tag: 'CallExpression',
+                    functionCall: {
+                        tag: 'ToTSQuery',
+                        text: normalized
+                    }
+                },
+            };
+
+        this.#addWhereCondition('OpAnd', expression);
+
+        this.query.orderByClause.push({ tag: 'OrderByTSRank', tsvector: field, tsquery: normalized });
+
+        return this;
+    }
 
     or(conditionBuilder) {
 	if (this.query.whereCondition === null) {


### PR DESCRIPTION
This allows a simple search fulltext search to implemented like this:

```javascript
function ProductSearch() {
    const [searchQuery, setSearchQuery] = useState('');
    const onChange = useCallback(event => setSearchQuery(event.target.value), [ setSearchQuery ]);

    const products = useQuery(query('products').whereTextSearchStartsWith('ts', searchQuery));

    return <form>
        <input type="text" className="form-control" value={searchQuery} onChange={onChange}/>

        <div>
            Result: {products?.map(product => <div>{product.name}</div>)}
        </div>
    </form>
}
```