### PR TITLE
Replace deprecated runCommandNoCC with runCommand

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -291,7 +291,7 @@ CABAL_EOF
             paths = [ runServer allScripts ] ++ pkgs.lib.optional hasJobs runJobs;
         };
 in
-    pkgs.runCommandNoCC appName { inherit static binaries; nativeBuildInputs = [ pkgs.makeWrapper ]; } ''
+    pkgs.runCommand appName { inherit static binaries; nativeBuildInputs = [ pkgs.makeWrapper ]; } ''
             # Hash that changes only when `static` changes:
             INPUT_HASH="$(basename ${static} | cut -d- -f1)"
             makeWrapper ${binaries}/bin/RunProdServer $out/bin/RunProdServer \


### PR DESCRIPTION
## Summary
- Replace `runCommandNoCC` with `runCommand` in `NixSupport/default.nix`
- `runCommandNoCC` has been renamed to `runCommand` in recent nixpkgs versions
- The behavior is identical - both use `stdenvNoCC` by default

This fixes the deprecation warning:
```
evaluation warning: 'runCommandNoCC' has been renamed to/replaced by 'runCommand'
```

## Test plan
- [ ] Verify `nix flake check --impure` passes without the deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)