### PR TITLE
Simplify session vault key handling

### DIFF
--- a/IHP/ApplicationContext.hs
+++ b/IHP/ApplicationContext.hs
@@ -1,7 +1,6 @@
 module IHP.ApplicationContext where
 
 import IHP.Prelude
-import Network.Wai.Session (Session)
 import IHP.AutoRefresh.Types (AutoRefreshServer)
 import IHP.FrameworkConfig (FrameworkConfig)
 import IHP.PGListener (PGListener)

--- a/IHP/ApplicationContext.hs
+++ b/IHP/ApplicationContext.hs
@@ -2,14 +2,12 @@ module IHP.ApplicationContext where
 
 import IHP.Prelude
 import Network.Wai.Session (Session)
-import qualified Data.Vault.Lazy as Vault
 import IHP.AutoRefresh.Types (AutoRefreshServer)
 import IHP.FrameworkConfig (FrameworkConfig)
 import IHP.PGListener (PGListener)
 
 data ApplicationContext = ApplicationContext
     { modelContext :: !ModelContext
-    , session :: !(Vault.Key (Session IO ByteString ByteString))
     , autoRefreshServer :: !(IORef AutoRefreshServer)
     , frameworkConfig :: !FrameworkConfig
     , pgListener :: PGListener

--- a/IHP/Controller/RequestContext.hs
+++ b/IHP/Controller/RequestContext.hs
@@ -8,8 +8,6 @@ import           ClassyPrelude
 import qualified Data.ByteString.Lazy as LBS
 import           Network.Wai                   (Request, Response, ResponseReceived)
 import           Network.Wai.Parse (File, Param)
-import qualified Data.Vault.Lazy               as Vault
-import           Network.Wai.Session           (Session)
 import           IHP.FrameworkConfig
 import qualified Data.Aeson as Aeson
 

--- a/IHP/Controller/RequestContext.hs
+++ b/IHP/Controller/RequestContext.hs
@@ -24,6 +24,5 @@ data RequestContext = RequestContext
     { request :: Request
     , respond :: Respond
     , requestBody :: RequestBody
-    , vault :: (Vault.Key (Session IO ByteString ByteString))
     , frameworkConfig :: FrameworkConfig
     }

--- a/IHP/Controller/Response.hs
+++ b/IHP/Controller/Response.hs
@@ -9,12 +9,11 @@ where
 import ClassyPrelude
 import Network.HTTP.Types.Header
 import qualified IHP.Controller.Context as Context
-import IHP.Controller.Context (ControllerContext(ControllerContext))
 import qualified Network.Wai
 import Network.Wai (Response)
 import qualified Control.Exception as Exception
 
-respondAndExit :: (?context::ControllerContext) => Response -> IO ()
+respondAndExit :: (?context :: Context.ControllerContext) => Response -> IO ()
 respondAndExit response = do
     responseWithHeaders <- addResponseHeadersFromContext response
     Exception.throwIO (ResponseException responseWithHeaders)
@@ -35,7 +34,7 @@ addResponseHeaders headers = Network.Wai.mapResponseHeaders (\hs -> headers <> h
 -- > addResponseHeadersFromContext response
 -- You probabaly want `setHeader`
 --
-addResponseHeadersFromContext :: (?context :: ControllerContext) => Response -> IO Response
+addResponseHeadersFromContext :: (?context :: Context.ControllerContext) => Response -> IO Response
 addResponseHeadersFromContext response = do
     maybeHeaders <- Context.maybeFromContext @[Header]
     let headers = fromMaybe [] maybeHeaders

--- a/IHP/Controller/Session.hs
+++ b/IHP/Controller/Session.hs
@@ -24,6 +24,7 @@ module IHP.Controller.Session
   , getSessionEither
   , deleteSession
   , getSessionAndClear
+  , sessionVaultKey
   ) where
 
 import IHP.Prelude
@@ -36,6 +37,8 @@ import qualified Network.Wai as Wai
 import qualified Data.Serialize as Serialize
 import Data.Serialize (Serialize)
 import Data.Serialize.Text ()
+import qualified Network.Wai.Session
+import System.IO.Unsafe (unsafePerformIO)
 
 -- | Types of possible errors as a result of
 -- requesting a value from the session storage
@@ -161,5 +164,9 @@ sessionVault = case vaultLookup of
         Just session -> session
         Nothing -> error "sessionInsert: The session vault is missing in the request"
     where
-        RequestContext { request, vault } = ?context.requestContext
-        vaultLookup = Vault.lookup vault (Wai.vault request)
+        RequestContext { request } = ?context.requestContext
+        vaultLookup = Vault.lookup sessionVaultKey request.vault
+
+sessionVaultKey :: Vault.Key (Network.Wai.Session.Session IO ByteString ByteString)
+sessionVaultKey = unsafePerformIO Vault.newKey
+{-# NOINLINE sessionVaultKey #-}

--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -29,7 +29,7 @@ module IHP.ControllerSupport
 
 import ClassyPrelude
 import IHP.HaskellSupport
-import Network.Wai (Response, Request, ResponseReceived, responseLBS, requestHeaders)
+import Network.Wai (Request, ResponseReceived, responseLBS, requestHeaders)
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai
 import IHP.ModelSupport
@@ -39,7 +39,6 @@ import qualified Data.ByteString.Lazy
 import qualified IHP.Controller.RequestContext as RequestContext
 import IHP.Controller.RequestContext (RequestContext, Respond)
 import qualified Data.CaseInsensitive
-import qualified Control.Exception as Exception
 import qualified IHP.ErrorController as ErrorController
 import qualified Data.Typeable as Typeable
 import IHP.FrameworkConfig (FrameworkConfig (..), ConfigProvider(..))

--- a/IHP/ControllerSupport.hs
+++ b/IHP/ControllerSupport.hs
@@ -259,7 +259,7 @@ requestBodyJSON =
 
 {-# INLINE createRequestContext #-}
 createRequestContext :: ApplicationContext -> Request -> Respond -> IO RequestContext
-createRequestContext ApplicationContext { session, frameworkConfig } request respond = do
+createRequestContext ApplicationContext { frameworkConfig } request respond = do
     let contentType = lookup hContentType (requestHeaders request)
     requestBody <- case contentType of
         "application/json" -> do
@@ -270,7 +270,7 @@ createRequestContext ApplicationContext { session, frameworkConfig } request res
             (params, files) <- WaiParse.parseRequestBodyEx frameworkConfig.parseRequestBodyOptions WaiParse.lbsBackEnd request
             pure RequestContext.FormBody { .. }
 
-    pure RequestContext.RequestContext { request, respond, requestBody, vault = session, frameworkConfig }
+    pure RequestContext.RequestContext { request, respond, requestBody, frameworkConfig }
 
 
 -- | Returns a custom config parameter

--- a/IHP/EnvVar.hs
+++ b/IHP/EnvVar.hs
@@ -11,7 +11,6 @@ import IHP.Prelude
 import Data.String.Interpolate.IsString (i)
 import qualified System.Posix.Env.ByteString as Posix
 import Network.Socket (PortNumber)
-import Data.Word (Word16)
 import IHP.Mail.Types
 import IHP.Environment
 

--- a/IHP/IDE/FileWatcher.hs
+++ b/IHP/IDE/FileWatcher.hs
@@ -9,7 +9,6 @@ import System.Directory (listDirectory, doesDirectoryExist)
 import qualified Data.Map as Map
 import qualified System.FSNotify as FS
 import IHP.IDE.Types
-import qualified Data.Time.Clock as Clock
 import qualified Data.List as List
 import IHP.IDE.LiveReloadNotificationServer (notifyAssetChange)
 import qualified Control.Debounce as Debounce

--- a/IHP/RouterSupport.hs
+++ b/IHP/RouterSupport.hs
@@ -838,7 +838,7 @@ withPrefix prefix routes = string prefix >> choice (map (\r -> r <* endOfInput) 
 
 frontControllerToWAIApp :: forall app (autoRefreshApp :: Type). (?applicationContext :: ApplicationContext, FrontController app, WSApp autoRefreshApp, Typeable autoRefreshApp, InitControllerContext ()) => Middleware -> app -> Application -> Application
 frontControllerToWAIApp middleware application notFoundAction request respond = do
-    let requestContext = RequestContext { request, respond, requestBody = FormBody { params = [], files = [] }, vault = ?applicationContext.session, frameworkConfig = ?applicationContext.frameworkConfig }
+    let requestContext = RequestContext { request, respond, requestBody = FormBody { params = [], files = [] }, frameworkConfig = ?applicationContext.frameworkConfig }
 
     let ?context = requestContext
 

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -5,19 +5,16 @@ import IHP.Prelude
 import qualified Network.Wai.Handler.Warp as Warp
 import Network.Wai
 import Network.Wai.Middleware.MethodOverridePost (methodOverridePost)
-import Network.Wai.Session (withSession, Session)
+import Network.Wai.Session (withSession)
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
 import IHP.Controller.Session (sessionVaultKey)
-import qualified Data.Vault.Lazy as Vault
 import IHP.ApplicationContext
-import qualified IHP.ControllerSupport as ControllerSupport
 import qualified IHP.Environment as Env
 import qualified IHP.PGListener as PGListener
 
 import IHP.FrameworkConfig
-import IHP.RouterSupport (frontControllerToWAIApp, FrontController, webSocketApp, webSocketAppWithCustomPath)
-import IHP.ErrorController
+import IHP.RouterSupport (frontControllerToWAIApp, FrontController)
 import qualified IHP.AutoRefresh as AutoRefresh
 import qualified IHP.AutoRefresh.Types as AutoRefresh
 import IHP.LibDir

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -8,6 +8,7 @@ import Network.Wai.Middleware.MethodOverridePost (methodOverridePost)
 import Network.Wai.Session (withSession, Session)
 import Network.Wai.Session.ClientSession (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
+import IHP.Controller.Session (sessionVaultKey)
 import qualified Data.Vault.Lazy as Vault
 import IHP.ApplicationContext
 import qualified IHP.ControllerSupport as ControllerSupport
@@ -48,14 +49,12 @@ run configBuilder = do
 
         withInitalizers frameworkConfig modelContext do
             withPGListener \pgListener -> do
-                sessionVault <- Vault.newKey
-
                 autoRefreshServer <- newIORef (AutoRefresh.newAutoRefreshServer pgListener)
 
                 let ?modelContext = modelContext
-                let ?applicationContext = ApplicationContext { modelContext = ?modelContext, session = sessionVault, autoRefreshServer, frameworkConfig, pgListener }
+                let ?applicationContext = ApplicationContext { modelContext = ?modelContext, autoRefreshServer, frameworkConfig, pgListener }
 
-                sessionMiddleware <- initSessionMiddleware sessionVault frameworkConfig
+                sessionMiddleware <- initSessionMiddleware frameworkConfig
                 staticApp <- initStaticApp frameworkConfig
                 let corsMiddleware = initCorsMiddleware frameworkConfig
                 let requestLoggerMiddleware = frameworkConfig.requestLoggerMiddleware
@@ -108,8 +107,8 @@ initStaticApp frameworkConfig = do
 
     pure (Static.staticApp appSettings)
 
-initSessionMiddleware :: Vault.Key (Session IO ByteString ByteString) -> FrameworkConfig -> IO Middleware
-initSessionMiddleware sessionVault FrameworkConfig { sessionCookie } = do
+initSessionMiddleware :: FrameworkConfig -> IO Middleware
+initSessionMiddleware FrameworkConfig { sessionCookie } = do
     let path = "Config/client_session_key.aes"
 
     hasSessionSecretEnvVar <- EnvVar.hasEnvVar "IHP_SESSION_SECRET"
@@ -118,7 +117,7 @@ initSessionMiddleware sessionVault FrameworkConfig { sessionCookie } = do
             if hasSessionSecretEnvVar || not doesConfigDirectoryExist
                 then ClientSession.getKeyEnv "IHP_SESSION_SECRET"
                 else ClientSession.getKey path
-    let sessionMiddleware :: Middleware = withSession store "SESSION" sessionCookie sessionVault
+    let sessionMiddleware :: Middleware = withSession store "SESSION" sessionCookie sessionVaultKey
     pure sessionMiddleware
 
 initCorsMiddleware :: FrameworkConfig -> Middleware

--- a/Test/Controller/AccessDeniedSpec.hs
+++ b/Test/Controller/AccessDeniedSpec.hs
@@ -74,7 +74,7 @@ config = do
 makeApplication :: (?applicationContext :: ApplicationContext) => IO Application
 makeApplication = do
     store <- Session.mapStore_
-    let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie ?applicationContext.session
+    let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie sessionVaultKey
     pure (sessionMiddleware $ (Server.application handleNotFound) (\app -> app))
 
 assertAccessDenied :: SResponse -> IO ()

--- a/Test/Controller/CookieSpec.hs
+++ b/Test/Controller/CookieSpec.hs
@@ -37,6 +37,6 @@ createControllerContext = do
     let
         requestBody = FormBody { params = [], files = [] }
         request = Wai.defaultRequest
-        requestContext = RequestContext { request, respond = error "respond", requestBody, vault = error "vault", frameworkConfig = error "frameworkConfig" }
+        requestContext = RequestContext { request, respond = error "respond", requestBody, frameworkConfig = error "frameworkConfig" }
     let ?requestContext = requestContext
     newControllerContext

--- a/Test/Controller/NotFoundSpec.hs
+++ b/Test/Controller/NotFoundSpec.hs
@@ -74,7 +74,7 @@ config = do
 makeApplication :: (?applicationContext :: ApplicationContext) => IO Application
 makeApplication = do
     store <- Session.mapStore_
-    let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie ?applicationContext.session
+    let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie sessionVaultKey
     pure (sessionMiddleware $ (Server.application handleNotFound) (\app -> app))
 
 assertNotFound :: SResponse -> IO ()

--- a/Test/Controller/ParamSpec.hs
+++ b/Test/Controller/ParamSpec.hs
@@ -434,14 +434,14 @@ createControllerContextWithParams params =
         let
             requestBody = FormBody { params, files = [] }
             request = Wai.defaultRequest
-            requestContext = RequestContext { request, respond = error "respond", requestBody, vault = error "vault", frameworkConfig = error "frameworkConfig" }
+            requestContext = RequestContext { request, respond = error "respond", requestBody, frameworkConfig = error "frameworkConfig" }
         in FrozenControllerContext { requestContext, customFields = TypeMap.empty }
 
 createControllerContextWithJson params =
         let
             requestBody = JSONBody { jsonPayload = Just (json params), rawPayload = cs params }
             request = Wai.defaultRequest
-            requestContext = RequestContext { request, respond = error "respond", requestBody, vault = error "vault", frameworkConfig = error "frameworkConfig" }
+            requestContext = RequestContext { request, respond = error "respond", requestBody, frameworkConfig = error "frameworkConfig" }
         in FrozenControllerContext { requestContext, customFields = TypeMap.empty }
 
 json :: Text -> Aeson.Value

--- a/Test/View/CSSFrameworkSpec.hs
+++ b/Test/View/CSSFrameworkSpec.hs
@@ -721,5 +721,5 @@ createControllerContextWithCSSFramework cssFramework = do
                 option cssFramework
     let requestBody = FormBody { params = [], files = [] }
     let request = Wai.defaultRequest
-    let requestContext = RequestContext { request, respond = error "respond", requestBody, vault = error "vault", frameworkConfig = frameworkConfig }
+    let requestContext = RequestContext { request, respond = error "respond", requestBody, frameworkConfig = frameworkConfig }
     pure FrozenControllerContext { requestContext, customFields = TypeMap.empty }

--- a/Test/View/FormSpec.hs
+++ b/Test/View/FormSpec.hs
@@ -49,7 +49,7 @@ createControllerContext = do
     frameworkConfig <- FrameworkConfig.buildFrameworkConfig (pure ())
     let requestBody = FormBody { params = [], files = [] }
     let request = Wai.defaultRequest
-    let requestContext = RequestContext { request, respond = undefined, requestBody, vault = undefined, frameworkConfig = frameworkConfig }
+    let requestContext = RequestContext { request, respond = undefined, requestBody, frameworkConfig = frameworkConfig }
     pure FrozenControllerContext { requestContext, customFields = mempty }
 
 data Project'  = Project {id :: (Id' "projects"), title :: Text, meta :: MetaBag} deriving (Eq, Show)

--- a/Test/ViewSupportSpec.hs
+++ b/Test/ViewSupportSpec.hs
@@ -101,7 +101,7 @@ config = do
 makeApplication :: (?applicationContext :: ApplicationContext) => IO Application
 makeApplication = do
     store <- Session.mapStore_
-    let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie ?applicationContext.session
+    let sessionMiddleware :: Middleware = Session.withSession store "SESSION" ?applicationContext.frameworkConfig.sessionCookie sessionVaultKey
     pure (sessionMiddleware $ (Server.application handleNotFound (\app -> app)))
 
 tests :: Spec


### PR DESCRIPTION
Moved the session vault key from the ApplicationContext and RequestContext data structure to a global variable. This is the suggested way by the WAI developers.

See https://www.yesodweb.com/blog/2015/10/using-wais-vault