### PR TITLE
Add back withHoogle support

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -59,6 +59,14 @@ ihpFlake:
                     type = lib.types.path;
                 };
 
+                withHoogle = lib.mkOption {
+                    description = ''
+                        Enable Hoogle support. Adds `hoogle` command to PATH.
+                    '';
+                    type = lib.types.bool;
+                    default = false;
+                };
+
                 dontCheckPackages = lib.mkOption {
                     description = ''
                         List of Haskell package names whose tests are skipped during build.
@@ -166,7 +174,9 @@ ihpFlake:
                 containers = lib.mkForce {};
 
                 languages.haskell.enable = true;
-                languages.haskell.package = ghcCompiler.ghc.withPackages cfg.haskellPackages;
+                languages.haskell.package = (if cfg.withHoogle
+                                             then ghcCompiler.ghc.withHoogle
+                                             else ghcCompiler.ghc.withPackages) cfg.haskellPackages;
 
                 languages.haskell.languageServer = ghcCompiler.haskell-language-server;
                 languages.haskell.stack = null; # Stack is not used in IHP


### PR DESCRIPTION
- Adds `withHoogle` support back: it was missing since the migration to flakes/flake-parts.
- Updates documentation to reflect the changes in configuration and usage since the migration to flake-parts.