### PR TITLE
Add (?request :: Request) implicit parameter alongside ?context

### DIFF
--- a/ihp-ide/IHP/IDE/Prelude.hs
+++ b/ihp-ide/IHP/IDE/Prelude.hs
@@ -31,10 +31,11 @@ import qualified IHP.Modal.ControllerFunctions as Modal
 import IHP.ViewSupport (View)
 import qualified IHP.ViewSupport as ViewSupport
 import IHP.ValidationSupport
+import qualified Network.Wai
 
 -- | Renders a view and stores it as modal HTML in the context for later rendering.
 --
 -- > setModal MyModalView { .. }
 --
-setModal :: (?context :: ControllerContext, View view) => view -> IO ()
-setModal view = Modal.setModal (let ?view = view in ViewSupport.html view)
+setModal :: (?context :: ControllerContext, ?request :: Network.Wai.Request, View view) => view -> IO ()
+setModal view = let ?view = view in Modal.setModal (ViewSupport.html view)

--- a/ihp-ide/IHP/IDE/SchemaDesigner/Controller/Helper.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/Controller/Helper.hs
@@ -8,6 +8,7 @@ import qualified IHP.IDE.SchemaDesigner.Compiler as SchemaCompiler
 import IHP.IDE.SchemaDesigner.View.Schema.Error
 import IHP.IDE.ToolServer.Helper.Controller
 import IHP.RequestBodyMiddleware (Respond)
+import qualified Network.Wai
 
 instance ParamReader PostgresType where
     readParameter byteString = case Megaparsec.runParser Parser.sqlType "" (cs byteString) of
@@ -29,6 +30,7 @@ readSchema ::
     , ?modelContext::ModelContext
     , ?theAction::controller
     , ?respond::Respond
+    , ?request :: Network.Wai.Request
     ) => IO [Statement]
 readSchema = Parser.parseSchemaSql >>= \case
         Left error -> do render ErrorView { error }; pure []
@@ -44,6 +46,7 @@ updateSchema ::
     , ?modelContext::ModelContext
     , ?theAction::controller
     , ?respond::Respond
+    , ?request :: Network.Wai.Request
     ) => ([Statement] -> [Statement]) -> IO ()
 updateSchema updateFn = do
     statements <- readSchema

--- a/ihp-job-dashboard/IHP/Job/Dashboard/Auth.hs
+++ b/ihp-job-dashboard/IHP/Job/Dashboard/Auth.hs
@@ -14,6 +14,7 @@ module IHP.Job.Dashboard.Auth (
 import IHP.Prelude
 import IHP.ControllerPrelude
 import qualified IHP.EnvVar as EnvVar
+import qualified Network.Wai as Wai
 
 -- | Defines one method, 'authenticate', called before every action. Use to authenticate user.
 --
@@ -24,7 +25,7 @@ import qualified IHP.EnvVar as EnvVar
 --
 -- Define your own implementation to use custom authentication for production.
 class AuthenticationMethod a where
-    authenticate :: (?context :: ControllerContext, ?modelContext :: ModelContext) => IO ()
+    authenticate :: (?context :: ControllerContext, ?modelContext :: ModelContext, ?request :: Wai.Request) => IO ()
 
 -- | Don't use any authentication for jobs.
 data NoAuth

--- a/ihp-ssc/IHP/ServerSideComponent/ControllerFunctions.hs
+++ b/ihp-ssc/IHP/ServerSideComponent/ControllerFunctions.hs
@@ -10,6 +10,7 @@ import IHP.ControllerPrelude
 import IHP.ServerSideComponent.Types as SSC
 
 import qualified Network.WebSockets as WebSocket
+import qualified Network.Wai as Wai
 import qualified Text.Blaze.Html.Renderer.Text as Blaze
 
 import qualified Data.Aeson as Aeson
@@ -23,7 +24,7 @@ $(Aeson.deriveJSON Aeson.defaultOptions { sumEncoding = defaultTaggedObject { ta
 $(Aeson.deriveJSON Aeson.defaultOptions { sumEncoding = defaultTaggedObject { tagFieldName = "type" }} ''Node)
 $(Aeson.deriveJSON Aeson.defaultOptions { sumEncoding = defaultTaggedObject { tagFieldName = "type" }} ''NodeOperation)
 
-setState :: (?instanceRef :: IORef (ComponentInstance state), ?connection :: WebSocket.Connection, Component state action, ?context :: ControllerContext) => state -> IO ()
+setState :: (?instanceRef :: IORef (ComponentInstance state), ?connection :: WebSocket.Connection, Component state action, ?context :: ControllerContext, ?request :: Wai.Request) => state -> IO ()
 setState state = do
     oldState <- (.state) <$> readIORef ?instanceRef
     let oldHtml = oldState

--- a/ihp/IHP/AuthSupport/Controller/Sessions.hs
+++ b/ihp/IHP/AuthSupport/Controller/Sessions.hs
@@ -20,6 +20,7 @@ import Data.Data
 import qualified IHP.AuthSupport.Lockable as Lockable
 import System.IO.Unsafe (unsafePerformIO)
 import IHP.RequestBodyMiddleware (Respond)
+import qualified Network.Wai
 
 -- | Displays the login form.
 --
@@ -27,6 +28,7 @@ import IHP.RequestBodyMiddleware (Respond)
 newSessionAction :: forall record action.
     ( ?theAction :: action
     , ?context :: ControllerContext
+    , ?request :: Network.Wai.Request
     , ?respond :: Respond
     , HasNewSessionUrl record
     , ?modelContext :: ModelContext
@@ -53,6 +55,7 @@ newSessionAction = do
 createSessionAction :: forall record action.
     (?theAction :: action
     , ?context :: ControllerContext
+    , ?request :: Network.Wai.Request
     , ?respond :: Respond
     , ?modelContext :: ModelContext
     , Data action
@@ -107,6 +110,7 @@ createSessionAction = do
 deleteSessionAction :: forall record action id.
     ( ?theAction :: action
     , ?context :: ControllerContext
+    , ?request :: Network.Wai.Request
     , ?respond :: Respond
     , ?modelContext :: ModelContext
     , Data action

--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -39,6 +39,7 @@ autoRefresh :: (
     , Controller action
     , ?modelContext :: ModelContext
     , ?context :: ControllerContext
+    , ?request :: Request
     ) => ((?modelContext :: ModelContext) => IO ()) -> IO ()
 autoRefresh runAction = do
     autoRefreshState <- fromContext @AutoRefreshState
@@ -135,7 +136,7 @@ instance WSApp AutoRefreshWSApp where
 
             async $ forever do
                 MVar.takeMVar event
-                let currentRequest = ?context.request
+                let currentRequest = ?request
                 -- Create a dummy respond function that does nothing, since actual response
                 -- is handled by the handleResponseException handler
                 let dummyRespond _ = error "AutoRefresh: respond should not be called directly"
@@ -188,7 +189,7 @@ registerNotificationTrigger touchedTablesVar autoRefreshServer = do
     pure ()
 
 -- | Returns the ids of all sessions available to the client based on what sessions are found in the session cookie
-getAvailableSessions :: (?context :: ControllerContext) => IORef AutoRefreshServer -> IO [UUID]
+getAvailableSessions :: (?request :: Request) => IORef AutoRefreshServer -> IO [UUID]
 getAvailableSessions autoRefreshServer = do
     allSessions <- (.sessions) <$> readIORef autoRefreshServer
     text <- fromMaybe "" <$> getSession "autoRefreshSessions"

--- a/ihp/IHP/Controller/AccessDenied.hs
+++ b/ihp/IHP/Controller/AccessDenied.hs
@@ -16,7 +16,6 @@ import qualified Text.Blaze.Html.Renderer.Utf8 as Blaze
 import qualified Data.ByteString.Lazy as LBS
 import IHP.HSX.QQ (hsx)
 import qualified System.Directory as Directory
-import IHP.Controller.Context
 import IHP.Controller.Response (respondAndExit)
 
 
@@ -31,7 +30,7 @@ import IHP.Controller.Response (respondAndExit)
 -- >     renderHtml EditView { .. }
 --
 -- This will throw an error and prevent the view from being rendered when the current user is not the author of the post.
-accessDeniedWhen :: (?context :: ControllerContext) => Bool -> IO ()
+accessDeniedWhen :: Bool -> IO ()
 accessDeniedWhen condition = when condition renderAccessDenied
 
 -- | Stops the action execution with an access denied message (403) when the access condition is False.
@@ -45,7 +44,7 @@ accessDeniedWhen condition = when condition renderAccessDenied
 -- >     renderHtml EditView { .. }
 --
 -- This will throw an error and prevent the view from being rendered when the current user is not the author of the post.
-accessDeniedUnless :: (?context :: ControllerContext) => Bool -> IO ()
+accessDeniedUnless :: Bool -> IO ()
 accessDeniedUnless condition = unless condition renderAccessDenied
 
 -- | Renders a 403 access denied response. If a static/403.html exists, that is rendered instead of the IHP access denied page.
@@ -153,7 +152,7 @@ customAccessDeniedResponse = do
 --
 -- You can override the default access denied page by creating a new file at @static/403.html@. Then IHP will render that HTML file instead of displaying the default IHP access denied page.
 --
-renderAccessDenied :: (?context :: ControllerContext) => IO ()
+renderAccessDenied :: IO ()
 renderAccessDenied = do
     response <- buildAccessDeniedResponse
     respondAndExit response

--- a/ihp/IHP/Controller/BasicAuth.hs
+++ b/ihp/IHP/Controller/BasicAuth.hs
@@ -8,7 +8,7 @@ module IHP.Controller.BasicAuth (basicAuth) where
 import IHP.Prelude
 import IHP.ControllerSupport
 import Network.HTTP.Types (status401)
-import Network.Wai (responseLBS)
+import Network.Wai (responseLBS, Request)
 import Network.Wai.Middleware.HttpAuth (extractBasicAuth)
 import Network.HTTP.Types.Header (hWWWAuthenticate)
 
@@ -19,7 +19,7 @@ import Network.HTTP.Types.Header (hWWWAuthenticate)
 -- 
 -- > beforeAction = basicAuth ... 
 -- 
-basicAuth :: (?context :: ControllerContext) => Text -> Text -> Text -> IO ()
+basicAuth :: (?request :: Request) => Text -> Text -> Text -> IO ()
 basicAuth uid pw realm = do
     let mein = Just (cs uid, cs pw)
     let cred = join $ fmap extractBasicAuth (getHeader "Authorization")

--- a/ihp/IHP/Controller/Cookie.hs
+++ b/ihp/IHP/Controller/Cookie.hs
@@ -10,6 +10,7 @@ import IHP.ControllerSupport
 import Web.Cookie
 import qualified Data.Binary.Builder as Binary
 import qualified Data.ByteString.Lazy as LBS
+import qualified Network.Wai
 
 -- | Sets a @Set-Cookie@ header
 --
@@ -34,11 +35,11 @@ setCookie cookie = setHeader ("Set-Cookie", cookieString)
 -- > getCookie "fbc"
 -- Just "1234"
 --
-getCookie :: (?context :: ControllerContext) => Text -> Maybe Text
+getCookie :: (?request :: Network.Wai.Request) => Text -> Maybe Text
 getCookie name =
     lookup name allCookies
 
 -- | Returns all cookies sent with the current request
-allCookies :: (?context :: ControllerContext) => [(Text, Text)]
+allCookies :: (?request :: Network.Wai.Request) => [(Text, Text)]
 allCookies =
     maybe [] parseCookiesText $ lookup "Cookie" request.requestHeaders

--- a/ihp/IHP/Controller/NotFound.hs
+++ b/ihp/IHP/Controller/NotFound.hs
@@ -16,7 +16,6 @@ import qualified Text.Blaze.Html.Renderer.Utf8 as Blaze
 import qualified Data.ByteString.Lazy as LBS
 import IHP.HSX.QQ (hsx)
 import qualified System.Directory as Directory
-import IHP.Controller.Context
 import IHP.Controller.Response (respondAndExit)
 
 
@@ -31,7 +30,7 @@ import IHP.Controller.Response (respondAndExit)
 -- >     renderHtml EditView { .. }
 --
 -- This will throw an error and prevent the view from being rendered when the current user is not the author of the post.
-notFoundWhen :: (?context :: ControllerContext) => Bool -> IO ()
+notFoundWhen :: Bool -> IO ()
 notFoundWhen condition = when condition renderNotFound
 
 -- | Stops the action execution with a not found message (404) when the access condition is False.
@@ -45,7 +44,7 @@ notFoundWhen condition = when condition renderNotFound
 -- >     renderHtml EditView { .. }
 --
 -- This will throw an error and prevent the view from being rendered when the current user is not the author of the post.
-notFoundUnless :: (?context :: ControllerContext) => Bool -> IO ()
+notFoundUnless :: Bool -> IO ()
 notFoundUnless condition = unless condition renderNotFound
 
 
@@ -153,7 +152,7 @@ customNotFoundResponse = do
 --
 -- You can override the default access denied page by creating a new file at @static/403.html@. Then IHP will render that HTML file instead of displaying the default IHP access denied page.
 --
-renderNotFound :: (?context :: ControllerContext) => IO ()
+renderNotFound :: IO ()
 renderNotFound = do
     response <- buildNotFoundResponse
     respondAndExit response

--- a/ihp/IHP/Controller/Redirect.hs
+++ b/ihp/IHP/Controller/Redirect.hs
@@ -20,6 +20,7 @@ import Network.URI (parseURI)
 import IHP.Router.UrlGenerator (HasPath (pathTo))
 import Network.HTTP.Types.Status
 import qualified Network.Wai.Middleware.Approot as Approot
+import Network.Wai (Request)
 
 import IHP.Controller.Context
 import IHP.ControllerSupport
@@ -31,14 +32,14 @@ import IHP.ControllerSupport
 -- > redirectTo ShowProjectAction { projectId = project.id }
 --
 -- Use 'redirectToPath' if you want to redirect to a non-action url.
-redirectTo :: (?context :: ControllerContext, HasPath action) => action -> IO ()
+redirectTo :: (?request :: Request, HasPath action) => action -> IO ()
 redirectTo action = redirectToPath (pathTo action)
 {-# INLINABLE redirectTo #-}
 
 -- | Redirects to an action using HTTP 303 See Other
 --
 -- Forces the follow-up request to be a GET (useful after POST/DELETE).
-redirectToSeeOther :: (?context :: ControllerContext, HasPath action) => action -> IO ()
+redirectToSeeOther :: (?request :: Request, HasPath action) => action -> IO ()
 redirectToSeeOther action = redirectToPathSeeOther (pathTo action)
 {-# INLINABLE redirectToSeeOther #-}
 
@@ -51,19 +52,19 @@ redirectToSeeOther action = redirectToPathSeeOther (pathTo action)
 -- > redirectToPath "/blog/wp-login.php"
 --
 -- Use 'redirectTo' if you want to redirect to a controller action.
-redirectToPath :: (?context :: ControllerContext) => Text -> IO ()
+redirectToPath :: (?request :: Request) => Text -> IO ()
 redirectToPath path = redirectToUrl (convertString baseUrl <> path)
     where
-        baseUrl = Approot.getApproot ?context.request
+        baseUrl = Approot.getApproot ?request
 {-# INLINABLE redirectToPath #-}
 
 -- | Redirects to a path using HTTP 303 See Other
 --
 -- Forces the follow-up request to be a GET (useful after POST/DELETE).
-redirectToPathSeeOther :: (?context :: ControllerContext) => Text -> IO ()
+redirectToPathSeeOther :: (?request :: Request) => Text -> IO ()
 redirectToPathSeeOther path = redirectToUrlSeeOther (convertString baseUrl <> path)
     where
-        baseUrl = Approot.getApproot ?context.request
+        baseUrl = Approot.getApproot ?request
 {-# INLINABLE redirectToPathSeeOther #-}
 
 -- | Redirects to a url (given as a string)
@@ -73,7 +74,7 @@ redirectToPathSeeOther path = redirectToUrlSeeOther (convertString baseUrl <> pa
 -- > redirectToUrl "https://example.com/hello-world.html"
 --
 -- Use 'redirectToPath' if you want to redirect to a relative path like @/hello-world.html@
-redirectToUrl :: (?context :: ControllerContext) => Text -> IO ()
+redirectToUrl :: Text -> IO ()
 redirectToUrl url = do
     let !parsedUrl = fromMaybe
             (error ("redirectToPath: Unable to parse url: " <> show url))
@@ -87,7 +88,7 @@ redirectToUrl url = do
 -- | Redirects to a url using HTTP 303 See Other
 --
 -- Forces the follow-up request to be a GET (useful after POST/DELETE).
-redirectToUrlSeeOther :: (?context :: ControllerContext) => Text -> IO ()
+redirectToUrlSeeOther :: Text -> IO ()
 redirectToUrlSeeOther url = do
     let !parsedUrl = fromMaybe
             (error ("redirectToUrlSeeOther: Unable to parse url: " <> show url))
@@ -115,7 +116,7 @@ redirectToUrlSeeOther url = do
 -- >
 -- >     redirectBack
 --
-redirectBack :: (?context :: ControllerContext) => IO ()
+redirectBack :: (?request :: Request) => IO ()
 redirectBack = redirectBackWithFallback "/"
 {-# INLINABLE redirectBack #-}
 
@@ -133,7 +134,7 @@ redirectBack = redirectBackWithFallback "/"
 -- >
 -- >     redirectBackWithFallback (pathTo ShowPostAction { postId = post.id })
 --
-redirectBackWithFallback :: (?context :: ControllerContext) => Text -> IO ()
+redirectBackWithFallback :: (?request :: Request) => Text -> IO ()
 redirectBackWithFallback fallbackPathOrUrl = do
     case getHeader "Referer" of
         Just referer -> case parseURI (cs referer) of

--- a/ihp/IHP/Controller/Response.hs
+++ b/ihp/IHP/Controller/Response.hs
@@ -1,5 +1,6 @@
 module IHP.Controller.Response
 ( respondAndExit
+, respondAndExitWithHeaders
 , addResponseHeaders
 , addResponseHeadersFromContext
 , ResponseException (..)
@@ -13,11 +14,17 @@ import qualified Network.Wai
 import Network.Wai (Response)
 import qualified Control.Exception as Exception
 
-respondAndExit :: (?context :: Context.ControllerContext) => Response -> IO ()
-respondAndExit response = do
+-- | Simple version - just throws the response, no context needed
+respondAndExit :: Response -> IO ()
+respondAndExit response = Exception.throwIO (ResponseException response)
+{-# INLINE respondAndExit #-}
+
+-- | Version that adds headers from context (for render, etc.)
+respondAndExitWithHeaders :: (?context :: Context.ControllerContext) => Response -> IO ()
+respondAndExitWithHeaders response = do
     responseWithHeaders <- addResponseHeadersFromContext response
     Exception.throwIO (ResponseException responseWithHeaders)
-{-# INLINE respondAndExit #-}
+{-# INLINE respondAndExitWithHeaders #-}
 
 -- | Add headers to current response
 -- | Returns a Response with headers

--- a/ihp/IHP/ControllerPrelude.hs
+++ b/ihp/IHP/ControllerPrelude.hs
@@ -59,6 +59,7 @@ import IHP.Fetch
 import IHP.FetchRelated
 import Data.Aeson hiding (Success)
 import Network.Wai.Parse (FileInfo(..))
+import qualified Network.Wai
 import IHP.RouterSupport hiding (get, post)
 import IHP.Controller.Redirect
 import Database.PostgreSQL.Simple.Types (Only (..))
@@ -92,5 +93,5 @@ import IHP.HSX.ToHtml ()
 --
 -- > setModal MyModalView { .. }
 --
-setModal :: (?context :: ControllerContext, View view) => view -> IO ()
-setModal view = Modal.setModal (let ?view = view in ViewSupport.html view)
+setModal :: (?context :: ControllerContext, ?request :: Network.Wai.Request, View view) => view -> IO ()
+setModal view = let ?view = view in Modal.setModal (ViewSupport.html view)

--- a/ihp/IHP/ErrorController.hs
+++ b/ihp/IHP/ErrorController.hs
@@ -209,6 +209,7 @@ paramNotFoundExceptionHandler :: (Show controller, ?context :: ControllerContext
 paramNotFoundExceptionHandler exception controller additionalInfo = do
     case fromException exception of
         Just (exception@(Param.ParamNotFoundException paramName)) -> Just do
+            let ?request = ?context.request
             let (controllerPath, _) = Text.breakOn ":" (tshow exception)
 
             let renderParam (paramName, paramValue) = [hsx|<li>{paramName}: {paramValue}</li>|]

--- a/ihp/IHP/FileStorage/ControllerFunctions.hs
+++ b/ihp/IHP/FileStorage/ControllerFunctions.hs
@@ -31,6 +31,7 @@ import IHP.ValidationSupport
 import Network.Minio
 import qualified Data.Conduit.Binary as Conduit
 import qualified Network.Wai.Parse as Wai
+import qualified Network.Wai
 
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
@@ -332,6 +333,7 @@ contentDispositionAttachmentAndFileName fileInfo = pure (Just ("attachment; file
 --
 uploadToStorageWithOptions :: forall (fieldName :: Symbol) record (tableName :: Symbol). (
         ?context :: ControllerContext
+        , ?request :: Network.Wai.Request
         , SetField fieldName record (Maybe Text)
         , KnownSymbol fieldName
         , HasField "id" record (ModelSupport.Id (ModelSupport.NormalizeModel record))
@@ -381,6 +383,7 @@ uploadToStorageWithOptions options field record = do
 --
 uploadToStorage :: forall (fieldName :: Symbol) record (tableName :: Symbol). (
         ?context :: ControllerContext
+        , ?request :: Network.Wai.Request
         , SetField fieldName record (Maybe Text)
         , KnownSymbol fieldName
         , HasField "id" record (ModelSupport.Id (ModelSupport.NormalizeModel record))

--- a/ihp/IHP/FlashMessages.hs
+++ b/ihp/IHP/FlashMessages.hs
@@ -30,8 +30,8 @@ import IHP.View.Types
 -- >     {renderFlashMessages}
 -- >     <main>{view}</main>
 -- > |]
-setSuccessMessage :: (?context :: ControllerContext) => Text -> IO ()
-setSuccessMessage = FlashMessages.setSuccessMessage sessionVaultKey ?context.request
+setSuccessMessage :: (?request :: Request) => Text -> IO ()
+setSuccessMessage = FlashMessages.setSuccessMessage sessionVaultKey ?request
 
 -- | Sets a flash messages. This is shown to the user when the next view is rendered.
 --
@@ -45,16 +45,16 @@ setSuccessMessage = FlashMessages.setSuccessMessage sessionVaultKey ?context.req
 -- >     {renderFlashMessages}
 -- >     <main>{view}</main>
 -- > |]
-setErrorMessage :: (?context :: ControllerContext) => Text -> IO ()
-setErrorMessage = FlashMessages.setErrorMessage sessionVaultKey ?context.request
+setErrorMessage :: (?request :: Request) => Text -> IO ()
+setErrorMessage = FlashMessages.setErrorMessage sessionVaultKey ?request
 
 -- | Returns the flash message currently set
-getSuccessMessage :: (?context :: ControllerContext) => IO (Maybe Text)
-getSuccessMessage = FlashMessages.getSuccessMessage sessionVaultKey ?context.request
+getSuccessMessage :: (?request :: Request) => IO (Maybe Text)
+getSuccessMessage = FlashMessages.getSuccessMessage sessionVaultKey ?request
 
 -- | Removes the current flash message
-clearSuccessMessage :: (?context :: ControllerContext) => IO ()
-clearSuccessMessage = FlashMessages.clearSuccessMessage sessionVaultKey ?context.request
+clearSuccessMessage :: (?request :: Request) => IO ()
+clearSuccessMessage = FlashMessages.clearSuccessMessage sessionVaultKey ?request
 
 flashVaultKey :: Vault.Key [FlashMessage]
 flashVaultKey = unsafePerformIO Vault.newKey

--- a/ihp/IHP/LoginSupport/Middleware.hs
+++ b/ihp/IHP/LoginSupport/Middleware.hs
@@ -10,10 +10,12 @@ import IHP.Fetch
 import IHP.ControllerSupport
 import IHP.ModelSupport
 import IHP.Controller.Context
+import qualified Network.Wai
 
 {-# INLINE initAuthentication #-}
 initAuthentication :: forall user normalizedModel.
         ( ?context :: ControllerContext
+        , ?request :: Network.Wai.Request
         , ?modelContext :: ModelContext
         , normalizedModel ~ NormalizeModel user
         , Typeable normalizedModel

--- a/ihp/IHP/Pagination/ViewFunctions.hs
+++ b/ihp/IHP/Pagination/ViewFunctions.hs
@@ -25,7 +25,7 @@ import IHP.View.Types (PaginationView(..), styledPagination, styledPaginationPag
 -- | Render a navigation for your pagination. This is to be used in your view whenever
 -- to allow users to change pages, including "Next" and "Previous".
 -- If there is only one page, this will not render anything.
-renderPagination :: (?context::ControllerContext) => Pagination -> Html
+renderPagination :: (?context :: ControllerContext, ?request :: Wai.Request) => Pagination -> Html
 renderPagination pagination@Pagination {currentPage, window, pageSize} =
         when (showPagination pagination) $ styledPagination theCSSFramework theCSSFramework paginationView
         where
@@ -136,7 +136,7 @@ renderPagination pagination@Pagination {currentPage, window, pageSize} =
 --              </div>
 --          </div>
 --        </div>
-renderFilter :: (?context::ControllerContext) =>
+renderFilter :: (?context::ControllerContext, ?request :: Wai.Request) =>
     Text    -- ^ Placeholder text for the text box
     -> Html
 renderFilter placeholder =

--- a/ihp/IHP/View/Form.hs
+++ b/ihp/IHP/View/Form.hs
@@ -22,6 +22,7 @@ import IHP.ModelSupport (getModelName, inputValue, isNew, Id', InputValue, didTo
 import IHP.HSX.QQ (hsx)
 import IHP.View.Types
 import IHP.View.Classes ()
+import qualified Network.Wai as Wai
 import Network.Wai (pathInfo)
 import IHP.Controller.Context
 
@@ -91,6 +92,7 @@ import IHP.Controller.Context
 -- > </div>
 formFor :: forall record. (
     ?context :: ControllerContext
+    , ?request :: Wai.Request
     , ModelFormAction record
     , HasField "meta" record MetaBag
     ) => record -> ((?context :: ControllerContext, ?formContext :: FormContext record) => Html5.Html) -> Html5.Html
@@ -115,6 +117,7 @@ formFor record formBody = formForWithOptions @record record (\c -> c) formBody
 --
 formForWithOptions :: forall record. (
     ?context :: ControllerContext
+    , ?request :: Wai.Request
     , ModelFormAction record
     , HasField "meta" record MetaBag
     ) => record -> (FormContext record -> FormContext record) -> ((?context :: ControllerContext, ?formContext :: FormContext record) => Html5.Html) -> Html5.Html
@@ -148,6 +151,7 @@ formForWithOptions record applyOptions formBody = buildForm (applyOptions (creat
 --
 formForWithoutJavascript :: forall record. (
     ?context :: ControllerContext
+    , ?request :: Wai.Request
     , ModelFormAction record
     , HasField "meta" record MetaBag
     ) => record -> ((?context :: ControllerContext, ?formContext :: FormContext record) => Html5.Html) -> Html5.Html
@@ -887,7 +891,7 @@ instance ToHtml SubmitButton where
 
 -- | Returns the form's action attribute for a given record.
 class ModelFormAction record where
-    modelFormAction :: (?context :: ControllerContext) => record -> Text
+    modelFormAction :: (?context :: ControllerContext, ?request :: Wai.Request) => record -> Text
 
 instance
     ( HasField "id" record (Id' (GetTableName record))

--- a/ihp/IHP/View/Types.hs
+++ b/ihp/IHP/View/Types.hs
@@ -24,9 +24,10 @@ import Network.Wai.Middleware.FlashMessages (FlashMessage (..))
 import IHP.ModelSupport (Violation)
 import IHP.Breadcrumb.Types
 import IHP.Pagination.Types
+import qualified Network.Wai as Wai
 
 
-type HtmlWithContext context = (?context :: context) => Blaze.Html
+type HtmlWithContext context = (?context :: context, ?request :: Wai.Request) => Blaze.Html
 
 -- | A layout is just a function taking a view and returning a new view.
 --

--- a/ihp/IHP/ViewPrelude.hs
+++ b/ihp/IHP/ViewPrelude.hs
@@ -36,6 +36,7 @@ module IHP.ViewPrelude (
     module IHP.PageHead.ViewFunctions,
     module IHP.Breadcrumb.ViewFunctions,
     module IHP.Pagination.ViewFunctions,
+    module Network.Wai,
 ) where
 
 import IHP.Prelude
@@ -68,3 +69,4 @@ import IHP.PageHead.ViewFunctions
 
 import IHP.Breadcrumb.ViewFunctions
 import IHP.Pagination.ViewFunctions
+import Network.Wai

--- a/ihp/IHP/ViewSupport.hs
+++ b/ihp/IHP/ViewSupport.hs
@@ -63,7 +63,7 @@ class View theView where
     beforeRender view = pure ()
 
     -- Renders the view as html
-    html :: (?context :: ControllerContext, ?view :: theView) => theView -> Html5.Html
+    html :: (?context :: ControllerContext, ?view :: theView, ?request :: Wai.Request) => theView -> Html5.Html
 
     -- | Renders the view to a JSON
     json :: theView -> JSON.Value
@@ -115,7 +115,7 @@ currentViewId =
 -- False
 --
 -- This function returns @False@ when a sub-path is request. Use 'isActivePathOrSub' if you want this example to return @True@.
-isActivePath :: (?context :: ControllerContext, PathString controller) => controller -> Bool
+isActivePath :: (?request :: Wai.Request, PathString controller) => controller -> Bool
 isActivePath route =
     let
         currentPath = Wai.rawPathInfo theRequest <> Wai.rawQueryString theRequest
@@ -135,7 +135,7 @@ isActivePath route =
 -- True
 --
 -- Also see 'isActivePath'.
-isActivePathOrSub :: (?context :: ControllerContext, PathString controller) => controller -> Bool
+isActivePathOrSub :: (?request :: Wai.Request, PathString controller) => controller -> Bool
 isActivePathOrSub route =
     let
         currentPath = Wai.rawPathInfo theRequest
@@ -172,7 +172,7 @@ isActiveController =
 -- >>> isActiveAction (ShowPostAction postId)
 -- True
 --
-isActiveAction :: forall controllerAction. (?context::ControllerContext, HasPath controllerAction) => controllerAction -> Bool
+isActiveAction :: forall controllerAction. (?request :: Wai.Request, HasPath controllerAction) => controllerAction -> Bool
 isActiveAction controllerAction =
     isActivePath (pathTo controllerAction)
 
@@ -182,8 +182,8 @@ onClick = A.onclick
 onLoad = A.onload
 
 -- | Returns the current request
-theRequest :: (?context :: ControllerContext) => Wai.Request
-theRequest = ?context.request
+theRequest :: (?request :: Wai.Request) => Wai.Request
+theRequest = ?request
 {-# INLINE theRequest #-}
 
 class PathString a where
@@ -250,7 +250,7 @@ instance InputValue (PrimaryKey table) => HSX.ApplyAttribute (Id' table) where
 --
 -- The asset version can be configured using the
 -- @IHP_ASSET_VERSION@ environment variable.
-assetPath :: (?context :: ControllerContext) => Text -> Text
+assetPath :: (?request :: Wai.Request) => Text -> Text
 assetPath assetPath = AssetPath.assetPath theRequest assetPath
 
 -- | Returns the assetVersion
@@ -260,5 +260,5 @@ assetPath assetPath = AssetPath.assetPath theRequest assetPath
 --
 -- The asset version can be configured using the
 -- @IHP_ASSET_VERSION@ environment variable.
-assetVersion :: (?context :: ControllerContext) => Text
+assetVersion :: (?request :: Wai.Request) => Text
 assetVersion = fromMaybe (error "assetPath middleware missing") (AssetPath.assetVersion theRequest)

--- a/ihp/Test/Test/Controller/ParamSpec.hs
+++ b/ihp/Test/Test/Controller/ParamSpec.hs
@@ -24,92 +24,113 @@ tests = do
         describe "param" do
             it "should parse valid input" do
                 let ?context = createControllerContextWithParams [("page", "1")]
+                let ?request = ?context.request
                 (param @Int "page") `shouldBe` 1
 
             it "should fail on empty input" do
                 let ?context = createControllerContextWithParams [("page", "")]
+                let ?request = ?context.request
                 (IO.evaluate (param @Int "page")) `shouldThrow` (== ParamCouldNotBeParsedException { name = "page", parserError = "has to be an integer" })
 
             it "should fail if param not provided" do
                 let ?context = createControllerContextWithParams []
+                let ?request = ?context.request
                 (IO.evaluate (param @Int "page")) `shouldThrow` (== ParamNotFoundException { name = "page" })
 
             it "should fail with a parser error on invalid input" do
                 let ?context = createControllerContextWithParams [("page", "NaN")]
+                let ?request = ?context.request
                 (IO.evaluate (param @Int "page")) `shouldThrow` (== ParamCouldNotBeParsedException { name = "page", parserError = "has to be an integer" })
 
         describe "paramOrNothing" do
             it "should parse valid input" do
                 let ?context = createControllerContextWithParams [("referredBy", "776ab71d-327f-41b3-90a8-7b5a251c4b88")]
+                let ?request = ?context.request
                 (paramOrNothing @UUID "referredBy") `shouldBe` (Just "776ab71d-327f-41b3-90a8-7b5a251c4b88")
 
             it "should return Nothing on empty input" do
                 let ?context = createControllerContextWithParams [("referredBy", "")]
+                let ?request = ?context.request
                 (paramOrNothing @UUID "referredBy") `shouldBe` Nothing
 
             it "should return Nothing if param not provided" do
                 let ?context = createControllerContextWithParams []
+                let ?request = ?context.request
                 (paramOrNothing @UUID "referredBy") `shouldBe` Nothing
 
             it "should fail with a parser error on invalid input" do
                 let ?context = createControllerContextWithParams [("referredBy", "not a uuid")]
+                let ?request = ?context.request
                 (IO.evaluate (paramOrNothing @UUID "referredBy")) `shouldThrow` (== ParamCouldNotBeParsedException { name = "referredBy", parserError = "has to be an UUID" })
 
         describe "paramOrDefault" do
             it "should parse valid input" do
                 let ?context = createControllerContextWithParams [("page", "1")]
+                let ?request = ?context.request
                 (paramOrDefault @Int 0 "page") `shouldBe` 1
 
             it "should return default value on empty input" do
                 let ?context = createControllerContextWithParams [("page", "")]
+                let ?request = ?context.request
                 (paramOrDefault @Int 10 "page") `shouldBe` 10
 
             it "should return default value if param not provided" do
                 let ?context = createControllerContextWithParams []
+                let ?request = ?context.request
                 (paramOrDefault @Int 10 "page") `shouldBe` 10
 
             it "should fail with a parser error on invalid input" do
                 let ?context = createControllerContextWithParams [("page", "NaN")]
+                let ?request = ?context.request
                 (IO.evaluate (paramOrDefault @Int 10 "page")) `shouldThrow` (== ParamCouldNotBeParsedException { name = "page", parserError = "has to be an integer" })
 
 
         describe "paramList" do
             it "should parse valid input" do
                 let ?context = createControllerContextWithParams [("ingredients", "milk"), ("ingredients", "egg")]
+                let ?request = ?context.request
                 (paramList @Text "ingredients") `shouldBe` ["milk", "egg"]
 
             it "should fail on invalid input" do
                 let ?context = createControllerContextWithParams [("numbers", "1"), ("numbers", "NaN")]
+                let ?request = ?context.request
                 (IO.evaluate (paramList @Int "numbers")) `shouldThrow` (errorCall "param: Parameter 'numbers' is invalid")
 
             it "should deal with empty input" do
                 let ?context = createControllerContextWithParams []
+                let ?request = ?context.request
                 (paramList @Int "numbers") `shouldBe` []
 
         describe "paramListOrNothing" do
             it "should parse valid input" do
                 let ?context = createControllerContextWithParams [("ingredients", "milk"), ("ingredients", ""), ("ingredients", "egg")]
+                let ?request = ?context.request
                 (paramListOrNothing @Text "ingredients") `shouldBe` [Just "milk", Nothing, Just "egg"]
 
             it "should not fail on invalid input" do
                 let ?context = createControllerContextWithParams [("numbers", "1"), ("numbers", "NaN")]
+                let ?request = ?context.request
                 (paramListOrNothing @Int "numbers") `shouldBe` [Just 1, Nothing]
 
             it "should deal with empty input" do
                 let ?context = createControllerContextWithParams []
+                let ?request = ?context.request
                 (paramListOrNothing @Int "numbers") `shouldBe` []
 
         describe "hasParam" do
             it "returns True if param given" do
                 let ?context = createControllerContextWithParams [("a", "test")]
+                let ?request = ?context.request
                 hasParam "a" `shouldBe` True
 
             it "returns True if param given but empty" do
                 let ?context = createControllerContextWithParams [("a", "")]
+                let ?request = ?context.request
                 hasParam "a" `shouldBe` True
 
             it "returns False if param missing" do
                 let ?context = createControllerContextWithParams []
+                let ?request = ?context.request
                 hasParam "a" `shouldBe` False
 
         describe "ParamReader" do
@@ -388,6 +409,7 @@ tests = do
         describe "fill" do
             it "should fill provided values if valid" do
                 let ?context = createControllerContextWithParams [("boolField", "on"), ("colorField", "Red")]
+                let ?request = ?context.request
 
                 let emptyRecord = FillRecord { boolField = False, colorField = Yellow, meta = def }
                 let expectedRecord = FillRecord { boolField = True, colorField = Red, meta = def { touchedFields = ["colorField", "boolField"] } }
@@ -397,6 +419,7 @@ tests = do
 
             it "should not touch fields if a field is missing" do
                 let ?context = createControllerContextWithParams [("colorField", "Red")]
+                let ?request = ?context.request
 
                 let emptyRecord = FillRecord { boolField = False, colorField = Yellow, meta = def }
                 let expectedRecord = FillRecord { boolField = False, colorField = Red, meta = def { touchedFields = ["colorField"] } }
@@ -406,6 +429,7 @@ tests = do
 
             it "should add validation errors if the parsing fails" do
                 let ?context = createControllerContextWithParams [("colorField", "invalid color")]
+                let ?request = ?context.request
 
                 let emptyRecord = FillRecord { boolField = False, colorField = Yellow, meta = def }
                 let expectedRecord = FillRecord { boolField = False, colorField = Yellow, meta = def { annotations = [("colorField", TextViolation "Invalid value")] } }
@@ -415,6 +439,7 @@ tests = do
 
             it "should deal with json values" do
                 let ?context = createControllerContextWithJson "{\"colorField\":\"Red\",\"boolField\":true}"
+                let ?request = ?context.request
 
                 let emptyRecord = FillRecord { boolField = False, colorField = Yellow, meta = def }
                 let expectedRecord = FillRecord { boolField = True, colorField = Red, meta = def { touchedFields = ["colorField", "boolField"] } }
@@ -424,6 +449,7 @@ tests = do
 
             it "should deal with empty json values" do
                 let ?context = createControllerContextWithJson "{}"
+                let ?request = ?context.request
 
                 let emptyRecord = FillRecord { boolField = False, colorField = Yellow, meta = def }
                 let expectedRecord = FillRecord { boolField = False, colorField = Yellow, meta = def }

--- a/ihp/Test/Test/View/CSSFrameworkSpec.hs
+++ b/ihp/Test/Test/View/CSSFrameworkSpec.hs
@@ -338,6 +338,7 @@ tests = do
 
                     context <- createControllerContextWithCSSFramework cssFramework
                     let ?context = context
+                    let ?request = ?context.request
 
                     let render = Blaze.renderMarkup $ renderPagination pagination
                     Text.isInfixOf "<nav aria-label=\"Page Navigator\"" (cs render) `shouldBe` True
@@ -353,6 +354,7 @@ tests = do
 
                     context <- createControllerContextWithCSSFramework cssFramework
                     let ?context = context
+                    let ?request = ?context.request
 
                     renderPagination pagination `shouldRenderTo` mempty
 
@@ -634,6 +636,7 @@ tests = do
 
                     context <- createControllerContextWithCSSFramework cssFramework
                     let ?context = context
+                    let ?request = ?context.request
 
                     let render = Blaze.renderMarkup $ renderPagination pagination
                     Text.isInfixOf "<nav aria-label=\"Page Navigator\"" (cs render) `shouldBe` True
@@ -649,6 +652,7 @@ tests = do
 
                     context <- createControllerContextWithCSSFramework cssFramework
                     let ?context = context
+                    let ?request = ?context.request
 
                     renderPagination pagination `shouldRenderTo` mempty
 

--- a/ihp/Test/Test/View/FormSpec.hs
+++ b/ihp/Test/Test/View/FormSpec.hs
@@ -27,6 +27,7 @@ tests = do
             it "should render a form" do
                 context <- createControllerContext
                 let ?context = context
+                let ?request = ?context.request
 
                 let form = formFor project [hsx|
                     {textField #title}
@@ -37,6 +38,7 @@ tests = do
             it "should render a form with a GET method" do
                 context <- createControllerContext
                 let ?context = context
+                let ?request = ?context.request
 
                 let options formContext = formContext |> set #formMethod "GET"
 
@@ -49,6 +51,7 @@ tests = do
             it "should render a date field with empty value attribute when value is Nothing" do
                 context <- createControllerContext
                 let ?context = context
+                let ?request = ?context.request
                 let event = newRecord @Event
 
                 let form = formFor event [hsx|
@@ -66,6 +69,7 @@ tests = do
             it "should render a datetime field with empty value attribute when value is Nothing" do
                 context <- createControllerContext
                 let ?context = context
+                let ?request = ?context.request
                 let event = newRecord @Event
 
                 let form = formFor event [hsx|


### PR DESCRIPTION
## Summary

- Binds `?request` alongside `?context` so functions that only need the request can use the simpler `(?request :: Request)` constraint instead of `(?context :: ControllerContext)`
- Allows for cleaner function signatures and better separation of concerns
- Functions that only access request data no longer need the full controller context

## Key Changes

- Bind `?request` in `runAction` and `startWSApp`
- Update `HtmlWithContext` type to include `?request`
- Split `respondAndExit` into simple and with-headers versions
- Refactor session, param, cookie, redirect, flash message functions to use `?request`
- Refactor file upload functions to use `?request`
- Add `?request` to `WSApp` class methods (`run`, `onPing`, `onClose`)
- Re-export `Network.Wai` from `ViewPrelude`

## Test plan

- [x] All existing tests pass (`nix flake check --impure`)
- [x] IDE tests pass (344 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.ai/code)