### PR TITLE
Split Generated.ActualTypes into per-table modules for parallel compilation

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -180,7 +180,7 @@ tests = do
                     type User = User' 
 
                     type instance GetTableName (User' ) = "users"
-                    type instance GetModelByTableName "users" = Generated.ActualTypes.User
+                    type instance GetModelByTableName "users" = User
 
                     instance Default (Id' "users") where def = Id def
 
@@ -253,7 +253,7 @@ tests = do
                     type User = User' 
 
                     type instance GetTableName (User' ) = "users"
-                    type instance GetModelByTableName "users" = Generated.ActualTypes.User
+                    type instance GetModelByTableName "users" = User
 
                     instance Default (Id' "users") where def = Id def
 
@@ -325,7 +325,7 @@ tests = do
                     type User = User' 
 
                     type instance GetTableName (User' ) = "users"
-                    type instance GetModelByTableName "users" = Generated.ActualTypes.User
+                    type instance GetModelByTableName "users" = User
 
                     instance Default (Id' "users") where def = Id def
 
@@ -442,7 +442,7 @@ tests = do
                     type LandingPage = LandingPage' (QueryBuilder.QueryBuilder "paragraph_ctas") (QueryBuilder.QueryBuilder "paragraph_ctas")
 
                     type instance GetTableName (LandingPage' _ _) = "landing_pages"
-                    type instance GetModelByTableName "landing_pages" = Generated.ActualTypes.LandingPage
+                    type instance GetModelByTableName "landing_pages" = LandingPage
 
                     instance Default (Id' "landing_pages") where def = Id def
 


### PR DESCRIPTION
## Summary

- Splits the monolithic `Generated.ActualTypes` module into per-table modules (`Generated.ActualTypes.User`, `Generated.ActualTypes.Post`, etc.) so GHC can compile them in parallel
- Transforms `Generated.ActualTypes` into a lightweight re-export hub with no type definitions, just imports and re-exports
- Fully backward-compatible: `import Generated.ActualTypes` and qualified names like `Generated.ActualTypes.User` continue to work unchanged

## Motivation

Previously, `Generated.ActualTypes` contained ALL table type definitions in one file, creating a serial compilation bottleneck:

```
Enums → ActualTypes (ONE BIG MODULE) → User, Post, ... → Types
```

Now the heavy work happens in parallel:

```
Enums → ActualTypes.User, ActualTypes.Post, ... (PARALLEL) → ActualTypes (re-export hub) → User, Post, ... → Types
```

Per-table ActualTypes modules have zero cross-table Haskell module-level dependencies (they use `Id' "tablename"` string literals, type variables for FK columns, and `QueryBuilder.QueryBuilder "tablename"` string literals), so they can all compile simultaneously.

## Test plan

- [x] Type-checks with `ghci`
- [x] All 357 tests pass (`echo -e ':l ihp-ide/Test/Main.hs\nmain' | ghci`)
- [ ] Full `nix flake check --impure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)