### PR TITLE
Added a migrate output to the IHP flake

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -127,7 +127,6 @@ ihpFlake:
                         projectSrc = pkgs.nix-gitignore.gitignoreSource [] cfg.projectPath;
                     in
                         pkgs.writeScriptBin "migrate" ''
-                            cd ${projectSrc}
                             ${ghcCompiler.ihp}/bin/migrate
                         '';
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -120,6 +120,15 @@ ihpFlake:
                     includeDevTools = false;
                     optimized = false;
                 };
+
+                migrate =
+                    let
+                        projectSrc = pkgs.nix-gitignore.gitignoreSource [] cfg.projectPath;
+                    in
+                        pkgs.writeScriptBin "migrate" ''
+                            cd ${projectSrc}
+                            ${ghcCompiler.ihp}/bin/migrate
+                        '';
             };
 
             devenv.shells.default = lib.mkIf cfg.enable {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -122,13 +122,9 @@ ihpFlake:
                 };
 
 
-                migrate =
-                    let
-                        projectSrc = pkgs.nix-gitignore.gitignoreSource [] cfg.projectPath;
-                    in
-                        pkgs.writeScriptBin "migrate" ''
-                            ${ghcCompiler.ihp}/bin/migrate
-                        '';
+                migrate = pkgs.writeScriptBin "migrate" ''
+                    ${ghcCompiler.ihp}/bin/migrate
+                '';
 
                 ihp-schema = pkgs.stdenv.mkDerivation {
                     name = "ihp-schema";


### PR DESCRIPTION
Potential fix for https://github.com/digitallyinduced/ihp/issues/1760

```bash
nix build .#migrate

# Now this runs the migration script, and automatically sets the working directory to the Project src
./result/bin/migrate
```

Likely (but untested) this can be used in nixos as:

```nix
environment.systemPackages = with pkgs; [ ihpApp.migrate ];
```

Then a global `migrate` command would be available