### PR TITLE
fix, ssc createNode operation bug, when target node (by path) is a tex…

### DIFF
--- a/lib/IHP/static/vendor/ihp-ssc.js
+++ b/lib/IHP/static/vendor/ihp-ssc.js
@@ -75,7 +75,12 @@ function evaluateNodeOperation(component, nodeOperation) {
 
 function createNode(component, nodeOperation) {
     var newElement = htmlStringToDomNode(nodeOperation.html);
-    nodeOperation.domNode.appendChild(newElement);
+    var domNode = nodeOperation.domNode;
+    if (domNode.nodeType == Node.TEXT_NODE) {
+        domNode.replaceWith(newElement);
+    } else {
+        domNode.appendChild(newElement);
+    }
 }
 
 function updateTextContent(component, nodeOperation) {


### PR DESCRIPTION
when I have a SSC e.g. with following DOM:

https://gist.github.com/leobm/6828c3db6398a4cd17518e55274dc450

and do the SSC Action and get following patchsets:

`[{ "type": "UpdateNode", "attributeOperations": [{ "type": "UpdateAttribute", "attributeName": "class", "attributeValue": "form-control is-invalid is-invalid" }], "path": [1, 0, 0] }, { "type": "CreateNode", "html": "<div class=\"invalid-feedback\">Not a valid YouTube URL</div>", "path": [2, 0, 0] }]`

I expect following final target HTML by this patchset.
https://gist.github.com/leobm/ee3e5e5b0c355ff9552bbeb48e95627c
 
but in the master branch the patchset failed, because we can't call the appendChild DOM method on a text node.
so I made this patch, which in that case replaces the text node with the DOM replaceWith method.
