### PR TITLE
Fix run-script argument handling

### DIFF
--- a/ihp-ide/exe/IHP/CLI/run-script
+++ b/ihp-ide/exe/IHP/CLI/run-script
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-TASK_PATH=$@
+TASK_PATH="$1"
 TASK_MODULE=${TASK_PATH##*/}
 TASK_MODULE="${TASK_MODULE%.*}"
 


### PR DESCRIPTION
Fixes #2085 - Replace $@ with "$1" to properly handle the script path argument and avoid "missing operand" errors.

🤖 Generated with [Claude Code](https://claude.ai/code)