### PR TITLE
Allow nonce and referrerpolicy

### DIFF
--- a/IHP/HSX/Parser.hs
+++ b/IHP/HSX/Parser.hs
@@ -352,7 +352,7 @@ attributes = Set.fromList
         , "visibility", "word-spacing", "writing-mode", "is"
         , "cellspacing", "cellpadding", "bgcolor", "classes"
         , "loading"
-        , "frameborder", "allow", "allowfullscreen"
+        , "frameborder", "allow", "allowfullscreen", "nonce"
         ]
 
 parents :: Set Text

--- a/IHP/HSX/Parser.hs
+++ b/IHP/HSX/Parser.hs
@@ -352,7 +352,7 @@ attributes = Set.fromList
         , "visibility", "word-spacing", "writing-mode", "is"
         , "cellspacing", "cellpadding", "bgcolor", "classes"
         , "loading"
-        , "frameborder", "allow", "allowfullscreen", "nonce"
+        , "frameborder", "allow", "allowfullscreen", "nonce", "referrerpolicy"
         ]
 
 parents :: Set Text


### PR DESCRIPTION
Allow `nonce` attribute so it's possible to set a really strong Content Security Policy for script and link tags:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src 


Also allow `referrerpolicy` as this a security attribute used by some cdns that probably is nice to have even though it still works if removed.

Example: `<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js" integrity="sha512-SVDh1zH5N9ChofSlNAK43lcNS7lWze6DTVx1JCXH1Tmno+0/1jMpdbR8YDgDUfcUrPp1xyE53G42GFrcM0CMVg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>`

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy