### PR TITLE
Fix Troubleshoot script

### DIFF
--- a/Troubleshoot/ihp-troubleshoot
+++ b/Troubleshoot/ihp-troubleshoot
@@ -216,8 +216,7 @@ with open(path.join(Path.home(), ".config/nix/nix.conf")) as file:
 show_step("Checking IHP files")
 
 SENSITIVE_FILES = [
-    ".ghci", "hie.yaml", "flake.nix",
-    "Makefile", "Config/nix/nixpkgs-config.nix"
+    ".ghci", "flake.nix", "Makefile", "Config/nix/nixpkgs-config.nix"
 ]
 for file_details in boilerplate_contents():
     file_path = file_details["path"]


### PR DESCRIPTION
- It didn't parse the nix output correctly
- It was looking for the `start` script
- It was looknig at `default.nix` instead of `flake.nix`

I'm still seeing two errors

![image](https://github.com/user-attachments/assets/7fa4636d-d4b5-422e-80a3-ba410bad1e90)


1.  `direnv`  not allowed, but I did run `direnv allow`
![image](https://github.com/user-attachments/assets/7940d67b-6284-408e-a285-7625ca0fcad7)

2. `Symlink build/ihp-lib target directory does not exist. Try `nix-shell --run "make -B build/ihp-lib"` to fix this` -- maybe because I'm running with local IHP?