### PR TITLE
Use wai-app-static instead of wai-middleware-static

### DIFF
--- a/IHP/IDE/ToolServer.hs
+++ b/IHP/IDE/ToolServer.hs
@@ -14,7 +14,6 @@ import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
 import qualified Data.Vault.Lazy as Vault
 import Network.Wai.Middleware.MethodOverridePost (methodOverridePost)
-import Network.Wai.Middleware.Static hiding ((<|>))
 import Network.Wai.Session (withSession)
 import qualified Network.WebSockets as Websocket
 import qualified Network.Wai.Handler.WebSockets as Websocket
@@ -47,6 +46,10 @@ import qualified IHP.Version as Version
 import qualified IHP.IDE.Types
 import qualified IHP.PGListener as PGListener
 
+import qualified Network.Wai.Application.Static as Static
+import qualified WaiAppStatic.Storage.Filesystem as Static
+import qualified WaiAppStatic.Types as Static
+
 withToolServer :: (?context :: Context) => IO () -> IO ()
 withToolServer inner = withAsyncBound async (\_ -> inner)
     where
@@ -75,16 +78,15 @@ startToolServer' port isDebugMode = do
     let modelContext = notConnectedModelContext undefined
     pgListener <- PGListener.init modelContext
     autoRefreshServer <- newIORef (AutoRefresh.newAutoRefreshServer pgListener)
+    staticApp <- initStaticApp
+
     let applicationContext = ApplicationContext { modelContext, session, autoRefreshServer, frameworkConfig, pgListener }
     let toolServerApplication = ToolServerApplication { devServerContext = ?context }
     let application :: Wai.Application = \request respond -> do
             let ?applicationContext = applicationContext
             requestContext <- ControllerSupport.createRequestContext applicationContext request respond
             let ?context = requestContext
-            frontControllerToWAIApp toolServerApplication [] ErrorController.handleNotFound
-
-    libDirectory <- cs <$> LibDir.findLibDirectory
-    let staticMiddleware :: Wai.Middleware = staticPolicy (addBase (libDirectory <> "static/"))
+            frontControllerToWAIApp toolServerApplication [] (staticApp request respond)
 
     let openAppUrl = openUrl ("http://localhost:" <> tshow port <> "/")
     let warpSettings = Warp.defaultSettings
@@ -94,11 +96,20 @@ startToolServer' port isDebugMode = do
     let logMiddleware = if isDebugMode then frameworkConfig.requestLoggerMiddleware else IHP.Prelude.id
 
     Warp.runSettings warpSettings $
-            staticMiddleware $ logMiddleware $ methodOverridePost $ sessionMiddleware
+            logMiddleware $ methodOverridePost $ sessionMiddleware
                 $ Websocket.websocketsOr
                     Websocket.defaultConnectionOptions
                     LiveReloadNotificationServer.app
                     application
+
+initStaticApp :: IO Wai.Application
+initStaticApp = do
+    libDirectory <- cs <$> LibDir.findLibDirectory
+    let staticSettings = (Static.defaultWebAppSettings (libDirectory <> "static/"))
+            { Static.ss404Handler = Just ErrorController.handleNotFound
+            , Static.ssMaxAge = Static.MaxAgeSeconds (60 * 60 * 24 * 30) -- 30 days
+            }
+    pure (Static.staticApp staticSettings)
 
 openUrl :: Text -> IO ()
 openUrl url = do

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -5,7 +5,6 @@ import IHP.Prelude
 import qualified Network.Wai.Handler.Warp as Warp
 import Network.Wai
 import Network.Wai.Middleware.MethodOverridePost (methodOverridePost)
-import Network.Wai.Middleware.Static
 import Network.Wai.Session (withSession, Session)
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
@@ -37,6 +36,10 @@ import qualified System.Directory as Directory
 import qualified GHC.IO.Encoding as IO
 import qualified System.IO as IO
 
+import qualified Network.Wai.Application.Static as Static
+import qualified WaiAppStatic.Storage.Filesystem as Static
+import qualified WaiAppStatic.Types as Static
+
 run :: (FrontController RootApplication, Job.Worker RootApplication) => ConfigBuilder -> IO ()
 run configBuilder = do
     -- We cannot use 'Main.Utf8.withUtf8' here, as this for some reason breaks live reloading
@@ -57,7 +60,7 @@ run configBuilder = do
                 let ?applicationContext = ApplicationContext { modelContext = ?modelContext, session = sessionVault, autoRefreshServer, frameworkConfig, pgListener }
 
                 sessionMiddleware <- initSessionMiddleware sessionVault frameworkConfig
-                staticMiddleware <- initStaticMiddleware frameworkConfig
+                staticApp <- initStaticApp frameworkConfig
                 let corsMiddleware = initCorsMiddleware frameworkConfig
                 let requestLoggerMiddleware = frameworkConfig.requestLoggerMiddleware
                 let CustomMiddleware customMiddleware = frameworkConfig.customMiddleware
@@ -65,12 +68,11 @@ run configBuilder = do
                 withBackgroundWorkers pgListener frameworkConfig 
                     . runServer frameworkConfig
                     . customMiddleware
-                    . staticMiddleware
                     . corsMiddleware
                     . sessionMiddleware
                     . requestLoggerMiddleware
                     . methodOverridePost 
-                    $ application
+                    $ application staticApp
 
 {-# INLINABLE run #-}
 
@@ -82,58 +84,34 @@ withBackgroundWorkers pgListener frameworkConfig app = do
             then withAsync (Job.devServerMainLoop frameworkConfig pgListener jobWorkers) (const app)
             else app
 
--- | Returns a middleware that returns files stored in the app's @static/@ directory and IHP's own @static/@  directory
+-- | Returns a WAI app that servers files stored in the app's @static/@ directory and IHP's own @static/@  directory
 --
 -- HTTP Cache headers are set automatically. This includes Cache-Control, Last-Mofified and ETag
 --
 -- The cache strategy works like this:
 -- - In dev mode we disable the browser cache for the app's @static/@ directory to make sure that always the latest CSS and JS is used
--- - In production mode: If the files are stored in @static/vendor@/ we cache up to 30 days. For all other files we cache up to one day. It's best for vendor files to have e.g. the version as part of the file name. So @static/vendor/jquery.js@ should become @static/vendor/jquery-3.6.1.js@. That way when updating jquery you will have no issues with the cache.
--- - Static files in IHP's @static/@ directory can be cached up to 30 days
-initStaticMiddleware :: FrameworkConfig -> IO Middleware
-initStaticMiddleware FrameworkConfig { environment } = do
-        libDirectory <- cs <$> findLibDirectory
+-- - In production mode: We cache files forever. IHP's 'assetPath' helper will add a hash to files to cache bust when something has changed.
+initStaticApp :: FrameworkConfig -> IO Application
+initStaticApp frameworkConfig = do
+    libDir <- cs <$> findLibDirectory
 
-        -- We have different caching rules for the app `static/` directory and the IHP `static/` directory
-        appStaticCache <- initCaching (CustomCaching getAppCacheHeader)
-        ihpStaticCache <- initCaching (CustomCaching getIHPCacheHeader)
-        let appCachingOptions = defaultOptions { cacheContainer = appStaticCache }
-        let ihpCachingOptions = defaultOptions { cacheContainer = ihpStaticCache }
+    let
+        maxAge = case frameworkConfig.environment of
+            Env.Development -> Static.MaxAgeSeconds 0
+            Env.Production -> Static.MaxAgeForever
 
-        let middleware =
-                      staticPolicyWithOptions appCachingOptions (addBase "static/")
-                    . staticPolicyWithOptions ihpCachingOptions (addBase (libDirectory <> "static/"))
-        pure middleware
-    where
-        -- In dev mode we disable the browser cache to make sure that always the latest CSS and JS is used
-        -- In production mode we cache static assets up to one day
-        getAppCacheHeader fileMeta =
-            case environment of
-                Env.Development -> [("Cache-Control", "no-cache,no-store,must-revalidate")]
-                Env.Production ->
-                    let
-                        -- Cache file in `static/vendor` for one month. Code that is stored in `vendor` should
-                        -- have the version number in it's file name. So `static/vendor/jquery.js` should become
-                        -- `static/vendor/jquery-3.6.1.js`. That way when updating jquery you will have no issues
-                        -- with the cache.
-                        isVendorFile = "static/vendor/" `List.isPrefixOf` (fm_fileName fileMeta)
-                        vendorCacheControl = ("Cache-Control", "no-transform,public,max-age=2592000,s-maxage=2592000")
-                        -- All other app files are cached for a day
-                        appCacheControl = ("Cache-Control", "no-transform,public,max-age=86400,s-maxage=86400")
-                    in
-                        [ if isVendorFile then vendorCacheControl else appCacheControl
-                        , ("Last-Modified", fm_lastModified fileMeta)
-                        , ("ETag", fm_etag fileMeta)
-                        , ("Vary", "Accept-Encoding")
-                        ]
+        
+        frameworkStaticDir = libDir <> "/static/"
+        frameworkSettings = (Static.defaultWebAppSettings frameworkStaticDir)
+                { Static.ss404Handler = Just ErrorController.handleNotFound
+                , Static.ssMaxAge = maxAge
+                }
+        appSettings = (Static.defaultWebAppSettings "static/")
+                { Static.ss404Handler = Just (Static.staticApp frameworkSettings)
+                , Static.ssMaxAge = maxAge
+                }
 
-        -- Files in IHP's own static directory are cached for one month
-        getIHPCacheHeader fileMeta =
-                    [ ("Cache-Control", "no-transform,public,max-age=2592000,s-maxage=2592000")
-                    , ("Last-Modified", fm_lastModified fileMeta)
-                    , ("ETag", fm_etag fileMeta)
-                    , ("Vary", "Accept-Encoding")
-                    ]
+    pure (Static.staticApp appSettings)
 
 initSessionMiddleware :: Vault.Key (Session IO ByteString ByteString) -> FrameworkConfig -> IO Middleware
 initSessionMiddleware sessionVault FrameworkConfig { sessionCookie } = do
@@ -153,15 +131,16 @@ initCorsMiddleware FrameworkConfig { corsResourcePolicy } = case corsResourcePol
         Just corsResourcePolicy -> Cors.cors (const (Just corsResourcePolicy))
         Nothing -> id
 
-application :: (FrontController RootApplication, ?applicationContext :: ApplicationContext) => Application
-application request respond = do
+application :: (FrontController RootApplication, ?applicationContext :: ApplicationContext) => Application -> Application
+application staticApp request respond = do
         requestContext <- ControllerSupport.createRequestContext ?applicationContext request respond
         let ?context = requestContext
         let builtinControllers = let ?application = () in
                 [ webSocketApp @AutoRefresh.AutoRefreshWSApp
                 , webSocketAppWithCustomPath @AutoRefresh.AutoRefreshWSApp "" -- For b.c. with older versions of ihp-auto-refresh.js
                 ]
-        frontControllerToWAIApp RootApplication builtinControllers ErrorController.handleNotFound
+
+        frontControllerToWAIApp RootApplication builtinControllers (staticApp request respond)
 {-# INLINABLE application #-}
 
 runServer :: (?applicationContext :: ApplicationContext) => FrameworkConfig -> Application -> IO ()

--- a/Test/SEO/Sitemap.hs
+++ b/Test/SEO/Sitemap.hs
@@ -13,6 +13,7 @@ import Network.HTTP.Types
 import IHP.SEO.Sitemap.Types
 import IHP.SEO.Sitemap.Routes
 import IHP.SEO.Sitemap.ControllerFunctions
+import qualified IHP.ErrorController as ErrorController
 
 data Post = Post
         { id :: UUID
@@ -78,5 +79,5 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
     describe "SEO" do
         describe "Sitemap" do
             it "should render a XML Sitemap" $ withContext do
-                runSession (testGet "/sitemap.xml") Server.application
+                runSession (testGet "/sitemap.xml") (Server.application ErrorController.handleNotFound)
                     >>= assertSuccess "<?xml version=\"1.0\" encoding=\"UTF-8\"?><urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"><url><loc>http://localhost:8000/test/ShowPost?postId=00000000-0000-0000-0000-000000000000</loc><lastmod>2105-04-16</lastmod><changefreq>hourly</changefreq></url></urlset>"

--- a/devenv.nix
+++ b/devenv.nix
@@ -28,7 +28,7 @@
                 inflections
                 text
                 postgresql-simple
-                wai-middleware-static
+                wai-app-static
                 wai-util
                 aeson
                 uuid

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -34,7 +34,7 @@ common shared-properties
             , inflections
             , text
             , postgresql-simple
-            , wai-middleware-static
+            , wai-app-static
             , wai-util
             , bytestring
             , network-uri

--- a/ihp.nix
+++ b/ihp.nix
@@ -17,7 +17,7 @@
 , inflections
 , text
 , postgresql-simple
-, wai-middleware-static
+, wai-app-static
 , wai-util
 , aeson
 , uuid
@@ -88,7 +88,7 @@ mkDerivation {
     inflections
     text
     postgresql-simple
-    wai-middleware-static
+    wai-app-static
     wai-util
     aeson
     uuid


### PR DESCRIPTION
The wai-app-static package is more actively maintained. The old wai-middleware-static had some issues, particular related to leaking file handles. Also wai-app-static has better cache handling for our dev mode