### PR TITLE
Make Application/Fixtures.sql optional in devenv postgres setup

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -345,7 +345,7 @@ ihpFlake:
                 services.postgres.initialDatabases = [
                     {
                     name = "app";
-                    schema = pkgs.runCommand "ihp-schema" {} ''
+                    schema = pkgs.runCommand "ihp-schema" {} (''
                         touch $out
 
                         echo "-- IHPSchema.sql" >> $out
@@ -355,11 +355,12 @@ ihpFlake:
                         echo "-- Application/Schema.sql" >> $out
                         echo "" >> $out
                         cat ${cfg.projectPath + "/Application/Schema.sql"} >> $out
+                    '' + (if builtins.pathExists (cfg.projectPath + "/Application/Fixtures.sql") then ''
                         echo "" >> $out
                         echo "-- Application/Fixtures.sql" >> $out
                         echo "" >> $out
                         cat ${cfg.projectPath + "/Application/Fixtures.sql"} >> $out
-                    '';
+                    '' else ""));
                     }
                 ];
 


### PR DESCRIPTION
## Summary
- Makes `Application/Fixtures.sql` optional in the devenv PostgreSQL `initialDatabases` schema setup
- Uses `builtins.pathExists` to conditionally include the file only when it exists
- Projects that have removed `Fixtures.sql` from their git tree will no longer fail at startup

Fixes #2234

## Test plan
- [ ] Verify a project **with** `Application/Fixtures.sql` still loads fixtures on `devenv up`
- [ ] Verify a project **without** `Application/Fixtures.sql` starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)