### PR TITLE
Add `NoRenderCommentNode` to hsx

### DIFF
--- a/Guide/hsx.markdown
+++ b/Guide/hsx.markdown
@@ -228,9 +228,32 @@ Spaces and newline characters are removed where possible at HSX parse time.
 
 HTML Comments are supported and can be used like this:
 
+```haskell
+[hsx|
+<div>
+    <!-- Comment with be shown on HTML -->
+    <h1>Hello</h1>
+</div>
+|]
+
+```
+
+We also support a "no render" comments, that can be used for adding comments inside `hsx`, but without being
+rendered to HTML.
+
+```haskell
+[hsx|
+    <div>
+        {- Comment with be shown on HTML -}
+        <h1>Hello</h1>
+    </div>
+|]
+```
+
+Will render to:
+
 ```html
 <div>
-    <!-- Begin of Main Section -->
     <h1>Hello</h1>
 </div>
 ```

--- a/Guide/hsx.markdown
+++ b/Guide/hsx.markdown
@@ -231,7 +231,7 @@ HTML Comments are supported and can be used like this:
 ```haskell
 [hsx|
 <div>
-    <!-- Comment with be shown on HTML -->
+    <!-- Comment will be shown on HTML -->
     <h1>Hello</h1>
 </div>
 |]
@@ -244,7 +244,7 @@ rendered to HTML.
 ```haskell
 [hsx|
     <div>
-        {- Comment with be shown on HTML -}
+        {- Comment will not be shown on HTML -}
         <h1>Hello</h1>
     </div>
 |]

--- a/IHP/ServerSideComponent/HtmlDiff.hs
+++ b/IHP/ServerSideComponent/HtmlDiff.hs
@@ -49,6 +49,7 @@ diffNodes' path CommentNode { comment = oldComment } CommentNode { comment = new
         if oldComment == newComment
             then []
             else [UpdateComment { comment = newComment, path }]
+diffNodes' path NoRenderCommentNode NoRenderCommentNode = []
 diffNodes' path PreEscapedTextNode { textContent = oldTextContent } PreEscapedTextNode { textContent = newTextContent } =
         if oldTextContent == newTextContent
             then []

--- a/IHP/ServerSideComponent/HtmlParser.hs
+++ b/IHP/ServerSideComponent/HtmlParser.hs
@@ -25,8 +25,8 @@ data Node = Node { tagName :: !Text, attributes :: ![Attribute], children :: ![N
     | TextNode { textContent :: !Text } -- ^ Note: doesn't unescape chars like &lt;
     | PreEscapedTextNode { textContent :: !Text } -- ^ Used in @script@ or @style@ bodies
     | Children { children :: ![Node] }
-    | CommentNode { comment :: !Text } -- ^ A Comment that is rendered in the final HTML.
-    | NoRenderCommentNode -- ^ A comment that is not rendered in the final HTML.
+    | CommentNode { comment :: !Text } -- ^ A Comment that is rendered in the final HTML
+    | NoRenderCommentNode -- ^ A comment that is not rendered in the final HTML
     deriving (Eq, Show)
 
 parseHtml :: Text -> Either (ParseErrorBundle Text Void) Node

--- a/IHP/ServerSideComponent/HtmlParser.hs
+++ b/IHP/ServerSideComponent/HtmlParser.hs
@@ -87,8 +87,8 @@ parseComment = do
 
 parseNoRenderComment :: Parser Node
 parseNoRenderComment = do
-    string "{<!--"
-    body :: String <- manyTill (satisfy (const True)) (string "-->}")
+    string "{-"
+    body :: String <- manyTill (satisfy (const True)) (string "-}")
     space
     pure NoRenderCommentNode
 

--- a/IHP/ServerSideComponent/HtmlParser.hs
+++ b/IHP/ServerSideComponent/HtmlParser.hs
@@ -88,8 +88,8 @@ parseComment = do
 parseNoRenderComment :: Parser Node
 parseNoRenderComment = do
     string "{-"
+    body :: String <- manyTill (satisfy (const True)) (string "-}")
     space
-    string "-}"
     pure NoRenderCommentNode
 
 parseNodeAttributes :: Parser a -> Parser [Attribute]

--- a/IHP/ServerSideComponent/HtmlParser.hs
+++ b/IHP/ServerSideComponent/HtmlParser.hs
@@ -87,8 +87,8 @@ parseComment = do
 
 parseNoRenderComment :: Parser Node
 parseNoRenderComment = do
-    string "{-"
-    body :: String <- manyTill (satisfy (const True)) (string "-}")
+    string "{<!--"
+    body :: String <- manyTill (satisfy (const True)) (string "-->}")
     space
     pure NoRenderCommentNode
 

--- a/IHP/ServerSideComponent/HtmlParser.hs
+++ b/IHP/ServerSideComponent/HtmlParser.hs
@@ -88,7 +88,7 @@ parseComment = do
 parseNoRenderComment :: Parser Node
 parseNoRenderComment = do
     string "{-"
-    body :: String <- manyTill (satisfy (const True)) (string "-}")
+    manyTill (satisfy (const True)) (string "-}")
     space
     pure NoRenderCommentNode
 

--- a/IHP/ServerSideComponent/HtmlParser.hs
+++ b/IHP/ServerSideComponent/HtmlParser.hs
@@ -25,8 +25,8 @@ data Node = Node { tagName :: !Text, attributes :: ![Attribute], children :: ![N
     | TextNode { textContent :: !Text } -- ^ Note: doesn't unescape chars like &lt;
     | PreEscapedTextNode { textContent :: !Text } -- ^ Used in @script@ or @style@ bodies
     | Children { children :: ![Node] }
-    | CommentNode { comment :: !Text }
-    | NoRenderCommentNode -- ^ Comments that are not rendered in the final HTML.
+    | CommentNode { comment :: !Text } -- ^ A Comment that is rendered in the final HTML.
+    | NoRenderCommentNode -- ^ A comment that is not rendered in the final HTML.
     deriving (Eq, Show)
 
 parseHtml :: Text -> Either (ParseErrorBundle Text Void) Node

--- a/IHP/ServerSideComponent/HtmlParser.hs
+++ b/IHP/ServerSideComponent/HtmlParser.hs
@@ -26,6 +26,7 @@ data Node = Node { tagName :: !Text, attributes :: ![Attribute], children :: ![N
     | PreEscapedTextNode { textContent :: !Text } -- ^ Used in @script@ or @style@ bodies
     | Children { children :: ![Node] }
     | CommentNode { comment :: !Text }
+    | NoRenderCommentNode -- ^ Comments that are not rendered in the final HTML.
     deriving (Eq, Show)
 
 parseHtml :: Text -> Either (ParseErrorBundle Text Void) Node
@@ -41,7 +42,7 @@ parser = do
     eof
     pure node
 
-parseElement = try parseComment <|> try parseNormalElement <|> try parseSelfClosingElement
+parseElement = try parseNoRenderComment <|> try parseComment <|> try parseNormalElement <|> try parseSelfClosingElement
 
 parseChildren = Children <$> many parseChild
 
@@ -84,9 +85,15 @@ parseComment = do
     space
     pure (CommentNode (cs body))
 
+parseNoRenderComment :: Parser Node
+parseNoRenderComment = do
+    string "{-"
+    space
+    string "-}"
+    pure NoRenderCommentNode
 
 parseNodeAttributes :: Parser a -> Parser [Attribute]
-parseNodeAttributes end = manyTill parseNodeAttribute end 
+parseNodeAttributes end = manyTill parseNodeAttribute end
 
 parseNodeAttribute = do
     attributeName <- parseAttributeName

--- a/Test/HSX/QQSpec.hs
+++ b/Test/HSX/QQSpec.hs
@@ -98,7 +98,7 @@ tests = do
             [hsx|<div><!--my comment--></div>|] `shouldBeHtml` "<div><!-- my comment --></div>"
 
         it "should work with no render comments" do
-            [hsx|<div>{<!--my comment-->}</div>|] `shouldBeHtml` "<div></div>"
+            [hsx|<div>{- my comment -}</div>|] `shouldBeHtml` "<div></div>"
 
         it "should escape variables to avoid XSS" do
             let variableContent :: Text = "<script>alert(1);</script>"

--- a/Test/HSX/QQSpec.hs
+++ b/Test/HSX/QQSpec.hs
@@ -97,6 +97,9 @@ tests = do
         it "should work with html comments" do
             [hsx|<div><!--my comment--></div>|] `shouldBeHtml` "<div><!-- my comment --></div>"
 
+        it "should work with no render comments" do
+            [hsx|<div>{<!--my comment-->}</div>|] `shouldBeHtml` "<div></div>"
+
         it "should escape variables to avoid XSS" do
             let variableContent :: Text = "<script>alert(1);</script>"
             [hsx|{variableContent}|] `shouldBeHtml` "&lt;script&gt;alert(1);&lt;/script&gt;"

--- a/Test/ServerSideComponent/HtmlDiffSpec.hs
+++ b/Test/ServerSideComponent/HtmlDiffSpec.hs
@@ -48,6 +48,13 @@ tests = do
                     let expected = [UpdateComment { comment = "new", path = [] }]
                     result `shouldBe` expected
 
+                it "should patch no render comment nodes" do
+                    let a = NoRenderCommentNode
+                    let b = NoRenderCommentNode
+                    let result = diffNodes a b
+                    let expected = []
+                    result `shouldBe` expected
+
                 it "should patch PreEscapedText nodes" do
                     let a = PreEscapedTextNode { textContent = "alert(1)" }
                     let b = PreEscapedTextNode { textContent = "alert(2)" }
@@ -59,7 +66,7 @@ tests = do
                     let a = Node {tagName = "span", attributes = [], children = [], startOffset = 0, endOffset = 0}
                     let b = Node {tagName = "span", attributes = [], children = [TextNode {textContent = "string"}, CommentNode {comment = "test"}], startOffset = 0, endOffset = 0}
                     let result = diffNodes a b
-                    let expected = 
+                    let expected =
                             [ CreateNode {html = "string", path = [0]}
                             , CreateNode {html = "<!--test-->", path = [1]}
                             ]
@@ -131,7 +138,7 @@ tests = do
                                 [ CreateNode {html = "<b/>", path = [1]}
                                 ]
                     result `shouldBe` expected
-                
+
                 it "should do efficiently remove old nodes if they are in the middle of the children" do
                     let ?oldHtml = "<div><a/><b/><c/></div>"
                     let ?newHtml = "<div><a/><c/></div>"

--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -43,8 +43,8 @@ data Node = Node !Text ![Attribute] ![Node] !Bool
     | PreEscapedTextNode !Text -- ^ Used in @script@ or @style@ bodies
     | SplicedNode !Haskell.Exp -- ^ Inline haskell expressions like @{myVar}@ or @{f "hello"}@
     | Children ![Node]
-    | CommentNode !Text
-    | NoRenderCommentNode -- ^ Comments that are not rendered in the final HTML.
+    | CommentNode !Text -- ^ A Comment that is rendered in the final HTML.
+    | NoRenderCommentNode -- ^ A comment that is not rendered in the final HTML.
     deriving (Eq, Show)
 
 -- | Parses a HSX text and returns a 'Node'
@@ -141,8 +141,8 @@ hsxComment = do
 
 hsxNoRenderComment :: Parser Node
 hsxNoRenderComment = do
-    string "{-"
-    body :: String <- manyTill (satisfy (const True)) (string "-}")
+    string "{<!--"
+    body :: String <- manyTill (satisfy (const True)) (string "-->}")
     space
     pure NoRenderCommentNode
 

--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -142,7 +142,7 @@ hsxComment = do
 hsxNoRenderComment :: Parser Node
 hsxNoRenderComment = do
     string "{-"
-    body :: String <- manyTill (satisfy (const True)) (string "-}")
+    manyTill (satisfy (const True)) (string "-}")
     space
     pure NoRenderCommentNode
 

--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -43,8 +43,8 @@ data Node = Node !Text ![Attribute] ![Node] !Bool
     | PreEscapedTextNode !Text -- ^ Used in @script@ or @style@ bodies
     | SplicedNode !Haskell.Exp -- ^ Inline haskell expressions like @{myVar}@ or @{f "hello"}@
     | Children ![Node]
-    | CommentNode !Text -- ^ A Comment that is rendered in the final HTML.
-    | NoRenderCommentNode -- ^ A comment that is not rendered in the final HTML.
+    | CommentNode !Text -- ^ A Comment that is rendered in the final HTML
+    | NoRenderCommentNode -- ^ A comment that is not rendered in the final HTML
     deriving (Eq, Show)
 
 -- | Parses a HSX text and returns a 'Node'

--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -142,8 +142,8 @@ hsxComment = do
 hsxNoRenderComment :: Parser Node
 hsxNoRenderComment = do
     string "{-"
+    body :: String <- manyTill (satisfy (const True)) (string "-}")
     space
-    string "-}"
     pure NoRenderCommentNode
 
 

--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -141,8 +141,8 @@ hsxComment = do
 
 hsxNoRenderComment :: Parser Node
 hsxNoRenderComment = do
-    string "{<!--"
-    body :: String <- manyTill (satisfy (const True)) (string "-->}")
+    string "{-"
+    body :: String <- manyTill (satisfy (const True)) (string "-}")
     space
     pure NoRenderCommentNode
 

--- a/ihp-hsx/IHP/HSX/QQ.hs
+++ b/ihp-hsx/IHP/HSX/QQ.hs
@@ -80,6 +80,7 @@ compileToHaskell (TextNode value) = [| Html5.preEscapedText value |]
 compileToHaskell (PreEscapedTextNode value) = [| Html5.preEscapedText value |]
 compileToHaskell (SplicedNode expression) = [| toHtml $(pure expression) |]
 compileToHaskell (CommentNode value) = [| Html5.textComment value |]
+compileToHaskell (NoRenderCommentNode) = [| mempty |]
 
 
 toStringAttribute :: Attribute -> TH.ExpQ


### PR DESCRIPTION
| hsx | Html |
| -- | -- |
| ![image](https://github.com/digitallyinduced/ihp/assets/125707/dd4d7ed3-f0df-464e-9381-5c79996e055a) | ![image](https://github.com/digitallyinduced/ihp/assets/125707/157f9c57-6d69-4c53-8a28-dfb3e5cf7e69) |


fixes #1722