### PR TITLE
Add mention of standalone CLI and ihp-tailwind-bootstrapper as alternative to npm

### DIFF
--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -12,6 +12,15 @@ We will also have PostCSS added as part of the installation. PostCSS is used for
 
 ## Installing
 
+### Standalone CLI
+
+Tailwind offers a Standalone CLI for frameworks like IHP, Rails and Phoenix as an alternative to installing npm just for the sake of Tailwind. 
+
+You can follow the [official article](https://tailwindcss.com/blog/standalone-cli) for checking a standalone Tailwind binary into your project.
+
+If you require cross-platform support, [ihp-tailwind-bootstrapper](https://github.com/ship-nix/ihp-tailwind-bootstrapper) uses Tailwind's official binaries and let's you access the correct one for you system. Only the binary used for deployment is checked into version control.
+
+
 ### NodeJS
 
 First, we need to add NodeJS to our project. **You should also follow this step if you have NodeJS already installed on your system.** Installing the NodeJS version via nix allows all people working on your project to get the same NodeJS version as you're using.

--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -18,7 +18,7 @@ Tailwind offers a Standalone CLI for frameworks like IHP, Rails and Phoenix as a
 
 You can follow the [official article](https://tailwindcss.com/blog/standalone-cli) for checking a standalone Tailwind binary into your project.
 
-If you require cross-platform support, [ihp-tailwind-bootstrapper](https://github.com/ship-nix/ihp-tailwind-bootstrapper) uses Tailwind's official binaries and let's you access the correct one for you system. Only the binary used for deployment is checked into version control.
+If you require cross-platform support, [ihp-tailwind-bootstrapper](https://github.com/ship-nix/ihp-tailwind-bootstrapper) uses Tailwind's official binaries and let's you automatically use the correct one for your system. Only the binary used for deployment is checked into version control.
 
 
 ### NodeJS


### PR DESCRIPTION
A key reason of the value of including this, apart from many's distaste for npm, is that it makes deployment much simpler when npm is not a requirement