### PR TITLE
Update oauth with the new `flake.nix`

### DIFF
--- a/Guide/oauth.markdown
+++ b/Guide/oauth.markdown
@@ -18,7 +18,7 @@ At the moment IHP supports these identity providers:
 
 To use the Login with Google functionality you first need to enable the `ihp-oauth-google` package.
 
-Open your project's `default.nix` and a `ihp-oauth-google` dependency to `haskellDeps`:
+Open your project's `flake.nix` and a `ihp-oauth-google` dependency to `haskellDeps`:
 
 ```nix
 let


### PR DESCRIPTION
I tried adding `ihp-oauth-google` to `flake.nix`, but I'm getting this error

<img width="785" alt="image" src="https://github.com/digitallyinduced/ihp/assets/125707/79748a66-6f17-4cf6-867c-a7ad22577dd0">
