### PR TITLE
Add backoff strategy when a PGListener fails

### DIFF
--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -245,7 +245,7 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                         Just (error :: AsyncCancelled) -> throw error
                         notification -> do
                             let ?context = ?modelContext -- Log onto the modelContext logger
-                            Log.info ("PGListener is going to restart, loop failed with exception: " <> displayException error <> ". Retrying in " <> formatTimeUnits nextDelay <> ".")
+                           
 
 
                             -- Sleep for the current delay 
@@ -254,13 +254,14 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                             let increasedDelay = delay * 2
                             -- Picks whichever delay is lowest of increasedDelay * 2 or maxDelay
                             let nextDelay = min increasedDelay maxDelay
+                            Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRety nextDelay) <> ".")
                             retryLoop nextDelay
                 Right _ -> pure ()
     retryLoop initialDelay
 
 printTimeToNextRety :: Int -> Text
 printTimeToNextRety microseconds
-    | microseconds >= 1000000 = show (microseconds `div` 1000000) ++ " s"
+    | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " s"
     | microseconds >= 1000 = show (microseconds `div` 1000) ++ " ms"
     | otherwise = show microseconds ++ " µs"
 

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -251,7 +251,7 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                             let increasedDelay = delay * 2
                             -- Picks whichever delay is lowest of increasedDelay * 2 or maxDelay
                             let nextDelay = min increasedDelay maxDelay
-                            Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRety nextDelay) <> ".")
+                            Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRetry nextDelay) <> ".")
                             retryLoop nextDelay
                 Right _ -> pure ()
     retryLoop initialDelay

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -257,10 +257,10 @@ notifyLoop listeningToVar listenToVar subscriptions = do
 
 printTimeToNextRetry :: Int -> Text
 printTimeToNextRetry microseconds
-    | microseconds >= 1000 =  show (microseconds `div` 1000000) ++ " min"
-    | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " s"
-    | microseconds >= 1000 = show (microseconds `div` 1000) ++ " ms"
-    | otherwise = show microseconds ++ " µs"
+    | microseconds >= 1000 =  show (microseconds `div` 1000000) <> " min"
+    | microseconds >= 1000000 =  show (microseconds `div` 1000000) <> " s"
+    | microseconds >= 1000 = show (microseconds `div` 1000) <> " ms"
+    | otherwise = show microseconds <> " µs"
 
 listenToChannel :: PG.Connection -> Channel -> IO ()
 listenToChannel databaseConnection channel = do

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -251,7 +251,7 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                             else do
                                 let increasedDelay = delay * 2 -- Double current delay
                                 let nextDelay = min increasedDelay maxDelay -- Picks whichever delay is lowest of increasedDelay * 2 or maxDelay
-                                Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRetry nextDelay) <> ".")
+                                Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRetry delay) <> ".")
                                 Control.Concurrent.threadDelay delay -- Sleep for the current delay
                                 retryLoop nextDelay False -- Retry with longer interval
                 Right _ -> 

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -252,7 +252,7 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                             -- Double current delay
                             let increasedDelay = delay * 2
                             -- Picks whichever delay is lowest of increasedDelay * 2 or maxDelay
-                            let nextDelay = (min increasedDelay maxDelay)
+                            let nextDelay = min increasedDelay maxDelay
                             retryLoop nextDelay
                 Right _ -> pure ()
     retryLoop initialDelay

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -260,7 +260,7 @@ notifyLoop listeningToVar listenToVar subscriptions = do
 
 printTimeToNextRetry :: Int -> Text
 printTimeToNextRetry microseconds
-    | microseconds >= 1000 =  show (microseconds `div` 1000000) <> " min"
+    | microseconds >= 1000000000 =  show (microseconds `div` 1000000000) <> " min"
     | microseconds >= 1000000 =  show (microseconds `div` 1000000) <> " s"
     | microseconds >= 1000 = show (microseconds `div` 1000) <> " ms"
     | otherwise = show microseconds <> " µs"

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -251,8 +251,8 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                             else do
                                 let increasedDelay = delay * 2 -- Double current delay
                                 let nextDelay = min increasedDelay maxDelay -- Picks whichever delay is lowest of increasedDelay * 2 or maxDelay
-                                Control.Concurrent.threadDelay delay -- Sleep for the current delay
                                 Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRetry nextDelay) <> ".")
+                                Control.Concurrent.threadDelay delay -- Sleep for the current delay
                                 retryLoop nextDelay False -- Retry with longer interval
                 Right _ -> 
                     retryLoop initialDelay True -- If all went well, re-run with no sleeping and reset current delay to the initial value

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -259,8 +259,8 @@ notifyLoop listeningToVar listenToVar subscriptions = do
 
 printTimeToNextRetry :: Int -> Text
 printTimeToNextRetry microseconds
-    | microseconds >= 1000 =  show (microseconds `div` 1000000) ++ " minutes"
-    | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " seconds"
+    | microseconds >= 1000 =  show (microseconds `div` 1000000) ++ " min"
+    | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " s"
     | microseconds >= 1000 = show (microseconds `div` 1000) ++ " ms"
     | otherwise = show microseconds ++ " µs"
 

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -236,7 +236,7 @@ notifyLoop listeningToVar listenToVar subscriptions = do
     let initialDelay = 500 * 1000
     -- Max delay (in microseconds)
     let maxDelay = 60 * 1000 * 1000
-
+    -- This outer loop restarts the listeners if the database connection dies (e.g. due to a timeout)
     let retryLoop delay = do
             result <- Exception.try innerLoop
             case result of

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -245,13 +245,14 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                         Just (error :: AsyncCancelled) -> throw error
                         notification -> do
                             let ?context = ?modelContext -- Log onto the modelContext logger
-                            -- Sleep for the current delay 
-                            Control.Concurrent.threadDelay delay
+
                             -- Double current delay
                             let increasedDelay = delay * 2
                             -- Picks whichever delay is lowest of increasedDelay * 2 or maxDelay
                             let nextDelay = min increasedDelay maxDelay
                             Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRetry nextDelay) <> ".")
+                            -- Sleep for the current delay 
+                            Control.Concurrent.threadDelay delay
                             retryLoop nextDelay
                 Right _ -> 
                     retryLoop initialDelay

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -259,8 +259,8 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                 Right _ -> pure ()
     retryLoop initialDelay
 
-printTimeToNextRety :: Int -> Text
-printTimeToNextRety microseconds
+printTimeToNextRetry :: Int -> Text
+printTimeToNextRetry microseconds
     | microseconds >= 1000 =  show (microseconds `div` 1000000) ++ " min"
     | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " s"
     | microseconds >= 1000 = show (microseconds `div` 1000) ++ " ms"

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -245,9 +245,6 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                         Just (error :: AsyncCancelled) -> throw error
                         notification -> do
                             let ?context = ?modelContext -- Log onto the modelContext logger
-                           
-
-
                             -- Sleep for the current delay 
                             Control.Concurrent.threadDelay delay
                             -- Double current delay
@@ -261,8 +258,8 @@ notifyLoop listeningToVar listenToVar subscriptions = do
 
 printTimeToNextRetry :: Int -> Text
 printTimeToNextRetry microseconds
-    | microseconds >= 1000 =  show (microseconds `div` 1000000) ++ " min"
-    | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " s"
+    | microseconds >= 1000 =  show (microseconds `div` 1000000) ++ " minutes"
+    | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " seconds"
     | microseconds >= 1000 = show (microseconds `div` 1000) ++ " ms"
     | otherwise = show microseconds ++ " µs"
 

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -253,7 +253,8 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                             let nextDelay = min increasedDelay maxDelay
                             Log.info ("PGListener is going to restart, loop failed with exception: " <> (displayException error) <> ". Retrying in " <> cs (printTimeToNextRetry nextDelay) <> ".")
                             retryLoop nextDelay
-                Right _ -> pure ()
+                Right _ -> 
+                    retryLoop initialDelay
     retryLoop initialDelay
 
 printTimeToNextRetry :: Int -> Text

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -261,6 +261,7 @@ notifyLoop listeningToVar listenToVar subscriptions = do
 
 printTimeToNextRety :: Int -> Text
 printTimeToNextRety microseconds
+    | microseconds >= 1000 =  show (microseconds `div` 1000000) ++ " min"
     | microseconds >= 1000000 =  show (microseconds `div` 1000000) ++ " s"
     | microseconds >= 1000 = show (microseconds `div` 1000) ++ " ms"
     | otherwise = show microseconds ++ " µs"

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -245,7 +245,8 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                         Just (error :: AsyncCancelled) -> throw error
                         notification -> do
                             let ?context = ?modelContext -- Log onto the modelContext logger
-                            Log.info ("PGListener is going to restart, loop failed with exception: " <> displayException error)
+                            Log.info ("PGListener is going to restart, loop failed with exception: " <> displayException error <> ". Retrying in " <> formatTimeUnits nextDelay <> ".")
+
 
                             -- Sleep for the current delay 
                             Control.Concurrent.threadDelay delay
@@ -257,6 +258,11 @@ notifyLoop listeningToVar listenToVar subscriptions = do
                 Right _ -> pure ()
     retryLoop initialDelay
 
+printTimeToNextRety :: Int -> Text
+printTimeToNextRety microseconds
+    | microseconds >= 1000000 = show (microseconds `div` 1000000) ++ " s"
+    | microseconds >= 1000 = show (microseconds `div` 1000) ++ " ms"
+    | otherwise = show microseconds ++ " µs"
 
 listenToChannel :: PG.Connection -> Channel -> IO ()
 listenToChannel databaseConnection channel = do


### PR DESCRIPTION
/claim #1621

Hi! 

I figured it would be fun to give this bounty hunt a try :)

I believe this should solve #1621 although I'm unsure of the best way to test a failed connection. Tested AutoRefresh with it and it seemed to work fine!

Added a sleep before re-running the function and replacing forever with a recursion.

Double the sleep delay for the next retry until it reaches a minute, then it retries every minute from then on.

I don't know what should be the best amounts here so feel free to suggest other values than min 500ms and max 1 minute.

