### PR TITLE
Improve static build

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -13,6 +13,7 @@
 , optimizationLevel ? "2"
 , filter
 , ihp-env-var-backwards-compat
+, static
 }:
 
 let
@@ -119,44 +120,27 @@ let
             '';
             src = filter { root = pkgs.nix-gitignore.gitignoreSource [] projectPath; include = [filter.isDirectory "Makefile" (filter.matchExt "hs")]; exclude = ["static" "Frontend"]; name = "${appName}-source"; };
             buildInputs = [allHaskellPackages];
-            nativeBuildInputs = [ pkgs.makeWrapper schemaObjectFiles];
+            nativeBuildInputs = [schemaObjectFiles];
             enableParallelBuilding = true;
             disallowedReferences = [ ihp ]; # Prevent including the large full IHP source code
         };
 in
-    pkgs.stdenv.mkDerivation {
-        name = appName;
-        buildPhase = ''
-            runHook preBuild
-
-            # When npm install is executed by the project's makefile it will fail with:
-            #
-            #     EACCES: permission denied, mkdir '/homeless-shelter'
-            #
-            # To avoid this error we use /tmp as our home directory for the build
-            #
-            # See https://github.com/svanderburg/node2nix/issues/217#issuecomment-751311272
-            export HOME=/tmp
-
-            export IHP_LIB=${ihp-env-var-backwards-compat}
-            export IHP=${ihp-env-var-backwards-compat}
-
-            make -j static/app.css static/app.js
-
-            runHook postBuild
-        '';
-        installPhase = ''
-            runHook preInstall
-
-            mkdir -p "$out"
-            mkdir -p $out/bin $out/lib
-
-            INPUT_HASH="$((basename $out) | cut -d - -f 1)"
-            makeWrapper ${binaries}/bin/RunProdServer $out/bin/RunProdServer --set-default IHP_ASSET_VERSION $INPUT_HASH --set-default IHP_LIB ${ihp-env-var-backwards-compat} --run "cd $out/lib" --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
+    pkgs.runCommandNoCC appName { inherit static binaries; nativeBuildInputs = [ pkgs.makeWrapper ]; } ''
+            # Hash that changes only when `static` changes:
+            IHP_ASSET_VERSION="$(basename ${static} | cut -d- -f1)"
+            makeWrapper ${binaries}/bin/RunProdServer $out/bin/RunProdServer \
+                --set-default IHP_ASSET_VERSION $IHP_ASSET_VERSION \
+                --set-default APP_STATIC ${static} \
+                --run "cd $out/lib" \
+                --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
 
             # Copy job runner binary to bin/ if we built it
             if [ -f ${binaries}/bin/RunJobs ]; then
-                makeWrapper ${binaries}/bin/RunJobs $out/bin/RunJobs --set-default IHP_ASSET_VERSION $INPUT_HASH --set-default IHP_LIB ${ihp-env-var-backwards-compat} --run "cd $out/lib" --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
+                makeWrapper ${binaries}/bin/RunJobs $out/bin/RunJobs \
+                    --set-default IHP_ASSET_VERSION $IHP_ASSET_VERSION \
+                    --set-default APP_STATIC ${static} \
+                    --run "cd $out/lib" \
+                    --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
             fi;
 
             # Copy other binaries, excluding RunProdServer and RunJobs
@@ -165,21 +149,4 @@ in
                     binary_basename=$(basename "$binary")
                     cp "$binary" "$out/bin/$binary_basename";
                 done
-
-            mv static "$out/lib/static"
-
-            runHook postInstall
-        '';
-        src = pkgs.nix-gitignore.gitignoreSource [] projectPath;
-        buildInputs = builtins.concatLists [ allNativePackages ];
-        nativeBuildInputs = builtins.concatLists [
-            [ pkgs.makeWrapper
-              pkgs.cacert # Needed for npm install to work from within the IHP build process
-              [allHaskellPackages] 
-            ]
-        ];
-        shellHook = "eval $(egrep ^export ${allHaskellPackages}/bin/ghc)";
-        enableParallelBuilding = true;
-        impureEnvVars = pkgs.lib.fetchers.proxyImpureEnvVars; # Needed for npm install to work from within the IHP build process
-        disallowedReferences = [ ihp ]; # Prevent including the large full IHP source code
-    }
+    ''

--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -127,19 +127,17 @@ let
 in
     pkgs.runCommandNoCC appName { inherit static binaries; nativeBuildInputs = [ pkgs.makeWrapper ]; } ''
             # Hash that changes only when `static` changes:
-            IHP_ASSET_VERSION="$(basename ${static} | cut -d- -f1)"
+            INPUT_HASH="$(basename ${static} | cut -d- -f1)"
             makeWrapper ${binaries}/bin/RunProdServer $out/bin/RunProdServer \
-                --set-default IHP_ASSET_VERSION $IHP_ASSET_VERSION \
+                --set-default IHP_ASSET_VERSION $INPUT_HASH \
                 --set-default APP_STATIC ${static} \
-                --run "cd $out/lib" \
                 --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
 
             # Copy job runner binary to bin/ if we built it
             if [ -f ${binaries}/bin/RunJobs ]; then
                 makeWrapper ${binaries}/bin/RunJobs $out/bin/RunJobs \
-                    --set-default IHP_ASSET_VERSION $IHP_ASSET_VERSION \
+                    --set-default IHP_ASSET_VERSION $INPUT_HASH \
                     --set-default APP_STATIC ${static} \
-                    --run "cd $out/lib" \
                     --prefix PATH : ${pkgs.lib.makeBinPath (otherDeps pkgs)}
             fi;
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -126,6 +126,15 @@ ihpFlake:
                         }
                     '';
                 };
+
+                static.makeBundling = lib.mkOption {
+                    type = lib.types.bool;
+                    default = true;
+                    description = ''
+                        Whether to build static files using the Makefile provided by IHP.
+                        If your app doesn't use the Makefile to bundle the CSS, you can disable this for faster builds.
+                    '';
+                };
             };
         }
     );
@@ -191,44 +200,13 @@ ihpFlake:
                         pkgs.symlinkJoin {
                             name = "${cfg.appName}-static";
                             paths = [
-                                (self'.packages.legacyStaticFilesCompiledByMake)
+                                (if cfg.static.makeBundling
+                                    then self'.packages.staticFilesCompiledByMake
+                                    else (let filter = ihpFlake.inputs.nix-filter.lib; in filter { root = cfg.projectPath; include = ["static"]; name = "static-directory"; }) + "/static"
+                                )
                                 extraStaticFarm
                             ];
                         };
-
-                legacyStaticFilesCompiledByMake = pkgs.stdenv.mkDerivation {
-                    name = "${config.ihp.appName}-legacyStaticFilesCompiledByMake";
-                    buildPhase = ''
-                        runHook preBuild
-                        # When npm install is executed by the project's makefile it will fail with:
-                        #
-                        #     EACCES: permission denied, mkdir '/homeless-shelter'
-                        #
-                        # To avoid this error we use /tmp as our home directory for the build
-                        #
-                        # See https://github.com/svanderburg/node2nix/issues/217#issuecomment-751311272
-                        export HOME=/tmp
-
-                        export IHP_LIB=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
-                        export IHP=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
-
-                        make -j static/app.css static/app.js
-                        runHook postBuild
-                    '';
-                    installPhase = ''
-                        cp -R static/. $out
-                    '';
-                    src = pkgs.nix-gitignore.gitignoreSource [] cfg.projectPath;
-                    buildInputs = cfg.packages;
-                    nativeBuildInputs = builtins.concatLists [
-                        [ pkgs.makeWrapper
-                          pkgs.cacert # Needed for npm install to work from within the IHP build process
-                        ]
-                    ];
-                    enableParallelBuilding = true;
-                    impureEnvVars = pkgs.lib.fetchers.proxyImpureEnvVars; # Needed for npm install to work from within the IHP build process
-                    disallowedReferences = [ ihp ]; # Prevent including the large full IHP source code
-                };
 
                 unoptimized-docker-image = pkgs.dockerTools.buildImage {
                     name = "ihp-app";
@@ -267,7 +245,41 @@ ihpFlake:
                         cp Application/Schema.sql $out/
                     '';
                 };
-            };
+            } // (if cfg.static.makeBundling then {
+                staticFilesCompiledByMake = pkgs.stdenv.mkDerivation {
+                    name = "${config.ihp.appName}-staticFilesCompiledByMake";
+                    buildPhase = ''
+                        runHook preBuild
+                        # When npm install is executed by the project's makefile it will fail with:
+                        #
+                        #     EACCES: permission denied, mkdir '/homeless-shelter'
+                        #
+                        # To avoid this error we use /tmp as our home directory for the build
+                        #
+                        # See https://github.com/svanderburg/node2nix/issues/217#issuecomment-751311272
+                        export HOME=/tmp
+
+                        export IHP_LIB=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
+                        export IHP=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
+
+                        make -j static/app.css static/app.js
+                        runHook postBuild
+                    '';
+                    installPhase = ''
+                        cp -R static/. $out
+                    '';
+                    src = pkgs.nix-gitignore.gitignoreSource [] cfg.projectPath;
+                    buildInputs = cfg.packages;
+                    nativeBuildInputs = builtins.concatLists [
+                        [ pkgs.makeWrapper
+                          pkgs.cacert # Needed for npm install to work from within the IHP build process
+                        ]
+                    ];
+                    enableParallelBuilding = true;
+                    impureEnvVars = pkgs.lib.fetchers.proxyImpureEnvVars; # Needed for npm install to work from within the IHP build process
+                    disallowedReferences = [ ihp ]; # Prevent including the large full IHP source code
+                };
+            } else {});
 
             devenv.shells.default = lib.mkIf cfg.enable {
                 packages = [ ghcCompiler.ihp ghcCompiler.ihp-ide pkgs.gnumake ]

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -114,6 +114,18 @@ ihpFlake:
                     type = lib.types.str;
                     default = "1";
                 };
+
+                static.extraDirs = lib.mkOption {
+                    type = lib.types.attrsOf (lib.types.oneOf [ lib.types.path lib.types.package ]);
+                    default = {};
+                    description = "Map of subdir name -> derivation/path to be mounted under static/";
+                    example = ''
+                        {
+                            Frontend = self.packages.${system}.frontend;   # -> /static/Frontend/...
+                            Bootstrap = "${pkgs.bootstrap5}/dist";         # mount subdir of a package
+                        }
+                    '';
+                };
             };
         }
     );
@@ -152,6 +164,7 @@ ihpFlake:
                     appName = cfg.appName;
                     filter = ihpFlake.inputs.nix-filter.lib;
                     ihp-env-var-backwards-compat = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
+                    static = self'.packages.static;
                 };
 
                 unoptimized-prod-server = import "${ihp}/NixSupport/default.nix" {
@@ -167,6 +180,54 @@ ihpFlake:
                     appName = cfg.appName;
                     filter = ihpFlake.inputs.nix-filter.lib;
                     ihp-env-var-backwards-compat = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
+                    static = self'.packages.static;
+                };
+
+                static =
+                    let
+                        # Turn { Frontend = drv; Admin = drv2; } into a farm
+                        extraStaticFarm = pkgs.linkFarm "${cfg.appName}-extra-static" (lib.mapAttrsToList (name: path: { inherit name path; }) cfg.static.extraDirs);
+                    in
+                        pkgs.symlinkJoin {
+                            name = "${cfg.appName}-static";
+                            paths = [
+                                (self'.packages.legacyStaticFilesCompiledByMake)
+                                extraStaticFarm
+                            ];
+                        };
+
+                legacyStaticFilesCompiledByMake = pkgs.stdenv.mkDerivation {
+                    name = "${config.ihp.appName}-legacyStaticFilesCompiledByMake";
+                    buildPhase = ''
+                        runHook preBuild
+                        # When npm install is executed by the project's makefile it will fail with:
+                        #
+                        #     EACCES: permission denied, mkdir '/homeless-shelter'
+                        #
+                        # To avoid this error we use /tmp as our home directory for the build
+                        #
+                        # See https://github.com/svanderburg/node2nix/issues/217#issuecomment-751311272
+                        export HOME=/tmp
+
+                        export IHP_LIB=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
+                        export IHP=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
+
+                        make -j static/app.css static/app.js
+                        runHook postBuild
+                    '';
+                    installPhase = ''
+                        cp -R static/. $out
+                    '';
+                    src = pkgs.nix-gitignore.gitignoreSource [] cfg.projectPath;
+                    buildInputs = cfg.packages;
+                    nativeBuildInputs = builtins.concatLists [
+                        [ pkgs.makeWrapper
+                          pkgs.cacert # Needed for npm install to work from within the IHP build process
+                        ]
+                    ];
+                    enableParallelBuilding = true;
+                    impureEnvVars = pkgs.lib.fetchers.proxyImpureEnvVars; # Needed for npm install to work from within the IHP build process
+                    disallowedReferences = [ ihp ]; # Prevent including the large full IHP source code
                 };
 
                 unoptimized-docker-image = pkgs.dockerTools.buildImage {

--- a/ihp/IHP/Server.hs
+++ b/ihp/IHP/Server.hs
@@ -95,6 +95,7 @@ withBackgroundWorkers pgListener frameworkConfig app = do
 initStaticApp :: FrameworkConfig -> IO Application
 initStaticApp frameworkConfig = do
     frameworkStaticDir <- getDataFileName "static"
+    appStaticDir <- EnvVar.envOrDefault "APP_STATIC" "static/"
     let
         maxAge = case frameworkConfig.environment of
             Env.Development -> Static.MaxAgeSeconds 0
@@ -104,7 +105,7 @@ initStaticApp frameworkConfig = do
                 { Static.ss404Handler = Just (frameworkConfig.requestLoggerMiddleware handleNotFound)
                 , Static.ssMaxAge = maxAge
                 }
-        appSettings = (Static.defaultWebAppSettings "static/")
+        appSettings = (Static.defaultWebAppSettings appStaticDir)
                 { Static.ss404Handler = Just (Static.staticApp frameworkSettings)
                 , Static.ssMaxAge = maxAge
                 }


### PR DESCRIPTION
Example: App that has a `static/Frontend` directory that contains an esbuild bundled JS app.

```nix

{
    inputs = {
        ihp.url = "path:///Users/marc/digitallyinduced/ihp-pro";
        ihp.inputs.nixpkgs.url = "github:mpscholten/nixpkgs/fix-sitemap2";
        nixpkgs.follows = "ihp/nixpkgs";
        flake-parts.follows = "ihp/flake-parts";
        devenv.follows = "ihp/devenv";
        systems.follows = "ihp/systems";
    };

    outputs = inputs@{ ihp, flake-parts, systems, self, ... }:
        flake-parts.lib.mkFlake { inherit inputs; } {

            systems = import systems;
            imports = [ ihp.flakeModules.default ];

            perSystem = { pkgs, system, config, ... }: {
                ihp = {
                    # ...

                    static.extraDirs.Frontend = self.packages.${system}.frontend;
                    static.makeBundling = false;
                };


                packages.frontend =
                    let
                        node-modules = pkgs.mkYarnModules {
                            pname = "${config.ihp.appName}-frontend-deps";
                            packageJSON = ./Frontend/package.json;
                            yarnLock = ./Frontend/yarn.lock;
                            version = "1.0.0";
                        };
                        filter = ihp.inputs.nix-filter.lib;
                    in pkgs.stdenv.mkDerivation {
                        name = "${config.ihp.appName}-frontend";
                        src = filter {
                            root = ./Frontend;
                            include = ["src" "lib" "hooks" "components" "types" (filter.matchExt "js") (filter.matchExt "ts") (filter.matchExt "tsx") (filter.matchExt "json") (filter.matchExt "css")];
                            exclude = ["node_modules"];
                        };
                        nativeBuildInputs = [pkgs.yarn node-modules pkgs.esbuild];
                        buildPhase = ''
                        ln -s ${node-modules}/node_modules ./node_modules
                        export PATH="node_modules/bin:$PATH"

                        mkdir -p ihp-node_modules
                        ln -s ${ihp}/ihp/data/DataSync ihp-node_modules/ihp-datasync

                        ${node-modules}/node_modules/.bin/tailwindcss -i ./src/styles/globals.css -o ./src/tailwind.css

                        NODE_PATH=ihp-node_modules:node_modules ${pkgs.esbuild}/bin/esbuild src/index.tsx \
                            --preserve-symlinks \
                            --bundle \
                            --loader:.woff=file \
                            --loader:.woff2=file \
                            --loader:.ttf=file \
                            --loader:.svg=file \
                            --loader:.png=file \
                            --loader:.gif=file \
                            --main-fields=module,main \
                            --define:global=globalThis \
                            --define:process.env.NODE_ENV=\"production\" \
                            --minify \
                            --legal-comments=none \
                            --outfile=$out/main.js
                        '';
                        allowedReferences = [];
                    };
            };

        };
}
```

Running `nix build` will now produce an app with a static/Frontend directory. It will internally call `nix build .#frontend` as specified by `static.extraDirs.Frontend = self.packages.${system}.frontend`.

With `static.makeBundling = false` we can skip the `make static/app.css` step done typically by IHP. This can speed up deployment a bit when it's not used anyways.