### PR TITLE
Make Logger functional with bracket-style resource management

### DIFF
--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -1,7 +1,6 @@
 module IHP.IDE.ToolServer (runToolServer, withToolServerApplication, ToolServerApplicationWithConfig(..)) where
 
 import IHP.Prelude
-import System.Log.FastLogger (LogType'(..), withFastLogger, defaultBufSize)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import IHP.IDE.Types
@@ -93,7 +92,7 @@ data ToolServerApplicationWithConfig = ToolServerApplicationWithConfig
 -- - websocket support (for live reload)
 withToolServerApplication :: ToolServerApplication -> Int -> _ -> (ToolServerApplicationWithConfig -> IO result) -> IO result
 withToolServerApplication toolServerApplication port liveReloadClients action = do
-    withFastLogger (LogStdout defaultBufSize) \logger -> do
+    Config.withLogger \logger -> do
         frameworkConfig <- Config.buildFrameworkConfig logger do
             Config.option $ Config.AppHostname "localhost"
             Config.option $ Config.AppPort port

--- a/ihp-ide/exe/IHP/IDE/DevServer.hs
+++ b/ihp-ide/exe/IHP/IDE/DevServer.hs
@@ -19,7 +19,7 @@ import Data.String.Conversions (cs)
 import qualified IHP.Telemetry as Telemetry
 import qualified IHP.Version as Version
 
-import System.Log.FastLogger (FastLogger, toLogStr, LogType'(..), withFastLogger, defaultBufSize)
+import System.Log.FastLogger (FastLogger, toLogStr)
 import qualified IHP.IDE.CodeGen.MigrationGenerator as MigrationGenerator
 import Main.Utf8 (withUtf8)
 import qualified IHP.FrameworkConfig as FrameworkConfig
@@ -90,7 +90,7 @@ mainWithOptions wrapWithDirenv = withUtf8 do
         -- ensuring seamless transitions during app restarts (no connection refused errors)
         appSocket <- createListeningSocket portConfig.appPort
 
-        withFastLogger (LogStdout defaultBufSize) \rawLogger -> do
+        FrameworkConfig.withLogger \rawLogger -> do
             let logger msg = rawLogger (msg <> "\n")
             (ghciInChan, ghciOutChan) <- Queue.newChan
             liveReloadClients <- newIORef mempty

--- a/ihp-log/IHP/Log.hs
+++ b/ihp-log/IHP/Log.hs
@@ -16,13 +16,11 @@ module IHP.Log
 , error
 , fatal
 , unknown
-, writeLog
 , makeRequestLogger
 , defaultRequestLogger
 ) where
 
 import Prelude hiding (error, log)
-import Control.Monad (when)
 import IHP.Log.Types
 import Network.Wai (Middleware)
 import Network.Wai.Middleware.RequestLogger (mkRequestLogger, RequestLoggerSettings, destination)
@@ -97,12 +95,9 @@ unknown :: (?context :: context, LoggingProvider context, FastLogger.ToLogStr st
 unknown = log Unknown
 
 -- | Write a log if the given log level is greater than or equal to the logger's log level.
+-- Level checking, formatting, and time caching are baked into the logger's 'log' closure.
 writeLog :: (FastLogger.ToLogStr string) => LogLevel -> Logger -> string -> IO ()
-writeLog level logger text = do
-    let write = logger.write
-    let formatter = logger.formatter
-    when (level >= logger.level) $
-        write (\time -> formatter time level (toLogStr text))
+writeLog level logger text = logger.log level (toLogStr text)
 
 -- | Wraps 'RequestLogger' from wai-extra to log to an IHP logger.
 -- See 'Network.Wai.Middleware.RequestLogger'.

--- a/ihp-log/IHP/Log/Types.hs
+++ b/ihp-log/IHP/Log/Types.hs
@@ -1,15 +1,18 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE NoFieldSelectors #-}
 {-|
 Module: IHP.Log.Types
 Description:  Types for the IHP logging system
 -}
 
 module IHP.Log.Types
-( Bytes(..)
-, LogStr
+( LogStr
 , BufSize
 , TimeFormat
-, RotateSettings(..)
+, LogType'(..)
+, LogType
+, FileLogSpec(..)
+, TimedFileLogSpec(..)
 , toLogStr
 , fromLogStr
 , defaultBufSize
@@ -17,14 +20,13 @@ module IHP.Log.Types
 , simpleTimeFormat'
 , Logger(..)
 , LogLevel(..)
-, LogDestination(..)
 , LoggingProvider(..)
-, LoggerSettings(..)
 , LogFormatter
 , FormattedTime
 , newLogger
 , defaultLogger
-, defaultDestination
+, withLogger
+, withDefaultLogger
 , defaultFormatter
 , withLevelFormatter
 , withTimeFormatter
@@ -35,10 +37,11 @@ module IHP.Log.Types
 import Prelude
 import Data.ByteString (ByteString)
 import Data.Text as Text
-import Data.Default (Default (def))
+import qualified Control.Exception as Exception
 import System.Log.FastLogger (
     LogStr,
     LogType'(..),
+    LogType,
     BufSize,
     FileLogSpec(..),
     TimedFileLogSpec(..),
@@ -53,9 +56,8 @@ import System.Log.FastLogger (
     ToLogStr (..)
     )
 
-import qualified System.Log.FastLogger as FastLogger (FormattedTime)
 import GHC.Records
-import System.OsPath (OsPath, encodeUtf, decodeUtf)
+import System.OsPath (OsPath)
 
 
 -- some functions brought over from IHP.Prelude
@@ -70,12 +72,13 @@ show = tshow
 -- | Interal logger type that encapsulates information needed to perform
 -- logging operations. Users can also access this though the 'LoggingProvider'
 -- class in controller and model actions to perform logic based on the set log level.
+--
+-- The 'log' closure bakes in level checking, formatting, and time caching,
+-- so callers just provide a level and message. Cleanup is handled externally
+-- via bracket (see 'withLogger', 'withDefaultLogger').
 data Logger = Logger {
-    write     :: !((FastLogger.FormattedTime -> LogStr) -> IO ()),
-    level     :: !LogLevel,
-    formatter :: !LogFormatter,
-    timeCache :: !(IO FastLogger.FormattedTime),
-    cleanup   :: !(IO ())
+    log   :: !(LogLevel -> LogStr -> IO ()),
+    level :: !LogLevel
 }
 
 data LogLevel
@@ -125,84 +128,6 @@ type FormattedTime = ByteString
 -- @
 type LogFormatter = FormattedTime -> LogLevel -> LogStr -> LogStr
 
--- | A number of bytes, used in 'RotateSettings'
-newtype Bytes = Bytes Integer
-
-data RotateSettings
-    -- | Log messages to a file which is never rotated.
-    --
-    -- @
-    -- newLogger def {
-    --    destination = File "Log/production.log" NoRotate defaultBufSize
-    --    }
-    -- @
-    = NoRotate
-    -- | Log messages to a file and rotate the file after it reaches the given size in bytes.
-    -- Third argument is the max number of rotated log files to keep around before overwriting the oldest one.
-    --
-    -- Example: log to a file rotated once it is 4MB, and keep 7 files before overwriting the first file.
-    --
-    -- @
-    --    newLogger def {
-    --      destination = File "Log/production.log" (SizeRotate (Bytes (4 * 1024 * 1024)) 7) defaultBufSize
-    --      }
-    -- @
-    | SizeRotate !Bytes !Int
-    -- | Log messages to a file rotated on a timed basis.
-    -- Expects a time format string as well as a function which compares two formatted time strings
-    -- which is used to determine if the file should be rotated.
-    -- Last argument is a function which is called on a log file once its rotated.
-    --
-    -- Example: rotate a file daily and compress the log file once rotated.
-    --
-    -- @
-    --   let
-    --       filePath = "Log/production.log"
-    --       formatString = "%FT%H%M%S"
-    --       timeCompare = (==) on C8.takeWhile (/=T))
-    --       compressFile fp = void . forkIO $
-    --           callProcess "tar" [ "--remove-files", "-caf", fp <> ".gz", fp ]
-    --   in
-    --     newLogger def {
-    --        destination = File
-    --          filePath
-    --          (TimedRotate formatString timeCompare compressFile)
-    --          defaultBufSize
-    --        }
-    -- @
-    | TimedRotate !TimeFormat (FastLogger.FormattedTime -> FastLogger.FormattedTime -> Bool) (OsPath -> IO ())
-
--- | Where logged messages will be delivered to.
-data LogDestination
-    = None
-    -- | Log messages to standard output.
-    | Stdout !BufSize
-    -- | Log messages to standard error.
-    | Stderr !BufSize
-    -- | Log message to a file. Rotate the log file with the behavior given by 'RotateSettings'.
-    | File !OsPath !RotateSettings !BufSize
-    -- | Send logged messages to a callback. Flush action called after every log.
-    | Callback !(LogStr -> IO ()) !(IO ())
-
-data LoggerSettings = LoggerSettings {
-    level       :: LogLevel,
-    formatter   :: LogFormatter,
-    destination :: LogDestination,
-    timeFormat  :: TimeFormat
-}
-
-instance Default LoggerSettings where
-    def = LoggerSettings {
-        level = Debug,
-        formatter = defaultFormatter,
-        destination = defaultDestination,
-        timeFormat = simpleTimeFormat'
-    }
-
--- | Logger default destination is to standard out.
-defaultDestination :: LogDestination
-defaultDestination = Stdout defaultBufSize
-
 -- | Used to get the logger for a given environment.
 -- | Call in any instance of 'LoggingProvider' get the the environment's current logger.
 -- Useful in controller and model actions, which both have logging contexts.
@@ -212,37 +137,44 @@ instance HasField "logger" Logger Logger where
     getField logger = logger
 
 -- | Create a new 'FastLogger' and wrap it in an IHP 'Logger'.
--- Use with the default logger settings and record update syntax for nice configuration:
 --
--- > newLogger def { level = Error }
-newLogger :: LoggerSettings -> IO Logger
-newLogger LoggerSettings { .. } = do
+-- Returns the logger and an IO action to clean up resources (flush and close).
+-- Use 'withLogger' for bracket-style resource management.
+--
+-- > (logger, cleanup) <- newLogger Debug defaultFormatter (LogStdout defaultBufSize) simpleTimeFormat'
+newLogger :: LogLevel -> LogFormatter -> LogType -> TimeFormat -> IO (Logger, IO ())
+newLogger level formatter destination timeFormat = do
     timeCache <- newTimeCache timeFormat
-    (write, cleanup) <- makeFastLogger timeCache destination
-    pure Logger { .. }
-    where
-        makeFastLogger timeCache = \case
-                None                    -> newTimedFastLogger timeCache LogNone
-                Stdout buf              -> newTimedFastLogger timeCache (LogStdout buf)
-                Stderr buf              -> newTimedFastLogger timeCache (LogStderr buf)
-                File path settings buf  -> do
-                    logType <- makeFileLogger path settings buf
-                    newTimedFastLogger timeCache logType
-                Callback callback flush -> newTimedFastLogger timeCache (LogCallback callback flush)
+    (write, cleanup) <- newTimedFastLogger timeCache destination
+    let log logLevel msg =
+            if logLevel >= level
+            then write (\time -> formatter time logLevel msg)
+            else pure ()
+    pure (Logger { log, level }, cleanup)
 
-        makeFileLogger path NoRotate buf = do
-            fp <- decodeUtf path
-            pure (LogFileNoRotate fp buf)
-        makeFileLogger path (SizeRotate (Bytes size) count) buf = do
-            fp <- decodeUtf path
-            pure (LogFile (FileLogSpec fp size count) buf)
-        makeFileLogger path (TimedRotate fmt cmp post) buf = do
-            fp <- decodeUtf path
-            pure (LogFileTimedRotate (TimedFileLogSpec fp fmt cmp (\fpStr -> post =<< encodeUtf fpStr)) buf)
+-- | Create a default logger that logs to stdout with no special formatting.
+--
+-- Returns the logger and an IO action to clean up resources.
+--
+-- > (logger, cleanup) <- defaultLogger
+defaultLogger :: IO (Logger, IO ())
+defaultLogger = newLogger Debug defaultFormatter (LogStdout defaultBufSize) simpleTimeFormat'
 
--- | Formats logs as-is to stdout.
-defaultLogger :: IO Logger
-defaultLogger = newLogger def
+-- | Bracket-style logger construction. Ensures cleanup runs even on exception.
+--
+-- > withLogger Debug defaultFormatter (LogStdout defaultBufSize) simpleTimeFormat' \logger -> do
+-- >     -- use logger
+withLogger :: LogLevel -> LogFormatter -> LogType -> TimeFormat -> (Logger -> IO a) -> IO a
+withLogger level formatter destination timeFormat action =
+    Exception.bracket (newLogger level formatter destination timeFormat) snd (action . fst)
+
+-- | Bracket-style default logger. Logs to stdout at Debug level.
+--
+-- > withDefaultLogger \logger -> do
+-- >     -- use logger
+withDefaultLogger :: (Logger -> IO a) -> IO a
+withDefaultLogger =
+    withLogger Debug defaultFormatter (LogStdout defaultBufSize) simpleTimeFormat'
 
 -- | Formats the log as-is with a newline added.
 defaultFormatter :: LogFormatter

--- a/ihp/IHP/FrameworkConfig.hs
+++ b/ihp/IHP/FrameworkConfig.hs
@@ -17,6 +17,7 @@ module IHP.FrameworkConfig
 , isDevelopment
 , isProduction
 , defaultCorsResourcePolicy
+, withLogger
 , withFrameworkConfig
 , configIO
 , ExceptionWithCallStack (..)
@@ -251,6 +252,15 @@ isProduction = isEnvironment Production
 defaultCorsResourcePolicy :: Maybe Cors.CorsResourcePolicy
 defaultCorsResourcePolicy = Nothing
 
+-- | Creates the default raw 'FastLogger' backend used by IHP.
+--
+-- The callback receives the logger exactly as provided by fast-logger. Pass it
+-- to 'buildFrameworkConfig' to obtain the newline-appending logger stored in
+-- 'FrameworkConfig'.
+withLogger :: (FastLogger -> IO result) -> IO result
+withLogger =
+    withFastLogger (LogStdout defaultBufSize)
+
 -- | Builds a config and calls the provided callback.
 --
 -- Once the callback has returned the resources allocated by the config are closed. Specifcally
@@ -265,7 +275,7 @@ defaultCorsResourcePolicy = Nothing
 --
 withFrameworkConfig :: ConfigBuilder -> (FrameworkConfig -> IO result) -> IO result
 withFrameworkConfig configBuilder callback =
-    withFastLogger (LogStdout defaultBufSize) \rawLogger -> do
+    withLogger \rawLogger -> do
         frameworkConfig <- buildFrameworkConfig rawLogger configBuilder
         callback frameworkConfig
 


### PR DESCRIPTION
## Summary

- Keep IHP core on master's direct `fast-logger` architecture; this PR does not wire framework packages back through `IHP.Log`.
- Add `IHP.FrameworkConfig.withLogger` as the framework-local bracketed default `FastLogger` helper and use it from `withFrameworkConfig`, the IDE dev server, and the tool server.
- Scope the `ihp-log` package cleanup to its standalone API: simplify `Logger` to `log` + `level`, bake level checking/formatting/time caching into the closure, and expose `withLogger` / `withDefaultLogger` for bracket-style resource management.

## Test plan

- [x] `nix develop --impure --command sh -c "printf ':l ihp/IHP/FrameworkConfig.hs\n:l ihp-ide/IHP/IDE/ToolServer.hs\n:l ihp-ide/exe/IHP/IDE/DevServer.hs\n' | ghci"`
- [x] `nix build --impure .#checks.aarch64-darwin.ghc912-ihp-log`
- [x] `nix build --impure .#checks.aarch64-darwin.ghc914-ihp-log`
