### PR TITLE
Add make to devenv

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -142,7 +142,7 @@ ihpFlake:
             };
 
             devenv.shells.default = lib.mkIf cfg.enable {
-                packages = [ ghcCompiler.ihp pkgs.postgresql_13 ] ++ cfg.packages;
+                packages = [ ghcCompiler.ihp pkgs.postgresql_13 pkgs.gnumake ] ++ cfg.packages;
 
                 /*
                 we currently don't use devenv containers, and they break nix flake show


### PR DESCRIPTION
(gnu)make is (still) needed for various stuff in the devenv, including the haskell IDE stuff.

I noticed that we don't yet have make added to the IHP devenv because don't have a global make install on my NixOS system as I rely on direnv and flakes to make it available where I need it. That led to unexpected and hard to debug errors in my VSCode haskell IDE stuff, because the hie-bios stuff is generated through a make task, which didn't work without make.

By adding make to the devenv, users don't need a global make install and we make sure it's available.