### PR TITLE
chore: fix all `unused-imports` warnings

### DIFF
--- a/IHP/Assets/ViewFunctions.hs
+++ b/IHP/Assets/ViewFunctions.hs
@@ -9,7 +9,6 @@ module IHP.Assets.ViewFunctions
 ) where
 
 import IHP.Prelude
-import IHP.Assets.Types
 import IHP.Controller.Context
 import qualified IHP.FrameworkConfig as Config
 

--- a/IHP/Controller/Render.hs
+++ b/IHP/Controller/Render.hs
@@ -5,7 +5,6 @@ import Network.Wai (responseLBS, responseBuilder, responseFile)
 import qualified Network.Wai
 import Network.HTTP.Types (Status, status200, status406)
 import Network.HTTP.Types.Header
-import IHP.ModelSupport
 import qualified Data.ByteString.Lazy
 import qualified IHP.ViewSupport as ViewSupport
 import qualified Data.Aeson

--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -37,7 +37,6 @@ import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai
 import IHP.ModelSupport
 import IHP.ApplicationContext (ApplicationContext (..))
-import qualified IHP.ApplicationContext as ApplicationContext
 import Network.Wai.Parse as WaiParse
 import qualified Data.ByteString.Lazy
 import qualified IHP.Controller.RequestContext as RequestContext
@@ -54,7 +53,6 @@ import qualified Data.Aeson as Aeson
 import qualified Network.Wai.Handler.WebSockets as WebSockets
 import qualified Network.WebSockets as WebSockets
 import qualified IHP.WebSocket as WebSockets
-import qualified Data.Typeable as Typeable
 import qualified Data.TMap as TypeMap
 
 type Action' = IO ResponseReceived

--- a/IHP/DataSync/ChangeNotifications.hs
+++ b/IHP/DataSync/ChangeNotifications.hs
@@ -11,17 +11,11 @@ module IHP.DataSync.ChangeNotifications
 
 import IHP.Prelude
 import qualified Database.PostgreSQL.Simple as PG
-import qualified Database.PostgreSQL.Simple.Types as PG
-import qualified Database.PostgreSQL.Simple.Notification as PG
 import IHP.ModelSupport
 import Data.String.Interpolate.IsString (i)
 import Data.Aeson
 import Data.Aeson.TH
-import qualified Control.Concurrent.MVar as MVar
-import IHP.DataSync.DynamicQuery (transformColumnNamesToFieldNames)
 import qualified IHP.DataSync.RowLevelSecurity as RLS
-import qualified IHP.PGListener as PGListener
-import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.UUID as UUID
 

--- a/IHP/DataSync/ControllerImpl.hs
+++ b/IHP/DataSync/ControllerImpl.hs
@@ -5,11 +5,9 @@ import IHP.ControllerPrelude hiding (OrderByClause)
 import qualified Control.Exception as Exception
 import qualified IHP.Log as Log
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Encoding.Internal as Aeson
 import qualified Data.Aeson.Key as Aeson
 
 import Data.Aeson.TH
-import Data.Aeson
 import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
@@ -23,15 +21,11 @@ import IHP.DataSync.DynamicQueryCompiler
 import qualified IHP.DataSync.ChangeNotifications as ChangeNotifications
 import IHP.DataSync.REST.Controller (aesonValueToPostgresValue)
 import qualified Data.ByteString.Char8 as ByteString
-import qualified Data.ByteString.Builder as ByteString
 import qualified IHP.PGListener as PGListener
 import IHP.ApplicationContext
-import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Pool as Pool
 
-import qualified Data.Attoparsec.Text as Attoparsec
-import qualified Network.WebSockets as WS
 
 $(deriveFromJSON defaultOptions ''DataSyncMessage)
 $(deriveToJSON defaultOptions 'DataSyncResult)

--- a/IHP/DataSync/DynamicQuery.hs
+++ b/IHP/DataSync/DynamicQuery.hs
@@ -8,13 +8,9 @@ module IHP.DataSync.DynamicQuery where
 
 import IHP.ControllerPrelude hiding (OrderByClause)
 import Data.Aeson
-import qualified Data.HashMap.Strict as HashMap
-import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.FromField as PG
-import qualified Database.PostgreSQL.Simple.FromRow as PG
 import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
-import qualified Database.PostgreSQL.Simple.Notification as PG
 import qualified IHP.QueryBuilder as QueryBuilder
 import Data.Aeson.TH
 import qualified GHC.Generics

--- a/IHP/DataSync/DynamicQueryCompiler.hs
+++ b/IHP/DataSync/DynamicQueryCompiler.hs
@@ -9,11 +9,8 @@ import IHP.Prelude
 import IHP.DataSync.DynamicQuery
 import qualified IHP.QueryBuilder as QueryBuilder
 import qualified Database.PostgreSQL.Simple as PG
-import qualified Database.PostgreSQL.Simple.FromField as PG
-import qualified Database.PostgreSQL.Simple.FromRow as PG
 import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
-import qualified Database.PostgreSQL.Simple.Notification as PG
 import qualified Data.List as List
 
 compileQuery :: DynamicSQLQuery -> (PG.Query, [PG.Action])

--- a/IHP/DataSync/REST/Controller.hs
+++ b/IHP/DataSync/REST/Controller.hs
@@ -4,11 +4,9 @@ module IHP.DataSync.REST.Controller where
 import IHP.ControllerPrelude hiding (OrderByClause)
 import IHP.DataSync.REST.Types
 import Data.Aeson
-import Data.Aeson.TH
 import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 import qualified Database.PostgreSQL.Simple as PG
-import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Vector as Vector
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Control.Exception as Exception
@@ -20,14 +18,11 @@ import IHP.DataSync.DynamicQueryCompiler
 import qualified Data.Text as Text
 import qualified Data.Scientific as Scientific
 
-import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.ByteString.Builder as ByteString
-import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encoding.Internal as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
 import qualified Data.Aeson.Key as Aeson
 
-import qualified Data.Attoparsec.Text as Attoparsec
 
 instance (
     PG.ToField (PrimaryKey (GetTableName CurrentUserRecord))

--- a/IHP/DataSync/Types.hs
+++ b/IHP/DataSync/Types.hs
@@ -2,10 +2,7 @@ module IHP.DataSync.Types where
 
 import IHP.Prelude
 import Data.Aeson
-import IHP.QueryBuilder
 import IHP.DataSync.DynamicQuery
-import Data.HashMap.Strict (HashMap)
-import qualified IHP.PGListener as PGListener
 import qualified Database.PostgreSQL.Simple as PG
 import Control.Concurrent.MVar as MVar
 

--- a/IHP/FlashMessages/ViewFunctions.hs
+++ b/IHP/FlashMessages/ViewFunctions.hs
@@ -5,7 +5,6 @@ Copyright: (c) digitally induced GmbH, 2020
 -}
 module IHP.FlashMessages.ViewFunctions where
 
-import IHP.Prelude
 import IHP.FlashMessages.Types
 import qualified Text.Blaze.Html5 as Html5
 import IHP.ViewSupport

--- a/IHP/IDE/CodeGen/Controller.hs
+++ b/IHP/IDE/CodeGen/Controller.hs
@@ -9,7 +9,6 @@ import IHP.IDE.CodeGen.View.NewView
 import IHP.IDE.CodeGen.View.NewMail
 import IHP.IDE.CodeGen.View.NewAction
 import IHP.IDE.CodeGen.View.NewApplication
-import IHP.IDE.CodeGen.View.NewMigration
 import IHP.IDE.CodeGen.View.NewJob
 import IHP.IDE.CodeGen.Types
 import IHP.IDE.CodeGen.ControllerGenerator as ControllerGenerator
@@ -26,8 +25,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Text.Inflections as Inflector
 import System.Directory
-import qualified IHP.SchemaMigration as SchemaMigration
-import IHP.Log.Types
 
 instance Controller CodeGenController where
     action GeneratorsAction = do

--- a/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -8,13 +8,9 @@ module IHP.IDE.CodeGen.MigrationGenerator where
 import IHP.Prelude
 import qualified System.Directory as Directory
 import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-import IHP.ModelSupport hiding (withTransaction)
 import qualified Data.Time.Clock.POSIX as POSIX
 import qualified IHP.NameSupport as NameSupport
 import qualified Data.Char as Char
-import IHP.Log.Types
-import IHP.SchemaMigration
 import qualified System.Process as Process
 import qualified IHP.IDE.SchemaDesigner.Parser as Parser
 import IHP.IDE.SchemaDesigner.Types

--- a/IHP/IDE/CodeGen/View/NewMigration.hs
+++ b/IHP/IDE/CodeGen/View/NewMigration.hs
@@ -2,7 +2,7 @@ module IHP.IDE.CodeGen.View.NewMigration where
 
 import IHP.ViewPrelude
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Layout
+import IHP.IDE.ToolServer.Routes ()
 import IHP.IDE.CodeGen.Types
 import IHP.IDE.CodeGen.View.Generators (renderPlan)
 

--- a/IHP/IDE/Data/Controller.hs
+++ b/IHP/IDE/Data/Controller.hs
@@ -17,7 +17,6 @@ import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 import qualified Data.Text as T
 import qualified Data.ByteString.Builder
-import Data.Functor ((<&>))
 
 instance Controller DataController where
     action ShowDatabaseAction = do

--- a/IHP/IDE/Data/View/Layout.hs
+++ b/IHP/IDE/Data/View/Layout.hs
@@ -17,7 +17,7 @@ module IHP.IDE.Data.View.Layout
 
 import IHP.ViewPrelude
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Routes
+import IHP.IDE.ToolServer.Routes ()
 import qualified Data.Text as Text
 import IHP.IDE.ToolServer.Helper.View
 

--- a/IHP/IDE/Data/View/ShowDatabase.hs
+++ b/IHP/IDE/Data/View/ShowDatabase.hs
@@ -1,10 +1,8 @@
 module IHP.IDE.Data.View.ShowDatabase where
 
 import IHP.ViewPrelude
-import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
 import IHP.IDE.Data.View.Layout
-import IHP.IDE.ToolServer.Routes
 
 data ShowDatabaseView = ShowDatabaseView {
         tableNames :: [Text]

--- a/IHP/IDE/Data/View/ShowForeignKeyHoverCard.hs
+++ b/IHP/IDE/Data/View/ShowForeignKeyHoverCard.hs
@@ -1,10 +1,7 @@
 module IHP.IDE.Data.View.ShowForeignKeyHoverCard where
 
 import IHP.ViewPrelude
-import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.Data.View.Layout
-import IHP.IDE.ToolServer.Routes
 
 data ShowForeignKeyHoverCardView = ShowForeignKeyHoverCardView
     { record :: [DynamicField]

--- a/IHP/IDE/SchemaDesigner/Controller/Columns.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Columns.hs
@@ -9,13 +9,10 @@ import IHP.IDE.SchemaDesigner.View.Columns.NewForeignKey
 import IHP.IDE.SchemaDesigner.View.Columns.EditForeignKey
 
 import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.SchemaDesigner.View.Layout (schemaDesignerLayout, findStatementByName, replace, findForeignKey, findTableIndex)
+import IHP.IDE.SchemaDesigner.View.Layout (schemaDesignerLayout, findStatementByName, replace)
 import IHP.IDE.SchemaDesigner.Controller.Helper
 import IHP.IDE.SchemaDesigner.Controller.Validation
 
-import qualified Data.Text as Text
-import qualified Data.Maybe as Maybe
-import qualified Data.List as List
 
 import qualified IHP.IDE.SchemaDesigner.SchemaOperations as SchemaOperations
 

--- a/IHP/IDE/SchemaDesigner/Controller/Indexes.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Indexes.hs
@@ -5,10 +5,8 @@ import IHP.IDE.ToolServer.Types
 
 import IHP.IDE.SchemaDesigner.View.Indexes.Edit
 
-import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.SchemaDesigner.View.Layout (schemaDesignerLayout)
 import IHP.IDE.SchemaDesigner.Controller.Helper
-import IHP.IDE.SchemaDesigner.Controller.Validation
 
 import qualified IHP.IDE.SchemaDesigner.SchemaOperations as SchemaOperations
 

--- a/IHP/IDE/SchemaDesigner/Controller/Migrations.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Migrations.hs
@@ -7,17 +7,10 @@ import IHP.IDE.SchemaDesigner.View.Migrations.Index
 import IHP.IDE.SchemaDesigner.View.Migrations.New
 import IHP.IDE.SchemaDesigner.View.Migrations.Edit
 
-import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.SchemaDesigner.View.Layout (schemaDesignerLayout, findStatementByName, replace, findForeignKey, findTableIndex)
-import IHP.IDE.SchemaDesigner.Controller.Helper
-import IHP.IDE.SchemaDesigner.Controller.Validation
+import IHP.IDE.SchemaDesigner.View.Layout (schemaDesignerLayout)
 
-import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import qualified Data.Maybe as Maybe
-import qualified Data.List as List
 
-import qualified IHP.IDE.SchemaDesigner.SchemaOperations as SchemaOperations
 import qualified IHP.SchemaMigration as SchemaMigration
 import qualified IHP.IDE.CodeGen.MigrationGenerator as MigrationGenerator
 import IHP.IDE.CodeGen.Controller
@@ -26,7 +19,6 @@ import IHP.Log.Types
 import qualified Control.Exception as Exception
 import qualified System.Directory as Directory
 import qualified Database.PostgreSQL.Simple as PG
-import qualified Database.PostgreSQL.Simple.Types as PG
 
 instance Controller MigrationsController where
     beforeAction = setLayout schemaDesignerLayout

--- a/IHP/IDE/SchemaDesigner/Controller/Policies.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Policies.hs
@@ -7,13 +7,9 @@ import IHP.IDE.SchemaDesigner.View.Policies.New
 import IHP.IDE.SchemaDesigner.View.Policies.Edit
 
 import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.SchemaDesigner.View.Layout (schemaDesignerLayout, findStatementByName, replace, findForeignKey, findTableIndex)
+import IHP.IDE.SchemaDesigner.View.Layout (schemaDesignerLayout, findStatementByName)
 import IHP.IDE.SchemaDesigner.Controller.Helper
-import IHP.IDE.SchemaDesigner.Controller.Validation
 
-import qualified Data.Text as Text
-import qualified Data.Maybe as Maybe
-import qualified Data.List as List
 
 import qualified IHP.IDE.SchemaDesigner.SchemaOperations as SchemaOperations
 

--- a/IHP/IDE/SchemaDesigner/Controller/Schema.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Schema.hs
@@ -4,21 +4,18 @@ import IHP.ControllerPrelude
 import IHP.IDE.ToolServer.Types
 
 import IHP.IDE.SchemaDesigner.View.Schema.Code
-import IHP.IDE.SchemaDesigner.View.Schema.Error
 import IHP.IDE.SchemaDesigner.View.Schema.GeneratedCode
 import IHP.IDE.SchemaDesigner.View.Schema.SchemaUpdateFailed
 
 import IHP.IDE.SchemaDesigner.Parser
-import IHP.IDE.SchemaDesigner.Compiler
-import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.SchemaDesigner.View.Layout (findStatementByName, findStatementByName, removeQuotes, replace)
 import qualified IHP.SchemaCompiler as SchemaCompiler
 import qualified System.Process as Process
 import System.Exit
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
+import IHP.IDE.SchemaDesigner.Controller.Tables ()
 import IHP.IDE.SchemaDesigner.View.Layout
-import IHP.IDE.SchemaDesigner.Controller.Tables
+import IHP.IDE.ToolServer.Routes ()
 import IHP.IDE.SchemaDesigner.Controller.Helper
 
 instance Controller SchemaController where

--- a/IHP/IDE/SchemaDesigner/Controller/Tables.hs
+++ b/IHP/IDE/SchemaDesigner/Controller/Tables.hs
@@ -9,7 +9,7 @@ import IHP.IDE.SchemaDesigner.View.Tables.Index
 import IHP.IDE.SchemaDesigner.View.Tables.Edit
 
 import IHP.IDE.SchemaDesigner.Types
-import IHP.IDE.SchemaDesigner.View.Layout (findStatementByName, replace, schemaDesignerLayout)
+import IHP.IDE.SchemaDesigner.View.Layout (findStatementByName, schemaDesignerLayout)
 import qualified IHP.SchemaCompiler as SchemaCompiler
 import IHP.IDE.SchemaDesigner.Controller.Helper
 import IHP.IDE.SchemaDesigner.Controller.Validation

--- a/IHP/IDE/SchemaDesigner/View/Columns/New.hs
+++ b/IHP/IDE/SchemaDesigner/View/Columns/New.hs
@@ -3,7 +3,7 @@ module IHP.IDE.SchemaDesigner.View.Columns.New where
 import IHP.ViewPrelude
 import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Layout
+import IHP.IDE.ToolServer.Routes ()
 import IHP.IDE.SchemaDesigner.View.Layout
 import IHP.IDE.SchemaDesigner.View.Columns.Edit (typeSelector)
 

--- a/IHP/IDE/SchemaDesigner/View/Enums/New.hs
+++ b/IHP/IDE/SchemaDesigner/View/Enums/New.hs
@@ -3,7 +3,6 @@ module IHP.IDE.SchemaDesigner.View.Enums.New where
 import IHP.ViewPrelude
 import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Layout
 import IHP.IDE.SchemaDesigner.View.Layout
 
 data NewEnumView = NewEnumView { statements :: [Statement] }

--- a/IHP/IDE/SchemaDesigner/View/Layout.hs
+++ b/IHP/IDE/SchemaDesigner/View/Layout.hs
@@ -21,8 +21,6 @@ import IHP.IDE.ToolServer.Types
 import IHP.IDE.ToolServer.Helper.View
 import IHP.IDE.ToolServer.Layout hiding (tableIcon)
 import IHP.IDE.SchemaDesigner.Compiler (compilePostgresType, compileExpression)
-import qualified IHP.IDE.SchemaDesigner.Parser as Parser
-import qualified Text.Megaparsec as Megaparsec
 import qualified Data.List as List
 
 schemaDesignerLayout :: Html -> Html

--- a/IHP/IDE/SchemaDesigner/View/Migrations/Edit.hs
+++ b/IHP/IDE/SchemaDesigner/View/Migrations/Edit.hs
@@ -1,10 +1,8 @@
 module IHP.IDE.SchemaDesigner.View.Migrations.Edit where
 import IHP.ViewPrelude
-import IHP.IDE.ToolServer.Helper.View
 import IHP.SchemaMigration
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Routes
-import IHP.IDE.CodeGen.Types
+import IHP.IDE.ToolServer.Routes ()
 
 data EditView = EditView
     { migration :: Migration

--- a/IHP/IDE/SchemaDesigner/View/Migrations/Index.hs
+++ b/IHP/IDE/SchemaDesigner/View/Migrations/Index.hs
@@ -3,9 +3,8 @@ import IHP.ViewPrelude
 import IHP.IDE.ToolServer.Helper.View
 import IHP.SchemaMigration
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Routes
+import IHP.IDE.ToolServer.Routes ()
 
-import qualified Data.Time.Clock as Clock
 import qualified Data.Time.Clock.POSIX as Clock
 
 type Revision = Int

--- a/IHP/IDE/SchemaDesigner/View/Migrations/New.hs
+++ b/IHP/IDE/SchemaDesigner/View/Migrations/New.hs
@@ -1,9 +1,7 @@
 module IHP.IDE.SchemaDesigner.View.Migrations.New where
 import IHP.ViewPrelude
-import IHP.IDE.ToolServer.Helper.View
-import IHP.SchemaMigration
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Routes
+import IHP.IDE.ToolServer.Routes ()
 import IHP.IDE.CodeGen.Types
 
 data NewView = NewView { plan :: [GeneratorAction] }

--- a/IHP/IDE/SchemaDesigner/View/Schema/Code.hs
+++ b/IHP/IDE/SchemaDesigner/View/Schema/Code.hs
@@ -1,9 +1,8 @@
 module IHP.IDE.SchemaDesigner.View.Schema.Code where
 
 import IHP.ViewPrelude
-import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.SchemaDesigner.View.Layout
+import IHP.IDE.ToolServer.Routes ()
 
 data CodeView = CodeView
     { schema :: Text

--- a/IHP/IDE/SchemaDesigner/View/Schema/Error.hs
+++ b/IHP/IDE/SchemaDesigner/View/Schema/Error.hs
@@ -1,7 +1,6 @@
 module IHP.IDE.SchemaDesigner.View.Schema.Error where
 
 import IHP.ViewPrelude
-import IHP.IDE.SchemaDesigner.View.Layout
 
 data ErrorView = ErrorView
     { error :: ByteString

--- a/IHP/IDE/SchemaDesigner/View/Schema/SchemaUpdateFailed.hs
+++ b/IHP/IDE/SchemaDesigner/View/Schema/SchemaUpdateFailed.hs
@@ -1,10 +1,8 @@
 module IHP.IDE.SchemaDesigner.View.Schema.SchemaUpdateFailed where
 
 import IHP.ViewPrelude
-import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Layout
-import IHP.IDE.SchemaDesigner.View.Layout
+import IHP.IDE.ToolServer.Routes ()
 import System.Exit
 import qualified Data.Text as Text
 

--- a/IHP/IDE/SchemaDesigner/View/Tables/Edit.hs
+++ b/IHP/IDE/SchemaDesigner/View/Tables/Edit.hs
@@ -3,7 +3,7 @@ module IHP.IDE.SchemaDesigner.View.Tables.Edit where
 import IHP.ViewPrelude
 import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Layout
+import IHP.IDE.ToolServer.Routes ()
 import IHP.IDE.SchemaDesigner.View.Layout
 
 data EditTableView = EditTableView

--- a/IHP/IDE/SchemaDesigner/View/Tables/New.hs
+++ b/IHP/IDE/SchemaDesigner/View/Tables/New.hs
@@ -3,7 +3,7 @@ module IHP.IDE.SchemaDesigner.View.Tables.New where
 import IHP.ViewPrelude
 import IHP.IDE.SchemaDesigner.Types
 import IHP.IDE.ToolServer.Types
-import IHP.IDE.ToolServer.Layout
+import IHP.IDE.ToolServer.Routes ()
 import IHP.IDE.SchemaDesigner.View.Layout
 
 data NewTableView = NewTableView { statements :: [Statement] }

--- a/IHP/IDE/ToolServer.hs
+++ b/IHP/IDE/ToolServer.hs
@@ -43,11 +43,9 @@ import IHP.Controller.Layout
 import qualified IHP.LibDir as LibDir
 import qualified IHP.IDE.LiveReloadNotificationServer as LiveReloadNotificationServer
 import qualified IHP.Version as Version
-import qualified IHP.IDE.Types
 import qualified IHP.PGListener as PGListener
 
 import qualified Network.Wai.Application.Static as Static
-import qualified WaiAppStatic.Storage.Filesystem as Static
 import qualified WaiAppStatic.Types as Static
 
 withToolServer :: (?context :: Context) => IO () -> IO ()

--- a/IHP/Job/Dashboard.hs
+++ b/IHP/Job/Dashboard.hs
@@ -32,21 +32,16 @@ module IHP.Job.Dashboard (
 ) where
 
 import IHP.Prelude
-import IHP.ViewPrelude (Html, View, hsx, html, timeAgo, columnNameToFieldLabel)
 import IHP.ModelSupport
 import IHP.ControllerPrelude
 import Unsafe.Coerce
 import IHP.Job.Queue ()
-import IHP.RouterPrelude hiding (get, tshow, error, map, putStrLn, elem)
 import IHP.Pagination.Types
-import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 import qualified Database.PostgreSQL.Simple.FromField as PG
 import qualified Database.PostgreSQL.Simple.ToField as PG
-import Database.PostgreSQL.Simple.FromRow (FromRow(..), field)
 import Network.Wai (requestMethod)
-import Network.HTTP.Types.Method (methodGet, methodPost)
-import GHC.TypeLits
+import Network.HTTP.Types.Method (methodPost)
 
 import IHP.Job.Dashboard.Types
 import IHP.Job.Dashboard.View

--- a/IHP/Job/Dashboard/Auth.hs
+++ b/IHP/Job/Dashboard/Auth.hs
@@ -12,7 +12,6 @@ module IHP.Job.Dashboard.Auth (
 ) where
 
 import IHP.Prelude
-import GHC.TypeLits
 import IHP.ControllerPrelude
 import System.Environment (lookupEnv)
 

--- a/IHP/Job/Dashboard/Types.hs
+++ b/IHP/Job/Dashboard/Types.hs
@@ -12,16 +12,11 @@ module IHP.Job.Dashboard.Types (
 
 import IHP.Prelude
 import IHP.ControllerPrelude
-import qualified Database.PostgreSQL.Simple as PG
-import qualified Database.PostgreSQL.Simple.Types as PG
-import qualified Database.PostgreSQL.Simple.FromField as PG
-import qualified Database.PostgreSQL.Simple.ToField as PG
-import IHP.ViewPrelude (Html, View, hsx, html, timeAgo, columnNameToFieldLabel, JobStatus(..))
+import IHP.ViewPrelude (Html)
 import IHP.RouterPrelude hiding (get, tshow, error, map, putStrLn, elem)
 import Database.PostgreSQL.Simple.FromRow (FromRow(..), field)
 import IHP.Job.Queue () -- get FromField definition for JobStatus
 
-import IHP.Job.Dashboard.Auth
 
 data BaseJob = BaseJob {
     table :: Text

--- a/IHP/Job/Dashboard/Utils.hs
+++ b/IHP/Job/Dashboard/Utils.hs
@@ -2,7 +2,6 @@ module IHP.Job.Dashboard.Utils where
 
 import IHP.Prelude
 import IHP.ModelSupport
-import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 
 numberOfPagesForTable :: (?modelContext::ModelContext) => Text -> Int -> IO Int

--- a/IHP/Job/Dashboard/View.hs
+++ b/IHP/Job/Dashboard/View.hs
@@ -8,13 +8,12 @@ Description:  Views for Job dashboard
 module IHP.Job.Dashboard.View where
 
 import IHP.Prelude
-import IHP.ViewPrelude (JobStatus(..), ControllerContext, Html, View, hsx, html, timeAgo, columnNameToFieldLabel)
+import IHP.ViewPrelude (JobStatus(..), ControllerContext, Html, View, hsx, html, timeAgo)
 import qualified Data.List as List
 import IHP.Job.Dashboard.Types
 import IHP.Job.Dashboard.Utils
 import IHP.Pagination.Types
 import IHP.Pagination.ViewFunctions
-import qualified IHP.Log as Log
 
 -- | Provides a type-erased view. This allows us to specify a view as a return type without needed
 -- to know exactly what type the view will be, which in turn allows for custom implmentations of

--- a/IHP/Job/Queue.hs
+++ b/IHP/Job/Queue.hs
@@ -11,7 +11,6 @@ import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 import qualified Database.PostgreSQL.Simple.FromField as PG
 import qualified Database.PostgreSQL.Simple.ToField as PG
-import qualified Database.PostgreSQL.Simple.Notification as PG
 import qualified Control.Concurrent.Async as Async
 import qualified Control.Concurrent as Concurrent
 import IHP.ModelSupport

--- a/IHP/Job/Runner.hs
+++ b/IHP/Job/Runner.hs
@@ -20,7 +20,6 @@ import qualified System.Exit as Exit
 import qualified System.Timeout as Timeout
 import qualified IHP.PGListener as PGListener
 
-import IHP.Log.Types
 import qualified IHP.Log as Log
 
 -- | Used by the RunJobs binary

--- a/IHP/Job/Types.hs
+++ b/IHP/Job/Types.hs
@@ -12,7 +12,6 @@ where
 
 import IHP.Prelude
 import IHP.FrameworkConfig
-import qualified Control.Concurrent.Async as Async
 import qualified IHP.PGListener as PGListener
 import qualified Control.Concurrent as Concurrent
 

--- a/IHP/Modal/ViewFunctions.hs
+++ b/IHP/Modal/ViewFunctions.hs
@@ -9,7 +9,7 @@ import IHP.Prelude
 import IHP.Controller.Context
 import IHP.HSX.QQ (hsx)
 import IHP.Modal.Types
-import Text.Blaze.Html5 (Html, preEscapedText)
+import Text.Blaze.Html5 (Html)
 
 renderModal modal = renderModal' modal True
 renderModal' Modal { .. } show = [hsx|

--- a/IHP/ModelSupport.hs
+++ b/IHP/ModelSupport.hs
@@ -40,7 +40,7 @@ import qualified Text.Read as Read
 import qualified Data.Pool as Pool
 import qualified GHC.Conc
 import IHP.Postgres.Point
-import IHP.Postgres.Interval
+import IHP.Postgres.Interval ()
 import IHP.Postgres.Polygon
 import IHP.Postgres.Inet ()
 import IHP.Postgres.TSVector

--- a/IHP/PGListener.hs
+++ b/IHP/PGListener.hs
@@ -21,7 +21,6 @@ module IHP.PGListener
 
 import IHP.Prelude hiding (init)
 import IHP.ModelSupport
-import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
@@ -29,7 +28,6 @@ import qualified Database.PostgreSQL.Simple.Notification as PG
 import qualified Data.UUID.V4 as UUID
 import Control.Concurrent.MVar (MVar)
 import qualified Control.Concurrent.MVar as MVar
-import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict as HashMap
 import qualified Control.Concurrent.Async as Async
 import qualified Data.List as List

--- a/IHP/Pagination/ViewFunctions.hs
+++ b/IHP/Pagination/ViewFunctions.hs
@@ -15,13 +15,11 @@ import IHP.HSX.QQ (hsx)
 
 import IHP.Controller.Param (paramOrNothing)
 
-import IHP.View.Classes
 import qualified Network.Wai as Wai
 import qualified Network.HTTP.Types.URI as Query
 import IHP.ViewSupport (theRequest, theCSSFramework)
 import qualified Data.Containers.ListUtils as List
 import IHP.View.Types (PaginationView(..), styledPagination, styledPaginationPageLink, styledPaginationDotDot, styledPaginationItemsPerPageSelector, styledPaginationLinkPrevious, styledPaginationLinkNext)
-import IHP.View.CSSFramework
 
 
 -- | Render a navigation for your pagination. This is to be used in your view whenever

--- a/IHP/QueryBuilder.hs
+++ b/IHP/QueryBuilder.hs
@@ -63,7 +63,6 @@ module IHP.QueryBuilder
 , OrderByDirection (..)
 )
 where
-import qualified Prelude
 import IHP.Prelude
 import Database.PostgreSQL.Simple.Types (In (In))
 import Database.PostgreSQL.Simple.ToField
@@ -74,7 +73,6 @@ import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.ByteString.Lazy as LByteString
 import qualified Control.DeepSeq as DeepSeq
 import qualified Data.Text.Encoding as Text
-import Debug.Trace
 import qualified GHC.Generics
 
 class DefaultScope table where

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -39,7 +39,6 @@ import IHP.FrameworkConfig
 import IHP.ApplicationContext hiding (frameworkConfig)
 import Data.UUID
 import Network.HTTP.Types.Method
-import GHC.Records
 import IHP.Controller.RequestContext
 import Network.Wai
 import IHP.ControllerSupport

--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -13,7 +13,6 @@ import Data.List.Split
 import IHP.HaskellSupport
 import qualified IHP.IDE.SchemaDesigner.Parser as SchemaDesigner
 import IHP.IDE.SchemaDesigner.Types
-import Control.Monad.Fail
 import qualified IHP.IDE.SchemaDesigner.Compiler as SqlCompiler
 import qualified Control.Exception as Exception
 import NeatInterpolation

--- a/IHP/SchemaMigration.hs
+++ b/IHP/SchemaMigration.hs
@@ -10,8 +10,6 @@ import qualified System.Directory as Directory
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import IHP.ModelSupport hiding (withTransaction)
-import qualified Data.Time.Clock.POSIX as POSIX
-import qualified IHP.NameSupport as NameSupport
 import qualified Data.Char as Char
 import IHP.Log.Types
 

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -9,24 +9,19 @@ import Network.Wai.Session (withSession, Session)
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
 import qualified Data.Vault.Lazy as Vault
-import IHP.ModelSupport
 import IHP.ApplicationContext
 import qualified IHP.ControllerSupport as ControllerSupport
 import qualified IHP.Environment as Env
-import IHP.Log.Types
 import qualified IHP.PGListener as PGListener
 
 import IHP.FrameworkConfig
 import IHP.RouterSupport (frontControllerToWAIApp, FrontController, webSocketApp, webSocketAppWithCustomPath)
 import qualified IHP.ErrorController as ErrorController
-import Control.Exception (finally)
 import qualified IHP.AutoRefresh as AutoRefresh
 import qualified IHP.AutoRefresh.Types as AutoRefresh
 import IHP.LibDir
 import qualified IHP.Job.Runner as Job
 import qualified IHP.Job.Types as Job
-import qualified Control.Concurrent.Async as Async
-import qualified Data.List as List
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Network.Wai.Middleware.Cors as Cors
 import qualified Control.Exception as Exception
@@ -37,7 +32,6 @@ import qualified GHC.IO.Encoding as IO
 import qualified System.IO as IO
 
 import qualified Network.Wai.Application.Static as Static
-import qualified WaiAppStatic.Storage.Filesystem as Static
 import qualified WaiAppStatic.Types as Static
 
 run :: (FrontController RootApplication, Job.Worker RootApplication) => ConfigBuilder -> IO ()

--- a/IHP/ServerSideComponent/Controller/ComponentsController.hs
+++ b/IHP/ServerSideComponent/Controller/ComponentsController.hs
@@ -6,7 +6,6 @@ import IHP.ServerSideComponent.Types as SSC
 import IHP.ServerSideComponent.ControllerFunctions as SSC
 
 import qualified Data.Aeson as Aeson
-import qualified Text.Blaze.Html.Renderer.Text as Blaze
 
 instance (Component component controller, FromJSON controller) => WSApp (ComponentsController component) where
     initialState = ComponentsController

--- a/IHP/ServerSideComponent/RouterFunctions.hs
+++ b/IHP/ServerSideComponent/RouterFunctions.hs
@@ -11,13 +11,10 @@ import qualified Data.Typeable as Typeable
 import qualified Data.ByteString.Char8 as ByteString
 import IHP.RouterSupport
 import qualified Prelude
-import Network.Wai
-import Data.Attoparsec.ByteString.Char8 (Parser)
 import IHP.ServerSideComponent.Controller.ComponentsController ()
 import Data.Aeson
 import IHP.ControllerSupport
 import IHP.ApplicationContext
-import IHP.RouterSupport (RouteParser)
 
 routeComponent :: forall component controller application.
     ( Typeable component

--- a/IHP/Test/Database.hs
+++ b/IHP/Test/Database.hs
@@ -3,11 +3,8 @@ module IHP.Test.Database where
 import IHP.Prelude
 import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
-import qualified Database.PostgreSQL.Simple.FromRow as PG
-import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Data.UUID.V4 as UUID
 import qualified Data.UUID as UUID
-import qualified System.Process as Process
 import qualified Data.Text as Text
 import qualified Data.ByteString as ByteString
 import qualified IHP.LibDir as LibDir

--- a/IHP/Test/Mocking.hs
+++ b/IHP/Test/Mocking.hs
@@ -9,17 +9,13 @@ module IHP.Test.Mocking where
 import           Data.ByteString.Builder                   (toLazyByteString)
 import qualified Data.ByteString.Lazy                      as LBS
 import qualified Data.Vault.Lazy                           as Vault
-import           Database.PostgreSQL.Simple                (connectPostgreSQL)
-import           Network.HTTP.Types.Header
 import qualified Network.HTTP.Types.Status                 as HTTP
 import           Network.Wai
 import           Network.Wai.Internal                      (ResponseReceived (..))
 import           Network.Wai.Parse                         (Param (..))
 
-import qualified IHP.ApplicationContext                    as ApplicationContext
 import           IHP.ApplicationContext                    (ApplicationContext (..))
 import qualified IHP.AutoRefresh.Types                     as AutoRefresh
-import qualified IHP.Controller.Context                    as Context
 import           IHP.Controller.RequestContext             (RequestBody (..), RequestContext (..))
 import           IHP.ControllerSupport                     (InitControllerContext, Controller, runActionWithNewContext)
 import           IHP.FrameworkConfig                       (ConfigBuilder (..), FrameworkConfig (..))
@@ -32,7 +28,6 @@ import qualified IHP.Test.Database as Database
 import Test.Hspec
 import qualified Data.Text as Text
 import qualified Network.Wai as Wai
-import qualified IHP.Controller.Session as Session
 import qualified IHP.LoginSupport.Helper.Controller as Session
 import qualified Network.Wai.Session
 import qualified Data.Serialize as Serialize

--- a/IHP/View/CSSFramework.hs
+++ b/IHP/View/CSSFramework.hs
@@ -17,7 +17,6 @@ import IHP.ModelSupport
 import IHP.Breadcrumb.Types
 import IHP.Pagination.Helpers
 import IHP.Pagination.Types
-import IHP.View.Types (PaginationView(linkPrevious, pagination))
 
 
 -- | Provides an unstyled CSSFramework

--- a/IHP/ViewPrelude.hs
+++ b/IHP/ViewPrelude.hs
@@ -41,14 +41,13 @@ module IHP.ViewPrelude (
 import IHP.Prelude
 import IHP.ViewErrorMessages ()
 import           IHP.ViewSupport
-import Text.Blaze (preEscapedText, stringValue, text, (!))
+import Text.Blaze (stringValue, (!))
 import Text.Blaze.Html5 (preEscapedToHtml, preEscapedTextValue)
 import IHP.View.Form
 import IHP.HSX.QQ (hsx)
 import IHP.HSX.ToHtml
 import IHP.View.TimeAgo
 import IHP.ValidationSupport
-import IHP.Controller.RequestContext
 import IHP.RouterSupport
 import IHP.ModelSupport
 import IHP.FrameworkConfig

--- a/IHP/WebSocket.hs
+++ b/IHP/WebSocket.hs
@@ -26,13 +26,8 @@ import qualified Control.Exception as Exception
 import IHP.Controller.Context
 import qualified Data.Aeson as Aeson
 
-import qualified IHP.Log.Types as Log
 import qualified IHP.Log as Log
 
-import Control.Concurrent.Chan
-import Control.Concurrent
-import System.Timeout
-import Data.Function (fix)
 import qualified Network.WebSockets.Connection as WebSocket
 
 class WSApp state where

--- a/exe/IHP/IDE/DevServer.hs
+++ b/exe/IHP/IDE/DevServer.hs
@@ -4,10 +4,9 @@ import ClassyPrelude
 import qualified System.Process as Process
 import IHP.HaskellSupport
 import qualified Data.ByteString.Char8 as ByteString
-import Control.Concurrent (threadDelay, myThreadId)
+import Control.Concurrent (myThreadId)
 import System.Exit
 import System.Posix.Signals
-import qualified System.FSNotify as FS
 
 import IHP.IDE.Types
 import IHP.IDE.Postgres
@@ -21,7 +20,6 @@ import Data.String.Conversions (cs)
 import qualified IHP.LibDir as LibDir
 import qualified IHP.Telemetry as Telemetry
 import qualified IHP.Version as Version
-import qualified Data.Time.Clock as Clock
 
 import qualified IHP.Log.Types as Log
 import qualified IHP.Log as Log


### PR DESCRIPTION
This PR fixes all unused import warning. I've fixed most of them using the "Remove all redundant imports" haskell-language-server code action. I also fixed a few instance imports manually (mostly `IHP.IDE.ToolServer.Routes`).

Maybe we should also promote this warning to an actual error so that it doesn't creep back into the codebase.

Relates to #1640.