### PR TITLE
Run `:l Main` automatically when opening ghci

### DIFF
--- a/exe/IHP/IDE/DevServer.hs
+++ b/exe/IHP/IDE/DevServer.hs
@@ -288,7 +288,6 @@ startAppGHCI = do
             [ ":script " <> cs libDirectory <> "/applicationGhciConfig"
             , ":set prompt \"\"" -- Disable the prompt as this caused output such as '[38;5;208mIHP>[m Ser[v3e8r; 5s;t2a0r8tmedI' instead of 'Server started'
             , "import qualified ClassyPrelude"
-            , ":l Main.hs"
             ]
 
     async $ forever $ ByteString.hGetLine outputHandle >>= \line -> do

--- a/lib/IHP/applicationGhciConfig
+++ b/lib/IHP/applicationGhciConfig
@@ -49,3 +49,5 @@
 :set -XOverloadedRecordDot
 :set -Werror=missing-fields
 :set -fwarn-incomplete-patterns
+:set -package ghc
+:l Main.hs


### PR DESCRIPTION
Fixes #1506

This mirror the expected behaviour when running e.g. `import Web.Types` (this fails without a `:l Main` first)