### PR TITLE
Single Routing Entrypoint

### DIFF
--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -90,7 +90,7 @@ runAction controller = do
 
 applyContextSetter :: (TypeMap.TMap -> TypeMap.TMap) -> ControllerContext -> IO ControllerContext
 applyContextSetter setter ctx@ControllerContext { customFieldsRef } = do
-    modifyIORef customFieldsRef (applySetter setter)
+    modifyIORef' customFieldsRef (applySetter setter)
     pure $ ctx { customFieldsRef }
     where
         fromSetter :: (TypeMap.TMap -> TypeMap.TMap) -> TypeMap.TMap

--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -49,7 +49,7 @@ import qualified IHP.ErrorController as ErrorController
 import qualified Data.Typeable as Typeable
 import IHP.FrameworkConfig (FrameworkConfig (..), ConfigProvider(..))
 import qualified IHP.Controller.Context as Context
-import IHP.Controller.Context (ControllerContext)
+import IHP.Controller.Context (ControllerContext(ControllerContext), customFieldsRef)
 import Network.HTTP.Types.Header
 import qualified Data.Aeson as Aeson
 import qualified Network.Wai.Handler.WebSockets as WebSockets
@@ -93,15 +93,37 @@ runAction controller = do
 runActionWithContext :: forall application controller. (Controller controller, ?modelContext :: ModelContext, ?applicationContext :: ApplicationContext, ?requestContext :: RequestContext) => ControllerContext -> controller -> IO ResponseReceived
 runActionWithContext controllerContext controller = let ?context = controllerContext in runAction controller
 
+applyContextSetter :: (TypeMap.TMap -> TypeMap.TMap) -> ControllerContext -> IO ControllerContext
+applyContextSetter setter ctx@ControllerContext { customFieldsRef } = do
+    modifyIORef customFieldsRef (applySetter setter)
+    pure $ ctx { customFieldsRef }
+    where
+        fromSetter :: (TypeMap.TMap -> TypeMap.TMap) -> TypeMap.TMap
+        fromSetter f = f TypeMap.empty
+
+        applySetter :: (TypeMap.TMap -> TypeMap.TMap) -> TypeMap.TMap -> TypeMap.TMap
+        applySetter f map = TypeMap.union (fromSetter f) map
+
 {-# INLINE newContextForAction #-}
-newContextForAction :: forall application controller. (Controller controller, ?applicationContext :: ApplicationContext, ?context :: RequestContext, InitControllerContext application, ?application :: application, Typeable application, Typeable controller) => controller -> IO (Either (IO ResponseReceived) ControllerContext)
-newContextForAction controller = do
+newContextForAction
+    :: forall application controller
+     . ( Controller controller
+       , ?applicationContext :: ApplicationContext
+       , ?context :: RequestContext
+       , InitControllerContext application
+       , ?application :: application
+       , Typeable application
+       , Typeable controller
+       )
+    => (TypeMap.TMap -> TypeMap.TMap) -> controller -> IO (Either (IO ResponseReceived) ControllerContext)
+newContextForAction contextSetter controller = do
     let ?modelContext = ApplicationContext.modelContext ?applicationContext
     let ?requestContext = ?context
     controllerContext <- Context.newControllerContext
     let ?context = controllerContext
     Context.putContext ?application
     Context.putContext (Context.ActionType (Typeable.typeOf controller))
+    applyContextSetter contextSetter controllerContext
 
     try (initContext @application) >>= \case
         Left (exception :: SomeException) -> do
@@ -115,7 +137,7 @@ newContextForAction controller = do
 {-# INLINE runActionWithNewContext #-}
 runActionWithNewContext :: forall application controller. (Controller controller, ?applicationContext :: ApplicationContext, ?context :: RequestContext, InitControllerContext application, ?application :: application, Typeable application, Typeable controller) => controller -> IO ResponseReceived
 runActionWithNewContext controller = do
-    contextOrResponse <- newContextForAction controller
+    contextOrResponse <- newContextForAction (\t -> t) controller
     case contextOrResponse of
         Left response -> response
         Right context -> do

--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -89,10 +89,6 @@ runAction controller = do
 
     doRunAction `catches` [ Handler handleResponseException, Handler (\exception -> ErrorController.displayException exception controller "")]
 
-{-# INLINE runActionWithContext #-}
-runActionWithContext :: forall application controller. (Controller controller, ?modelContext :: ModelContext, ?applicationContext :: ApplicationContext, ?requestContext :: RequestContext) => ControllerContext -> controller -> IO ResponseReceived
-runActionWithContext controllerContext controller = let ?context = controllerContext in runAction controller
-
 applyContextSetter :: (TypeMap.TMap -> TypeMap.TMap) -> ControllerContext -> IO ControllerContext
 applyContextSetter setter ctx@ControllerContext { customFieldsRef } = do
     modifyIORef customFieldsRef (applySetter setter)
@@ -143,7 +139,8 @@ runActionWithNewContext controller = do
         Right context -> do
             let ?modelContext = ApplicationContext.modelContext ?applicationContext
             let ?requestContext = ?context
-            runActionWithContext context controller
+            let ?context = context
+            runAction controller
 
 -- | If 'IHP.LoginSupport.Helper.Controller.enableRowLevelSecurityIfLoggedIn' was called, this will copy the
 -- the prepared RowLevelSecurityContext from the controller context into the ModelContext.

--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -18,7 +18,6 @@ module IHP.ControllerSupport
 , InitControllerContext (..)
 , runActionWithNewContext
 , newContextForAction
-, runActionWithContext
 , respondAndExit
 , ResponseException (..)
 , jumpToAction

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -10,6 +10,7 @@ CanRoute (..)
 , frontControllerToWAIApp
 , withPrefix
 , FrontController (..)
+, defaultRouter
 , parseRoute
 , catchAll
 , mountFrontController
@@ -137,13 +138,13 @@ class FrontController application where
         => [RouteParser] -> RouteParser
     router = defaultRouter
 
-    defaultRouter
-        :: (?applicationContext :: ApplicationContext, ?application :: application, ?context :: RequestContext)
-        => [RouteParser] -> RouteParser
-    defaultRouter additionalControllers = do
-        let allControllers = controllers <> additionalControllers
-        ioResponseReceived <- choice $ map (\r -> r <* endOfInput) allControllers
-        pure ioResponseReceived
+defaultRouter
+    :: (?applicationContext :: ApplicationContext, ?application :: application, ?context :: RequestContext, FrontController application)
+    => [RouteParser] -> RouteParser
+defaultRouter additionalControllers = do
+    let allControllers = controllers <> additionalControllers
+    ioResponseReceived <- choice $ map (\r -> r <* endOfInput) allControllers
+    pure ioResponseReceived
 
 class HasPath controller where
     -- | Returns the path to a given action

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -27,6 +27,7 @@ CanRoute (..)
 , onlyAllowMethods
 , getMethod
 , routeParam
+, putContextRouter
 ) where
 
 import qualified Prelude
@@ -70,6 +71,12 @@ import IHP.Controller.Context
 import IHP.Controller.Param
 import qualified Data.TMap as TMap
 import qualified IHP.ApplicationContext as ApplicationContext
+
+putContextRouter :: forall value. (Typeable value) => value -> RouteParser -> RouteParser
+putContextRouter value parser = do
+    ioRouteResult <- parser
+    let ioRouteResult' = fmap (\(routeSetters, action) -> (routeSetters . TMap.insert value, action)) ioRouteResult
+    pure ioRouteResult'
 
 applyContextSetter :: (TMap.TMap -> TMap.TMap) -> ControllerContext -> IO ControllerContext
 applyContextSetter setter ctx@ControllerContext { customFieldsRef } = do

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -29,6 +29,7 @@ CanRoute (..)
 , getMethod
 , routeParam
 , putContextRouter
+, RouteParser
 ) where
 
 import qualified Prelude

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -97,7 +97,7 @@ runAction' controller contextSetter = do
     contextOrErrorResponse <- newContextForAction contextSetter controller
     case contextOrErrorResponse of
         Left res -> res
-        Right context -> runActionWithContext context controller
+        Right context -> let ?context = context in runAction controller
 
 type RouteParseResult = IO (TMap.TMap -> TMap.TMap, (TMap.TMap -> TMap.TMap) -> IO ResponseReceived)
 type RouteParser = Parser (RouteParseResult)

--- a/IHP/ServerSideComponent/RouterFunctions.hs
+++ b/IHP/ServerSideComponent/RouterFunctions.hs
@@ -27,7 +27,7 @@ routeComponent :: forall component controller application.
     , ?application :: application
     , ?applicationContext :: IHP.ApplicationContext.ApplicationContext
     , ?context :: RequestContext
-    ) => Parser (IO ResponseReceived)
+    ) => Parser (IO (TMap -> TMap, IO ResponseReceived))
 routeComponent = webSocketAppWithCustomPath @(ComponentsController component) @application ("SSC/" <> typeName)
     where
         typeName :: ByteString

--- a/IHP/ServerSideComponent/RouterFunctions.hs
+++ b/IHP/ServerSideComponent/RouterFunctions.hs
@@ -17,6 +17,7 @@ import IHP.ServerSideComponent.Controller.ComponentsController ()
 import Data.Aeson
 import IHP.ControllerSupport
 import IHP.ApplicationContext
+import IHP.RouterSupport (RouteParser)
 
 routeComponent :: forall component controller application.
     ( Typeable component
@@ -27,7 +28,7 @@ routeComponent :: forall component controller application.
     , ?application :: application
     , ?applicationContext :: IHP.ApplicationContext.ApplicationContext
     , ?context :: RequestContext
-    ) => Parser (IO (TMap -> TMap, IO ResponseReceived))
+    ) => RouteParser
 routeComponent = webSocketAppWithCustomPath @(ComponentsController component) @application ("SSC/" <> typeName)
     where
         typeName :: ByteString


### PR DESCRIPTION
This PR introduces an optional `router` function for `FrontController`s, which allows handling the routing for that FrontController only in that function, or extending the `defaultRouter`, which is the previous behavior. Additionally, the function allows using `putContextRouter`, a new function that is used to modify the `ControllerContext` during routing, ~*before*~ ~*after*~ *before* `initContext` is called.

The default implementation for `router` is `router = defaultRouter`, which is 100% backwards-compatible.

An example of why this is useful and how it is used is this router implementation:

```haskell
instance FrontController WebApplication where
    ... -- the previous code assigning controllers is still required

    router additionalControllers = do
        mlocale <- optional do
            string "/"
            string "en"

        let router = defaultRouter additionalControllers

        case mlocale of
            Just locale -> case locale of
                "en" -> putContextRouter EN_UK router
                _ -> IHP.RouterPrelude.error "This should be unreachable"
            Nothing -> router
```

This handles all routes as before but also allows an optional `/en` to be added in front of all routes. In case it is added, the `ControllerContext` is modified to contain a locale (`EN_UK`), which allows the application to show in English (instead of the default German for this application).

~The `additionalControllers` are the `controllers` of the `FrontController`, and the other controllers added by IHP by default (for example for DataSync).~
The `additionalControllers` are the controllers added by IHP by default (for example for DataSync). The controllers of the `FrontController` itself are accessible via the typeclass' `controllers` function.

Since `controllers` returns a list of `RouteParser`s, it is possible to nest these custom routers using `mountFrontController` as before. This means it is possible to override all routing by implementing `router` for the `RootApplication`.

---

Since implementing the `router` function can change how routes are handled, it can also break using `pathTo`, `urlTo`, or implicit `pathTo` in HSX. In the future, `pathTo` should be made `ControllerContext`-aware so those methods can be compatible with the `router`. In the meantime, I suggest not adding this feature to the documentation yet, to avoid unnecessary confusion.

As an example, in the above application, none of `pathTo`, `urlTo`, or implicit `pathTo` in HSX would ever result in an `/en` being added to the url. By making `pathTo` `ControllerContext`-aware, it could read the current locale from context, and prepend `/en` to the path if the locale is `EN_UK`. As a workaround for this application, a `localizedPathTo` and `localizedUrlTo` will be added, which does this, but care has to be taken to use these functions instead of `pathTo` and `urlTo`, and implicit `pathTo` cannot be used.

---

**Edit:** updated the PR text to match actual behavior that I wrongly remembered.