### PR TITLE
ihp-hsx: version 1.5.0

### DIFF
--- a/ihp-hsx/changelog.md
+++ b/ihp-hsx/changelog.md
@@ -1,5 +1,11 @@
 # Changelog for `ihp-hsx`
 
+## Version 1.5.0
+
+- Suport for GHC 9.10.x and 9.12.x
+- Add backend for lucid2 via dedidcated ihp-hsx-lucid2 library
+- Add missing attributes muted, onkeypress
+
 ## Versions < 0.18:
 
 [See the IHP main upgrade instructions](https://github.com/digitallyinduced/ihp/blob/master/UPGRADE.md)

--- a/ihp-hsx/ihp-hsx.cabal
+++ b/ihp-hsx/ihp-hsx.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                ihp-hsx
-version:             1.4.1
+version:             1.5.0
 synopsis:            JSX-like but for Haskell
 description:         JSX-like templating syntax for Haskell
 license:             MIT


### PR DESCRIPTION
@iteratee I'll push the lucid2 changes to hackage via version 1.5.0 in a few minutes.

Maybe we should refactor the package structure such that we have two hackage packages. Otherwise all users of ihp-hsx will always depend on lucid2 (e.g. splitting into ihp-hsx-parser, ihp-hsx-blaze and ihp-hsx-lucid2)