### PR TITLE
Show On Delete constraint in the schema designer

### DIFF
--- a/ihp-ide/IHP/IDE/SchemaDesigner/View/Layout.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/View/Layout.hs
@@ -404,7 +404,7 @@ renderColumn Column { name, columnType, defaultValue, notNull, isUnique } id tab
                 Just value -> [hsx|default: {compileExpression value} |]
                 Nothing -> mempty
         renderForeignKey = case findForeignKey statements tableName name of
-            Just addConstraint@AddConstraint { constraint = ForeignKeyConstraint { name = Just constraintName, referenceTable } } -> [hsx|<a href={EditForeignKeyAction tableName name constraintName referenceTable} class="d-block nounderline">FOREIGN KEY: {referenceTable}</a>|]
+            Just addConstraint@AddConstraint { constraint = ForeignKeyConstraint { name = Just constraintName, referenceTable, onDelete = onDeleteConstraint } } -> [hsx|<a href={EditForeignKeyAction tableName name constraintName referenceTable} class="d-block nounderline">FOREIGN KEY: {referenceTable} (On Delete: {tshow onDeleteConstraint})</a>|]
             _ -> mempty
         foreignKeyOption = case findForeignKey statements tableName name of
             Just addConstraint@AddConstraint { constraint = ForeignKeyConstraint { name = Just constraintName, referenceTable } } ->


### PR DESCRIPTION
This PR adds the ON DELETE constraint information to the Schema Designer, making it easier to see constraint types without opening the Edit Foreign Key modal or checking the schema directly.

![image](https://github.com/user-attachments/assets/2341810c-73ec-4629-9079-03abacf4d957)