### PR TITLE
Fix deprecated 'convert' command to 'magick' in ImageMagick.hs

### DIFF
--- a/IHP/FileStorage/Preprocessor/ImageMagick.hs
+++ b/IHP/FileStorage/Preprocessor/ImageMagick.hs
@@ -59,7 +59,7 @@ applyImageMagick convertTo otherParams fileInfo = do
             |> LBS.writeFile tempFilePath
 
         let params :: [String] = [tempFilePath] <> otherParams <> [convertedFilePath]
-        Process.callProcess "convert" params
+        Process.callProcess "magick" params
 
         newContent <- LBS.readFile convertedFilePath
         pure fileInfo { Wai.fileContent = newContent }


### PR DESCRIPTION
This PR fixes issue #2071 by replacing the deprecated convert command with the recommended magick command in the file ihp/IHP/FileStorage/Preprocessor/ImageMagick.hs. This change ensures compatibility with ImageMagick version 7 and above.
 

