### PR TITLE
Allow a submit button to be disabled

### DIFF
--- a/IHP/View/CSSFramework.hs
+++ b/IHP/View/CSSFramework.hs
@@ -272,9 +272,9 @@ instance Default CSSFramework where
 
             styledValidationResultClass = ""
 
-            styledSubmitButton cssFramework SubmitButton { label, buttonClass } =
+            styledSubmitButton cssFramework SubmitButton { label, buttonClass, disabled } =
                 let className :: Text = cssFramework.styledSubmitButtonClass
-                in [hsx|<button class={classes [(className, True), (buttonClass, not (null buttonClass))]} type="submit">{label}</button>|]
+                in [hsx|<button class={classes [(className, True), (buttonClass, not (null buttonClass))]} disabled={disabled} type="submit">{label}</button>|]
 
             styledInputClass _ _ = ""
             styledInputInvalidClass _ _ = "invalid"

--- a/IHP/View/CSSFramework.hs
+++ b/IHP/View/CSSFramework.hs
@@ -272,9 +272,9 @@ instance Default CSSFramework where
 
             styledValidationResultClass = ""
 
-            styledSubmitButton cssFramework SubmitButton { label, buttonClass, disabled } =
+            styledSubmitButton cssFramework SubmitButton { label, buttonClass, buttonDisabled } =
                 let className :: Text = cssFramework.styledSubmitButtonClass
-                in [hsx|<button class={classes [(className, True), (buttonClass, not (null buttonClass))]} disabled={disabled} type="submit">{label}</button>|]
+                in [hsx|<button class={classes [(className, True), (buttonClass, not (null buttonClass))]} disabled={buttonDisabled} type="submit">{label}</button>|]
 
             styledInputClass _ _ = ""
             styledInputInvalidClass _ _ = "invalid"

--- a/IHP/View/CSSFramework.hs
+++ b/IHP/View/CSSFramework.hs
@@ -628,9 +628,9 @@ bootstrap4 = def
                 [hsx|<div class={className}>{message}</div>|]
         styledValidationResult _ _ = mempty
 
-        styledSubmitButton cssFramework SubmitButton { label, buttonClass } =
+        styledSubmitButton cssFramework SubmitButton { label, buttonClass, buttonDisabled } =
             let className :: Text = cssFramework.styledSubmitButtonClass
-            in [hsx|<button class={classes [(className, True), (buttonClass, not (null buttonClass))]} type="submit">{label}</button>|]
+            in [hsx|<button class={classes [(className, True), (buttonClass, not (null buttonClass))]} disabled={buttonDisabled} type="submit">{label}</button>|]
 
         styledPagination :: CSSFramework -> PaginationView -> Blaze.Html
         styledPagination _ paginationView =

--- a/IHP/View/Form.hs
+++ b/IHP/View/Form.hs
@@ -302,6 +302,7 @@ submitButton =
     { label = cs $ (if isNew then "Create " else "Save ") <> buttonText
     , buttonClass = mempty
     , cssFramework = ?formContext.cssFramework
+    , disabled = False
     }
 {-# INLINE submitButton #-}
 

--- a/IHP/View/Form.hs
+++ b/IHP/View/Form.hs
@@ -292,6 +292,19 @@ nestedFormFor field nestedRenderForm = forEach children renderChild
 -- > <form method="POST" action="/CreatePost" id="" class="new-form">
 -- >     <button class="btn btn-primary create-button">Create Post</button>
 -- > </form>
+--
+-- __Disabled button__
+--
+-- > renderForm :: Post -> Html
+-- > renderForm post = formFor post [hsx|
+-- >     {submitButton { buttonDisabled = True } }
+-- > |]
+--
+-- This will generate code like this:
+--
+-- > <form method="POST" action="/CreatePost" id="" class="new-form">
+-- >     <button class="btn btn-primary create-button" disabled="disabled">Create Post</button>
+-- > </form>
 submitButton :: forall model. (?formContext :: FormContext model, HasField "meta" model MetaBag, KnownSymbol (GetModelName model)) => SubmitButton
 submitButton =
     let

--- a/IHP/View/Form.hs
+++ b/IHP/View/Form.hs
@@ -314,8 +314,8 @@ submitButton =
     in SubmitButton
     { label = cs $ (if isNew then "Create " else "Save ") <> buttonText
     , buttonClass = mempty
+    , buttonDisabled = False
     , cssFramework = ?formContext.cssFramework
-    , disabled = False
     }
 {-# INLINE submitButton #-}
 

--- a/IHP/View/Types.hs
+++ b/IHP/View/Types.hs
@@ -67,6 +67,7 @@ data SubmitButton = SubmitButton
     { label :: Blaze.Html
     , buttonClass :: Text
     , cssFramework :: CSSFramework
+    , disabled :: Bool
     }
 
 data FormContext model = FormContext

--- a/IHP/View/Types.hs
+++ b/IHP/View/Types.hs
@@ -66,8 +66,8 @@ data FormField = FormField
 data SubmitButton = SubmitButton
     { label :: Blaze.Html
     , buttonClass :: Text
+    , buttonDisabled :: Bool
     , cssFramework :: CSSFramework
-    , disabled :: Bool
     }
 
 data FormContext model = FormContext

--- a/Test/View/CSSFrameworkSpec.hs
+++ b/Test/View/CSSFrameworkSpec.hs
@@ -40,13 +40,15 @@ tests = do
                 styledFlashMessage cssFramework cssFramework flashMessage `shouldRenderTo` "<div class=\"alert alert-danger\">You have successfully registered for an account</div>"
 
             describe "submit button" do
-                let submitButton = SubmitButton { label = "Save Project" , buttonClass = "my-custom-button" , cssFramework }
+                let submitButton = SubmitButton { label = "Save Project" , buttonClass = "my-custom-button" , cssFramework, buttonDisabled = False }
                 it "should render" do
                     styledSubmitButton cssFramework cssFramework submitButton `shouldRenderTo` "<button class=\"btn btn-primary my-custom-button\" type=\"submit\">Save Project</button>"
 
                 it "should render with empty class" do
                     styledSubmitButton cssFramework cssFramework (submitButton { buttonClass = "" }) `shouldRenderTo` "<button class=\"btn btn-primary\" type=\"submit\">Save Project</button>"
 
+                it "should render with disabled button" do
+                    styledSubmitButton cssFramework cssFramework (submitButton { buttonDisabled = True }) `shouldRenderTo`  "<button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Save Project</button>"
 
             describe "text field" do
                 let baseTextField = FormField
@@ -396,12 +398,15 @@ tests = do
                 styledFlashMessage cssFramework cssFramework flashMessage `shouldRenderTo` "<div class=\"alert alert-danger\">You have successfully registered for an account</div>"
 
             describe "submit button" do
-                let submitButton = SubmitButton { label = "Save Project" , buttonClass = "my-custom-button" , cssFramework }
+                let submitButton = SubmitButton { label = "Save Project" , buttonClass = "my-custom-button" , cssFramework, buttonDisabled = False }
                 it "should render" do
                     styledSubmitButton cssFramework cssFramework submitButton `shouldRenderTo` "<button class=\"btn btn-primary my-custom-button\" type=\"submit\">Save Project</button>"
 
                 it "should render with empty class" do
                     styledSubmitButton cssFramework cssFramework (submitButton { buttonClass = "" }) `shouldRenderTo` "<button class=\"btn btn-primary\" type=\"submit\">Save Project</button>"
+
+                it "should render with disabled button" do
+                    styledSubmitButton cssFramework cssFramework (submitButton { buttonDisabled = True }) `shouldRenderTo` "<button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Save Project</button>"
 
 
             describe "text field" do

--- a/Test/View/CSSFrameworkSpec.hs
+++ b/Test/View/CSSFrameworkSpec.hs
@@ -48,7 +48,7 @@ tests = do
                     styledSubmitButton cssFramework cssFramework (submitButton { buttonClass = "" }) `shouldRenderTo` "<button class=\"btn btn-primary\" type=\"submit\">Save Project</button>"
 
                 it "should render with disabled button" do
-                    styledSubmitButton cssFramework cssFramework (submitButton { buttonDisabled = True }) `shouldRenderTo`  "<button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Save Project</button>"
+                    styledSubmitButton cssFramework cssFramework (submitButton { buttonClass = "", buttonDisabled = True }) `shouldRenderTo`  "<button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Save Project</button>"
 
             describe "text field" do
                 let baseTextField = FormField
@@ -406,7 +406,7 @@ tests = do
                     styledSubmitButton cssFramework cssFramework (submitButton { buttonClass = "" }) `shouldRenderTo` "<button class=\"btn btn-primary\" type=\"submit\">Save Project</button>"
 
                 it "should render with disabled button" do
-                    styledSubmitButton cssFramework cssFramework (submitButton { buttonDisabled = True }) `shouldRenderTo` "<button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Save Project</button>"
+                    styledSubmitButton cssFramework cssFramework (submitButton { buttonClass = "", buttonDisabled = True }) `shouldRenderTo` "<button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Save Project</button>"
 
 
             describe "text field" do

--- a/Test/View/FormSpec.hs
+++ b/Test/View/FormSpec.hs
@@ -42,19 +42,6 @@ tests = do
                 |]
                 form `shouldRenderTo` "<form method=\"GET\" action=\"/CreateProject\" id=\"\" class=\"new-form\" data-disable-javascript-submission=\"false\"><div class=\"mb-3\" id=\"form-group-project_title\"><label class=\"form-label\" for=\"project_title\">Title</label><input type=\"text\" name=\"title\" placeholder=\"\" id=\"project_title\" class=\"form-control\"> </div> <button class=\"btn btn-primary\" type=\"submit\">Create Project</button></form>"
 
-            it "should render a form with disabled button" do
-                context <- createControllerContext
-                let ?context = context
-
-                let options formContext = formContext |> set #formMethod "GET"
-
-                let form = formForWithOptions project options [hsx|
-                    {textField #title}
-                    {submitButton {buttonDisabled = True}}
-                |]
-                form `shouldRenderTo` "<form method=\"GET\" action=\"/CreateProject\" id=\"\" class=\"new-form\" data-disable-javascript-submission=\"false\"><div class=\"mb-3\" id=\"form-group-project_title\"><label class=\"form-label\" for=\"project_title\">Title</label><input type=\"text\" name=\"title\" placeholder=\"\" id=\"project_title\" class=\"form-control\"> </div> <button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Create Project</button></form>"
-
-
 shouldRenderTo renderFunction expectedHtml = Blaze.renderMarkup renderFunction `shouldBe` expectedHtml
 
 createControllerContext :: IO ControllerContext

--- a/Test/View/FormSpec.hs
+++ b/Test/View/FormSpec.hs
@@ -29,7 +29,7 @@ tests = do
                     {submitButton}
                 |]
                 form `shouldRenderTo` "<form method=\"POST\" action=\"/CreateProject\" id=\"\" class=\"new-form\" data-disable-javascript-submission=\"false\"><div class=\"mb-3\" id=\"form-group-project_title\"><label class=\"form-label\" for=\"project_title\">Title</label><input type=\"text\" name=\"title\" placeholder=\"\" id=\"project_title\" class=\"form-control\"> </div> <button class=\"btn btn-primary\" type=\"submit\">Create Project</button></form>"
-            
+
             it "should render a form with a GET method" do
                 context <- createControllerContext
                 let ?context = context
@@ -41,6 +41,19 @@ tests = do
                     {submitButton}
                 |]
                 form `shouldRenderTo` "<form method=\"GET\" action=\"/CreateProject\" id=\"\" class=\"new-form\" data-disable-javascript-submission=\"false\"><div class=\"mb-3\" id=\"form-group-project_title\"><label class=\"form-label\" for=\"project_title\">Title</label><input type=\"text\" name=\"title\" placeholder=\"\" id=\"project_title\" class=\"form-control\"> </div> <button class=\"btn btn-primary\" type=\"submit\">Create Project</button></form>"
+
+            it "should render a form with disabled button" do
+                context <- createControllerContext
+                let ?context = context
+
+                let options formContext = formContext |> set #formMethod "GET"
+
+                let form = formForWithOptions project options [hsx|
+                    {textField #title}
+                    {submitButton {disabled = True}}
+                |]
+                form `shouldRenderTo` "<form method=\"GET\" action=\"/CreateProject\" id=\"\" class=\"new-form\" data-disable-javascript-submission=\"false\"><div class=\"mb-3\" id=\"form-group-project_title\"><label class=\"form-label\" for=\"project_title\">Title</label><input type=\"text\" name=\"title\" placeholder=\"\" id=\"project_title\" class=\"form-control\"> </div> <button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Create Project</button></form>"
+
 
 shouldRenderTo renderFunction expectedHtml = Blaze.renderMarkup renderFunction `shouldBe` expectedHtml
 
@@ -54,7 +67,7 @@ createControllerContext = do
 
 data Project'  = Project {id :: (Id' "projects"), title :: Text, meta :: MetaBag} deriving (Eq, Show)
 instance InputValue Project where inputValue = IHP.ModelSupport.recordToInputValue
-type Project = Project' 
+type Project = Project'
 
 type instance GetTableName (Project' ) = "projects"
 type instance GetModelByTableName "projects" = Project

--- a/Test/View/FormSpec.hs
+++ b/Test/View/FormSpec.hs
@@ -50,7 +50,7 @@ tests = do
 
                 let form = formForWithOptions project options [hsx|
                     {textField #title}
-                    {submitButton {disabled = True}}
+                    {submitButton {buttonDisabled = True}}
                 |]
                 form `shouldRenderTo` "<form method=\"GET\" action=\"/CreateProject\" id=\"\" class=\"new-form\" data-disable-javascript-submission=\"false\"><div class=\"mb-3\" id=\"form-group-project_title\"><label class=\"form-label\" for=\"project_title\">Title</label><input type=\"text\" name=\"title\" placeholder=\"\" id=\"project_title\" class=\"form-control\"> </div> <button class=\"btn btn-primary\" disabled=\"disabled\" type=\"submit\">Create Project</button></form>"
 


### PR DESCRIPTION
Sometimes we may wish to have the submit button disabled. In my case, I later enable it via JS, if the form has changed.

```haskell
renderForm :: LandingPage -> Html
renderForm landingPage = formFor landingPage [hsx|
    {(textField #title)}

    {submitButton {label = "Save Landing page", buttonDisabled = True}}
|]
```

<img width="1120" alt="image" src="https://github.com/digitallyinduced/ihp/assets/125707/cf5f8731-e8cf-4a7b-9954-d18c38b66550">
