### PR TITLE
`UploadedFile` record helper and guide

### DIFF
--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -384,14 +384,13 @@ Our Companies controller will now change to:
         signedUrl <- createTemporaryDownloadUrl storedFile
 
         -- Create the UploadedFile record. Set the signed URL, path, content-type etc.
-        uploadedFile <- newRecord @UploadedFile |> createRecord
-        uploadedFile <- uploadedFile
-            |> set #signedUrl signedUrl.url
-            |> set #signedUrlExpiredAt signedUrl.expiredAt
-            |> set #path storedFile.path
-            |> set #fileName (cs file.fileName)
-            |> set #contentType (cs $ Wai.fileContentType file)
-            |> updateRecord
+        uploadedFile <- newRecord @UploadedFile
+                |> set #signedUrl signedUrl.url
+                |> set #signedUrlExpiredAt signedUrl.expiredAt
+                |> set #path storedFile.path
+                |> set #fileName (cs file.fileName)
+                |> set #contentType (cs $ Wai.fileContentType file)
+                |> createRecord
 
         let company = newRecord @Company
         company

--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -632,8 +632,7 @@ If the [`StaticDirStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileSt
 
 The signed url is valid for 7 days.
 
-@todo: Add about refresh.
-
+You can use the [`refreshTemporaryDownloadUrl`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:refreshTemporaryDownloadUrl) function to refresh the signed url. See the [example above](#required-uploads-with-a-file-record) for an example.
 
 ## File Upload Limits
 


### PR DESCRIPTION
- Explanation on how to use the `UploadedFile` (or any other name)  record
- Add a `refreshTemporaryDownloadUrl` helper function

For posterity, working PR using the helper function here https://github.com/amitaibu/ihp-landing-page/pull/18