### PR TITLE
Request logger static files

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake . --impure
+export IHP_LIB=lib/IHP/

--- a/IHP/IDE/ToolServer.hs
+++ b/IHP/IDE/ToolServer.hs
@@ -37,6 +37,7 @@ import qualified System.Process as Process
 import System.Info
 import qualified IHP.EnvVar as EnvVar
 import qualified IHP.AutoRefresh.Types as AutoRefresh
+import qualified IHP.AutoRefresh as AutoRefresh
 import IHP.Controller.Context
 import qualified IHP.IDE.ToolServer.Layout as Layout
 import IHP.Controller.Layout
@@ -85,7 +86,7 @@ startToolServer' port isDebugMode = do
             let ?applicationContext = applicationContext
             requestContext <- ControllerSupport.createRequestContext applicationContext request respond
             let ?context = requestContext
-            frontControllerToWAIApp toolServerApplication [] (staticApp request respond)
+            frontControllerToWAIApp @ToolServerApplication @AutoRefresh.AutoRefreshWSApp (\app -> app) toolServerApplication staticApp request respond
 
     let openAppUrl = openUrl ("http://localhost:" <> tshow port <> "/")
     let warpSettings = Warp.defaultSettings

--- a/Main.hs
+++ b/Main.hs
@@ -13,11 +13,18 @@ data DemoController = DemoAction deriving (Eq, Show, Data)
 
 instance AutoRoute DemoController
 instance InitControllerContext RootApplication
-instance FrontController RootApplication where
+data WebApplication = WebApplication deriving (Eq, Show)
+
+instance InitControllerContext WebApplication where
+    initContext = pure ()
+
+instance FrontController WebApplication where
     controllers =
-        [ parseRoute @DemoController
-        , startPage DemoAction
+        [ startPage DemoAction
         ]
+
+instance FrontController RootApplication where
+    controllers = [ mountFrontController WebApplication ]
 
 instance Controller DemoController where
     action DemoAction = renderPlain "Hello World!"

--- a/Test/Controller/AccessDeniedSpec.hs
+++ b/Test/Controller/AccessDeniedSpec.hs
@@ -75,7 +75,7 @@ makeApplication :: (?applicationContext :: ApplicationContext) => IO Application
 makeApplication = do
     store <- Session.mapStore_
     let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie ?applicationContext.session
-    pure (sessionMiddleware (Server.application handleNotFound))
+    pure (sessionMiddleware $ (Server.application handleNotFound) (\app -> app))
 
 assertAccessDenied :: SResponse -> IO ()
 assertAccessDenied response = do

--- a/Test/Controller/NotFoundSpec.hs
+++ b/Test/Controller/NotFoundSpec.hs
@@ -75,7 +75,7 @@ makeApplication :: (?applicationContext :: ApplicationContext) => IO Application
 makeApplication = do
     store <- Session.mapStore_
     let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie ?applicationContext.session
-    pure (sessionMiddleware (Server.application handleNotFound))
+    pure (sessionMiddleware $ (Server.application handleNotFound) (\app -> app))
 
 assertNotFound :: SResponse -> IO ()
 assertNotFound response = do

--- a/Test/RouterSupportSpec.hs
+++ b/Test/RouterSupportSpec.hs
@@ -141,7 +141,7 @@ config = do
     option (AppPort 8000)
 
 application :: (?applicationContext :: ApplicationContext) => Application
-application = Server.application handleNotFound
+application = Server.application handleNotFound (\app -> app)
 
 tests :: Spec
 tests = beforeAll (mockContextNoDatabase WebApplication config) do

--- a/Test/SEO/Sitemap.hs
+++ b/Test/SEO/Sitemap.hs
@@ -79,5 +79,5 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
     describe "SEO" do
         describe "Sitemap" do
             it "should render a XML Sitemap" $ withContext do
-                runSession (testGet "/sitemap.xml") (Server.application handleNotFound)
+                runSession (testGet "/sitemap.xml") (Server.application handleNotFound (\app -> app))
                     >>= assertSuccess "<?xml version=\"1.0\" encoding=\"UTF-8\"?><urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"><url><loc>http://localhost:8000/test/ShowPost?postId=00000000-0000-0000-0000-000000000000</loc><lastmod>2105-04-16</lastmod><changefreq>hourly</changefreq></url></urlset>"

--- a/Test/ViewSupportSpec.hs
+++ b/Test/ViewSupportSpec.hs
@@ -102,7 +102,7 @@ makeApplication :: (?applicationContext :: ApplicationContext) => IO Application
 makeApplication = do
     store <- Session.mapStore_
     let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie ?applicationContext.session
-    pure (sessionMiddleware (Server.application handleNotFound))
+    pure (sessionMiddleware $ (Server.application handleNotFound (\app -> app)))
 
 tests :: Spec
 tests = beforeAll (mockContextNoDatabase WebApplication config) do


### PR DESCRIPTION
This PR makes the request logger only log requests that are to actual IHP controllers, ignroing any static files. This was the behaviour until a while ago.