### PR TITLE
Recommend running a nix ad-hoc shell instead of nix-env

### DIFF
--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -251,7 +251,7 @@ To use the older version of the package we need to override the package definiti
 nix-shell -p cabal2nix -p cabal-install
 ```
 
-Now inside this shell, we can use `cabal2nix` it to get a nix package definition for the older version of google-oauth2:
+Now inside this shell, we can use `cabal2nix` to get a nix package definition for the older version of google-oauth2:
 
 ```bash
 cabal2nix cabal://google-oauth2-0.2.2

--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -245,13 +245,13 @@ Let's say we want to use [the google-oauth2 package from hackage](https://hackag
 
 This will install version 0.3.0.0 of the google-oauth2 package, as this is the latest version available in the package set used by IHP. For our specific application requirements, we want to use version 0.2.2, an older version of this package.
 
-To use the older version of the package we need to override the package definition. To do this you need to install `cabal2nix` first:
+To use the older version of the package we need to override the package definition. To do this, enter an ad-hoc Nix shell with `cabal2nix` and `cabal-install`:
 
 ```bash
-nix-env -i cabal2nix
+nix-shell -p cabal2nix -p cabal-install
 ```
 
-After cabal2nix is installed we can use it to get a nix package definition for the older version of google-oauth2:
+Now inside this shell, we can use `cabal2nix` it to get a nix package definition for the older version of google-oauth2:
 
 ```bash
 cabal2nix cabal://google-oauth2-0.2.2

--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -245,7 +245,7 @@ Let's say we want to use [the google-oauth2 package from hackage](https://hackag
 
 This will install version 0.3.0.0 of the google-oauth2 package, as this is the latest version available in the package set used by IHP. For our specific application requirements, we want to use version 0.2.2, an older version of this package.
 
-To use the older version of the package we need to override the package definition. To do this, enter an temporary Nix shell with `cabal2nix` and `cabal-install`:
+To use the older version of the package we need to override the package definition. To do this, enter a temporary Nix shell with `cabal2nix` and `cabal-install`:
 
 ```bash
 nix-shell -p cabal2nix -p cabal-install

--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -245,7 +245,7 @@ Let's say we want to use [the google-oauth2 package from hackage](https://hackag
 
 This will install version 0.3.0.0 of the google-oauth2 package, as this is the latest version available in the package set used by IHP. For our specific application requirements, we want to use version 0.2.2, an older version of this package.
 
-To use the older version of the package we need to override the package definition. To do this, enter an ad-hoc Nix shell with `cabal2nix` and `cabal-install`:
+To use the older version of the package we need to override the package definition. To do this, enter an temporary Nix shell with `cabal2nix` and `cabal-install`:
 
 ```bash
 nix-shell -p cabal2nix -p cabal-install


### PR DESCRIPTION
Instead of installing cabal2nix permanently for one-time use with `nix-env`, rather use `nix-shell` which is also the recommended way on [NixOS packages](https://search.nixos.org/packages?channel=23.05&show=haskellPackages.cabal2nix&from=0&size=50&sort=relevance&type=packages&query=cabal2nix).  

![image](https://github.com/digitallyinduced/ihp/assets/9317208/12ea7641-7059-496a-9d09-cce4ac13df5e)
