### PR TITLE
Add slot parameter for custom elements

### DIFF
--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -365,7 +365,7 @@ attributes = Set.fromList
         , "visibility", "word-spacing", "writing-mode", "is"
         , "cellspacing", "cellpadding", "bgcolor", "classes"
         , "loading"
-        , "frameborder", "allow", "allowfullscreen", "nonce", "referrerpolicy"
+        , "frameborder", "allow", "allowfullscreen", "nonce", "referrerpolicy", "slot"
         ]
 
 parents :: Set Text


### PR DESCRIPTION
To make slots for custom elements work, a `slot` parameter needs to be enabled.

Usage example:

```html
<my-paragraph>
  <span slot="my-text">Let's have some different text!</span>
</my-paragraph>
```

Source:
https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots#adding_flexibility_with_slots