### PR TITLE
Enable record dot syntax

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -39,5 +39,6 @@
 :set -XStandaloneDeriving
 :set -XDerivingVia
 :set -XDeepSubsumption
+:set -XOverloadedRecordDot
 :set -Werror=missing-fields
 :set -fwarn-incomplete-patterns

--- a/IHP/Fetch.hs
+++ b/IHP/Fetch.hs
@@ -107,7 +107,7 @@ instance (model ~ GetModelByTableName table, KnownSymbol table, FromField value,
 
 
 {-# INLINE commonFetch #-}
-commonFetch :: forall model table queryBuilderProvider joinRegister.(Table model, HasQueryBuilder queryBuilderProvider joinRegister, model ~ GetModelByTableName table, KnownSymbol table, PG.FromRow model, ?modelContext :: ModelContext) => queryBuilderProvider table -> IO [model]
+commonFetch :: forall model table queryBuilderProvider joinRegister. (Table model, HasQueryBuilder queryBuilderProvider joinRegister, model ~ GetModelByTableName table, KnownSymbol table, PG.FromRow model, ?modelContext :: ModelContext) => queryBuilderProvider table -> IO [model]
 commonFetch !queryBuilder = do
     let !(theQuery, theParameters) = queryBuilder
             |> toSQL
@@ -115,7 +115,7 @@ commonFetch !queryBuilder = do
     sqlQuery (Query $ cs theQuery) theParameters
 
 {-# INLINE commonFetchOneOrNothing #-}
-commonFetchOneOrNothing :: forall model table queryBuilderProvider joinRegister.(?modelContext :: ModelContext) => (Table model, KnownSymbol table, HasQueryBuilder queryBuilderProvider joinRegister, PG.FromRow model) => queryBuilderProvider table -> IO (Maybe model)
+commonFetchOneOrNothing :: forall model table queryBuilderProvider joinRegister. (?modelContext :: ModelContext) => (Table model, KnownSymbol table, HasQueryBuilder queryBuilderProvider joinRegister, PG.FromRow model) => queryBuilderProvider table -> IO (Maybe model)
 commonFetchOneOrNothing !queryBuilder = do
     let !(theQuery, theParameters) = queryBuilder
             |> buildQuery
@@ -126,7 +126,7 @@ commonFetchOneOrNothing !queryBuilder = do
     pure $ listToMaybe results
 
 {-# INLINE commonFetchOne #-}
-commonFetchOne :: forall model table queryBuilderProvider joinRegister.(?modelContext :: ModelContext) => (Table model, KnownSymbol table, Fetchable (queryBuilderProvider table) model, HasQueryBuilder queryBuilderProvider joinRegister, PG.FromRow model) => queryBuilderProvider table -> IO model
+commonFetchOne :: forall model table queryBuilderProvider joinRegister. (?modelContext :: ModelContext) => (Table model, KnownSymbol table, Fetchable (queryBuilderProvider table) model, HasQueryBuilder queryBuilderProvider joinRegister, PG.FromRow model) => queryBuilderProvider table -> IO model
 commonFetchOne !queryBuilder = do
     maybeModel <- fetchOneOrNothing queryBuilder
     case maybeModel of

--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -151,7 +151,7 @@ hsxSplicedAttributes = do
     name <- between (string "{...") (string "}") (takeWhile1P Nothing (\c -> c /= '}'))
     space
     haskellExpression <- case Haskell.parseExp (cs name) of
-            Right expression -> pure (patchExpr expression)
+            Right expression -> pure expression
             Left error -> fail (show error)
     pure (SpreadAttributes haskellExpression)
 
@@ -207,7 +207,7 @@ hsxSplicedValue :: Parser AttributeValue
 hsxSplicedValue = do
     value <- between (char '{') (char '}') (takeWhile1P Nothing (\c -> c /= '}'))
     haskellExpression <- case Haskell.parseExp (cs value) of
-            Right expression -> pure (patchExpr expression)
+            Right expression -> pure expression
             Left error -> fail (show error)
     pure (ExpressionValue haskellExpression)
 
@@ -238,7 +238,7 @@ hsxSplicedNode :: Parser Node
 hsxSplicedNode = do
         expression <- doParse
         haskellExpression <- case Haskell.parseExp (cs expression) of
-                Right expression -> pure (patchExpr expression)
+                Right expression -> pure expression
                 Left error -> fail (show error)
         pure (SplicedNode haskellExpression)
     where
@@ -593,40 +593,3 @@ collapseSpace text = cs $ filterDuplicateSpaces (cs text)
         filterDuplicateSpaces' (char:rest) False | Char.isSpace char = ' ':(filterDuplicateSpaces' rest True)
         filterDuplicateSpaces' (char:rest) isRemovingSpaces = char:(filterDuplicateSpaces' rest False)
         filterDuplicateSpaces' [] isRemovingSpaces = []
-
-
-patchExpr :: TH.Exp -> TH.Exp
-patchExpr (TH.UInfixE (TH.VarE varName) (TH.VarE hash) (TH.VarE labelValue)) | hash == TH.mkName "#" = TH.AppE (TH.VarE varName) fromLabel
-    where
-            fromLabel = TH.AppTypeE (TH.VarE (TH.mkName "fromLabel")) (TH.LitT (TH.StrTyLit (show labelValue)))
---- UInfixE (UInfixE a (VarE |>) (VarE get)) (VarE #) (VarE firstName)
-patchExpr input@(TH.UInfixE (TH.UInfixE a (TH.VarE arrow) (TH.VarE get)) (TH.VarE hash) (TH.VarE labelValue)) | (hash == TH.mkName "#") && (arrow == TH.mkName "|>") && (get == TH.mkName "get") =
-        (TH.UInfixE (patchExpr a) (TH.VarE arrow) (TH.AppE (TH.VarE get) fromLabel))
-    where
-            fromLabel = TH.AppTypeE (TH.VarE (TH.mkName "fromLabel")) (TH.LitT (TH.StrTyLit (show labelValue)))
--- UInfixE (UInfixE a (VarE $) (VarE get)) (VarE #) (AppE (VarE id) (VarE checklist))
-patchExpr (TH.UInfixE (TH.UInfixE a b get) (TH.VarE hash) (TH.AppE (TH.VarE labelValue) (TH.VarE d))) | (hash == TH.mkName "#") =
-        TH.UInfixE (patchExpr a) (patchExpr b) (TH.AppE (TH.AppE get fromLabel) (TH.VarE d))
-    where
-            fromLabel = TH.AppTypeE (TH.VarE (TH.mkName "fromLabel")) (TH.LitT (TH.StrTyLit (show labelValue)))
-patchExpr (TH.UInfixE (TH.VarE varName) (TH.VarE hash) (TH.AppE (TH.VarE labelValue) arg)) | hash == TH.mkName "#" = TH.AppE (TH.AppE (TH.VarE varName) fromLabel) arg
-    where
-            fromLabel = TH.AppTypeE (TH.VarE (TH.mkName "fromLabel")) (TH.LitT (TH.StrTyLit (show labelValue)))
-patchExpr (TH.UInfixE (TH.VarE a) (TH.VarE hash) (TH.AppE (TH.VarE labelValue) (TH.VarE b))) | hash == TH.mkName "#" =
-        TH.AppE (TH.AppE (TH.VarE a) fromLabel) (TH.VarE b)
-    where
-            fromLabel = TH.AppTypeE (TH.VarE (TH.mkName "fromLabel")) (TH.LitT (TH.StrTyLit (show labelValue)))
-
-patchExpr (TH.UInfixE a b c) = TH.UInfixE (patchExpr a) (patchExpr b) (patchExpr c)
-patchExpr (TH.ParensE e) = TH.ParensE (patchExpr e)
-patchExpr (TH.RecUpdE a b) = TH.RecUpdE (patchExpr a) b
-patchExpr (TH.AppE a b) = TH.AppE (patchExpr a) (patchExpr b)
-patchExpr (TH.LamE a b) = TH.LamE a (patchExpr b)
-patchExpr (TH.LetE a b) = TH.LetE a' (patchExpr b)
-    where
-        a' = List.map patchDec a
-        patchDec (TH.ValD a (TH.NormalB b) c) = (TH.ValD a (TH.NormalB (patchExpr b)) c)
-        patchDec a = a
-patchExpr (TH.CondE a b c) = TH.CondE (patchExpr a) (patchExpr b) (patchExpr c)
-patchExpr (TH.SigE a b) = TH.SigE (patchExpr a) b
-patchExpr e = e

--- a/ihp-hsx/ihp-hsx.cabal
+++ b/ihp-hsx/ihp-hsx.cabal
@@ -29,6 +29,7 @@ library
         , haskell-src-meta   >= 0.8.7 && < 0.9
         , megaparsec         >= 9.0.1 && < 9.3
         , string-conversions >= 0.4.0 && < 0.5
+        , haskell-src-exts
     default-extensions:
         OverloadedStrings
         , NoImplicitPrelude

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -137,6 +137,7 @@ common shared-properties
         , LambdaCase
         , StandaloneDeriving
         , TemplateHaskell
+        , OverloadedRecordDot
     if flag(FastBuild)
         ghc-options:
             -j

--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -57,6 +57,7 @@ GHC_EXTENSIONS+= -Werror=missing-fields
 GHC_EXTENSIONS+= -fwarn-incomplete-patterns
 GHC_EXTENSIONS+= -XTemplateHaskell
 GHC_EXTENSIONS+= -XDeepSubsumption
+GHC_EXTENSIONS+= -XOverloadedRecordDot
 
 GHC_RTS_FLAGS := -A256m -n2m -N
 

--- a/lib/IHP/applicationGhciConfig
+++ b/lib/IHP/applicationGhciConfig
@@ -46,5 +46,6 @@
 :set -XDerivingVia
 :set -XTemplateHaskell
 :set -XDeepSubsumption
+:set -XOverloadedRecordDot
 :set -Werror=missing-fields
 :set -fwarn-incomplete-patterns


### PR DESCRIPTION
This branch allows us to use GHC's new record dot syntax in IHP projects:

```haskell
-- old:
get #id project

--new:
project.id
```

This syntax doesn't work in HSX yet sadly.