### PR TITLE
Hsx conpat

### DIFF
--- a/Guide/scripts.markdown
+++ b/Guide/scripts.markdown
@@ -64,6 +64,29 @@ This is made possible because of the [she-bang line](https://en.wikipedia.org/wi
 
 In case you get a permission error, try to add the executable flag via `chmod +x Application/Script/HelloWorldToAllUsers.hs`.
 
+## Running a script from ghci
+
+You can also open a ghci prompt to test features in scripts interactively.
+
+```bash
+make ghci
+```
+
+Then you can load your script into the interpreter:
+```
+:l Application/Scripts/MyScript
+```
+
+and run the script from the IHP ghci command line:
+
+```haskell
+IHP> runScript ihpDefaultConfig runTestName
+```
+
+The `ihpDefaultConfig` is made available from the `Application.Script.Prelude` import but can be substituted
+with your own `Config` data structure. This is particularly useful for adjusting logging levels or
+testing new APIs that require certain configuration variables.
+
 ## Building a script
 
 In production, you might want to build a script to a binary for performance reasons. Use make like this:

--- a/Test/HSX/QQSpec.hs
+++ b/Test/HSX/QQSpec.hs
@@ -31,6 +31,16 @@ tests = do
             let project = Project { name = "Testproject" }
             [hsx|<h1>Project: {get #name project}</h1>|] `shouldBeHtml` "<h1>Project: Testproject</h1>"
 
+        it "should support lambdas and pattern matching on constructors" do
+            let placeData = PlaceId "Punches Cross"
+            [hsx|<h1>{(\(PlaceId x) -> x)(placeData)}</h1>|] `shouldBeHtml` "<h1>Punches Cross</h1>"
+
+        it "should support infix notation for standard constructors e.g. (:):" do
+            [hsx| <h1>{show $ (:) 1  [2,3,42]}</h1> |] `shouldBeHtml` "<h1>[1,2,3,42]</h1>"
+
+        it "should support infix notation for standard constructors e.g. (,):" do
+            [hsx|<h1>{((,) 1 2)}</h1>|] `shouldBeHtml` "<h1>(1,2)</h1>"
+
         it "should support self closing tags" do
             [hsx|<input>|] `shouldBeHtml` "<input>"
             [hsx|<br><br/>|] `shouldBeHtml` "<br><br>"
@@ -159,12 +169,12 @@ tests = do
                     ("hello", "world")
                     ]
             [hsx|<div {...customAttributes}></div>|] `shouldBeHtml` "<div hello=\"world\"></div>"
-        
+
         it "should handle spread attributes with a list" do
             -- See https://github.com/digitallyinduced/ihp/issues/1226
 
             [hsx|<div {...[ ("data-hoge" :: Text, "Hello World!" :: Text) ]}></div>|] `shouldBeHtml` "<div data-hoge=\"Hello World!\"></div>"
-        
+
         it "should support pre escaped class names" do
             -- See https://github.com/digitallyinduced/ihp/issues/1527
 
@@ -172,5 +182,14 @@ tests = do
             [hsx|<div class={className}></div>|] `shouldBeHtml` "<div class=\"a&\"></div>"
 
 data Project = Project { name :: Text }
+
+data PlaceId  = PlaceId Text
+data LocationId  = LocationId Int PlaceId
+newtype NewPlaceId = NewPlaceId Text
+
+newPlaceData = NewPlaceId "New Punches Cross"
+locationId = LocationId 17 (PlaceId "Punches Cross")
+
+
 
 shouldBeHtml hsx expectedHtml = (Blaze.renderMarkup hsx) `shouldBe` expectedHtml

--- a/ihp-hsx/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/IHP/HSX/HsExpToTH.hs
@@ -71,11 +71,14 @@ toName n = case n of
 toFieldExp :: a
 toFieldExp = undefined
 
+-- Th.ConP Name [Type] [Pat]
+-- ConPat (XConPat p) (XRec p (ConLikeP p)) (HsConPatDetails p)
+-- type XConPat GhcRn = NoExtField see
 toPat :: Pat.Pat GhcPs -> TH.Pat
 toPat (Pat.VarPat _ (unLoc -> name)) = TH.VarP (toName name)
 toPat (TuplePat _ p _) = TH.TupP (map (toPat . unLoc) p)
 toPat (ParPat xP lP) = (toPat . unLoc) lP --error "TH.ParPat not implemented"
-toPat (ConPat pat_con pat_args pat_con_ext) = TH.ConP (toName pat_con) () --error "TH.ConstructorPattern not implemented"
+toPat (ConPat pat_con_ext pat_con pat_args) = TH.ConP (toName pat_con_ext) (map toType (pat_con)) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
 toPat (ViewPat pat_con pat_args pat_con_ext) = error "TH.ViewPattern not implemented"
 toPat (SumPat _ _ _ _) = error "TH.SumPat not implemented"
 toPat (WildPat _ ) = error "TH.WildPat not implemented"

--- a/ihp-hsx/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/IHP/HSX/HsExpToTH.hs
@@ -79,7 +79,8 @@ toPat :: Pat.Pat GhcPs -> TH.Pat
 toPat (Pat.VarPat _ (unLoc -> name)) = TH.VarP (toName name)
 toPat (TuplePat _ p _) = TH.TupP (map (toPat . unLoc) p)
 toPat (ParPat xP lP) = (toPat . unLoc) lP --error "TH.ParPat not implemented"
-toPat (ConPat pat_con_ext pat_con pat_args) = TH.ConP (toName pat_con_ext) (map toType (map hsLPatType (Pat.hsConPatArgs pat_args))) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
+toPat (ConPat pat_con_ext ((unLoc -> name)) pat_args) = TH.ConP (toName name) (map toType []) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
+--toPat (ConPat pat_con_ext pat_con pat_args) = TH.ConP (toName pat_con_ext) (map (toType . unLoc) (hsPatSigType pat_args)) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
 toPat (ViewPat pat_con pat_args pat_con_ext) = error "TH.ViewPattern not implemented"
 toPat (SumPat _ _ _ _) = error "TH.SumPat not implemented"
 toPat (WildPat _ ) = error "TH.WildPat not implemented"

--- a/ihp-hsx/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/IHP/HSX/HsExpToTH.hs
@@ -65,8 +65,8 @@ toName :: RdrName -> TH.Name
 toName n = case n of
   (Unqual o) -> TH.mkName (occNameString o)
   (Qual m o) -> TH.mkName (Module.moduleNameString m <> "." <> occNameString o)
+  (Exact name) -> TH.mkName ((occNameString . rdrNameOcc . getRdrName) name) --error "exact"
   (Orig _ _) -> error "orig"
-  (Exact _) -> error "exact"
 
 toFieldExp :: a
 toFieldExp = undefined

--- a/ihp-hsx/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/IHP/HSX/HsExpToTH.hs
@@ -14,6 +14,7 @@ import GHC.Hs.Expr as Expr
 import GHC.Hs.Extension as Ext
 import GHC.Hs.Pat as Pat
 import GHC.Hs.Lit
+import qualified GHC.Hs.Utils as Utils
 import qualified Data.ByteString as B
 import qualified Language.Haskell.TH.Syntax as TH
 import GHC.Types.SrcLoc
@@ -27,6 +28,7 @@ import qualified GHC.Unit.Module as Module
 import GHC.Stack
 import qualified Data.List.NonEmpty as NonEmpty
 import Language.Haskell.Syntax.Type
+
 
 fl_value = rationalFromFractionalLit
 
@@ -72,6 +74,12 @@ toFieldExp = undefined
 toPat :: Pat.Pat GhcPs -> TH.Pat
 toPat (Pat.VarPat _ (unLoc -> name)) = TH.VarP (toName name)
 toPat (TuplePat _ p _) = TH.TupP (map (toPat . unLoc) p)
+toPat (ParPat xP lP) = (toPat . unLoc) lP --error "TH.ParPat not implemented"
+toPat (ConPat pat_con pat_args pat_con_ext) = TH.ConP (toName pat_con) () --error "TH.ConstructorPattern not implemented"
+toPat (ViewPat pat_con pat_args pat_con_ext) = error "TH.ViewPattern not implemented"
+toPat (SumPat _ _ _ _) = error "TH.SumPat not implemented"
+toPat (WildPat _ ) = error "TH.WildPat not implemented"
+toPat (NPat _ _ _ _ ) = error "TH.NPat not implemented"
 toPat p = todo "toPat" p
 
 toExp :: Expr.HsExpr GhcPs -> TH.Exp

--- a/ihp-hsx/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/IHP/HSX/HsExpToTH.hs
@@ -74,11 +74,12 @@ toFieldExp = undefined
 -- Th.ConP Name [Type] [Pat]
 -- ConPat (XConPat p) (XRec p (ConLikeP p)) (HsConPatDetails p)
 -- type XConPat GhcRn = NoExtField see
+-- Looks like we need the https://hackage.haskell.org/package/ghc-9.4.2/docs/GHC-Hs-Syn-Type.html hsLPatType :: LPat GhcTc -> Type
 toPat :: Pat.Pat GhcPs -> TH.Pat
 toPat (Pat.VarPat _ (unLoc -> name)) = TH.VarP (toName name)
 toPat (TuplePat _ p _) = TH.TupP (map (toPat . unLoc) p)
 toPat (ParPat xP lP) = (toPat . unLoc) lP --error "TH.ParPat not implemented"
-toPat (ConPat pat_con_ext pat_con pat_args) = TH.ConP (toName pat_con_ext) (map toType (pat_con)) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
+toPat (ConPat pat_con_ext pat_con pat_args) = TH.ConP (toName pat_con_ext) (map toType (map hsLPatType (Pat.hsConPatArgs pat_args))) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
 toPat (ViewPat pat_con pat_args pat_con_ext) = error "TH.ViewPattern not implemented"
 toPat (SumPat _ _ _ _) = error "TH.SumPat not implemented"
 toPat (WildPat _ ) = error "TH.WildPat not implemented"

--- a/ihp-hsx/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/IHP/HSX/HsExpToTH.hs
@@ -71,16 +71,11 @@ toName n = case n of
 toFieldExp :: a
 toFieldExp = undefined
 
--- Th.ConP Name [Type] [Pat]
--- ConPat (XConPat p) (XRec p (ConLikeP p)) (HsConPatDetails p)
--- type XConPat GhcRn = NoExtField see
--- Looks like we need the https://hackage.haskell.org/package/ghc-9.4.2/docs/GHC-Hs-Syn-Type.html hsLPatType :: LPat GhcTc -> Type
 toPat :: Pat.Pat GhcPs -> TH.Pat
 toPat (Pat.VarPat _ (unLoc -> name)) = TH.VarP (toName name)
 toPat (TuplePat _ p _) = TH.TupP (map (toPat . unLoc) p)
-toPat (ParPat xP lP) = (toPat . unLoc) lP --error "TH.ParPat not implemented"
-toPat (ConPat pat_con_ext ((unLoc -> name)) pat_args) = TH.ConP (toName name) (map toType []) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
---toPat (ConPat pat_con_ext pat_con pat_args) = TH.ConP (toName pat_con_ext) (map (toType . unLoc) (hsPatSigType pat_args)) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))  --error "TH.ConstructorPattern not implemented"
+toPat (ParPat xP lP) = (toPat . unLoc) lP
+toPat (ConPat pat_con_ext ((unLoc -> name)) pat_args) = TH.ConP (toName name) (map toType []) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))
 toPat (ViewPat pat_con pat_args pat_con_ext) = error "TH.ViewPattern not implemented"
 toPat (SumPat _ _ _ _) = error "TH.SumPat not implemented"
 toPat (WildPat _ ) = error "TH.WildPat not implemented"


### PR DESCRIPTION
Mapped a few more data types from HsSyn to TH. Pattern matching on Constructors and infix operators like (:), (,) should now work in [hsx||] blocks. This should address issue #1495. Note the Constructors in hsx blocks don't support Type Annotations (may require ghc 9.4.2?).  