### PR TITLE
Fix conditional GHC 9.6 compilation

### DIFF
--- a/ihp-hsx/IHP/HSX/HaskellParser.hs
+++ b/ihp-hsx/IHP/HSX/HaskellParser.hs
@@ -30,7 +30,7 @@ parseHaskellExpression sourcePos extensions input =
                     error = renderWithContext defaultSDocContext
                         $ vcat
                         $ map (formatBulleted defaultSDocContext)
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
                         $ map (diagnosticMessage NoDiagnosticOpts)
 #else
                         $ map diagnosticMessage

--- a/ihp-hsx/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/IHP/HSX/HsExpToTH.hs
@@ -28,7 +28,7 @@ import qualified GHC.Unit.Module as Module
 import GHC.Stack
 import qualified Data.List.NonEmpty as NonEmpty
 import Language.Haskell.Syntax.Type
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
 import Language.Haskell.Syntax.Basic
 #endif
 
@@ -92,7 +92,7 @@ toExp (Expr.HsVar _ n) =
         then TH.ConE (toName n')
         else TH.VarE (toName n')
 
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
 toExp (Expr.HsUnboundVar _ n)              = TH.UnboundVarE (TH.mkName . occNameString $ occName n)
 #else
 toExp (Expr.HsUnboundVar _ n)              = TH.UnboundVarE (TH.mkName . occNameString $ n)
@@ -110,7 +110,7 @@ toExp (Expr.HsOverLit _ OverLit {ol_val})
 toExp (Expr.HsApp _ e1 e2)
   = TH.AppE (toExp . unLoc $ e1) (toExp . unLoc $ e2)
 
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
 toExp (Expr.HsAppType _ e _ HsWC {hswc_body}) = TH.AppTypeE (toExp . unLoc $ e) (toType . unLoc $ hswc_body)
 #else
 toExp (Expr.HsAppType _ e HsWC {hswc_body}) = TH.AppTypeE (toExp . unLoc $ e) (toType . unLoc $ hswc_body)
@@ -124,7 +124,7 @@ toExp (Expr.NegApp _ e _)
   = TH.AppE (TH.VarE 'negate) (toExp . unLoc $ e)
 
 -- NOTE: for lambda, there is only one match
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
 toExp (Expr.HsLam _ (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)]))))
 #else
 toExp (Expr.HsLam _ (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)])) _))
@@ -199,7 +199,7 @@ toExp (Expr.HsProjection _ locatedFields) =
     extractFieldLabel (DotFieldOcc _ locatedStr) = locatedStr
     extractFieldLabel _ = error "Don't know how to handle XDotFieldOcc constructor..."
   in
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
     TH.ProjectionE (NonEmpty.map (unpackFS . (.field_label) . unLoc . extractFieldLabel . unLoc) locatedFields)
 #else
     TH.ProjectionE (NonEmpty.map (unpackFS . unLoc . extractFieldLabel . unLoc) locatedFields)
@@ -210,13 +210,13 @@ toExp (Expr.HsGetField _ expr locatedField) =
     extractFieldLabel (DotFieldOcc _ locatedStr) = locatedStr
     extractFieldLabel _ = error "Don't know how to handle XDotFieldOcc constructor..."
   in
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
     TH.GetFieldE (toExp (unLoc expr)) (unpackFS . (.field_label) . unLoc . extractFieldLabel . unLoc $ locatedField)
 #else
     TH.GetFieldE (toExp (unLoc expr)) (unpackFS . unLoc . extractFieldLabel . unLoc $ locatedField)
 #endif
 
-#if __GLASGOW_HASKELL__ >= 960
+#if __GLASGOW_HASKELL__ >= 906
 toExp (Expr.HsOverLabel _ _ fastString) = TH.LabelE (unpackFS fastString)
 #else
 toExp (Expr.HsOverLabel _ fastString) = TH.LabelE (unpackFS fastString)


### PR DESCRIPTION
The CPP macro __GLASGOW_HASKELL__ was using an incorrect integer numbering scheme for GHC versions, making the conditional compilation incorrect (960 means GHC 9.60, whereas 906 means GHC 9.6).

See https://downloads.haskell.org/ghc/latest/docs/users_guide/intro.html#version-numbering