### PR TITLE
Add appName To options for flake.

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -11,6 +11,7 @@
 , optimized ? false
 , includeDevTools ? !optimized # Include Postgres?
 , rtsFlags ? ""
+, appName ? "app"
 , optimizationLevel ? "2"
 }:
 
@@ -32,7 +33,7 @@ let
       else "build/bin/RunJobs";
 in
     pkgs.stdenv.mkDerivation {
-        name = "app";
+        name = appName;
         buildPhase = ''
           runHook preBuild
 

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -90,7 +90,6 @@ that is defined in flake-module.nix
                         hspec
                         ihp-hsx
                         ihp-postgresql-simple-extra
-                        haskell-language-server
                     ]);
 
             scripts.tests.exec = ''
@@ -112,7 +111,7 @@ that is defined in flake-module.nix
             '';
 
             languages.haskell.stack = null; # Stack is not used in IHP
-            #languages.haskell.languageServer = ghcCompiler.haskell-language-server;
+            languages.haskell.languageServer = ghcCompiler.haskell-language-server;
         };
 
         packages = {

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -90,6 +90,7 @@ that is defined in flake-module.nix
                         hspec
                         ihp-hsx
                         ihp-postgresql-simple-extra
+                        haskell-language-server
                     ]);
 
             scripts.tests.exec = ''
@@ -111,7 +112,7 @@ that is defined in flake-module.nix
             '';
 
             languages.haskell.stack = null; # Stack is not used in IHP
-            languages.haskell.languageServer = ghcCompiler.haskell-language-server;
+            #languages.haskell.languageServer = ghcCompiler.haskell-language-server;
         };
 
         packages = {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -61,20 +61,6 @@ ihpFlake:
                  default="app";
                 };
 
-                pName = lib.mkOption {
-                  description = ''
-                      The package name.
-                  '';
-                 type= lib.types.str;
-                };
-
-                version = lib.mkOption {
-                  description = ''
-                      The package version.
-                  '';
-                 type= lib.types.str;
-                };
-
                 projectPath = lib.mkOption {
                     description = ''
                         Path to the IHP project. You likely want to set this to `./.`.
@@ -162,6 +148,7 @@ ihpFlake:
                     pkgs = pkgs;
                     rtsFlags = cfg.rtsFlags;
                     optimizationLevel = cfg.optimizationLevel;
+                    appName=cfg.appName;
                 };
 
                 unoptimized-prod-server = import "${ihp}/NixSupport/default.nix" {
@@ -175,6 +162,7 @@ ihpFlake:
                     pkgs = pkgs;
                     rtsFlags = cfg.rtsFlags;
                     optimizationLevel = "0";
+                    appName=cfg.appName;
                 };
 
                 unoptimized-docker-image = pkgs.dockerTools.buildImage {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -53,12 +53,11 @@ ihpFlake:
                 };
 
                 appName = lib.mkOption {
-                  description ='' 
-                  The derivation name.
-                  Can be omitted if pname and version are set, in which case it is automatically set to ''${pname}-''${version}.
-                '';
-                 type= lib.types.str;
-                 default="app";
+                    description = '' 
+                        The derivation name.
+                    '';
+                    type = lib.types.str;
+                    default = "app";
                 };
 
                 projectPath = lib.mkOption {
@@ -148,7 +147,7 @@ ihpFlake:
                     pkgs = pkgs;
                     rtsFlags = cfg.rtsFlags;
                     optimizationLevel = cfg.optimizationLevel;
-                    appName=cfg.appName;
+                    appName = cfg.appName;
                 };
 
                 unoptimized-prod-server = import "${ihp}/NixSupport/default.nix" {
@@ -162,7 +161,7 @@ ihpFlake:
                     pkgs = pkgs;
                     rtsFlags = cfg.rtsFlags;
                     optimizationLevel = "0";
-                    appName=cfg.appName;
+                    appName = cfg.appName;
                 };
 
                 unoptimized-docker-image = pkgs.dockerTools.buildImage {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -52,6 +52,29 @@ ihpFlake:
                     ];
                 };
 
+                appName = lib.mkOption {
+                  description ='' 
+                  The derivation name.
+                  Can be omitted if pname and version are set, in which case it is automatically set to ''${pname}-''${version}.
+                '';
+                 type= lib.types.str;
+                 default="app";
+                };
+
+                pName = lib.mkOption {
+                  description = ''
+                      The package name.
+                  '';
+                 type= lib.types.str;
+                };
+
+                version = lib.mkOption {
+                  description = ''
+                      The package version.
+                  '';
+                 type= lib.types.str;
+                };
+
                 projectPath = lib.mkOption {
                     description = ''
                         Path to the IHP project. You likely want to set this to `./.`.

--- a/flake.lock
+++ b/flake.lock
@@ -30,6 +30,42 @@
         "type": "github"
       }
     },
+    "cachix_2": {
+      "inputs": {
+        "devenv": "devenv_4",
+        "flake-compat": [
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": [
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "pre-commit-hooks"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712055811,
+        "narHash": "sha256-7FcfMm5A/f02yyzuavJe06zLa9hcMHsagE28ADcmQvk=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "02e38da89851ec7fec3356a5c04bc8349cae0e30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
     "devenv": {
       "inputs": {
         "cachix": "cachix",
@@ -88,14 +124,78 @@
     },
     "devenv_3": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "nix": "nix_3",
+        "cachix": "cachix_2",
+        "flake-compat": "flake-compat_4",
+        "nix": "nix_4",
         "nixpkgs": [
           "ihp-boilerplate",
           "ihp",
           "nixpkgs"
         ],
         "pre-commit-hooks": "pre-commit-hooks_2"
+      },
+      "locked": {
+        "lastModified": 1714390914,
+        "narHash": "sha256-W5DFIifCjGYJXJzLU3RpqBeqes4zrf0Sr/6rwzTygPU=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "34e6461fd76b5f51ad5f8214f5cf22c4cd7a196e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "refs/tags/v1.0.5",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devenv_4": {
+      "inputs": {
+        "flake-compat": [
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "cachix",
+          "flake-compat"
+        ],
+        "nix": "nix_3",
+        "nixpkgs": "nixpkgs_2",
+        "poetry2nix": "poetry2nix_2",
+        "pre-commit-hooks": [
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "cachix",
+          "pre-commit-hooks"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708704632,
+        "narHash": "sha256-w+dOIW60FKMaHI1q5714CSibk99JfYxm0CzTinYWr+Q=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "2ee4450b0f4b95a1b90f2eb5ffea98b90e48c196",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "python-rewrite",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devenv_5": {
+      "inputs": {
+        "flake-compat": "flake-compat_5",
+        "nix": "nix_5",
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks_3"
       },
       "locked": {
         "lastModified": 1694422554,
@@ -111,18 +211,20 @@
         "type": "github"
       }
     },
-    "devenv_4": {
+    "devenv_6": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
-        "nix": "nix_4",
+        "flake-compat": "flake-compat_6",
+        "nix": "nix_6",
         "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
           "ihp-boilerplate",
           "ihp",
           "ihp-boilerplate",
           "ihp",
           "nixpkgs"
         ],
-        "pre-commit-hooks": "pre-commit-hooks_3"
+        "pre-commit-hooks": "pre-commit-hooks_4"
       },
       "locked": {
         "lastModified": 1686054274,
@@ -189,6 +291,38 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
         "lastModified": 1673956053,
         "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
@@ -209,6 +343,28 @@
         ]
       },
       "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "ihp-boilerplate",
+          "ihp",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
         "lastModified": 1714641030,
         "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
@@ -222,7 +378,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
@@ -240,7 +396,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
@@ -299,6 +455,42 @@
         "systems": "systems_3"
       },
       "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_5"
+      },
+      "locked": {
         "lastModified": 1685518550,
         "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
@@ -312,7 +504,7 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_6": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -360,11 +552,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -399,26 +591,54 @@
         "type": "github"
       }
     },
+    "gitignore_4": {
+      "inputs": {
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "ihp": {
       "inputs": {
         "devenv": "devenv_3",
         "flake-parts": "flake-parts_2",
         "ihp-boilerplate": "ihp-boilerplate_2",
-        "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs_3",
-        "systems": "systems_5"
+        "nix-filter": "nix-filter_2",
+        "nixpkgs": "nixpkgs_5",
+        "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1700013490,
-        "narHash": "sha256-oQz7ZBrHe6WwYMwnxxUgnYM55CuH5Oxjz6mrLnYbB7U=",
+        "lastModified": 1714870134,
+        "narHash": "sha256-DmaIr9kF+TG24wVNPVufxC74TYMCLziLYS9hCZHBDTc=",
         "owner": "digitallyinduced",
         "repo": "ihp",
-        "rev": "d59a65d71943cb506eee3ad6255f017963237359",
+        "rev": "29436fd63f11ccad9b10168bba7d14df737ee287",
         "type": "github"
       },
       "original": {
         "owner": "digitallyinduced",
-        "ref": "v1.2",
+        "ref": "v1.3",
         "repo": "ihp",
         "type": "github"
       }
@@ -448,11 +668,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710175252,
-        "narHash": "sha256-QIFqo64U69uUGJ7pgBr37T3yAKK0n1ueqagKmnm+XWw=",
+        "lastModified": 1714870368,
+        "narHash": "sha256-40eI5uHSTrKgHX6qJz4muP3MVjg2Zhxt3fIktqsx7GU=",
         "owner": "digitallyinduced",
         "repo": "ihp-boilerplate",
-        "rev": "323591d6135f7a89b5b4e518d5d420cd5b046fe2",
+        "rev": "68eb3debd8e353653391214a658deafa6f72d91c",
         "type": "github"
       },
       "original": {
@@ -494,6 +714,60 @@
         ]
       },
       "locked": {
+        "lastModified": 1710175252,
+        "narHash": "sha256-QIFqo64U69uUGJ7pgBr37T3yAKK0n1ueqagKmnm+XWw=",
+        "owner": "digitallyinduced",
+        "repo": "ihp-boilerplate",
+        "rev": "323591d6135f7a89b5b4e518d5d420cd5b046fe2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "digitallyinduced",
+        "repo": "ihp-boilerplate",
+        "type": "github"
+      }
+    },
+    "ihp-boilerplate_3": {
+      "inputs": {
+        "devenv": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "devenv"
+        ],
+        "flake-parts": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "flake-parts"
+        ],
+        "ihp": "ihp_3",
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "nixpkgs"
+        ],
+        "systems": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "systems"
+        ]
+      },
+      "locked": {
         "lastModified": 1689954789,
         "narHash": "sha256-RsgD1YGSlx+K/GkTspOdg/tz47PyZZDc66PzfFZvqBk=",
         "owner": "digitallyinduced",
@@ -507,7 +781,7 @@
         "type": "github"
       }
     },
-    "ihp-boilerplate_3": {
+    "ihp-boilerplate_4": {
       "flake": false,
       "locked": {
         "lastModified": 1686165507,
@@ -526,11 +800,35 @@
     },
     "ihp_2": {
       "inputs": {
-        "devenv": "devenv_4",
+        "devenv": "devenv_5",
         "flake-parts": "flake-parts_3",
         "ihp-boilerplate": "ihp-boilerplate_3",
-        "nixpkgs": "nixpkgs_2",
-        "systems": "systems_4"
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs_4",
+        "systems": "systems_7"
+      },
+      "locked": {
+        "lastModified": 1700013490,
+        "narHash": "sha256-oQz7ZBrHe6WwYMwnxxUgnYM55CuH5Oxjz6mrLnYbB7U=",
+        "owner": "digitallyinduced",
+        "repo": "ihp",
+        "rev": "d59a65d71943cb506eee3ad6255f017963237359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "digitallyinduced",
+        "ref": "v1.2",
+        "repo": "ihp",
+        "type": "github"
+      }
+    },
+    "ihp_3": {
+      "inputs": {
+        "devenv": "devenv_6",
+        "flake-parts": "flake-parts_4",
+        "ihp-boilerplate": "ihp-boilerplate_4",
+        "nixpkgs": "nixpkgs_3",
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1689949405,
@@ -635,9 +933,50 @@
         "type": "github"
       }
     },
+    "nix-filter_3": {
+      "locked": {
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
+          "devenv",
+          "cachix",
+          "devenv",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688870561,
+        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-github-actions_2": {
+      "inputs": {
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
           "devenv",
           "cachix",
           "devenv",
@@ -688,14 +1027,75 @@
     },
     "nix_3": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression_3"
+      },
+      "locked": {
+        "lastModified": 1712911606,
+        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "devenv-2.21",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_4": {
+      "inputs": {
+        "flake-compat": [
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "flake-compat"
+        ],
         "nixpkgs": [
           "ihp-boilerplate",
           "ihp",
           "devenv",
           "nixpkgs"
         ],
-        "nixpkgs-regression": "nixpkgs-regression_3"
+        "nixpkgs-regression": "nixpkgs-regression_4"
+      },
+      "locked": {
+        "lastModified": 1712911606,
+        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "devenv-2.21",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_5": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression_5"
       },
       "locked": {
         "lastModified": 1676545802,
@@ -712,7 +1112,7 @@
         "type": "github"
       }
     },
-    "nix_4": {
+    "nix_6": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
         "nixpkgs": [
@@ -720,10 +1120,12 @@
           "ihp",
           "ihp-boilerplate",
           "ihp",
+          "ihp-boilerplate",
+          "ihp",
           "devenv",
           "nixpkgs"
         ],
-        "nixpkgs-regression": "nixpkgs-regression_4"
+        "nixpkgs-regression": "nixpkgs-regression_6"
       },
       "locked": {
         "lastModified": 1676545802,
@@ -856,6 +1258,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression_5": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_6": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1710695816,
@@ -874,6 +1308,22 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_3": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -888,7 +1338,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_3": {
+    "nixpkgs-stable_4": {
       "locked": {
         "lastModified": 1678872516,
         "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
@@ -906,6 +1356,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1692808169,
+        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1681488673,
         "narHash": "sha256-PmojOyePBNvbY3snYE7NAQHTLB53t7Ro+pgiJ4wPCuk=",
         "owner": "NixOS",
@@ -920,7 +1386,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1696291921,
         "narHash": "sha256-isKgVAoUxuxYEuO3Q4xhbfKcZrF/+UkJtOTv0eb/W5E=",
@@ -936,7 +1402,22 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1714864423,
+        "narHash": "sha256-Wx3Y6arRJD1pd3c8SnD7dfW7KWuCr/r248P/5XLaMdM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "54b4bb956f9891b872904abdb632cea85a033ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1714864423,
         "narHash": "sha256-Wx3Y6arRJD1pd3c8SnD7dfW7KWuCr/r248P/5XLaMdM=",
@@ -957,6 +1438,33 @@
         "flake-utils": "flake-utils",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
+          "devenv",
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1692876271,
+        "narHash": "sha256-IXfZEkI0Mal5y1jr6IRWMqK8GW2/f28xJenZIPQqkY0=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "d5006be9c2c2417dafb2e2e5034d83fabd207ee3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nix-github-actions": "nix-github-actions_2",
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
           "devenv",
           "cachix",
           "devenv",
@@ -1013,7 +1521,7 @@
           "devenv",
           "flake-compat"
         ],
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "ihp-boilerplate",
@@ -1024,11 +1532,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1688056373,
-        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
+        "lastModified": 1713775815,
+        "narHash": "sha256-Wu9cdYTnGQQwtT20QQMg7jzkANKQjwBD9iccfGKkfls=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "rev": "2ac4dcbf55ed43f3be0bae15e181f08a57af24a4",
         "type": "github"
       },
       "original": {
@@ -1047,7 +1555,7 @@
           "devenv",
           "flake-compat"
         ],
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "gitignore": "gitignore_3",
         "nixpkgs": [
           "ihp-boilerplate",
@@ -1058,6 +1566,46 @@
           "nixpkgs"
         ],
         "nixpkgs-stable": "nixpkgs-stable_3"
+      },
+      "locked": {
+        "lastModified": 1688056373,
+        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_4": {
+      "inputs": {
+        "flake-compat": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils_6",
+        "gitignore": "gitignore_4",
+        "nixpkgs": [
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "ihp-boilerplate",
+          "ihp",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
         "lastModified": 1682596858,
@@ -1078,9 +1626,9 @@
         "devenv": "devenv",
         "flake-parts": "flake-parts",
         "ihp-boilerplate": "ihp-boilerplate",
-        "nix-filter": "nix-filter_2",
-        "nixpkgs": "nixpkgs_4",
-        "systems": "systems_6"
+        "nix-filter": "nix-filter_3",
+        "nixpkgs": "nixpkgs_6",
+        "systems": "systems_9"
       }
     },
     "systems": {
@@ -1159,6 +1707,51 @@
       }
     },
     "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_8": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_9": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
When hosting multiple ihp apps on a particular server it is helpful for debugging/maintenance/tooling to be able to inspect which binaries are in the production servers /nix/store by their name (not just hash). This is consistent with all other nixpkgs that contain the hash and the package name in the store. 

For managed production clusters it is also  nice for roll back to be able to give semver names to app packages so that it is easy to instantly roll back to a prev version of app binary on a prod server if required. This PR adds option of appName to ihp flake-modules so users can specify the appName. The appName option gets passed all the way to ihp's (un)optimized-prod-server package `mkDerivation` (where it is called `name` and is a standard attribute for nix's mkDerivation.). We could call it `name` at the top level so it matches specifically but in the context of the app level flake it is probably less ambiguous to call it `appName`.

Furthermore having an appName option at top level flake has been found useful for a number of other IHP production helpers i.e. scripts to synchronize databases and deploy to servers etc. that can leverage the appName variable as well. 