### PR TITLE
Allow sql dumping via the Makefile

### DIFF
--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -123,6 +123,9 @@ dumpdb: dump_db ## Saves the current database state into the Fixtures.sql
 dump_db: ## Saves the current database state into the Fixtures.sql
 	pg_dump -a --inserts --column-inserts --disable-triggers -h $$PWD/build/db app | sed -e '/^--/d' > Application/Fixtures.sql
 
+sql_dump:
+	@pg_dump -h $$PWD/build/db app | sed -e '/^--/d'
+
 build/Generated/Types.hs: Application/Schema.sql ## Rebuilds generated types
 	mkdir -p build/Generated
 	build-generated-code


### PR DESCRIPTION
```
make sql_dump > /tmp/app.sql
```

In some cases, it's easier to handle fixtures and schema altogether.