### PR TITLE
Database change notifications with Server Sent Events

### DIFF
--- a/IHP/DBEvent.hs
+++ b/IHP/DBEvent.hs
@@ -54,11 +54,6 @@ respondDbEvent eventName  = do
                             sqlExec createTriggerSql ()
                             pure ()
 
-                        -- pgListener |> PGListener.subscribe (channelName table) \notification -> do
-                        --     let pid = notification.notificationPid |> show |> cs
-                        --     sendChunk (ByteString.stringUtf8 $ "id:" <> pid <> "\nevent:" <> cs eventName <> "\ndata: " <> cs table <> " change event triggered\n\n") >> flush
-                        --     )
-
                         pgListener |> PGListener.subscribe (channelName table) \notification -> do
                             let pid = notification.notificationPid |> show |> cs
                             (sendChunk (ByteString.stringUtf8 $ "id:" <> pid <> "\nevent:" <> cs eventName <> "\ndata: " <> cs table <> " change event triggered\n\n") >> flush) `Exception.catch ` (\e -> putStrLn $ "Error sending chunk: " ++ show (e :: Exception.SomeException)))

--- a/IHP/DBEvent.hs
+++ b/IHP/DBEvent.hs
@@ -1,4 +1,4 @@
-module IHP.DBvent (respondDbEvent, initDbEvents) where
+module IHP.DBEvent (respondDbEvent, initDbEvents) where
 
 
 import IHP.Prelude

--- a/IHP/DBvent.hs
+++ b/IHP/DBvent.hs
@@ -1,0 +1,109 @@
+module IHP.DBvent (respondDbEvent, initDbEvents) where
+
+
+import IHP.Prelude
+import IHP.ControllerSupport
+-- import qualified Network.Wai.Internal as Wai
+-- import qualified Data.Binary.Builder as ByteString
+import qualified Data.Set as Set
+import IHP.ModelSupport ( withTableReadTracker, withRowLevelSecurityDisabled, sqlExec, trackTableRead )
+import qualified IHP.PGListener as PGListener
+import qualified Database.PostgreSQL.Simple.Types as PG
+import Data.String.Interpolate.IsString
+import Network.Wai ( responseStream )
+import qualified Network.Wai.Internal as Wai
+import Application.Script.Prelude (runAction)
+import qualified Control.Exception as Exception
+import qualified Data.Binary.Builder as ByteString
+import qualified Data.ByteString.Builder as ByteString
+import IHP.ApplicationContext
+import IHP.Controller.Context
+import Network.HTTP.Types (status200)
+import Network.HTTP.Types.Header ( hContentType )
+import Control.Concurrent (threadDelay, forkIO)
+import Database.PostgreSQL.Simple.Notification (notificationPid)
+
+
+
+initDbEvents :: (?context :: ControllerContext, ?applicationContext :: ApplicationContext) => IO ()
+initDbEvents = do
+    putContext ?applicationContext.pgListener
+        
+
+
+respondDbEvent :: (?modelContext :: ModelContext, ?context :: ControllerContext, ?touchedTables::IORef (Set ByteString)) => ByteString -> IO ()
+respondDbEvent eventName  = do
+    touchedTables <- Set.toList <$> readIORef ?touchedTables
+    putStrLn $ "Registering notification trigger for tables: " <> show touchedTables
+
+    let headers = 
+                 [ ("Cache-Control", "no-store")
+                 , ("Connection", "keep-alive")
+                 , (hContentType, "text/event-stream")
+                 ]
+
+    let streamBody sendChunk flush = do
+                    sendChunk (ByteString.stringUtf8 "data: Connection established!\n\n") >> flush
+
+                        
+                    pgListener <- fromContext @PGListener.PGListener
+                    touchedTables |> mapM (\table -> do
+                        let createTriggerSql = notificationTrigger table
+
+                        withRowLevelSecurityDisabled do
+                            sqlExec createTriggerSql ()
+                            pure ()
+
+                        -- pgListener |> PGListener.subscribe (channelName table) \notification -> do
+                        --     let pid = notification.notificationPid |> show |> cs
+                        --     sendChunk (ByteString.stringUtf8 $ "id:" <> pid <> "\nevent:" <> cs eventName <> "\ndata: " <> cs table <> " change event triggered\n\n") >> flush
+                        --     )
+
+                        pgListener |> PGListener.subscribe (channelName table) \notification -> do
+                            let pid = notification.notificationPid |> show |> cs
+                            (sendChunk (ByteString.stringUtf8 $ "id:" <> pid <> "\nevent:" <> cs eventName <> "\ndata: " <> cs table <> " change event triggered\n\n") >> flush) `Exception.catch ` (\e -> putStrLn $ "Error sending chunk: " ++ show (e :: Exception.SomeException)))
+
+                    forever do
+                        threadDelay (30 * 1000000)
+                        sendChunk (ByteString.stringUtf8 ": heartbeat\n\n") >> flush
+                    pure ()
+
+
+    respondAndExit $ responseStream 
+                            status200 
+                            [ ("Cache-Control", "no-store")
+                            , ("Connection", "keep-alive")
+                            , (hContentType, "text/event-stream")
+                            ] 
+                            streamBody
+
+
+
+channelName :: ByteString -> ByteString
+channelName tableName = "dbe_did_change_" <> tableName
+
+notificationTrigger :: ByteString -> PG.Query
+notificationTrigger tableName = PG.Query [i|
+        BEGIN;
+            CREATE OR REPLACE FUNCTION #{functionName}() RETURNS TRIGGER AS $$
+                BEGIN
+                    PERFORM pg_notify('#{channelName tableName}', '');
+                    RETURN new;
+                END;
+            $$ language plpgsql;
+            DROP TRIGGER IF EXISTS #{insertTriggerName} ON #{tableName};
+            CREATE TRIGGER #{insertTriggerName} AFTER INSERT ON "#{tableName}" FOR EACH STATEMENT EXECUTE PROCEDURE #{functionName}();
+            
+            DROP TRIGGER IF EXISTS #{updateTriggerName} ON #{tableName};
+            CREATE TRIGGER #{updateTriggerName} AFTER UPDATE ON "#{tableName}" FOR EACH STATEMENT EXECUTE PROCEDURE #{functionName}();
+
+            DROP TRIGGER IF EXISTS #{deleteTriggerName} ON #{tableName};
+            CREATE TRIGGER #{deleteTriggerName} AFTER DELETE ON "#{tableName}" FOR EACH STATEMENT EXECUTE PROCEDURE #{functionName}();
+        
+        COMMIT;
+    |]
+    where
+        functionName = "dbe_notify_did_change_" <> tableName
+        insertTriggerName = "dbe_did_insert_" <> tableName
+        updateTriggerName = "dbe_did_update_" <> tableName
+        deleteTriggerName = "dbe_did_delete_" <> tableName


### PR DESCRIPTION
This is a proposal for making endpoints that subscribe to database changes through [Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events), letting you execute custom behaviour. 

## What's the win here, really?

The simplicity of `autoRefresh`, but allows for very advanced use-cases and I'm sure something like this would eliminate 99,9% of all "SPA island" use-cases for me and let me serve all front-end needs from IHP.

## Why SSE

The implementation of it is far simpler than websockets, using only one-way communication, which is all that really is needed for triggering client-side updates from database events.

Although, if we could achieve the same functionality easier with WebSockets instead. It just seemed to me SSE is the most natural choice, and easy to work with.

## Description

Like `autoRefresh` it tracks tables, but instead of forcing a full page reload, it triggers an event that can be recieved in the browser, and you are free to to whatever you want after the event trigger.

This lets us customize the behaviour of such an event. This can create some opportunities like only refreshing a localized part of a webpage, which can allow for far more complex usecases than autoRefresh. 

Basically this can give you something in-between `DataSync` and `autoRefresh`.

Some advantages over DataSync is less need for adding a lot of JavaScript. This for example allows for subscribing to changes and using HTMX to keep a certain part of the DOM updated.

```html
        <div hx-ext="sse" {...[("sse-connect", pathTo StreamPostsEvents)]}>
            <div hx-get={PostsAction} hx-trigger="sse:posts_updated">
                {printPosts posts}
            </div>
        </div>
```

Instead of HTMX, you could also recieve these vents from JavaScript directly, so also for non-HTMX-users. The example below plays a sound for each time the server event is trigged:

```javascript
function initializeEventSource() {
    const eventSource = new EventSource("/StreamPostsEvents");

    eventSource.onopen = function () {
        console.log("Connection opened.");
    };
    eventSource.onerror = function (err) {
        console.error("EventSource failed:", err);
    };
    eventSource.onmessage = function (event) {
        console.log("Received message:", event.data);
    };

    eventSource.addEventListener('ping', function (e) {
        console.log('ping', e.data);
    }, false);

    eventSource.addEventListener('posts_updated', function (e) {
        const notificationSound = new Audio("/msn-sound.wav")
        notificationSound.play();
        console.log('posts_updated', e);
    }, false);

    return eventSource;
}
```

I have made a complete, but  crude example just showing a simple chat that uses htmx to subscribe to the event and update the chat window:
https://github.com/kodeFant/ihp-sse

![image](https://github.com/digitallyinduced/ihp/assets/9317208/e76ed603-930f-49d8-ba11-56fb8c85cb7f)


The current API could be better:

```hs
    action StreamPostsEvents =  withTableReadTracker do
        query @Post |> fetch
        DBEvent.respondDbEvent "posts_updated"
```

But I wasn't able to successfully properly use it with `withTableReadTracker`. Probably I am missing something. A better way would be something like this:

```hs
    action StreamPostsEvents =  DBEvent.respondDbEvent "posts_updated" do
        query @Post |> fetch
        pure ()
        
```

but wasn't able to make it work as I couldn't track the tables right.

Also not sure about the naming.




## Some challenges

There are sometimes some problems that I'm not yet sure why are happening like this can appear in the console:

```sh
Error sending chunk: Network.Socket.sendBuf: invalid argument (Bad file descriptor)
```