### PR TITLE
Remove Attics in examples.markdown

### DIFF
--- a/Guide/examples.markdown
+++ b/Guide/examples.markdown
@@ -29,13 +29,6 @@ Here are some open-source IHP apps created by the community:
 - [Source Code on GitHub](https://github.com/rametta/retros)
 - by [@rametta](https://github.com/rametta)
 
-**🎧 Attics -- Thousands of live concerts at your fingertips**
-- [Source Code on GitHub](https://github.com/zacwood9/Attics)
-- by [@zacwood9](https://github.com/zacwood9/Attics)
-- The project consists of an iOS Frontend and an IHP backend
-- [Demo on the App Store](https://apps.apple.com/us/app/attics/id1434981632)
-- [YouTube](https://www.youtube.com/watch?v=9_cUNM0H8QU)
-
 **🌎 CO2 Database**
 - [Source Code on GitHub](https://github.com/philschonholzer/co2db)
 - by [@philschonholzer](https://github.com/philschonholzer)


### PR DESCRIPTION
Attics no longer uses IHP but rather Ruby on Rails.