### PR TITLE
Disable profiling and haddock for faster local builds

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -109,7 +109,7 @@ CABAL_EOF
     };
 
     # Build the models package as a proper Haskell package
-    modelsPackage = pkgs.haskell.lib.dontHaddock (ghc.callCabal2nix "${appName}-models" modelsPackageSrc {});
+    modelsPackage = pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (ghc.callCabal2nix "${appName}-models" modelsPackageSrc {}));
 
     allHaskellPackages =
         (if withHoogle

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -7,15 +7,20 @@ final: prev: {
         overrides = self: super:
             let
                 filter = inputs.nix-filter.lib;
-                localPackage = name: super.callCabal2nix name (filter { root = "${toString flakeRoot}/${name}"; include = [ (filter.matchExt "hs") (filter.matchExt "cabal") (filter.matchExt "md") filter.isDirectory "LICENSE" "data" ]; }) {};
+                # Disable profiling and haddock for faster local builds
+                fastBuild = pkg: final.haskell.lib.disableLibraryProfiling (final.haskell.lib.dontHaddock pkg);
+                localPackage = name: fastBuild (super.callCabal2nix name (filter { root = "${toString flakeRoot}/${name}"; include = [ (filter.matchExt "hs") (filter.matchExt "cabal") (filter.matchExt "md") filter.isDirectory "LICENSE" "data" ]; }) {});
+                # ihp-with-docs has haddock for reference docs
+                localPackageWithHaddock = name: final.haskell.lib.disableLibraryProfiling (super.callCabal2nix name (filter { root = "${toString flakeRoot}/${name}"; include = [ (filter.matchExt "hs") (filter.matchExt "cabal") (filter.matchExt "md") filter.isDirectory "LICENSE" "data" ]; }) {});
         in {
             ihp = localPackage "ihp";
+            ihp-with-docs = localPackageWithHaddock "ihp";
             ihp-ide = localPackage "ihp-ide";
             ihp-migrate = (localPackage "ihp-migrate").overrideAttrs (old: { mainProgram = "migrate"; });
             ihp-openai = localPackage "ihp-openai";
             ihp-postgresql-simple-extra = localPackage "ihp-postgresql-simple-extra";
             ihp-ssc = localPackage "ihp-ssc";
-            ihp-zip = super.callCabal2nix "ihp-zip" (final.fetchFromGitHub { owner = "digitallyinduced"; repo = "ihp-zip"; rev = "1c0d812d12d21269f83d6480a6ec7a8cdd054485"; sha256 = "0y0dj8ggi1jqzy74i0d6k9my8kdvfi516zfgnsl7znicwq9laald"; }) {};
+            ihp-zip = fastBuild (super.callCabal2nix "ihp-zip" (final.fetchFromGitHub { owner = "digitallyinduced"; repo = "ihp-zip"; rev = "1c0d812d12d21269f83d6480a6ec7a8cdd054485"; sha256 = "0y0dj8ggi1jqzy74i0d6k9my8kdvfi516zfgnsl7znicwq9laald"; }) {});
             ihp-hsx = localPackage "ihp-hsx";
             ihp-graphql = localPackage "ihp-graphql";
             ihp-datasync-typescript = localPackage "ihp-datasync-typescript";

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -218,9 +218,9 @@ that is defined in flake-module.nix
                 pkgs.stdenv.mkDerivation {
                     name = "ihp-reference";
                     src = self;
-                    nativeBuildInputs = with pkgs; [ pkgs.ghc.ihp ];
+                    nativeBuildInputs = with pkgs; [ pkgs.ghc.ihp-with-docs ];
                     buildPhase = ''
-                        cp -r ${pkgs.ghc.ihp.doc}/share/doc/ihp-*/html haddock-build
+                        cp -r ${pkgs.ghc.ihp-with-docs.doc}/share/doc/ihp-*/html haddock-build
                         chmod -R u+w haddock-build
 
                         cd haddock-build


### PR DESCRIPTION
nixpkgs enables profiling by default for Haskell packages. This disables both profiling and haddock generation for IHP packages to speed up local development builds.

- Add fastBuild helper in overlay.nix that applies disableLibraryProfiling and dontHaddock
- Add ihp-with-docs for reference documentation builds that need haddock
- Apply same optimizations to models package in default.nix