### PR TITLE
Fix naming in test docs

### DIFF
--- a/Guide/testing.markdown
+++ b/Guide/testing.markdown
@@ -12,7 +12,7 @@ The following setup and tests can be viewed in the [Blog example](https://github
 
 1. Add `hspec` in `flake.nix`
 ```nix
-        haskellDeps = p: with p; [
+        haskellPackages = p: with p; [
             cabal-install
             # ...
             p.ihp


### PR DESCRIPTION
I guess the naming got updated, but not in the docs. In my tests the attribute is called `haskellPackages`, not `haskellDeps`.