### PR TITLE
Initial State Is Sent Back To The SSC

### DIFF
--- a/IHP/ServerSideComponent/Controller/ComponentsController.hs
+++ b/IHP/ServerSideComponent/Controller/ComponentsController.hs
@@ -7,7 +7,7 @@ import IHP.ServerSideComponent.ControllerFunctions as SSC
 
 import qualified Data.Aeson as Aeson
 
-instance (Component component controller, FromJSON controller) => WSApp (ComponentsController component) where
+instance (Component component controller, Aeson.FromJSON component, FromJSON controller, ToJSON controller) => WSApp (ComponentsController component) where
     initialState = ComponentsController
 
     run = do
@@ -30,3 +30,13 @@ instance (Component component controller, FromJSON controller) => WSApp (Compone
                     nextState <- SSC.action currentState theAction
                     SSC.setState nextState
                 Left error -> putStrLn (cs error)
+                Left error -> do
+                    let theState = Aeson.eitherDecode @component actionPayload
+
+                    case theState of
+                        Right initialState -> do
+                            SSC.setState initialState
+                        Left error -> do
+                            putStrLn "Failed Parsing Server Side Component Message As JSON"
+                            putStrLn (cs actionPayload)
+                            putStrLn (cs error)

--- a/IHP/ServerSideComponent/RouterFunctions.hs
+++ b/IHP/ServerSideComponent/RouterFunctions.hs
@@ -18,8 +18,10 @@ import IHP.ApplicationContext
 
 routeComponent :: forall component controller application.
     ( Typeable component
+    , FromJSON component
     , Component component controller
     , FromJSON controller
+    , ToJSON controller
     , InitControllerContext application
     , Typeable application
     , ?application :: application

--- a/IHP/ServerSideComponent/ViewFunctions.hs
+++ b/IHP/ServerSideComponent/ViewFunctions.hs
@@ -9,14 +9,15 @@ import IHP.Prelude
 import IHP.ViewSupport
 import IHP.ServerSideComponent.Types
 import IHP.HSX.QQ (hsx)
+import qualified Data.Aeson as Aeson
 
 import qualified Data.Typeable as Typeable
 
-component :: forall component action. (Component component action, Typeable component) => Html
+component :: forall component action. (Component component action, Typeable component, Aeson.ToJSON component) => Html
 component = componentFromState (initialState @component)
 
-componentFromState :: forall component action. (Component component action, Typeable component) => component -> Html
-componentFromState state = [hsx|<div class="ihp-ssc" data-path={path}>{render state}</div>|]
+componentFromState :: forall component action. (Component component action, Typeable component, Aeson.ToJSON component) => component -> Html
+componentFromState state = [hsx|<div class="ihp-ssc" data-path={path} data-initial-state={Aeson.encode state}>{render state}</div>|]
     where
         path = "/SSC/" <> typeName
         typeName = (undefined :: component)

--- a/lib/IHP/static/vendor/ihp-ssc.js
+++ b/lib/IHP/static/vendor/ihp-ssc.js
@@ -28,6 +28,9 @@ function initalizeSSC(component) {
 
     component.connection.onopen = function (event) {
         if (debugMode) console.log('Connected');
+
+        // Send Initial State
+        component.connection.send(component.dataset.initialState)
     };
 
     component.connection.onclose = function (event) {


### PR DESCRIPTION
My attempt at fixing issue https://github.com/digitallyinduced/ihp/issues/936

Send the Initial State To the Browser, And send it back when the component is initialized.

This requires the component to be an instance of `FromJSON` and `ToJSON`.

```haskell
module Web.Component.PolicyEditor where

import Web.Component.Prelude
import Data.Aeson.TH

data PolicyEditor
    = PolicyEditor
          { maybeFacilityId :: Maybe (Id' "company_facilities")
          , maybePolicyId   :: Maybe (Id' "facility_policies")
          , modalOpen :: Bool
          }
    deriving (Data, Eq, Show)

$(deriveJSON defaultOptions 'PolicyEditor)

data PolicyEditorController
    = OpenModalAction
    | CloseModalAction
    deriving (Data, Eq, Show)

$(deriveSSC ''PolicyEditorController)

....
```