### PR TITLE
Make it easier to spot schema + fixture errors

### DIFF
--- a/lib/IHP/Makefile.dist
+++ b/lib/IHP/Makefile.dist
@@ -114,10 +114,10 @@ psql: ## Connects to the running postgresql server
 	@psql -h $$PWD/build/db -d app
 
 db: Application/Schema.sql Application/Fixtures.sql ## Creates a new database with the current Schema and imports Fixtures.sql
-	echo "drop schema public cascade; create schema public;" | psql -h $$PWD/build/db -d app
-	psql -h $$PWD/build/db -d app < "${IHP_LIB}/IHPSchema.sql"
-	psql -h $$PWD/build/db -d app < Application/Schema.sql
-	psql -h $$PWD/build/db -d app < Application/Fixtures.sql
+	(echo "drop schema public cascade; create schema public;" | psql -h $${PWD}/build/db -d app) && \
+	psql -v ON_ERROR_STOP=1 -h $${PWD}/build/db -d app < "$${IHP_LIB}/IHPSchema.sql" && \
+	psql -v ON_ERROR_STOP=1 -h $${PWD}/build/db -d app < Application/Schema.sql && \
+	psql -v ON_ERROR_STOP=1 -h $${PWD}/build/db -d app < Application/Fixtures.sql
 
 dumpdb: dump_db ## Saves the current database state into the Fixtures.sql
 dump_db: ## Saves the current database state into the Fixtures.sql


### PR DESCRIPTION
`make db` right now silently moves on if there's an error in the Schema or in the Fixture. It should not be like that.