### PR TITLE
Added logger field to ControllerContext and added mapContext

### DIFF
--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -66,6 +66,10 @@ class InitControllerContext application where
     initContext = pure ()
     {-# INLINABLE initContext #-}
 
+    mapContext :: (?modelContext :: ModelContext, ?requestContext :: RequestContext, ?applicationContext :: ApplicationContext, ?context :: ControllerContext) => ControllerContext -> ControllerContext
+    mapContext context = context
+    {-# INLINABLE mapContext #-}
+
 {-# INLINE runAction #-}
 runAction :: forall controller. (Controller controller, ?context :: ControllerContext, ?modelContext :: ModelContext, ?applicationContext :: ApplicationContext, ?requestContext :: RequestContext) => controller -> IO ResponseReceived
 runAction controller = do
@@ -123,7 +127,7 @@ newContextForAction contextSetter controller = do
                     let respond = ?context.requestContext.respond
                     in respond response
                 Nothing -> ErrorController.displayException exception controller " while calling initContext"
-        Right _ -> pure $ Right ?context
+        Right _ -> pure $ Right (mapContext @application ?context)
 
 {-# INLINE runActionWithNewContext #-}
 runActionWithNewContext :: forall application controller. (Controller controller, ?applicationContext :: ApplicationContext, ?context :: RequestContext, InitControllerContext application, ?application :: application, Typeable application, Typeable controller) => controller -> IO ResponseReceived

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -955,7 +955,7 @@ routeParam :: (?context::RequestContext, ParamReader paramType) => ByteString ->
 routeParam paramName =
     let requestContext = ?context
     in
-        let ?context = FrozenControllerContext { requestContext = requestContext, customFields = mempty }
+        let ?context = FrozenControllerContext { requestContext = requestContext, customFields = mempty, logger = requestContext.frameworkConfig.logger }
         in param paramName
 
 -- | Display a better error when the user missed to pass an argument to an action.

--- a/Test/Controller/ParamSpec.hs
+++ b/Test/Controller/ParamSpec.hs
@@ -435,14 +435,14 @@ createControllerContextWithParams params =
             requestBody = FormBody { params, files = [] }
             request = Wai.defaultRequest
             requestContext = RequestContext { request, respond = error "respond", requestBody, vault = error "vault", frameworkConfig = error "frameworkConfig" }
-        in FrozenControllerContext { requestContext, customFields = TypeMap.empty }
+        in FrozenControllerContext { requestContext, customFields = TypeMap.empty, logger = error "logger is missing" }
 
 createControllerContextWithJson params =
         let
             requestBody = JSONBody { jsonPayload = Just (json params), rawPayload = cs params }
             request = Wai.defaultRequest
             requestContext = RequestContext { request, respond = error "respond", requestBody, vault = error "vault", frameworkConfig = error "frameworkConfig" }
-        in FrozenControllerContext { requestContext, customFields = TypeMap.empty }
+        in FrozenControllerContext { requestContext, customFields = TypeMap.empty, logger = error "logger is missing" }
 
 json :: Text -> Aeson.Value
 json string =

--- a/Test/View/CSSFrameworkSpec.hs
+++ b/Test/View/CSSFrameworkSpec.hs
@@ -722,4 +722,4 @@ createControllerContextWithCSSFramework cssFramework = do
     let requestBody = FormBody { params = [], files = [] }
     let request = Wai.defaultRequest
     let requestContext = RequestContext { request, respond = error "respond", requestBody, vault = error "vault", frameworkConfig = frameworkConfig }
-    pure FrozenControllerContext { requestContext, customFields = TypeMap.empty }
+    pure FrozenControllerContext { requestContext, customFields = TypeMap.empty, logger = requestContext.frameworkConfig.logger }

--- a/Test/View/FormSpec.hs
+++ b/Test/View/FormSpec.hs
@@ -50,7 +50,7 @@ createControllerContext = do
     let requestBody = FormBody { params = [], files = [] }
     let request = Wai.defaultRequest
     let requestContext = RequestContext { request, respond = undefined, requestBody, vault = undefined, frameworkConfig = frameworkConfig }
-    pure FrozenControllerContext { requestContext, customFields = mempty }
+    pure FrozenControllerContext { requestContext, customFields = mempty, logger = requestContext.frameworkConfig.logger }
 
 data Project'  = Project {id :: (Id' "projects"), title :: Text, meta :: MetaBag} deriving (Eq, Show)
 instance InputValue Project where inputValue = IHP.ModelSupport.recordToInputValue


### PR DESCRIPTION
@amitaibu this PR adds a new `mapContext` that allows us to swap out the logger object before the IHP action is run

This can be used like the following (not tested yet):

```haskell
import IHP.Log.Types
import IHP.Controller.Context

instance InitControllerContext WebApplication where
    initContext = pure ()
    mapContext context =            
        context { logger = context.logger { Log.formatter = userIdFormatter context.logger.formatter } }

userIdFormatter :: (?context :: Context) => Log.LogFormatter -> Log.LogFormatter
userIdFormatter existingFormatter time level string =
        existingFormatter time level (prependUserId string)

preprendUserId :: (?context :: Context) => Text -> Text
preprendUserId string = "userId: " <> show currentUserId <> " " <> string
```