### PR TITLE
 fix zsh config in ihp-new

### DIFF
--- a/ProjectGenerator/bin/ihp-new
+++ b/ProjectGenerator/bin/ihp-new
@@ -103,7 +103,7 @@ if ! [ -x "$(command -v direnv)" ]; then
 				case "${SHELL##*/}" in
 				zsh )
 					echo "Adding hook to ~/.zshrc...";
-					echo 'eval "$(direnv hook bash)"' >> $HOME/.zshrc
+					echo 'eval "$(direnv hook zsh)"' >> $HOME/.zshrc
 					DIRENV_HOOK_ADDED=1
 					;;
 				bash )


### PR DESCRIPTION
 ## Why is the change being made?

 this was misconfiguring direnv for zsh shells previously