### PR TITLE
feat: do not watch .direnv and .devenv subdirectories

### DIFF
--- a/IHP/IDE/FileWatcher.hs
+++ b/IHP/IDE/FileWatcher.hs
@@ -3,28 +3,57 @@ module IHP.IDE.FileWatcher (withFileWatcher) where
 import IHP.Prelude
 import Control.Exception
 import Control.Concurrent (threadDelay, myThreadId)
-import Control.Monad (filterM)
+import Control.Concurrent.MVar
+import Control.Monad (filterM, guard)
 import System.Directory (listDirectory, doesDirectoryExist)
+import qualified Data.Map as Map
 import qualified System.FSNotify as FS
 import IHP.IDE.Types
 import qualified Data.Time.Clock as Clock
 import qualified Data.List as List
 import IHP.IDE.LiveReloadNotificationServer (notifyAssetChange)
+import qualified IHP.Log as Log
 
 withFileWatcher :: (?context :: Context) => IO () -> IO ()
 withFileWatcher inner = withAsync callback \_ -> inner
     where
         callback = FS.withManagerConf fileWatcherConfig \manager -> do
-                watchRootDirectoryFiles manager
-                watchSubDirectories manager
+                state <- newFileWatcherState
+                watchRootDirectoryFiles manager state
+                watchSubDirectories manager state
                 forever (threadDelay maxBound) `finally` FS.stopManager manager
-        watchRootDirectoryFiles manager = 
-                FS.watchDir manager "." shouldActOnFileChange handleFileChange 
-        watchSubDirectories manager = do
+        watchRootDirectoryFiles manager state = 
+                FS.watchDir manager "." shouldActOnRootFileChange (handleRootFileChange manager state)
+        watchSubDirectories manager state = do
                 directories <- listWatchableDirectories
                 forM_ directories \directory -> do
-                  FS.watchTree manager directory shouldActOnFileChange handleFileChange
-           
+                  startWatchingSubDirectory manager state directory
+
+type WatchedDirectories = Map FilePath FS.StopListening
+
+type FileWatcherState = MVar WatchedDirectories
+
+newFileWatcherState :: IO FileWatcherState
+newFileWatcherState = newMVar mempty
+
+startWatchingSubDirectory :: (?context :: Context) => FS.WatchManager -> FileWatcherState -> FilePath -> IO ()
+startWatchingSubDirectory manager state path = do
+  watchedDirectories <- readMVar state
+  case Map.lookup path watchedDirectories of
+    Just _ -> pure ()
+    Nothing -> do
+        stop <- FS.watchTree manager path shouldActOnFileChange handleFileChange
+        putMVar state $ Map.insert path stop watchedDirectories
+
+stopWatchingSubDirectory :: FileWatcherState -> FilePath -> IO ()
+stopWatchingSubDirectory state path = do
+  watchedDirectories <- readMVar state
+  case Map.lookup path watchedDirectories of
+    Just stop -> do
+      stop
+      putMVar state $ Map.delete path watchedDirectories
+    Nothing -> pure ()
+
 listWatchableDirectories :: IO [String]
 listWatchableDirectories = do
   rootDirectoryContents <- listDirectory "."
@@ -33,8 +62,11 @@ listWatchableDirectories = do
 shouldWatchDirectory :: String -> IO Bool
 shouldWatchDirectory path = do
   isDirectory <- doesDirectoryExist path
-  pure $ isDirectory && path /= ".devenv" && path /= ".direnv"
+  pure $ isDirectory && isDirectoryWatchable path
 
+isDirectoryWatchable :: String -> Bool
+isDirectoryWatchable path = 
+  path /= ".devenv" && path /= ".direnv"
 
 fileWatcherDebounceTime :: NominalDiffTime
 fileWatcherDebounceTime = Clock.secondsToNominalDiffTime 0.1 -- 100ms
@@ -52,7 +84,29 @@ handleFileChange event = do
             else if isAssetFile filePath
                 then notifyAssetChange
                 else mempty
+                  
+handleRootFileChange :: (?context :: Context) => FS.WatchManager -> FileWatcherState -> FS.Event -> IO ()                 
+handleRootFileChange manager state event =
+  case event of
+    FS.Added filePath _ true -> 
+      if isDirectoryWatchable filePath then do
+        Log.info $ "Watching directory " <> tshow filePath
+        startWatchingSubDirectory manager state filePath
+      else pure ()
+    FS.Removed filePath _ true -> 
+      if isDirectoryWatchable filePath then do
+        Log.info $ "Unwatching directory " <> tshow filePath
+        stopWatchingSubDirectory state filePath
+      else pure ()
+    _ -> 
+      handleFileChange event
 
+shouldActOnRootFileChange :: FS.ActionPredicate
+shouldActOnRootFileChange event =
+    if FS.eventIsDirectory event
+    then isDirectoryWatchable (getEventFilePath event)
+    else shouldActOnFileChange event
+    
 shouldActOnFileChange :: FS.ActionPredicate
 shouldActOnFileChange event =
     let path = getEventFilePath event

--- a/IHP/IDE/FileWatcher.hs
+++ b/IHP/IDE/FileWatcher.hs
@@ -12,7 +12,6 @@ import IHP.IDE.Types
 import qualified Data.Time.Clock as Clock
 import qualified Data.List as List
 import IHP.IDE.LiveReloadNotificationServer (notifyAssetChange)
-import qualified IHP.Log as Log
 
 withFileWatcher :: (?context :: Context) => IO () -> IO ()
 withFileWatcher inner = withAsync callback \_ -> inner
@@ -90,12 +89,10 @@ handleRootFileChange manager state event =
   case event of
     FS.Added filePath _ true -> 
       if isDirectoryWatchable filePath then do
-        Log.info $ "Watching directory " <> tshow filePath
         startWatchingSubDirectory manager state filePath
       else pure ()
     FS.Removed filePath _ true -> 
       if isDirectoryWatchable filePath then do
-        Log.info $ "Unwatching directory " <> tshow filePath
         stopWatchingSubDirectory state filePath
       else pure ()
     _ -> 

--- a/IHP/IDE/FileWatcher.hs
+++ b/IHP/IDE/FileWatcher.hs
@@ -2,9 +2,9 @@ module IHP.IDE.FileWatcher (withFileWatcher) where
 
 import IHP.Prelude
 import Control.Exception
-import Control.Concurrent (threadDelay, myThreadId)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar
-import Control.Monad (filterM, guard)
+import Control.Monad (filterM)
 import System.Directory (listDirectory, doesDirectoryExist)
 import qualified Data.Map as Map
 import qualified System.FSNotify as FS

--- a/IHP/IDE/FileWatcher.hs
+++ b/IHP/IDE/FileWatcher.hs
@@ -26,7 +26,7 @@ withFileWatcher inner = withAsync callback \_ -> inner
         watchSubDirectories manager state = do
                 directories <- listWatchableDirectories
                 forM_ directories \directory -> do
-                  startWatchingSubDirectory manager state directory
+                    startWatchingSubDirectory manager state directory
 
 type WatchedDirectories = Map FilePath FS.StopListening
 
@@ -37,35 +37,35 @@ newFileWatcherState = newMVar mempty
 
 startWatchingSubDirectory :: (?context :: Context) => FS.WatchManager -> FileWatcherState -> FilePath -> IO ()
 startWatchingSubDirectory manager state path = do
-  watchedDirectories <- readMVar state
-  case Map.lookup path watchedDirectories of
-    Just _ -> pure ()
-    Nothing -> do
-        stop <- FS.watchTree manager path shouldActOnFileChange handleFileChange
-        putMVar state $ Map.insert path stop watchedDirectories
+    watchedDirectories <- readMVar state
+    case Map.lookup path watchedDirectories of
+        Just _ -> pure ()
+        Nothing -> do
+            stop <- FS.watchTree manager path shouldActOnFileChange handleFileChange
+            putMVar state $ Map.insert path stop watchedDirectories
 
 stopWatchingSubDirectory :: FileWatcherState -> FilePath -> IO ()
 stopWatchingSubDirectory state path = do
-  watchedDirectories <- readMVar state
-  case Map.lookup path watchedDirectories of
-    Just stop -> do
-      stop
-      putMVar state $ Map.delete path watchedDirectories
-    Nothing -> pure ()
+    watchedDirectories <- readMVar state
+    case Map.lookup path watchedDirectories of
+        Just stop -> do
+            stop
+            putMVar state $ Map.delete path watchedDirectories
+        Nothing -> pure ()
 
 listWatchableDirectories :: IO [String]
 listWatchableDirectories = do
-  rootDirectoryContents <- listDirectory "."
-  filterM shouldWatchDirectory rootDirectoryContents
+    rootDirectoryContents <- listDirectory "."
+    filterM shouldWatchDirectory rootDirectoryContents
 
 shouldWatchDirectory :: String -> IO Bool
 shouldWatchDirectory path = do
-  isDirectory <- doesDirectoryExist path
-  pure $ isDirectory && isDirectoryWatchable path
+    isDirectory <- doesDirectoryExist path
+    pure $ isDirectory && isDirectoryWatchable path
 
 isDirectoryWatchable :: String -> Bool
 isDirectoryWatchable path = 
-  path /= ".devenv" && path /= ".direnv"
+    path /= ".devenv" && path /= ".direnv"
 
 fileWatcherDebounceTime :: NominalDiffTime
 fileWatcherDebounceTime = Clock.secondsToNominalDiffTime 0.1 -- 100ms
@@ -86,15 +86,15 @@ handleFileChange event = do
                   
 handleRootFileChange :: (?context :: Context) => FS.WatchManager -> FileWatcherState -> FS.Event -> IO ()                 
 handleRootFileChange manager state event =
-  case event of
-    FS.Added filePath _ true -> 
-      if isDirectoryWatchable filePath then do
-        startWatchingSubDirectory manager state filePath
-      else pure ()
-    FS.Removed filePath _ true -> 
-      stopWatchingSubDirectory state filePath
-    _ ->
-      handleFileChange event
+    case event of
+        FS.Added filePath _ true ->
+            if isDirectoryWatchable filePath then do
+                startWatchingSubDirectory manager state filePath
+            else pure ()
+        FS.Removed filePath _ true ->
+            stopWatchingSubDirectory state filePath
+        _ ->
+            handleFileChange event
 
 shouldActOnRootFileChange :: FS.ActionPredicate
 shouldActOnRootFileChange event =

--- a/IHP/IDE/FileWatcher.hs
+++ b/IHP/IDE/FileWatcher.hs
@@ -92,10 +92,8 @@ handleRootFileChange manager state event =
         startWatchingSubDirectory manager state filePath
       else pure ()
     FS.Removed filePath _ true -> 
-      if isDirectoryWatchable filePath then do
-        stopWatchingSubDirectory state filePath
-      else pure ()
-    _ -> 
+      stopWatchingSubDirectory state filePath
+    _ ->
       handleFileChange event
 
 shouldActOnRootFileChange :: FS.ActionPredicate

--- a/IHP/IDE/FileWatcher.hs
+++ b/IHP/IDE/FileWatcher.hs
@@ -3,6 +3,8 @@ module IHP.IDE.FileWatcher (withFileWatcher) where
 import IHP.Prelude
 import Control.Exception
 import Control.Concurrent (threadDelay, myThreadId)
+import Control.Monad (filterM)
+import System.Directory (listDirectory, doesDirectoryExist)
 import qualified System.FSNotify as FS
 import IHP.IDE.Types
 import qualified Data.Time.Clock as Clock
@@ -13,8 +15,26 @@ withFileWatcher :: (?context :: Context) => IO () -> IO ()
 withFileWatcher inner = withAsync callback \_ -> inner
     where
         callback = FS.withManagerConf fileWatcherConfig \manager -> do
-                FS.watchTree manager "." shouldActOnFileChange handleFileChange
+                watchRootDirectoryFiles manager
+                watchSubDirectories manager
                 forever (threadDelay maxBound) `finally` FS.stopManager manager
+        watchRootDirectoryFiles manager = 
+                FS.watchDir manager "." shouldActOnFileChange handleFileChange 
+        watchSubDirectories manager = do
+                directories <- listWatchableDirectories
+                forM_ directories \directory -> do
+                  FS.watchTree manager directory shouldActOnFileChange handleFileChange
+           
+listWatchableDirectories :: IO [String]
+listWatchableDirectories = do
+  rootDirectoryContents <- listDirectory "."
+  filterM shouldWatchDirectory rootDirectoryContents
+
+shouldWatchDirectory :: String -> IO Bool
+shouldWatchDirectory path = do
+  isDirectory <- doesDirectoryExist path
+  pure $ isDirectory && path /= ".devenv" && path /= ".direnv"
+
 
 fileWatcherDebounceTime :: NominalDiffTime
 fileWatcherDebounceTime = Clock.secondsToNominalDiffTime 0.1 -- 100ms


### PR DESCRIPTION
The file watcher used by the dev server to automatically reload on changes seems to have issues with large directories with Ubuntu (see https://github.com/digitallyinduced/ihp/issues/1714).

The System.FSNotify API does not allow us to exclude sub-trees from the paths watched by `watchTree`. Instead we can watch file changes in the root directory using `watchDir` and use `watchTree` on sub-directories excluding `.direnv` and `.devenv` which are known to be large directories and are not relevant with regard do reloading.

We also keep track of directories added and removed from the root directory and watch them accordingly.