### PR TITLE
Fix back button after form submit

### DIFF
--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -116,10 +116,11 @@ function initDelete() {
 }
 
 function initDisableButtonsOnSubmit() {
-    if (window.initDisableButtonsOnSubmitRun) {
+    if (Boolean(document.initDisableButtonsOnSubmit) === true) {
         return;
     }
-    window.initDisableButtonsOnSubmitRun = true;
+
+    document.initDisableButtonsOnSubmit = true;
 
     var lastClicked = null;
     document.addEventListener('submit', function (event) {

--- a/lib/IHP/static/helpers.js
+++ b/lib/IHP/static/helpers.js
@@ -8,7 +8,6 @@ window.addEventListener('beforeunload', function () {
 document.addEventListener('DOMContentLoaded', function () {
     initDelete();
     initDisableButtonsOnSubmit();
-    initBack();
     initToggle();
     initTime();
     initDatePicker();
@@ -19,7 +18,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
 document.addEventListener('turbolinks:load', function () {
     initDelete();
-    initBack();
     initToggle();
     initTime();
     initFileUploadPreview();
@@ -117,30 +115,6 @@ function initDelete() {
     }
 }
 
-function initBack() {
-    var elements = document.getElementsByClassName('js-back');
-
-    function handleClick(event) {
-        event.preventDefault();
-        event.target.setAttribute('disabled', 'disabled');
-        event.target.classList.add('disabled');
-
-        window.history.back();
-    }
-
-    for (var i in elements) {
-        var element = elements[i];
-        if (element instanceof HTMLButtonElement) {
-            element.addEventListener('click', handleClick);
-        } else if (element instanceof HTMLAnchorElement) {
-            console.error(
-                'js-back does not supports <a> elements, use a <button> instead',
-                element
-            );
-        }
-    }
-}
-
 function initDisableButtonsOnSubmit() {
     if (window.initDisableButtonsOnSubmitRun) {
         return;
@@ -169,8 +143,8 @@ window.submitForm = function (form, possibleClickedButton) {
     // We cannot use `form.action` here because there could be a <input name="action"/>
     // See https://github.com/digitallyinduced/ihp/issues/1203
     var formAction = (possibleClickedButton && possibleClickedButton.getAttribute('formAction'))
-		? possibleClickedButton.getAttribute('formAction')
-		: form.getAttribute('action');
+        ? possibleClickedButton.getAttribute('formAction')
+        : form.getAttribute('action');
     var formMethod = form.getAttribute('method') || 'GET';
 
     var request = new XMLHttpRequest();


### PR DESCRIPTION
fixes #2063 

- Remove `initBack` which seems no longer used (?)
- Modernize `initDisableButtonsOnSubmit` to use a better way to prevent double binding

@unhammer could you try this PR locally to confirm it works for you?