### PR TITLE
Use Approot middleware for redirects

### DIFF
--- a/IHP/Controller/Redirect.hs
+++ b/IHP/Controller/Redirect.hs
@@ -18,6 +18,7 @@ import IHP.Controller.RequestContext
 import IHP.RouterSupport (HasPath (pathTo))
 import IHP.FrameworkConfig
 import Network.HTTP.Types.Status
+import qualified Network.Wai.Middleware.Approot as Approot
 
 import IHP.Controller.Context
 import IHP.ControllerSupport
@@ -43,7 +44,9 @@ redirectTo action = redirectToPath (pathTo action)
 --
 -- Use 'redirectTo' if you want to redirect to a controller action.
 redirectToPath :: (?context :: ControllerContext) => Text -> IO ()
-redirectToPath path = redirectToUrl (?context.frameworkConfig.baseUrl <> path)
+redirectToPath path = redirectToUrl (convertString baseUrl <> path)
+    where
+        baseUrl = Approot.getApproot ?context.requestContext.request
 {-# INLINABLE redirectToPath #-}
 
 -- | Redirects to a url (given as a string)

--- a/IHP/Server.hs
+++ b/IHP/Server.hs
@@ -24,6 +24,7 @@ import qualified IHP.Job.Runner as Job
 import qualified IHP.Job.Types as Job
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Network.Wai.Middleware.Cors as Cors
+import qualified Network.Wai.Middleware.Approot as Approot
 import qualified Control.Exception as Exception
 
 import qualified System.Directory as Directory
@@ -47,6 +48,8 @@ run configBuilder = do
     withFrameworkConfig configBuilder \frameworkConfig -> do
         modelContext <- IHP.FrameworkConfig.initModelContext frameworkConfig
 
+        approotMiddleware <- Approot.envFallback
+
         withInitalizers frameworkConfig modelContext do
             PGListener.withPGListener modelContext \pgListener -> do
                 autoRefreshServer <- newIORef (AutoRefresh.newAutoRefreshServer pgListener)
@@ -69,6 +72,7 @@ run configBuilder = do
                     . corsMiddleware
                     . methodOverridePost
                     . sessionMiddleware
+                    . approotMiddleware
                     $ application staticApp requestLoggerMiddleware
 
 {-# INLINABLE run #-}


### PR DESCRIPTION
Makes redirects more flexible when an IHP app is running on multiple domains