### PR TITLE
Add `Ord` to Enums

### DIFF
--- a/IHP/SchemaCompiler.hs
+++ b/IHP/SchemaCompiler.hs
@@ -450,7 +450,7 @@ findForeignKeyConstraint CreateTable { name } column =
 compileEnumDataDefinitions :: (?schema :: Schema) => Statement -> Text
 compileEnumDataDefinitions CreateEnumType { values = [] } = "" -- Ignore enums without any values
 compileEnumDataDefinitions enum@(CreateEnumType { name, values }) =
-        "data " <> modelName <> " = " <> (intercalate " | " valueConstructors) <> " deriving (Eq, Show, Read, Enum, Bounded)\n"
+        "data " <> modelName <> " = " <> (intercalate " | " valueConstructors) <> " deriving (Eq, Show, Read, Enum, Bounded, Ord)\n"
         <> "instance FromField " <> modelName <> " where\n"
         <> indent (unlines (map compileFromFieldInstanceForValue values))
         <> "    fromField field (Just value) = returnError ConversionFailed field (\"Unexpected value for enum value. Got: \" <> Data.String.Conversions.cs value)\n"

--- a/Test/SchemaCompilerSpec.hs
+++ b/Test/SchemaCompilerSpec.hs
@@ -178,7 +178,7 @@ tests = do
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User'
+                    type User = User' 
 
                     type instance GetTableName (User' ) = "users"
                     type instance GetModelByTableName "users" = User
@@ -247,7 +247,7 @@ tests = do
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User'
+                    type User = User' 
 
                     type instance GetTableName (User' ) = "users"
                     type instance GetModelByTableName "users" = User
@@ -316,7 +316,7 @@ tests = do
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User'
+                    type User = User' 
 
                     type instance GetTableName (User' ) = "users"
                     type instance GetModelByTableName "users" = User

--- a/Test/SchemaCompilerSpec.hs
+++ b/Test/SchemaCompilerSpec.hs
@@ -19,7 +19,7 @@ tests = do
                 let output = compileStatementPreview [statement] statement |> Text.strip
 
                 output `shouldBe` [trimming|
-                    data Mood = Happy | VeryHappy | Sad | VerySad deriving (Eq, Show, Read, Enum, Bounded)
+                    data Mood = Happy | VeryHappy | Sad | VerySad deriving (Eq, Show, Read, Enum, Bounded, Ord)
                     instance FromField Mood where
                         fromField field (Just value) | value == (Data.Text.Encoding.encodeUtf8 "happy") = pure Happy
                         fromField field (Just value) | value == (Data.Text.Encoding.encodeUtf8 "very happy") = pure VeryHappy
@@ -56,7 +56,7 @@ tests = do
                 let output = compileStatementPreview [statement] statement |> Text.strip
 
                 output `shouldBe` [trimming|
-                    data Province = Alberta | Britishcolumbia | Saskatchewan | Manitoba | Ontario | Quebec | Novascotia | Newbrunswick | Princeedwardisland | Newfoundlandandlabrador deriving (Eq, Show, Read, Enum, Bounded)
+                    data Province = Alberta | Britishcolumbia | Saskatchewan | Manitoba | Ontario | Quebec | Novascotia | Newbrunswick | Princeedwardisland | Newfoundlandandlabrador deriving (Eq, Show, Read, Enum, Bounded, Ord)
                     instance FromField Province where
                         fromField field (Just value) | value == (Data.Text.Encoding.encodeUtf8 "Alberta") = pure Alberta
                         fromField field (Just value) | value == (Data.Text.Encoding.encodeUtf8 "BritishColumbia") = pure Britishcolumbia
@@ -102,7 +102,7 @@ tests = do
                 let output = compileStatementPreview [enum1, enum2] enum1 |> Text.strip
 
                 output `shouldBe` [trimming|
-                    data PropertyType = PropertyTypeApartment | House deriving (Eq, Show, Read, Enum, Bounded)
+                    data PropertyType = PropertyTypeApartment | House deriving (Eq, Show, Read, Enum, Bounded, Ord)
                     instance FromField PropertyType where
                         fromField field (Just value) | value == (Data.Text.Encoding.encodeUtf8 "APARTMENT") = pure PropertyTypeApartment
                         fromField field (Just value) | value == (Data.Text.Encoding.encodeUtf8 "HOUSE") = pure House
@@ -178,7 +178,7 @@ tests = do
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User' 
+                    type User = User'
 
                     type instance GetTableName (User' ) = "users"
                     type instance GetModelByTableName "users" = User
@@ -247,7 +247,7 @@ tests = do
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User' 
+                    type User = User'
 
                     type instance GetTableName (User' ) = "users"
                     type instance GetModelByTableName "users" = User
@@ -316,7 +316,7 @@ tests = do
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User' 
+                    type User = User'
 
                     type instance GetTableName (User' ) = "users"
                     type instance GetModelByTableName "users" = User


### PR DESCRIPTION
I'd like to have an associate list with an enum as key.

Assuming Foo is an Enum:

```haskell
import qualified Data.Map as Map

let value = Map.lookup Foo treeJson
```

Without this PR we get error:

```
Could not deduce (Ord ProductItemType)
        arising from a use of ‘Map.lookup’
```