### PR TITLE
Bringing Test Suite sqlImport in line with IDE. 

### DIFF
--- a/IHP/Test/Database.hs
+++ b/IHP/Test/Database.hs
@@ -10,6 +10,9 @@ import qualified Data.ByteString as ByteString
 import qualified IHP.LibDir as LibDir
 import qualified Control.Exception as Exception
 
+import qualified System.Process as Process
+import qualified System.Directory as Directory
+
 data TestDatabase = TestDatabase
     { name :: Text
     , url :: ByteString
@@ -22,6 +25,7 @@ data TestDatabase = TestDatabase
 --
 createTestDatabase :: ByteString -> IO TestDatabase
 createTestDatabase databaseUrl = do
+    currentDir <- Directory.getCurrentDirectory
     databaseId <- UUID.nextRandom
     let databaseName = "test-" <> UUID.toText databaseId
 
@@ -34,8 +38,11 @@ createTestDatabase databaseUrl = do
             |> cs
 
     libDir <- LibDir.findLibDirectory
-    importSql newUrl (cs libDir <> "/IHPSchema.sql")
-    importSql newUrl "Application/Schema.sql"
+
+    let importSql file = Process.callCommand ("psql -h '" <> currentDir <> "/build/db' -d " <> (cs databaseName) <> " < " <> file)
+
+    importSql (cs libDir <> "/IHPSchema.sql")
+    importSql "Application/Schema.sql"
 
     pure TestDatabase { name = databaseName, url = newUrl }
 
@@ -54,10 +61,5 @@ deleteDatabase masterDatabaseUrl testDatabase = do
         PG.execute connection "DROP DATABASE ? WITH (FORCE)" [PG.Identifier (testDatabase.name)]
     pure ()
 
-importSql url file = do
-    schemaSql <- ByteString.readFile file
-
-    withConnection url \connection -> do
-        PG.execute connection (PG.Query schemaSql) ()
 
 withConnection databaseUrl = Exception.bracket (PG.connectPostgreSQL databaseUrl) PG.close

--- a/IHP/Test/Database.hs
+++ b/IHP/Test/Database.hs
@@ -25,7 +25,7 @@ data TestDatabase = TestDatabase
 --
 createTestDatabase :: ByteString -> IO TestDatabase
 createTestDatabase databaseUrl = do
-    currentDir <- Directory.getCurrentDirectory
+--    currentDir <- Directory.getCurrentDirectory
     databaseId <- UUID.nextRandom
     let databaseName = "test-" <> UUID.toText databaseId
 
@@ -39,7 +39,7 @@ createTestDatabase databaseUrl = do
 
     libDir <- LibDir.findLibDirectory
 
-    let importSql file = Process.callCommand ("psql -h '" <> currentDir <> "/build/db' -d " <> (cs databaseName) <> " < " <> file)
+    let importSql file = Process.callCommand ("psql " <> (cs newUrl) <> " < " <> file)
 
     importSql (cs libDir <> "/IHPSchema.sql")
     importSql "Application/Schema.sql"

--- a/IHP/Test/Database.hs
+++ b/IHP/Test/Database.hs
@@ -39,6 +39,8 @@ createTestDatabase databaseUrl = do
 
     libDir <- LibDir.findLibDirectory
 
+    -- We use the system psql to handle the initial Schema Import as it can handle
+    -- complex Schema including variations in formatting, custom types, functions, and table definitions.
     let importSql file = Process.callCommand ("psql " <> (cs newUrl) <> " < " <> file)
 
     importSql (cs libDir <> "/IHPSchema.sql")


### PR DESCRIPTION
The old importSql function in createTestDatabase for Mocking used a raw byte string and then imported Schema as a PGConnect/PGQuery. This ran into parsing issues when init a complex schema into test database. The IDE had no problem importing same Schema with psql. This PR updates testDatabase to work with psql import. 