### PR TITLE
ihp-troubleshoot should look for `flake.nix` instead of `start` script

### DIFF
--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -104,6 +104,12 @@ path_exists(
     "Main.hs missing. Is this an IHP project?"
 )
 
+path_exists(
+    "flake.nix",
+    "Found flake.nix",
+    "flake.nix missing. Is this an IHP project?"
+)
+
 nix_output = run_command(["nix", "--version"])
 
 if nix_output.returncode != 0:

--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -104,12 +104,6 @@ path_exists(
     "Main.hs missing. Is this an IHP project?"
 )
 
-path_exists(
-    "start",
-    "Found start script",
-    "start script missing. Is this an IHP project?"
-)
-
 nix_output = run_command(["nix", "--version"])
 
 if nix_output.returncode != 0:


### PR DESCRIPTION
As it's no longer required, since we're using `devenv up`