### PR TITLE
Add docs for enabling flakes, recommend direnv extension

### DIFF
--- a/Guide/editors.markdown
+++ b/Guide/editors.markdown
@@ -14,9 +14,9 @@ You will also find steps on how to get autocompletion and smart IDE features. Th
 
 **Install the following extensions:**
 
--   [`nix-env-selector`](https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector), this loads the project `default.nix` file, so all the right Haskell packages are available to VSCode
--   [`Haskell`](https://marketplace.visualstudio.com/items?itemName=haskell.haskell), this gets smart IDE features with haskell-language-server
--   [`Haskell HSX`](https://marketplace.visualstudio.com/items?itemName=s0kil.vscode-hsx), provides support for [HSX](https://ihp.digitallyinduced.com/Guide/hsx.html)
+- [`direnv`](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv), this loads the project `.envrc` file, so all the right Haskell packages are available to VSCode
+- [`Haskell`](https://marketplace.visualstudio.com/items?itemName=haskell.haskell), this gets smart IDE features with haskell-language-server
+- [`Haskell HSX`](https://marketplace.visualstudio.com/items?itemName=s0kil.vscode-hsx), provides support for [HSX](https://ihp.digitallyinduced.com/Guide/hsx.html)
 
 To make file paths clickable inside the web browser (e.g. when a type error happens), export this env var in your shell (e.g. in `.bashrc`):
 
@@ -185,7 +185,7 @@ When something goes wrong you can also run `haskell-language-server` inside the 
 
 ### Customizing the Web Browser used by IHP
 
-When running `devenv up` the application will automatically be opened in your default browser. You can manually specify a browser by setting the env var `IHP_BROWSER`:
+When running `devenv up` the application will automatically be opened in your default browser. You can manually specify a browser by setting the env var `IHP_BROWSER` in `.envrc`:
 
 ```bash
 export IHP_BROWSER=firefox

--- a/Guide/installation.markdown
+++ b/Guide/installation.markdown
@@ -166,9 +166,9 @@ If you want to try it out before making your own repo, use this button below:
 
 ## 3. Setting up your editor
 
-Also check this out if you're editor is already set up. You might miss a plugin that's recommended for IHP to work well.
+Also check this out if your editor is already set up. You might miss a plugin that's recommended for IHP to work well.
 
--   [VS Code](https://ihp.digitallyinduced.com/Guide/editors.html#using-ihp-with-visual-studio-code-vscode) **Don't have nix-env-selector installed? Read this link**
+-   [VS Code](https://ihp.digitallyinduced.com/Guide/editors.html#using-ihp-with-visual-studio-code-vscode) **Don't have the direnv extension installed? Read this link**
 -   [Sublime Text](https://ihp.digitallyinduced.com/Guide/editors.html#using-ihp-with-sublime-text)
 -   [Emacs](https://ihp.digitallyinduced.com/Guide/editors.html#using-ihp-with-emacs)
 -   [Vim / NeoVim](https://ihp.digitallyinduced.com/Guide/editors.html#using-ihp-with-vim-neovim)

--- a/Guide/installation.markdown
+++ b/Guide/installation.markdown
@@ -112,6 +112,18 @@ Installing nix for IHP was done using [this guide](https://nathan.gs/2019/04/12/
 
 Note that nix can gradually grow to use several GB of disk space, especially after upgrading IHP. You can always run `nix-collect-garbage` in a `nix-shell` which will delete older/unused files.
 
+### Enabling flakes
+
+IHP uses Nix flakes. While already widely used, they are still a quite new feature and not yet enabled by default by the Nix install scripts.
+
+If you use IHP normally and with direnv this won't be a problem for you because all the Nix stuff is being handled for you. However, it's a good idea to enable flakes, so you can benefit from their features if you need them or want to try them out.
+
+To enable flakes, either edit `~/.config/nix/nix.conf` (to enable just for your user) or `/etc/nix/nix.conf` (to enable flakes globally) and add the following line:
+
+```bash
+experimental-features = nix-command flakes
+```
+
 ## 2. Installing IHP
 
 You can now install IHP by running:
@@ -148,7 +160,7 @@ nix.settings.trusted-users = [ "root" "USERNAME_HERE" ];
 
 #### GitHub Codespaces / VSCode Devcontainers
 
-To get started with IHP on [GitHub Codespaces](https://docs.github.com/en/codespaces/getting-started/quickstart), simply use the [Codespaces IHP Template](https://github.com/rvarun11/codespaces-ihp) to create a new GitHub repo. On the first start up, a new IHP boilerplate will be generated which you can commit. 
+To get started with IHP on [GitHub Codespaces](https://docs.github.com/en/codespaces/getting-started/quickstart), simply use the [Codespaces IHP Template](https://github.com/rvarun11/codespaces-ihp) to create a new GitHub repo. On the first start up, a new IHP boilerplate will be generated which you can commit.
 
 To try it out before making your own repo, you can simply start a Codespace from the template itself.
 


### PR DESCRIPTION
Some doc stuff for the new flake architecture.

While nix-env-selector *should* work through the flake-compat default.nix, we should rather recommend the direnv extension for VSCode so it uses the correct environment. That extension also tends to work more reliably and can be used in non-nix projects as well, so it's the better choice IMO.