### PR TITLE
Disable -fexpose-all-unfoldings

### DIFF
--- a/ihp-hsx/ihp-hsx.cabal
+++ b/ihp-hsx/ihp-hsx.cabal
@@ -77,7 +77,6 @@ library
         -fspecialise-aggressively
         -funfolding-use-threshold=120
         -fdicts-strict
-        -fexpose-all-unfoldings
         -optc-O3
     hs-source-dirs: .
     exposed-modules:

--- a/ihp-openai/ihp-openai.cabal
+++ b/ihp-openai/ihp-openai.cabal
@@ -46,7 +46,6 @@ library
         -Wmissing-fields
         -Winaccessible-code
         -Wmissed-specialisations
-        -fexpose-all-unfoldings
     hs-source-dirs: .
     exposed-modules:
         IHP.OpenAI

--- a/ihp.cabal
+++ b/ihp.cabal
@@ -168,7 +168,15 @@ common shared-properties
             -Winaccessible-code
             -Wmissed-specialisations
             -Wall-missed-specialisations
-            -fexpose-all-unfoldings
+
+            -- We cannot use expose-all-unfoldings as this increases the symbol count of the binaries
+            -- This causes very slow load times on macOS.
+            -- See https://gitlab.haskell.org/ghc/ghc/-/issues/23415
+            --
+            -- -fexpose-all-unfoldings
+            --
+
+            -Wno-ambiguous-fields
 
 library
     import: shared-properties
@@ -396,7 +404,6 @@ executable RunDevServer
     else
         ghc-options:
             -fconstraint-solver-iterations=100
-            -fexpose-all-unfoldings
             -flate-dmd-anal
             -flate-specialise
             -fmax-worker-args=15

--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -77,7 +77,6 @@ PROD_GHC_OPTIONS+= -funfolding-use-threshold=120
 PROD_GHC_OPTIONS+= -optc-O3
 PROD_GHC_OPTIONS+= -funbox-strict-fields
 PROD_GHC_OPTIONS+= -fconstraint-solver-iterations=100
-PROD_GHC_OPTIONS+= -fexpose-all-unfoldings
 PROD_GHC_OPTIONS+= -flate-dmd-anal
 PROD_GHC_OPTIONS+= -fspec-constr-keen
 PROD_GHC_OPTIONS+= -fspecialise-aggressively


### PR DESCRIPTION
This will speed up linking time on macOS

See https://gitlab.haskell.org/ghc/ghc/-/issues/23415