### PR TITLE
Use ByteString.Builder in toSQL' to reduce allocations

### DIFF
--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -465,7 +465,7 @@ class
     -- "users"
     --
     tableNameByteString :: ByteString
-    tableNameByteString = Text.encodeUtf8 (tableName @record)
+    tableNameByteString = symbolToByteString @(GetTableName record)
     {-# INLINE tableNameByteString #-}
 
     -- | Returns the list of column names for a given model


### PR DESCRIPTION
## Summary
- Rewrite `toSQL'` to use `ByteString.Builder` concatenation instead of `catMaybes` + `ByteString.intercalate " "`, eliminating intermediate ByteString allocations (previously 2 per column per query from `selectFrom <> "." <> column`)
- Change `tableNameByteString` default to use `symbolToByteString` directly, skipping the `String → Text → ByteString` roundtrip
- Remove `Control.DeepSeq` import — `LByteString.toStrict . Builder.toLazyByteString` forces evaluation by construction

## Test plan
- [x] `ihp/IHP/QueryBuilder/Compiler.hs` compiles cleanly
- [x] All 362 tests pass (`echo -e ':l ihp-ide/Test/Main.hs\nmain' | ghci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)