### PR TITLE
Migration path Env Var.

### DIFF
--- a/Guide/database-migrations.markdown
+++ b/Guide/database-migrations.markdown
@@ -73,6 +73,20 @@ migrate
 
 A good value for `MINIMUM_REVISION` is typically the unix timestamp of the time when the database was initially created.
 
+
+### IHP_MIGRATIONS_DIR
+
+In production when running the migrations binary it is sometimes convenient to have all your Migrations in a non-standard place:
+e.g. if you need to push migrations onto production server without rebuilding the application. There is an Environment variable
+`IHP_MIGRATION_DIR` to accomplish this.
+
+```
+IHP_MIGRATION_DIR=path/to/my/migration/dir
+```
+
+This can be set in the environment attribute set of your IHP app flake.
+
+
 ## Common Issues
 
 ### ALTER TYPE ... ADD cannot run inside a transaction block

--- a/Guide/database-migrations.markdown
+++ b/Guide/database-migrations.markdown
@@ -74,7 +74,7 @@ migrate
 A good value for `MINIMUM_REVISION` is typically the unix timestamp of the time when the database was initially created.
 
 
-### IHP_MIGRATIONS_DIR
+### IHP MIGRATIONS DIR
 
 In production when running the migrations binary it is sometimes convenient to have all your Migrations in a non-standard place:
 e.g. if you need to push migrations onto production server without rebuilding the application. There is an Environment variable

--- a/NixSupport/nixosModules/options.nix
+++ b/NixSupport/nixosModules/options.nix
@@ -13,63 +13,70 @@ with lib;
             type = types.str;
             default = "https://${config.services.ihp.domain}";
         };
-        
+
         migrations = mkOption {
             type = types.path;
         };
-        
+
         schema = mkOption {
             type = types.path;
         };
-        
+
         fixtures = mkOption {
             type = types.path;
         };
-        
+
         httpsEnabled = mkOption {
             type = types.bool;
             default = true;
         };
-        
+
         databaseName = mkOption {
             type = types.str;
             default = "app";
         };
-        
+
         databaseUser = mkOption {
             type = types.str;
             default = "ihp";
         };
-        
+
         databaseUrl = mkOption {
             type = types.str;
         };
-        
+
         # https://ihp.digitallyinduced.com/Guide/database-migrations.html#skipping-old-migrations
         minimumRevision = mkOption {
             type = types.int;
             default = 0;
         };
-        
+
+        # https://ihp.digitallyinduced.com/Guide/database-migrations.html#ihp-migrations-dir
+        ihpMigrationDir = mkOption {
+            type = types.str;
+            default = "Application/Migration/";
+        };
+
+
         ihpEnv = mkOption {
             type = types.str;
             default = "Production";
         };
-        
+
         appPort = mkOption {
             type = types.int;
             default = 8000;
         };
-        
+
         requestLoggerIPAddrSource = mkOption {
             type = types.str;
             default = "FromHeader";
         };
-        
+
         sessionSecret = mkOption {
             type = types.str;
         };
-        
+
         additionalEnvVars = mkOption {
             type = types.attrs;
             default = {};
@@ -79,7 +86,7 @@ with lib;
             type = types.package;
             default = if config.services.ihp.optimized then self.packages."${pkgs.system}".optimized-prod-server else self.packages."${pkgs.system}".default;
         };
-        
+
         optimized = mkOption {
             type = types.bool;
             default = false;
@@ -91,4 +98,3 @@ with lib;
         };
     };
 }
-

--- a/NixSupport/nixosModules/services/migrate.nix
+++ b/NixSupport/nixosModules/services/migrate.nix
@@ -22,6 +22,7 @@ in
             environment = {
                 DATABASE_URL = cfg.databaseUrl;
                 MINIMUM_REVISION = "${toString cfg.minimumRevision}";
+                IHP_MIGRATION_DIR = cfg.ihpMigrationDir;
             };
     };
 }

--- a/ihp-ide/IHP/IDE/SchemaDesigner/Controller/Migrations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/Controller/Migrations.hs
@@ -61,7 +61,7 @@ instance Controller MigrationsController where
                         let errorMessage = case fromException exception of
                                 Just (exception :: EnhancedSqlError) -> cs exception.sqlError.sqlErrorMsg
                                 Nothing -> tshow exception
-                        
+
                         setErrorMessage errorMessage
                         redirectTo MigrationsAction
                     Right _ -> do
@@ -79,14 +79,14 @@ instance Controller MigrationsController where
     action UpdateMigrationAction { migrationId } = do
         migration <- findMigrationByRevision migrationId
         let sqlStatements = param "sqlStatements"
-
-        Text.writeFile (cs $ SchemaMigration.migrationPath migration) sqlStatements
+        migrationFilePath <- SchemaMigration.migrationPath migration
+        Text.writeFile (cs migrationFilePath) sqlStatements
 
         redirectTo MigrationsAction
 
     action DeleteMigrationAction { migrationId } = do
         migration <- findMigrationByRevision migrationId
-        let path = cs $ SchemaMigration.migrationPath migration
+        path <- cs $ SchemaMigration.migrationPath migration
 
         Directory.removeFile path
 
@@ -101,7 +101,7 @@ instance Controller MigrationsController where
                 let errorMessage = case fromException exception of
                         Just (exception :: EnhancedSqlError) -> cs exception.sqlError.sqlErrorMsg
                         Nothing -> tshow exception
-                
+
                 setErrorMessage errorMessage
                 redirectTo MigrationsAction
             Right _ -> do
@@ -109,7 +109,9 @@ instance Controller MigrationsController where
                 redirectTo MigrationsAction
 
 readSqlStatements :: SchemaMigration.Migration -> IO Text
-readSqlStatements migration = Text.readFile (cs $ SchemaMigration.migrationPath migration)
+readSqlStatements migration = do
+    migrationFilePath <- (SchemaMigration.migrationPath migration)
+    pure Text.readFile (migrationFilePath)
 
 findRecentMigrations :: IO [SchemaMigration.Migration]
 findRecentMigrations = take 20 . reverse <$> SchemaMigration.findAllMigrations

--- a/ihp-ide/IHP/IDE/SchemaDesigner/Controller/Migrations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/Controller/Migrations.hs
@@ -86,7 +86,7 @@ instance Controller MigrationsController where
 
     action DeleteMigrationAction { migrationId } = do
         migration <- findMigrationByRevision migrationId
-        path <- cs $ SchemaMigration.migrationPath migration
+        path <- cs <$> SchemaMigration.migrationPath migration
 
         Directory.removeFile path
 

--- a/ihp.nix
+++ b/ihp.nix
@@ -145,7 +145,7 @@ mkDerivation {
 
   # For faster builds when hacking on IHP:
   # Uncommenting will build without optimizations
-   configureFlags = [ "--flag FastBuild" ];
+  # configureFlags = [ "--flag FastBuild" ];
   # Uncommenting will not generate documentation
-   doHaddock = false;
+  # doHaddock = false;
 }

--- a/ihp.nix
+++ b/ihp.nix
@@ -145,7 +145,7 @@ mkDerivation {
 
   # For faster builds when hacking on IHP:
   # Uncommenting will build without optimizations
-  # configureFlags = [ "--flag FastBuild" ];
+   configureFlags = [ "--flag FastBuild" ];
   # Uncommenting will not generate documentation
-  # doHaddock = false;
+   doHaddock = false;
 }


### PR DESCRIPTION
Adds an environment variable so user can run migration systemd service from any directory on FileSystem. Useful in certain production situations. Defaults to the previous value. Docs updated. 