### PR TITLE
Improved ihp lib

### DIFF
--- a/IHP/LibDir.hs
+++ b/IHP/LibDir.hs
@@ -22,20 +22,8 @@ import qualified IHP.FrameworkConfig as Config
 -- while the dev server binary is located at @bin/RunDevServer@.
 findLibDirectory :: IO Text
 findLibDirectory = do
-    frameworkMountedLocally <- Directory.doesDirectoryExist "IHP"
-    if frameworkMountedLocally
-        then pure "IHP/lib/IHP/"
-        else do
-            -- The IHP_LIB env var is set in flake-module.nix
-            ihpLibVar <- Config.envOrNothing "IHP_LIB"
-            case ihpLibVar of
-                Just ihpLib -> pure ihpLib
-                Nothing -> do
-                    -- This branch deals with legacy IHP versions before v1.1
-                    -- We can remove this in the future
-                    ihpLibSymlinkAvailable <- Directory.doesDirectoryExist "build/ihp-lib"
-                    if ihpLibSymlinkAvailable
-                        then pure "build/ihp-lib/"
-                        else do
-                            binDir <- cs <$> Process.readCreateProcess (Process.shell "dirname $(which RunDevServer)") ""
-                            pure (Text.strip binDir <> "/../lib/IHP/")
+    -- The IHP_LIB env var is set in flake-module.nix
+    ihpLibVar <- Config.envOrNothing "IHP_LIB"
+    case ihpLibVar of
+        Just ihpLib -> pure ihpLib
+        Nothing -> error "IHP_LIB env var is not set. Please run 'nix develop --impure' before running the dev server, or make sure that your direnv integration is working correctly."

--- a/IHP/LibDir.hs
+++ b/IHP/LibDir.hs
@@ -25,5 +25,5 @@ findLibDirectory = do
     -- The IHP_LIB env var is set in flake-module.nix
     ihpLibVar <- Config.envOrNothing "IHP_LIB"
     case ihpLibVar of
-        Just ihpLib -> pure ihpLib
+        Just ihpLib -> pure (ihpLib <> "/")
         Nothing -> error "IHP_LIB env var is not set. Please run 'nix develop --impure' before running the dev server, or make sure that your direnv integration is working correctly."

--- a/IHP/LibDir.hs
+++ b/IHP/LibDir.hs
@@ -3,7 +3,7 @@ Module: IHP.LibDir
 Description: Functions to access the IHP lib/ directory at runtime
 Copyright: (c) digitally induced GmbH, 2020
 -}
-module IHP.LibDir (findLibDirectory, ensureSymlink) where
+module IHP.LibDir (findLibDirectory) where
 
 import IHP.Prelude
 import qualified System.Directory as Directory
@@ -31,40 +31,3 @@ findLibDirectory = do
             else do
                 binDir <- cs <$> Process.readCreateProcess (Process.shell "dirname $(which RunDevServer)") ""
                 pure (Text.strip binDir <> "/../lib/IHP/")
-
--- | Creates the build/ihp-lib symlink if missing
---
--- This is called in dev mode to make sure that build/ihp-lib points to the right IHP version.
--- Otherwise the CLI tools might not work as expected, e.g. @make db@ might fail.
---
--- If the symlink is missing, it tries to fix this by starting a new nix-shell and pinpointing the framework lib dir in there
-ensureSymlink :: IO ()
-ensureSymlink = do
-    frameworkMountedLocally <- Directory.doesDirectoryExist "IHP"
-    ihpLibSymlinkAvailable <- Directory.doesDirectoryExist "build/ihp-lib"
-
-    unless ihpLibSymlinkAvailable do
-        -- Make sure the build directory exists, otherwise we cannot add the symlink
-        Directory.createDirectoryIfMissing False "build"
-
-        libDir <- if frameworkMountedLocally
-            then pure "../IHP/lib/IHP/"
-            else do
-                putStrLn "Building build/ihp-lib. This might take a few seconds"
-                binDir <- cs <$> Process.readCreateProcess (Process.shell "nix-shell --run 'dirname $(which RunDevServer)'") ""
-                pure (Text.strip binDir <> "/../lib/IHP/")
-
-
-        -- Below code could fail with 'createSymbolicLink: already exists (File exists)'
-        -- This happens when the symlink points to a non existing target
-        --
-        -- Therefore we retry this operation on error and try to remove a possible
-        -- existing symlink in that case.
-        let createLink = Files.createSymbolicLink (cs libDir) "build/ihp-lib"
-
-        result <- Exception.try createLink
-        case result of
-            Left (exception :: SomeException) -> do
-                Files.removeLink "build/ihp-lib"
-                createLink
-            Right ok -> pure ok

--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -39,8 +39,6 @@ in
         buildPhase = ''
           mkdir -p build
 
-          mkdir -p IHP
-
           # When npm install is executed by the project's makefile it will fail with:
           #
           #     EACCES: permission denied, mkdir '/homeless-shelter'
@@ -49,6 +47,9 @@ in
           #
           # See https://github.com/svanderburg/node2nix/issues/217#issuecomment-751311272
           export HOME=/tmp
+
+          export IHP_LIB=${ihp}/lib/IHP
+          export IHP=${ihp}/lib/IHP
 
           make -j ${appBinary}
 

--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -38,11 +38,8 @@ in
         name = "app";
         buildPhase = ''
           mkdir -p build
-          rm -f build/ihp-lib
 
           mkdir -p IHP
-          ln -s "${ihp}/lib/IHP" build/ihp-lib
-          ln -s "${ihp}/lib" IHP/lib # Avoid the Makefile calling 'which RunDevServer'
 
           # When npm install is executed by the project's makefile it will fail with:
           #
@@ -81,12 +78,12 @@ in
           mv ${appBinary} $out/bin/RunProdServerWithoutOptions
 
           INPUT_HASH="$((basename $out) | cut -d - -f 1)"
-          makeWrapper $out/bin/RunProdServerWithoutOptions $out/bin/RunProdServer --set-default IHP_ASSET_VERSION $INPUT_HASH --run "cd $out/lib" --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
+          makeWrapper $out/bin/RunProdServerWithoutOptions $out/bin/RunProdServer --set-default IHP_ASSET_VERSION $INPUT_HASH --set-default IHP_LIB ${ihp}/lib/IHP --run "cd $out/lib" --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
 
           # Copy job runner binary to bin/ if we built it
           if [ -f ${jobsBinary} ]; then
             mv ${jobsBinary} $out/bin/RunJobsWithoutOptions;
-            makeWrapper $out/bin/RunJobsWithoutOptions $out/bin/RunJobs --set-default IHP_ASSET_VERSION $INPUT_HASH --run "cd $out/lib" --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
+            makeWrapper $out/bin/RunJobsWithoutOptions $out/bin/RunJobs --set-default IHP_ASSET_VERSION $INPUT_HASH --set-default IHP_LIB ${ihp}/lib/IHP --run "cd $out/lib" --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
           fi;
 
           # Copy IHP Script binaries to bin/
@@ -97,8 +94,6 @@ in
               mv "build/bin/Script/$script_basename" "$out/bin/$script_basename";
             done
 
-          mkdir -p "$out/lib/build"
-          cp -R "${ihp}/lib/IHP" "$out/lib/build/ihp-lib"
           mv static "$out/lib/static"
         '';
         dontFixup = true;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -315,7 +315,29 @@ This means that from now on when adding new packages, you need to do it in a sin
 
     This will finally solve all the issues that typically happen around IHP's stateful `build/ihp-lib` symlink. This symlink is now replaced with an env variable called `IHP_LIB` that is automatically provided by devenv.
 
-10. **Migration finished**
+10. **Update `Makefile`**
+    
+    Open your `Makefile` and remove the following boilerplate code at the top of the file:
+
+    ```Makefile
+    ifneq ($(wildcard IHP/.*),)
+    IHP = IHP/lib/IHP
+    else
+    ifneq ($(wildcard build/ihp-lib),)
+    IHP = build/ihp-lib
+    else
+    ifneq ($(shell which RunDevServer),)
+    IHP = $(shell dirname $$(which RunDevServer))/../lib/IHP
+    else
+    IHP = $(error IHP not found! Run the following command to fix this:    nix-shell --run 'make .envrc'    )
+    endif
+    endif
+    endif
+
+    # ...
+    ```
+
+11. **Migration finished**
 
     Finally, approve the new `.envrc`:
 
@@ -327,7 +349,7 @@ This means that from now on when adding new packages, you need to do it in a sin
     You can answer "y" to all of them. This will take some time, as all your packages are now being built.
     Once done, you can commit `flake.lock` to your git repository.
 
-11. **Start project**
+12. **Start project**
 
     Start your project with `devenv up`.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -302,7 +302,20 @@ This means that from now on when adding new packages, you need to do it in a sin
     }
     ```
 
-9. **Migration finished**
+9. **Update `.ghci`**
+
+    Replace your current `.ghci` with the following:
+
+    ```
+    :set -XNoImplicitPrelude
+    :def loadFromIHP \file -> (System.Environment.getEnv "IHP_LIB") >>= (\ihpLib -> readFile (ihpLib <> "/" <> file))
+    :loadFromIHP applicationGhciConfig
+    import IHP.Prelude
+    ```
+
+    This will finally solve all the issues that typically happen around IHP's stateful `build/ihp-lib` symlink. This symlink is now replaced with an env variable called `IHP_LIB` that is automatically provided by devenv.
+
+10. **Migration finished**
 
     Finally, approve the new `.envrc`:
 
@@ -314,7 +327,7 @@ This means that from now on when adding new packages, you need to do it in a sin
     You can answer "y" to all of them. This will take some time, as all your packages are now being built.
     Once done, you can commit `flake.lock` to your git repository.
 
-10. **Start project**
+11. **Start project**
 
     Start your project with `devenv up`.
 

--- a/exe/IHP/IDE/DevServer.hs
+++ b/exe/IHP/IDE/DevServer.hs
@@ -35,7 +35,6 @@ main = withUtf8 do
     actionVar <- newEmptyMVar
     appStateRef <- emptyAppState >>= newIORef
     portConfig <- findAvailablePortConfig
-    LibDir.ensureSymlink
     ensureUserIsNotRoot
 
     -- Start the dev server in Debug mode by setting the env var DEBUG=1

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -172,6 +172,7 @@ ihpFlake:
                 ];
 
                 env.IHP_LIB = "${ihp}/lib/IHP";
+                env.IHP = "${ihp}/lib/IHP"; # Used in the Makefile
             };
         };
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -170,6 +170,8 @@ ihpFlake:
                     '';
                     }
                 ];
+
+                env.IHP_LIB = "${ihp}/lib/IHP";
             };
         };
 

--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -90,12 +90,6 @@ PROD_GHC_OPTIONS+= -with-rtsopts="-A512m -n4m -N"
 .DEFAULT_GOAL := help
 RUNGHC=runghc
 
-ifneq ($(wildcard IHP/.*),)
-IHP_LIB = IHP/lib/IHP
-else
-IHP_LIB = $(shell dirname $$(which RunDevServer))/../lib/IHP
-endif
-
 all: build/Generated/Types.hs
 
 .envrc:

--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -96,7 +96,7 @@ else
 IHP_LIB = $(shell dirname $$(which RunDevServer))/../lib/IHP
 endif
 
-all: build/ihp-lib build/Generated/Types.hs
+all: build/Generated/Types.hs
 
 .envrc:
 	echo "This command is deprecated. Please use 'devenv up' instead"
@@ -161,15 +161,6 @@ print-ghc-extensions: ## Prints all used ghc extensions. Useful for scripting
 help: ## This help page
 	@grep -h -E '^[a-zA-Z_///-\.]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build/ihp-lib: # Used by application .ghci
-	mkdir -p build
-	rm -f build/ihp-lib
-ifneq ($(wildcard IHP/.*),)
-	ln -s ../IHP/lib/IHP build/ihp-lib
-else
-	ln -s ${IHP_LIB} build/ihp-lib
-endif
-
 build/bin/Script/%: build/Script/Main/%.hs
 	mkdir -p build/bin/Script
 	# If RunOptimizedProdServer is compiled, likely we have object files with O2 in the build directory, so we're making an optimized script
@@ -211,7 +202,7 @@ build/RunJobs.hs: build/Generated/Types.hs
 hie.yaml: # Configuration for haskell-language-server
 	echo "cradle:" > hie.yaml
 	echo "  bios:" >> hie.yaml
-	echo "    program: build/ihp-lib/.hie-bios" >> hie.yaml
+	echo "    program: ${IHP_LIB}/.hie-bios" >> hie.yaml
 
 # https://github.com/digitallyinduced/ihp/issues/130
 ghci:


### PR DESCRIPTION
This PR removes all of `build/ihp-lib` and replaces with an env var managed by devenv.

Fixes https://github.com/digitallyinduced/ihp/issues/1751