### PR TITLE
helpers.js: Support formAction attribute on <button>

### DIFF
--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -168,7 +168,9 @@ window.submitForm = function (form, possibleClickedButton) {
 
     // We cannot use `form.action` here because there could be a <input name="action"/>
     // See https://github.com/digitallyinduced/ihp/issues/1203
-    var formAction = form.getAttribute('action');
+    var formAction = (possibleClickedButton && possibleClickedButton.getAttribute('formAction'))
+		? possibleClickedButton.getAttribute('formAction')
+		: form.getAttribute('action');
     var formMethod = form.getAttribute('method') || 'GET';
 
     var request = new XMLHttpRequest();


### PR DESCRIPTION
So you can have e.g.

            <button class="btn btn-primary" type="submit" formaction={CreateAction}>
              Submit
            </button>
            <button class="btn btn-secondary" type="submit" formaction={SaveProgressAction} formnovalidate>
              Save progress
            </button>