### PR TITLE
Migrate PGListener from postgresql-simple to hasql-notifications

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -71,6 +71,7 @@ that is defined in flake-module.nix
                         text
                         postgresql-simple
                         hasql
+                        hasql-notifications
                         hasql-pool
                         hasql-dynamic-statements
                         hasql-implicits

--- a/ihp/IHP/Job/Runner.hs
+++ b/ihp/IHP/Job/Runner.hs
@@ -43,7 +43,7 @@ dedicatedProcessMainLoop jobWorkers = do
     -- The job workers use their own dedicated PG listener as e.g. AutoRefresh or DataSync
     -- could overload the main PGListener connection. In that case we still want jobs to be
     -- run independent of the system being very busy.
-    PGListener.withPGListener ?modelContext \pgListener -> do
+    PGListener.withPGListener ?context.databaseUrl ?context.logger \pgListener -> do
         stopSignal <- Concurrent.newEmptyMVar
 
         runResourceT do

--- a/ihp/IHP/Server.hs
+++ b/ihp/IHP/Server.hs
@@ -54,7 +54,7 @@ run configBuilder = do
     withFrameworkConfig configBuilder \frameworkConfig -> do
         IHP.FrameworkConfig.withModelContext frameworkConfig \modelContext -> do
             withInitalizers frameworkConfig modelContext do
-                PGListener.withPGListener modelContext \pgListener -> do
+                PGListener.withPGListener frameworkConfig.databaseUrl frameworkConfig.logger \pgListener -> do
                     let ?modelContext = modelContext
 
                     middleware <- initMiddlewareStack frameworkConfig modelContext (Just pgListener)

--- a/ihp/Test/Test/PGListenerSpec.hs
+++ b/ihp/Test/Test/PGListenerSpec.hs
@@ -7,17 +7,23 @@ module Test.PGListenerSpec where
 import Test.Hspec
 import IHP.Prelude
 import IHP.HaskellSupport
-import IHP.ModelSupport
 import qualified IHP.PGListener as PGListener
+import IHP.Log.Types (Logger(..), LogLevel(..))
 import Data.HashMap.Strict as HashMap
 
 tests = do
     describe "IHP.PGListener" do
-        let modelContext = notConnectedModelContext undefined
+        let logger = Logger
+                { write = \_ -> pure ()
+                , level = Debug
+                , formatter = \_ _ msg -> msg
+                , timeCache = pure ""
+                , cleanup = pure ()
+                }
 
         describe "subscribe" do
             it "should add a subscriber" do
-                PGListener.withPGListener modelContext \pgListener -> do
+                PGListener.withPGListener "" logger \pgListener -> do
                     subscriptionsCount <- length . concat . HashMap.elems <$> readIORef pgListener.subscriptions
                     subscriptionsCount `shouldBe` 0
 
@@ -30,7 +36,7 @@ tests = do
 
         describe "unsubscribe" do
             it "remove the subscription" do
-                PGListener.withPGListener modelContext \pgListener -> do
+                PGListener.withPGListener "" logger \pgListener -> do
                     subscription <- pgListener |> PGListener.subscribe "did_insert_record" (const (pure ()))
                     pgListener |> PGListener.unsubscribe subscription
 

--- a/ihp/default.nix
+++ b/ihp/default.nix
@@ -2,7 +2,8 @@
 , binary, blaze-html, blaze-markup, bytestring, case-insensitive
 , cereal, cereal-text, classy-prelude, clientsession, conduit-extra
 , containers, cookie, countable-inflections, data-default, deepseq
-, directory, fast-logger, filepath, ghc-prim, hashable
+, directory, fast-logger, filepath, ghc-prim, hashable, hasql
+, hasql-notifications
 , haskell-src-exts, haskell-src-meta, hspec, http-client
 , http-client-tls, http-media, http-types, ihp-context, ihp-hsx
 , ihp-imagemagick, ihp-log, ihp-modal, ihp-pagehead
@@ -29,7 +30,8 @@ mkDerivation {
     blaze-markup bytestring case-insensitive cereal cereal-text
     classy-prelude clientsession conduit-extra containers cookie
     countable-inflections data-default deepseq directory fast-logger
-    filepath ghc-prim hashable haskell-src-exts haskell-src-meta hspec
+    filepath ghc-prim hashable hasql hasql-notifications
+    haskell-src-exts haskell-src-meta hspec
     http-client http-client-tls http-media http-types ihp-context
     ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
     ihp-postgresql-simple-extra inflections interpolate ip lens
@@ -49,7 +51,8 @@ mkDerivation {
     blaze-markup bytestring case-insensitive cereal cereal-text
     classy-prelude clientsession conduit-extra containers cookie
     countable-inflections data-default deepseq directory fast-logger
-    filepath ghc-prim hashable haskell-src-exts haskell-src-meta hspec
+    filepath ghc-prim hashable hasql hasql-notifications
+    haskell-src-exts haskell-src-meta hspec
     http-client http-client-tls http-media http-types ihp-context
     ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
     ihp-postgresql-simple-extra inflections interpolate ip lens

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -53,6 +53,8 @@ common shared-properties
             , inflections
             , text
             , postgresql-simple
+            , hasql
+            , hasql-notifications
             , wai-app-static
             , wai-util
             , bytestring


### PR DESCRIPTION
## Summary

- Migrate **only PGListener** from postgresql-simple to hasql-notifications as an incremental first step toward hasql adoption
- Add `databaseUrl :: ByteString` field to `ModelContext` so PGListener can acquire its own dedicated hasql connection
- Replace `PG.Notification` with a new `PGListener.Notification` type preserving the same field names (`notificationChannel`, `notificationData`)
- Add reconnection with exponential backoff (500ms → 60s) and proper connection release via `Exception.finally`

All other database operations (sqlQuery, sqlExec, QueryBuilder, Fetch, DataSync, Job queue, AutoRefresh) remain on postgresql-simple.

## Test plan

- [x] `echo ':l ihp/IHP/PGListener.hs' | ghci` — compiles
- [x] `echo ':l ihp/IHP/Server.hs' | ghci` — compiles (pulls in AutoRefresh, Job, RequestVault)
- [x] All 401 tests pass (`echo -e ':l ihp/Test/Test/Main.hs\nmain' | ghci`)
- [ ] Manual: `devenv up` with host app, verify LISTEN/NOTIFY (DataSync subs, AutoRefresh, job notifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)