### PR TITLE
exclude constraint using index_type

### DIFF
--- a/IHP/IDE/SchemaDesigner/Parser.hs
+++ b/IHP/IDE/SchemaDesigner/Parser.hs
@@ -189,6 +189,7 @@ parseCheckConstraint name = do
 
 parseExcludeConstraint name = do
     lexeme "EXCLUDE"
+    optional $ lexeme "USING btree"
     excludeElements <- between (char '(' >> space) (char ')' >> space) $ excludeElement `sepBy` (char ',' >> space)
     predicate <- optional do
         lexeme "WHERE"

--- a/IHP/IDE/SchemaDesigner/Parser.hs
+++ b/IHP/IDE/SchemaDesigner/Parser.hs
@@ -189,12 +189,12 @@ parseCheckConstraint name = do
 
 parseExcludeConstraint name = do
     lexeme "EXCLUDE"
-    optional $ lexeme "USING btree"
+    indexType <- optional parseIndexType
     excludeElements <- between (char '(' >> space) (char ')' >> space) $ excludeElement `sepBy` (char ',' >> space)
     predicate <- optional do
         lexeme "WHERE"
         between (char '(' >> space) (char ')' >> space) expression
-    pure ExcludeConstraint { name, excludeElements, predicate }
+    pure ExcludeConstraint { name, excludeElements, predicate, indexType }
     where
         excludeElement = do
             element <- identifier
@@ -547,20 +547,22 @@ createIndex = do
     indexName <- identifier
     lexeme "ON"
     tableName <- qualifiedIdentifier
-    indexType <- optional do
-        lexeme "USING"
-
-        let btree = do symbol' "btree"; pure Btree
-        let gin = do symbol' "gin"; pure Gin
-        let gist = do symbol' "gist"; pure Gist
-
-        btree <|> gin <|> gist
+    indexType <- optional parseIndexType
     expressions <- between (char '(' >> space) (char ')' >> space) (expression `sepBy1` (char ',' >> space))
     whereClause <- optional do
         lexeme "WHERE"
         expression
     char ';'
     pure CreateIndex { indexName, unique, tableName, expressions, whereClause, indexType }
+
+parseIndexType = do
+    lexeme "USING"
+
+    choice $ map (\(s, v) -> do symbol' s; pure v)
+        [ ("btree", Btree)
+        , ("gin", Gin)
+        , ("gist", Gist)
+        ]
 
 createFunction = do
     lexeme "CREATE"

--- a/IHP/IDE/SchemaDesigner/Types.hs
+++ b/IHP/IDE/SchemaDesigner/Types.hs
@@ -133,6 +133,7 @@ data Constraint
         { name :: !(Maybe Text)
         , excludeElements :: ![ExcludeConstraintElement]
         , predicate :: !(Maybe Expression)
+        , indexType :: !(Maybe IndexType)
         }
     | AlterTableAddPrimaryKey
         { name :: !(Maybe Text)

--- a/Test/IDE/SchemaDesigner/CompilerSpec.hs
+++ b/Test/IDE/SchemaDesigner/CompilerSpec.hs
@@ -301,11 +301,63 @@ tests = do
                             , ExcludeConstraintElement { element = "author", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Nothing
                     , deferrableType = Nothing
                     }
             compileSql [statement] `shouldBe` "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE (title WITH =, author WITH =);\n"
+
+        it "should compile ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE .. USING BTREE" do
+            let statement = AddConstraint
+                    { tableName = "posts"
+                    , constraint = ExcludeConstraint
+                        { name = "unique_title_by_author"
+                        , excludeElements =
+                            [ ExcludeConstraintElement { element = "title", operator = "=" }
+                            , ExcludeConstraintElement { element = "author", operator = "=" }
+                            ]
+                        , predicate = Nothing
+                        , indexType = Just Btree
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
+                    }
+            compileSql [statement] `shouldBe` "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE USING BTREE (title WITH =, author WITH =);\n"
+
+        it "should compile ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE .. USING GIST" do
+            let statement = AddConstraint
+                    { tableName = "posts"
+                    , constraint = ExcludeConstraint
+                        { name = "unique_title_by_author"
+                        , excludeElements =
+                            [ ExcludeConstraintElement { element = "title", operator = "=" }
+                            , ExcludeConstraintElement { element = "author", operator = "=" }
+                            ]
+                        , predicate = Nothing
+                        , indexType = Just Gist
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
+                    }
+            compileSql [statement] `shouldBe` "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE USING GIST (title WITH =, author WITH =);\n"
+
+        it "should compile ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE .. USING GIN" do
+            let statement = AddConstraint
+                    { tableName = "posts"
+                    , constraint = ExcludeConstraint
+                        { name = "unique_title_by_author"
+                        , excludeElements =
+                            [ ExcludeConstraintElement { element = "title", operator = "=" }
+                            , ExcludeConstraintElement { element = "author", operator = "=" }
+                            ]
+                        , predicate = Nothing
+                        , indexType = Just Gin
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
+                    }
+            compileSql [statement] `shouldBe` "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE USING GIN (title WITH =, author WITH =);\n"
 
         it "should compile ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE .. WHERE .." do
             let statement = AddConstraint
@@ -317,6 +369,7 @@ tests = do
                             , ExcludeConstraintElement { element = "author", operator = "=" }
                             ]
                         , predicate = Just $ EqExpression (VarExpression "title") (TextExpression "why")
+                        , indexType = Nothing
                         }
                     , deferrable = Nothing
                     , deferrableType = Nothing
@@ -336,6 +389,7 @@ tests = do
                             , ExcludeConstraintElement { element = "i5", operator = "OR" }
                             ]
                         , predicate = Just $ EqExpression (VarExpression "title") (TextExpression "why")
+                        , indexType = Nothing
                         }
                     , deferrable = Nothing
                     , deferrableType = Nothing
@@ -351,6 +405,7 @@ tests = do
                             [ ExcludeConstraintElement { element = "title", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Just True
                     , deferrableType = Nothing
@@ -366,6 +421,7 @@ tests = do
                             [ ExcludeConstraintElement { element = "title", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Just False
                     , deferrableType = Nothing
@@ -381,6 +437,7 @@ tests = do
                             [ ExcludeConstraintElement { element = "title", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Just True
                     , deferrableType = Just InitiallyImmediate
@@ -396,6 +453,7 @@ tests = do
                             [ ExcludeConstraintElement { element = "title", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Just True
                     , deferrableType = Just InitiallyDeferred

--- a/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -348,6 +348,21 @@ tests = do
                     , deferrableType = Nothing
                     }
 
+        it "should parse ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE USING btree .." do
+            parseSql "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE USING btree (title WITH =, author WITH =);" `shouldBe` AddConstraint
+                    { tableName = "posts"
+                    , constraint = ExcludeConstraint
+                        { name = "unique_title_by_author"
+                        , excludeElements =
+                            [ ExcludeConstraintElement { element = "title", operator = "=" }
+                            , ExcludeConstraintElement { element = "author", operator = "=" }
+                            ]
+                        , predicate = Nothing
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
+                    }
+
         it "should parse ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE .. WHERE .." do
             parseSql "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE (title WITH =, author WITH =) WHERE (title = 'why');" `shouldBe` AddConstraint
                     { tableName = "posts"

--- a/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -343,6 +343,7 @@ tests = do
                             , ExcludeConstraintElement { element = "author", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Nothing
                     , deferrableType = Nothing
@@ -358,6 +359,39 @@ tests = do
                             , ExcludeConstraintElement { element = "author", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Just Btree
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
+                    }
+
+        it "should parse ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE USING gin .." do
+            parseSql "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE USING gin (title WITH =, author WITH =);" `shouldBe` AddConstraint
+                    { tableName = "posts"
+                    , constraint = ExcludeConstraint
+                        { name = "unique_title_by_author"
+                        , excludeElements =
+                            [ ExcludeConstraintElement { element = "title", operator = "=" }
+                            , ExcludeConstraintElement { element = "author", operator = "=" }
+                            ]
+                        , predicate = Nothing
+                        , indexType = Just Gin
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
+                    }
+
+        it "should parse ALTER TABLE .. ADD CONSTRAINT .. EXCLUDE USING gist .." do
+            parseSql "ALTER TABLE posts ADD CONSTRAINT unique_title_by_author EXCLUDE USING gist (title WITH =, author WITH =);" `shouldBe` AddConstraint
+                    { tableName = "posts"
+                    , constraint = ExcludeConstraint
+                        { name = "unique_title_by_author"
+                        , excludeElements =
+                            [ ExcludeConstraintElement { element = "title", operator = "=" }
+                            , ExcludeConstraintElement { element = "author", operator = "=" }
+                            ]
+                        , predicate = Nothing
+                        , indexType = Just Gist
                         }
                     , deferrable = Nothing
                     , deferrableType = Nothing
@@ -373,6 +407,7 @@ tests = do
                             , ExcludeConstraintElement { element = "author", operator = "=" }
                             ]
                         , predicate = Just $ EqExpression (VarExpression "title") (TextExpression "why")
+                        , indexType = Nothing
                         }
                     , deferrable = Nothing
                     , deferrableType = Nothing
@@ -391,6 +426,7 @@ tests = do
                             , ExcludeConstraintElement { element = "i5", operator = "OR" }
                             ]
                         , predicate = Just $ EqExpression (VarExpression "title") (TextExpression "why")
+                        , indexType = Nothing
                         }
                     , deferrable = Nothing
                     , deferrableType = Nothing
@@ -405,6 +441,7 @@ tests = do
                             [ ExcludeConstraintElement { element = "title", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Just True
                     , deferrableType = Nothing
@@ -419,6 +456,7 @@ tests = do
                             [ ExcludeConstraintElement { element = "title", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Just True
                     , deferrableType = Just InitiallyImmediate
@@ -433,6 +471,7 @@ tests = do
                             [ ExcludeConstraintElement { element = "title", operator = "=" }
                             ]
                         , predicate = Nothing
+                        , indexType = Nothing
                         }
                     , deferrable = Just True
                     , deferrableType = Just InitiallyDeferred


### PR DESCRIPTION
Required for migrations to work, as pg_dump always sets the index type used for the exclude constraint.