### PR TITLE
Revert "Force evaluation of blaze HTML also on `ProdMode`"

### DIFF
--- a/IHP/Controller/Render.hs
+++ b/IHP/Controller/Render.hs
@@ -26,18 +26,25 @@ renderPlain text = respondAndExit $ responseLBS status200 [(hContentType, "text/
 
 respondHtml :: (?context :: ControllerContext) => Html -> IO ()
 respondHtml html =
-        -- The seq is required to force evaluation of `evaluatedBuilder` before returning the IO action. See below for details
-        evaluatedBuilder `seq` (respondAndExit $ responseBuilder status200 [(hContentType, "text/html; charset=utf-8"), (hConnection, "keep-alive")] evaluatedBuilder)
+        -- The seq is required to force evaluation of `maybeEvaluatedBuilder` before returning the IO action. See below for details
+        maybeEvaluatedBuilder `seq` (respondAndExit $ responseBuilder status200 [(hContentType, "text/html; charset=utf-8"), (hConnection, "keep-alive")] maybeEvaluatedBuilder)
     where
         builder = Blaze.renderHtmlBuilder html
         builderAsByteString = ByteString.toLazyByteString builder
 
-        -- We force the full evaluation of the blaze html expressions to catch
+        -- In dev mode we force the full evaluation of the blaze html expressions to catch
         -- any runtime errors with the IHP error middleware. Without this full evaluation
         -- certain thunks might only cause an error when warp is building the response string.
         -- But then it's already too late to catch the exception and the user will only get
         -- the default warp error message instead of our nice IHP error message design.
-        evaluatedBuilder = Data.ByteString.Lazy.length builderAsByteString `seq` ByteString.lazyByteString builderAsByteString
+        --
+        -- In production we only evaluate lazy as it improves performance and these kind of
+        -- errors are unlikely to happen in production
+        --
+        -- See https://github.com/digitallyinduced/ihp/issues/1028
+        maybeEvaluatedBuilder = if FrameworkConfig.isDevelopment
+            then (Data.ByteString.Lazy.length builderAsByteString) `seq` (ByteString.lazyByteString builderAsByteString)
+            else builder
 {-# INLINABLE respondHtml #-}
 
 respondSvg :: (?context :: ControllerContext) => Html -> IO ()


### PR DESCRIPTION
Reverts digitallyinduced/ihp#2044

I believe this PR can be reverted. I've originally reported not seeing the exceptions being caught on logs.

However, my mistake was that I expected it to be shown as part of the 500 error. In reality, it's logged as a _separate_ log item.

In the screenshot, we can see that my app has sent those logs on 19 Feb -- two days before #2044 was merged. 

![image](https://github.com/user-attachments/assets/f062ced9-3bd5-47f2-b911-52b69e2a2f3e)
