### PR TITLE
Add out of the box docker image build targets

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -125,6 +125,16 @@ ihpFlake:
                     pkgs = pkgs;
                 };
 
+                unoptimized-docker-image = pkgs.dockerTools.buildImage {
+                    name = "ihp-app";
+                    config = { Cmd = [ "${self'.packages.unoptimized-prod-server}/bin/RunProdServer" ]; };
+                };
+                
+                optimized-docker-image = pkgs.dockerTools.buildImage {
+                    name = "ihp-app";
+                    config = { Cmd = [ "${self'.packages.optimized-prod-server}/bin/RunProdServer" ]; };
+                };
+
 
                 migrate = pkgs.writeScriptBin "migrate" ''
                     ${ghcCompiler.ihp}/bin/migrate


### PR DESCRIPTION
Usage from an IHP app:

```
# Faster build times, but unoptimized GHC binaries
nix build .#unoptimized-docker-image

# Slow build times, but optimized GHC binaries
nix build .#optimized-docker-image
```