### PR TITLE
Pinning devenv with Mac Fix for Process Sockets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
         # used for setting up development environments
-        devenv.url = "github:cachix/devenv?ref=main&rev=800f19d1b999f89464fd8e0226abf4b3b444b0fa";
+        devenv.url = "github:cachix/devenv?rev=800f19d1b999f89464fd8e0226abf4b3b444b0fa";
         devenv.inputs.nixpkgs.follows = "nixpkgs";
 
         # TODO use a corresponding release branch

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
         # used for setting up development environments
-        devenv.url = "github:cachix/devenv?ref=refs/tags/v1.0.5";
+        devenv.url = "github:cachix/devenv?ref=main&rev=800f19d1b999f89464fd8e0226abf4b3b444b0fa";
         devenv.inputs.nixpkgs.follows = "nixpkgs";
 
         # TODO use a corresponding release branch


### PR DESCRIPTION
devenv up failing on macs in latest version. This new devenv version should fix it.