### PR TITLE
Allow attributes sse-connect and sse-swap

### DIFF
--- a/ihp-hsx/IHP/HSX/Parser.hs
+++ b/ihp-hsx/IHP/HSX/Parser.hs
@@ -397,6 +397,7 @@ attributes = Set.fromList
         , "frameborder", "allow", "allowfullscreen", "nonce", "referrerpolicy", "slot"
         , "kind"
         , "html"
+        , "sse-connect", "sse-swap"
         ]
 
 parents :: Set Text


### PR DESCRIPTION
HTMX has extracted the SSE functionality to a plugin and renamed the attribute "hx-sse" to two new attributes ("sse-connect" and "sse-swap").

For details and reasoning for this change see:
https://htmx.org/extensions/server-sent-events/#migrating-from-previous-versions