### PR TITLE
Update tailwindcss instructions

### DIFF
--- a/Guide/search/package-lock.json
+++ b/Guide/search/package-lock.json
@@ -177,6 +177,29 @@
         "react-dom": ">= 16.8.0 < 18.0.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
+      "peer": true
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.75",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.75.tgz",
+      "integrity": "sha512-MSA+NzEzXnQKrqpO63CYqNstFjsESgvJAdAyyJ1n6ZQq/GLgf6nOfIKwk+Twuz0L1N6xPe+qz5xRCJrbhMaLsw==",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "peer": true
+    },
     "node_modules/algoliasearch": {
       "version": "4.10.5",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
@@ -197,6 +220,12 @@
         "@algolia/requester-node-http": "4.10.5",
         "@algolia/transporter": "4.10.5"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "node_modules/esbuild": {
       "version": "0.13.2",
@@ -629,6 +658,29 @@
         "algoliasearch": "^4.0.0"
       }
     },
+    "@types/prop-types": {
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
+      "peer": true
+    },
+    "@types/react": {
+      "version": "17.0.75",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.75.tgz",
+      "integrity": "sha512-MSA+NzEzXnQKrqpO63CYqNstFjsESgvJAdAyyJ1n6ZQq/GLgf6nOfIKwk+Twuz0L1N6xPe+qz5xRCJrbhMaLsw==",
+      "peer": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "peer": true
+    },
     "algoliasearch": {
       "version": "4.10.5",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
@@ -649,6 +701,12 @@
         "@algolia/requester-node-http": "4.10.5",
         "@algolia/transporter": "4.10.5"
       }
+    },
+    "csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "esbuild": {
       "version": "0.13.2",

--- a/Guide/search/package-lock.json
+++ b/Guide/search/package-lock.json
@@ -177,29 +177,6 @@
         "react-dom": ">= 16.8.0 < 18.0.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.11",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "peer": true
-    },
-    "node_modules/@types/react": {
-      "version": "17.0.75",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.75.tgz",
-      "integrity": "sha512-MSA+NzEzXnQKrqpO63CYqNstFjsESgvJAdAyyJ1n6ZQq/GLgf6nOfIKwk+Twuz0L1N6xPe+qz5xRCJrbhMaLsw==",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "peer": true
-    },
     "node_modules/algoliasearch": {
       "version": "4.10.5",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
@@ -220,12 +197,6 @@
         "@algolia/requester-node-http": "4.10.5",
         "@algolia/transporter": "4.10.5"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "peer": true
     },
     "node_modules/esbuild": {
       "version": "0.13.2",
@@ -658,29 +629,6 @@
         "algoliasearch": "^4.0.0"
       }
     },
-    "@types/prop-types": {
-      "version": "15.7.11",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "peer": true
-    },
-    "@types/react": {
-      "version": "17.0.75",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.75.tgz",
-      "integrity": "sha512-MSA+NzEzXnQKrqpO63CYqNstFjsESgvJAdAyyJ1n6ZQq/GLgf6nOfIKwk+Twuz0L1N6xPe+qz5xRCJrbhMaLsw==",
-      "peer": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "peer": true
-    },
     "algoliasearch": {
       "version": "4.10.5",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
@@ -701,12 +649,6 @@
         "@algolia/requester-node-http": "4.10.5",
         "@algolia/transporter": "4.10.5"
       }
-    },
-    "csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "peer": true
     },
     "esbuild": {
       "version": "0.13.2",

--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -96,63 +96,44 @@ We also need a CSS entry point for Tailwind. Create a new file at `tailwind/app.
 
 To start the TailwindCSS build process with the IHP dev server, add the following to your flake.nix:
 
-```
+```nix
 ...
-outputs = inputs@{ ihp, flake-parts, systems, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-
-        systems = import systems;
-        imports = [ ihp.flakeModules.default ];
-
-        perSystem = { pkgs, ... }: {
-            ihp = {
-                enable = true;
-                projectPath = ./.;
-                packages = with pkgs; [
-                    # Native dependencies, e.g. imagemagick
-                    (nodePackages.tailwindcss.overrideAttrs
-                        (_: {
-                            plugins = [
-                                nodePackages."@tailwindcss/aspect-ratio"
-                                nodePackages."@tailwindcss/forms"
-                                nodePackages."@tailwindcss/language-server"
-                                nodePackages."@tailwindcss/line-clamp"
-                                nodePackages."@tailwindcss/typography"
-                            ];
-                        })
-                    )
-                    just
+ihp = {
+    enable = true;
+    projectPath = ./.;
+    packages = with pkgs; [
+        # Native dependencies, e.g. imagemagick
+        (nodePackages.tailwindcss.overrideAttrs
+            (_: {
+                plugins = [
+                    nodePackages."@tailwindcss/aspect-ratio"
+                    nodePackages."@tailwindcss/forms"
+                    nodePackages."@tailwindcss/language-server"
+                    nodePackages."@tailwindcss/line-clamp"
+                    nodePackages."@tailwindcss/typography"
                 ];
-                haskellPackages = p: with p; [
-                    # Haskell dependencies go here
-                    ...
-                 ];
-            };
+            })
+        )
+        just
+    ];
+    haskellPackages = p: with p; [
+        # Haskell dependencies go here
+        ...
+     ];
+};
 
-            # Add TailwindCSS build command here
-            devenv.shells.default = {
-                processes = {
-                    tailwind.exec = "tailwindcss -c tailwind/tailwind.config.js -i ./tailwind/app.css -o static/app.css --watch=always";
-                };
-            };
-        };
+# Add TailwindCSS build command here
+devenv.shells.default = {
+    processes = {
+        tailwind.exec = "tailwindcss -c tailwind/tailwind.config.js -i ./tailwind/app.css -o static/app.css --watch=always";
     };
+};
+...
 ```
 
-Now when you use `devenv up` to start the IHP dev server, the TailwindCSS build process will be started as well.
+Now when you use `devenv up` to start the IHP dev server, the TailwindCSS build process will be started as well. The `--watch=always` flag forces `tailwindcss` to always stay running and watch for any CSS changes in your project and rebuild the `static/app.css` file as needed.
 
-### Adding the build step
-
-We need to add a new build command for starting a tailwind build process to our `Makefile`. For that append this to the `Makefile` in your project:
-
-```makefile
-tailwind-dev:
-	tailwindcss -c tailwind/tailwind.config.js -i ./tailwind/app.css -o static/app.css --watch
-```
-
-**Make requires tab characters instead of 4 spaces in the second line. Make sure you're using a tab character when pasting this into the file**
-
-This defines a new command `make tailwind-dev` that runs `npx tailwindcss build` whenever a CSS file inside the `tailwind/` directory changes. The CSS output will be placed at `static/app.css` (the standard main CSS file of IHP apps). It will use the tailwind configuration at `tailwind/tailwind.config.js`.
+### Adding additional build step for production
 
 For production builds, we also need a new make target:
 
@@ -253,17 +234,6 @@ config = do
     option customTailwind -- ADD THIS OPTION
     pure ()
 ```
-
-
-## Developing with Tailwind
-
-Once everything is installed, you can start your tailwind build by calling:
-
-```bash
-make tailwind-dev
-```
-
-Whenever you change any CSS file in `tailwind/` it will automatically rebuild your styles and write it to `static/app.css`.
 
 ## Building for production
 

--- a/Guide/tailwindcss.markdown
+++ b/Guide/tailwindcss.markdown
@@ -114,7 +114,6 @@ ihp = {
                 ];
             })
         )
-        just
     ];
     haskellPackages = p: with p; [
         # Haskell dependencies go here


### PR DESCRIPTION
I updated the tailwindcss instructions to use `devenv` to launch tailwind.

I removed the redundant `make tailwind-dev` instructions to keep things simple. But let me know if you prefer to keep them for users of older IHP versions.