### PR TITLE
`fileOrNothing` should check `fileContent` isn't empty

### DIFF
--- a/IHP/Controller/FileUpload.hs
+++ b/IHP/Controller/FileUpload.hs
@@ -57,7 +57,7 @@ fileOrNothing !name =
             FormBody { files } ->
                 -- Search for the file, and confirm it's not an empty one.
                 case lookup name files of
-                    Just file | fileContent file /= "" -> Just file
+                    Just fileInfo | not (LBS.null (fileInfo.fileContent)) -> Just fileInfo
                     _ -> Nothing
             _ -> Nothing
 
@@ -159,10 +159,10 @@ uploadImageWithOptions options _ user =
         imagePath :: Text = baseImagePath <> "jpg"
         uploadFilePath = baseImagePath <> "upload"
     in case fileOrNothing fieldName of
-        Just file | fileContent file /= "" -> liftIO do
+        Just file -> liftIO do
             _ <- Process.system ("mkdir -p `dirname " <> cs (uploadDir <> uploadFilePath) <> "`")
             let fullImagePath = uploadDir <> imagePath
-            (fileContent file) |> LBS.writeFile (cs (uploadDir <> uploadFilePath))
+            fileContent file |> LBS.writeFile (cs (uploadDir <> uploadFilePath))
             Process.runCommand (cs ("convert " <> cs uploadDir <> uploadFilePath <> " " <> (getField @"imageMagickOptions" options) <> " " <> cs fullImagePath))
             user
                 |> setField @fieldName (Just (cs imagePath :: Text))
@@ -207,9 +207,9 @@ uploadImageFile ext _ user =
         uploadDir :: Text = "static"
         imagePath :: Text = "/uploads/" <> tableName <> "/" <> tshow user.id <> "/picture." <> ext
     in case fileOrNothing fieldName of
-        Just file | fileContent file /= "" -> liftIO do
+        Just file -> liftIO do
             _ <- Process.system ("mkdir -p `dirname " <> cs (uploadDir <> imagePath) <> "`")
-            (fileContent file) |> LBS.writeFile (cs $ uploadDir <> imagePath)
+            fileContent file |> LBS.writeFile (cs $ uploadDir <> imagePath)
             user
                 |> setField @fieldName (Just (cs imagePath :: Text))
                 |> pure

--- a/IHP/FileStorage/ControllerFunctions.hs
+++ b/IHP/FileStorage/ControllerFunctions.hs
@@ -330,7 +330,7 @@ uploadToStorageWithOptions options field record = do
     let directory = tableName <> "/" <> cs fieldName
 
     case fileOrNothing fieldName of
-        Just fileInfo | not (LBS.null (fileInfo.fileContent)) -> do
+        Just fileInfo -> do
             storeFileWithOptions fileInfo options { directory }
             |> Exception.try
             >>= \case


### PR DESCRIPTION
Right now we return a `Just file`, even when there's no file.

This is similar to the check we already have here https://github.com/digitallyinduced/ihp/blob/d0658832f6d51160678f3a03d0920f3621b844e2/IHP/FileStorage/ControllerFunctions.hs#L333