### PR TITLE
Removed out of scope event from reconnect.

### DIFF
--- a/lib/IHP/DataSync/ihp-datasync.js
+++ b/lib/IHP/DataSync/ihp-datasync.js
@@ -202,7 +202,7 @@ class DataSyncController {
             await this.startConnection();
 
             for (const listener of this.eventListeners.reconnect) {
-                listener(event);
+                listener();
             }
         }, 1000);
     }


### PR DESCRIPTION
In browser event on the dom but in mobile/react native the event is out of scope. 