### PR TITLE
Change IDE approot name

### DIFF
--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -73,7 +73,7 @@ startToolServer' toolServerApplication port isDebugMode liveReloadClients = do
     store <- fmap clientsessionStore (ClientSession.getKey "Config/client_session_key.aes")
     let sessionMiddleware :: Wai.Middleware = withSession store "SESSION" (frameworkConfig.sessionCookie) sessionVaultKey
 
-    approotMiddleware <- Approot.envFallback
+    approotMiddleware <- Approot.envFallbackNamed "IDE_APPROOT"
     
     staticApp <- initStaticApp
 


### PR DESCRIPTION
This is a simple PR to hopefully fix #2144. I tried testing this on my macOS Apple Silicon laptop and it didn't build properly, complaining about a library being available in x86 instead of ARM, so worth looking into whether this is a problem more broadly with IHP. It worked on the x86-based Codespace I ran it on. 

This APPROOT bug is preventing us from being able to update to IHP v1.4.x, so I hope we can get this fix deployed soon :) 