### PR TITLE
Add `Bounded` to Enums

### DIFF
--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -450,7 +450,7 @@ findForeignKeyConstraint CreateTable { name } column =
 compileEnumDataDefinitions :: (?schema :: Schema) => Statement -> Text
 compileEnumDataDefinitions CreateEnumType { values = [] } = "" -- Ignore enums without any values
 compileEnumDataDefinitions enum@(CreateEnumType { name, values }) =
-        "data " <> modelName <> " = " <> (intercalate " | " valueConstructors) <> " deriving (Eq, Show, Read, Enum)\n"
+        "data " <> modelName <> " = " <> (intercalate " | " valueConstructors) <> " deriving (Eq, Show, Read, Enum, Bounded)\n"
         <> "instance FromField " <> modelName <> " where\n"
         <> indent (unlines (map compileFromFieldInstanceForValue values))
         <> "    fromField field (Just value) = returnError ConversionFailed field (\"Unexpected value for enum value. Got: \" <> Data.String.Conversions.cs value)\n"


### PR DESCRIPTION
Example code of how I'm using it, for adding steps counter.

```haskell
breadcrumb =renderBreadcrumb
          [ breadcrumbLink "Overview" (ShowLearningMapNameAction learningMapName.id)
          , breadcrumbText $ (renderLearningMapStep learningMapStep) ++ cs (" (Step " ++ (show $ position learningMapStep) ++ " of " ++ (show totalElements) ++ ")")
          ]

  position :: LearningMapStep -> Int
  position step = fromEnum step + 1

  -- Calculate total number of elements
  totalElements :: Int
  totalElements = fromEnum (maxBound :: LearningMapStep) + 1
```

This results with:

<img width="474" alt="image" src="https://github.com/digitallyinduced/ihp/assets/125707/10ac6436-c542-46c5-9fbf-6a7c67bdecde">
