### PR TITLE
Give example on how to see an existing image on file upload

### DIFF
--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -285,6 +285,7 @@ renderForm company = formFor company [hsx|
 |]
 ```
 
+On the "Edit.hs" file, it can be helpful to see the logo that has already been uploaded. To do this, change "<img id="logoUrlPreview"/>" to "<img id="logoUrlPreview" src={comapny.logoUrl}/>." This will allow the preview to show the existing logo, and also update to display any newly uploaded logos.
 
 ### Image Preprocessing
 


### PR DESCRIPTION
On edit, we expect to see the existing uploaded file/ image. PR explains how to do it.

![image](https://github.com/digitallyinduced/ihp/assets/125707/21c9f429-2c6c-4f6d-8970-da7ec1ef7eb1)
