### PR TITLE
Contribute doc fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,14 +29,18 @@ cd IHP
 # from "ihp.url=..." to use the local IHP path as an input to your flake
 sed -i "s|ihp.url = .*|ihp.url = \"path://$(pwd)\";|" ../flake.nix
 
-# Note on mac/bsd sed you may have to alter the above patch (which will also create a backup of your flake):
+# Note if you are on mac and direnv has not loaded you may have to alter the above patch :
 # sed -i '.bak' -E "s|^([[:space:]]*)ihp\.url = \".*\";|\1ihp.url = \"path://$PWD\";|" ../flake.nix
+
 
 # Enable direnv
 direnv allow
 
 # Switch back to the host project directory
 cd -
+
+# update your flake lock to make sure your flake references the local version of ihp.
+nix flake update
 ```
 
 ### Running the development server


### PR DESCRIPTION
A couple tweaks to the contributing doc. I added a comment as when I went to patch the flake path using sed script the mac system sed fell over. A new contributor might not want to parse the sed script themselves so added a comment explaining it was patching the ihp.url input to refer to the path version.

Also added note saying suggesting to run `nix flake update` which I needed to do to get the app to ref the local ihp version (maybe it was still fetching according to the inputs in the lock file?).