### PR TITLE
Remove `%` from sessionSecret

### DIFF
--- a/exe/IHP/CLI/NewSessionSecret.hs
+++ b/exe/IHP/CLI/NewSessionSecret.hs
@@ -12,4 +12,8 @@ main :: IO ()
 main = withUtf8 do
     (string, _) <- ClientSession.randomKey
     let encoded = Base64.encode string
-    ByteString.putStr encoded
+
+    -- Create a ByteString from a newline character.
+    let newline = Char8.pack "\n"
+    -- Append newline to encoded output and print, so it won't print `%` as a suffix on certain terminals.
+    ByteString.putStr (ByteString.append encoded newline)


### PR DESCRIPTION
This is the output I get when I execute on Ubuntu:

```
$ new-session-secret
vKfe21qHkQwwLAf+vWVEhywVMujoZlsg2ZBRuIKlrAfM4TlGgaaj5MOfplDdmpOlkqTkAttpy32GnLhPIwiF7+kB+e4ofoyOkqWNz9//pZts7jxkdgOc8MoY7FY3FH8F%   
```

Notice the `%` on the end.  PR is an attempt to add a new line at the end of the string. 

However, I don't know how to execute this locally to test it.