### PR TITLE
Runscript in devshell

### DIFF
--- a/ihp-ide/exe/IHP/CLI/run-script
+++ b/ihp-ide/exe/IHP/CLI/run-script
@@ -42,8 +42,8 @@ else
     echo "import IHP.ScriptSupport" >> "$GHCI_SCRIPT"
 fi
 echo ":set -i." 
-echo ":l Config/Config.hs Application/Script/$TASK_MODULE.hs"
-echo "import qualified Application.Script.$TASK_MODULE as Script"
+echo ":l Config/Config.hs $TASK_PATH"
+echo "import qualified $TASK_MODULE as Script"
 echo "IHP.ScriptSupport.runScript config Script.run"
 echo ":quit"
 } > "$GHCI_SCRIPT"


### PR DESCRIPTION
Looking at issue #2042 I wonder if alot of problems solved by just moving a runscript command into the devshell? Then all path manipulation in bash is no longer needed and it fits nice with some of the refactoring going on across ihp into nix/devenv.