### PR TITLE
ihp-hsx: Add support for GHC 9.10.x and 9.12.x

### DIFF
--- a/ihp-hsx/Test/IHP/HSX/QQSpec.hs
+++ b/ihp-hsx/Test/IHP/HSX/QQSpec.hs
@@ -13,7 +13,7 @@ import qualified IHP.HSX.Lucid2.Attribute as Lucid2
 import qualified Text.Blaze.Renderer.Text as Blaze
 import qualified Text.Blaze as Blaze
 import Text.Blaze (preEscapedTextValue)
-import Data.Text
+import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 import IHP.HSX.CustomHsxCases
 import qualified "lucid2" Lucid.Base as Lucid2 (Html, HtmlT, renderText, renderTextT)

--- a/ihp-hsx/blaze/IHP/HSX/ToHtml.hs
+++ b/ihp-hsx/blaze/IHP/HSX/ToHtml.hs
@@ -11,7 +11,7 @@ module IHP.HSX.ToHtml where
 import Prelude
 import qualified Text.Blaze.Html5 as Html5
 import qualified Text.Blaze.Internal
-import Data.Text
+import Data.Text (Text)
 import Data.ByteString
 import Data.String.Conversions (cs)
 import IHP.HSX.ConvertibleStrings ()

--- a/ihp-hsx/ihp-hsx.cabal
+++ b/ihp-hsx/ihp-hsx.cabal
@@ -72,9 +72,9 @@ common common-flags
 
 common common-depends
     build-depends:
-          base >= 4.17.0 && < 4.20
+          base >= 4.17.0 && < 4.22
         , bytestring
-        , template-haskell >= 2.19.0 && < 2.22
+        , template-haskell >= 2.19.0 && < 2.24
         , text
         , containers
         , megaparsec
@@ -85,7 +85,7 @@ library ihp-hsx-parser
     import: common-extensions, common-flags, common-depends
     default-language: Haskell2010
     build-depends:
-        ghc >= 9.4.4 && < 9.9
+        ghc >= 9.4.4 && < 9.13
     hs-source-dirs: parser
     exposed-modules:
         IHP.HSX.Parser

--- a/ihp-hsx/parser/IHP/HSX/Parser.hs
+++ b/ihp-hsx/parser/IHP/HSX/Parser.hs
@@ -19,7 +19,7 @@ module IHP.HSX.Parser
 ) where
 
 import Prelude
-import Data.Text
+import Data.Text (Text)
 import Data.Set
 import Text.Megaparsec
 import Text.Megaparsec.Char


### PR DESCRIPTION
Fix the version dependent bits of HsExpToTH to support 9.10.x and 9.12.x.
Bump the version bounds in ihp-hsx.cabal.
Use explicit imports for Data.Text, as it now exports a `show` that conflicts with the `show` in Prelude.