### PR TITLE
Fix modal close button

### DIFF
--- a/IHP/Modal/ViewFunctions.hs
+++ b/IHP/Modal/ViewFunctions.hs
@@ -45,9 +45,7 @@ renderModalHeader :: Text -> Text -> Html
 renderModalHeader title closeUrl = [hsx|
     <div class="modal-header">
       <h5 class="modal-title" id="modal-title">{title}</h5>
-      <a href={closeUrl} class="btn-link close" data-dismiss="modal" aria-label="Close">
-        <span aria-hidden="true">{preEscapedText "&times;"}</span>
-      </a>
+      <a href={closeUrl} class="btn-close" data-dismiss="modal" aria-label="Close"></a>
     </div>
 |]
 


### PR DESCRIPTION
I replaced the close button previously used for modals using the times-symbol, which looks bad in Bootstrap 5. It now uses the new btn-close class (instead of the old close class).

See:
- https://getbootstrap.com/docs/5.2/migration/#close-button
- https://getbootstrap.com/docs/5.2/components/modal/#modal-components

Note that I tested the HTML code changes in the developer console of my browser, but haven't tested this change in an actual IHP project yet.