### PR TITLE
Fix spelling of Postgres

### DIFF
--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -18,7 +18,7 @@ When the development server is running, you can connect to it via `postgresql://
 
 ### Connecting to DB via UI
 
-When the development server is running, you can use your favorite UI tool (e.g. [TablePlus](https://tableplus.com/)) that allows connecting to Postgress. To do that you would need the following credentials:
+When the development server is running, you can use your favorite UI tool (e.g. [TablePlus](https://tableplus.com/)) that allows connecting to Postgres. To do that you would need the following credentials:
 
 Database Host: This is the application root + "/build/db". Use this command on terminal form the root of you app and copy the output:
 ```


### PR DESCRIPTION
Changed `Postgress` to `Postgres`.