### PR TITLE
Replace DynamicValue with Aeson Value in DataSync

### DIFF
--- a/ihp-datasync/IHP/DataSync/TypedEncoder.hs
+++ b/ihp-datasync/IHP/DataSync/TypedEncoder.hs
@@ -11,14 +11,13 @@ that occur in the extended query protocol when sending text-typed parameters for
 module IHP.DataSync.TypedEncoder
 ( ColumnTypeMap
 , makeCachedColumnTypeLookup
-, typedDynamicValueParam
+, typedValueParam
 , typedAesonValueToSnippet
 ) where
 
 import IHP.Prelude
-import IHP.DataSync.DynamicQuery (DynamicValue(..), ColumnTypeMap, aesonToDynamicValue, quoteIdentifier)
+import IHP.DataSync.DynamicQuery (ColumnTypeMap, quoteIdentifier)
 import IHP.Postgres.Point (Point(..))
-import IHP.Postgres.TimeParser (PGInterval(..))
 import qualified Data.HashMap.Strict as HashMap
 import qualified Hasql.Pool
 import qualified Hasql.Session as Session
@@ -28,7 +27,7 @@ import qualified Hasql.Decoders as Decoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
 import Hasql.DynamicStatements.Snippet (Snippet)
 import IHP.DataSync.Hasql (runSession)
-import Data.Aeson (Value(Object, Array, String, Number, Bool))
+import Data.Aeson (Value(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
 import qualified Data.UUID as UUID
@@ -39,6 +38,7 @@ import qualified Data.Time.Format.ISO8601 as ISO8601
 import qualified Data.Attoparsec.Text as Attoparsec
 import qualified Data.Text as Text
 import qualified Data.List as List
+import qualified Data.Vector as Vector
 
 -- | Creates a cached lookup function that queries column types from @pg_attribute@/@pg_type@
 -- and caches the result per table name.
@@ -72,60 +72,14 @@ columnTypesStatement = Statement.Statement
         typName <- Decoders.column (Decoders.nonNullable Decoders.text)
         pure (colName, typName)
 
--- | Encode a 'DynamicValue' as a typed Snippet parameter.
+-- | Encode an Aeson 'Value' as a typed Snippet parameter.
 --
 -- When a column type is known (from 'ColumnTypeMap'), uses 'Snippet.encoderAndParam'
 -- with the correct typed encoder. Errors when no type info is available, since
 -- 'makeCachedColumnTypeLookup' should always provide column types.
-typedDynamicValueParam :: Maybe Text -> DynamicValue -> Snippet
-typedDynamicValueParam _ Null = Snippet.sql "NULL"
-typedDynamicValueParam _ (PointValue (Point x y)) = Snippet.sql ("point(" <> cs (tshow x) <> "," <> cs (tshow y) <> ")")
-typedDynamicValueParam pgType (ArrayValue values) =
-    let elemType = case pgType of
-            Just t | "_" `Text.isPrefixOf` t -> Just (Text.drop 1 t)
-            _ -> pgType
-    in Snippet.sql "ARRAY[" <> mconcat (List.intersperse (Snippet.sql ", ") (map (typedDynamicValueParam elemType) values)) <> Snippet.sql "]"
-typedDynamicValueParam (Just pgType) value = encodeWithType pgType value
-typedDynamicValueParam Nothing value = error ("typedDynamicValueParam: No column type available for value: " <> show value)
-
--- | Encode a 'DynamicValue' using a specific PostgreSQL type encoder.
---
--- Maps PostgreSQL type names to the corresponding hasql encoder and converts
--- the 'DynamicValue' to the appropriate Haskell type.
-encodeWithType :: Text -> DynamicValue -> Snippet
-encodeWithType _             Null = Snippet.sql "NULL"
-encodeWithType "uuid"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.uuid) (toUUID val)
-encodeWithType "text"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
-encodeWithType "varchar"     val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
-encodeWithType "bpchar"      val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
-encodeWithType "name"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
-encodeWithType "int4"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.int4) (toInt32 val)
-encodeWithType "int8"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.int8) (toInt64 val)
-encodeWithType "int2"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.int2) (toInt16 val)
-encodeWithType "bool"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.bool) (toBool val)
-encodeWithType "timestamptz" val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.timestamptz) (toUTCTime val)
-encodeWithType "timestamp"   val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.timestamp) (toLocalTime val)
-encodeWithType "date"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.date) (toDay val)
-encodeWithType "float8"      val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.float8) (toDouble val)
-encodeWithType "float4"      val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.float4) (toFloat val)
-encodeWithType "numeric"     val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.numeric) (toScientific val)
-encodeWithType "jsonb"       val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.jsonb) (toJSON val)
-encodeWithType "json"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.json) (toJSON val)
-encodeWithType "bytea"       val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.bytea) (toByteString val)
--- Interval uses text+cast because PGInterval can contain years/months/days
--- which DiffTime (used by Encoders.interval) cannot represent.
-encodeWithType "interval"    val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val) <> Snippet.sql "::interval"
-encodeWithType pgType        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val) <> Snippet.sql "::" <> quoteIdentifier pgType
-
--- | Encode an Aeson 'Value' as a typed Snippet parameter for INSERT/UPDATE operations.
---
--- JSON/JSONB columns get special handling to preserve the Aeson Value as-is,
--- rather than converting through DynamicValue (which would lose structure).
-typedAesonValueToSnippet :: Maybe Text -> Value -> Snippet
-typedAesonValueToSnippet (Just "jsonb") val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.jsonb) val
-typedAesonValueToSnippet (Just "json")  val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.json) val
-typedAesonValueToSnippet _ (Aeson.Null) = Snippet.sql "NULL"
-typedAesonValueToSnippet colType (Object values)
+typedValueParam :: Maybe Text -> Value -> Snippet
+typedValueParam _ Aeson.Null = Snippet.sql "NULL"
+typedValueParam colType (Object values)
     | colType == Just "point" =
         let
             tryDecodeAsPoint :: Maybe Point
@@ -141,119 +95,143 @@ typedAesonValueToSnippet colType (Object values)
                     pure Point { x, y }
         in
             if Aeson.size values == 2
-                then fromMaybe (typedDynamicValueParam colType (aesonToDynamicValue (Object values))) (pointToSnippet <$> tryDecodeAsPoint)
-                else typedDynamicValueParam colType (aesonToDynamicValue (Object values))
-    | otherwise = typedDynamicValueParam colType (aesonToDynamicValue (Object values))
+                then fromMaybe (error "Cannot decode as Point") (pointToSnippet <$> tryDecodeAsPoint)
+                else error "Cannot decode as Point: expected {x, y} object"
     where
         pointToSnippet (Point x y) = Snippet.sql ("point(" <> cs (tshow x) <> "," <> cs (tshow y) <> ")")
-typedAesonValueToSnippet colType value = typedDynamicValueParam colType (aesonToDynamicValue value)
+typedValueParam pgType (Array arr) =
+    let elemType = case pgType of
+            Just t | "_" `Text.isPrefixOf` t -> Just (Text.drop 1 t)
+            _ -> pgType
+    in Snippet.sql "ARRAY[" <> mconcat (List.intersperse (Snippet.sql ", ") (map (typedValueParam elemType) (Vector.toList arr))) <> Snippet.sql "]"
+typedValueParam (Just pgType) value = encodeWithType pgType value
+typedValueParam Nothing value = error ("typedValueParam: No column type available for value: " <> show value)
 
--- Conversion helpers
+-- | Encode an Aeson 'Value' using a specific PostgreSQL type encoder.
+--
+-- Maps PostgreSQL type names to the corresponding hasql encoder and converts
+-- the 'Value' to the appropriate Haskell type.
+encodeWithType :: Text -> Value -> Snippet
+encodeWithType _             Aeson.Null = Snippet.sql "NULL"
+encodeWithType "uuid"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.uuid) (toUUID val)
+encodeWithType "text"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
+encodeWithType "varchar"     val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
+encodeWithType "bpchar"      val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
+encodeWithType "name"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val)
+encodeWithType "int4"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.int4) (toInt32 val)
+encodeWithType "int8"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.int8) (toInt64 val)
+encodeWithType "int2"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.int2) (toInt16 val)
+encodeWithType "bool"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.bool) (toBool val)
+encodeWithType "timestamptz" val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.timestamptz) (toUTCTime val)
+encodeWithType "timestamp"   val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.timestamp) (toLocalTime val)
+encodeWithType "date"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.date) (toDay val)
+encodeWithType "float8"      val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.float8) (toDouble val)
+encodeWithType "float4"      val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.float4) (toFloat val)
+encodeWithType "numeric"     val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.numeric) (toScientific val)
+encodeWithType "jsonb"       val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.jsonb) val
+encodeWithType "json"        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.json) val
+encodeWithType "bytea"       val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.bytea) (toByteString val)
+-- Interval uses text+cast because PGInterval can contain years/months/days
+-- which DiffTime (used by Encoders.interval) cannot represent.
+encodeWithType "interval"    val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val) <> Snippet.sql "::interval"
+encodeWithType pgType        val = Snippet.encoderAndParam (Encoders.nonNullable Encoders.text) (toText val) <> Snippet.sql "::" <> quoteIdentifier pgType
 
-toUUID :: DynamicValue -> UUID
-toUUID (UUIDValue u) = u
-toUUID (TextValue t) = fromMaybe (error ("Invalid UUID: " <> cs t)) (UUID.fromText t)
+-- | Encode an Aeson 'Value' as a typed Snippet parameter for INSERT/UPDATE operations.
+--
+-- Delegates directly to 'typedValueParam'.
+typedAesonValueToSnippet :: Maybe Text -> Value -> Snippet
+typedAesonValueToSnippet = typedValueParam
+
+-- Conversion helpers (from Aeson Value to Haskell types)
+
+toUUID :: Value -> UUID
+toUUID (String t) = fromMaybe (error ("Invalid UUID: " <> cs t)) (UUID.fromText t)
 toUUID v = error ("Cannot convert to UUID: " <> show v)
 
-toText :: DynamicValue -> Text
-toText (TextValue t) = t
-toText (IntValue i) = tshow i
-toText (DoubleValue d) = tshow d
-toText (BoolValue b) = if b then "true" else "false"
-toText (UUIDValue u) = UUID.toText u
-toText (DateTimeValue t) = tshow t
-toText (IntervalValue (PGInterval bs)) = cs bs
-toText (PointValue (Point x y)) = "(" <> tshow x <> "," <> tshow y <> ")"
-toText (ArrayValue vs) = "{" <> mconcat (List.intersperse "," (map toText vs)) <> "}"
+toText :: Value -> Text
+toText (String t) = t
+toText (Number n) = case Scientific.floatingOrInteger n of
+    Left (d :: Double) -> tshow d
+    Right (i :: Integer) -> tshow i
+toText (Bool b) = if b then "true" else "false"
 toText v = error ("Cannot convert to Text: " <> show v)
 
-toInt32 :: DynamicValue -> Int32
-toInt32 (IntValue i) = fromIntegral i
-toInt32 (DoubleValue d) = round d
-toInt32 (TextValue t) = case Attoparsec.parseOnly (Attoparsec.signed Attoparsec.decimal) t of
+toInt32 :: Value -> Int32
+toInt32 (Number n) = case Scientific.floatingOrInteger n of
+    Left (d :: Double) -> round d
+    Right (i :: Integer) -> fromIntegral i
+toInt32 (String t) = case Attoparsec.parseOnly (Attoparsec.signed Attoparsec.decimal) t of
     Right i -> i
     Left _ -> error ("Cannot parse Int32 from text: " <> cs t)
 toInt32 v = error ("Cannot convert to Int32: " <> show v)
 
-toInt64 :: DynamicValue -> Int64
-toInt64 (IntValue i) = fromIntegral i
-toInt64 (DoubleValue d) = round d
-toInt64 (TextValue t) = case Attoparsec.parseOnly (Attoparsec.signed Attoparsec.decimal) t of
+toInt64 :: Value -> Int64
+toInt64 (Number n) = case Scientific.floatingOrInteger n of
+    Left (d :: Double) -> round d
+    Right (i :: Integer) -> fromIntegral i
+toInt64 (String t) = case Attoparsec.parseOnly (Attoparsec.signed Attoparsec.decimal) t of
     Right i -> i
     Left _ -> error ("Cannot parse Int64 from text: " <> cs t)
 toInt64 v = error ("Cannot convert to Int64: " <> show v)
 
-toInt16 :: DynamicValue -> Int16
-toInt16 (IntValue i) = fromIntegral i
-toInt16 (DoubleValue d) = round d
-toInt16 (TextValue t) = case Attoparsec.parseOnly (Attoparsec.signed Attoparsec.decimal) t of
+toInt16 :: Value -> Int16
+toInt16 (Number n) = case Scientific.floatingOrInteger n of
+    Left (d :: Double) -> round d
+    Right (i :: Integer) -> fromIntegral i
+toInt16 (String t) = case Attoparsec.parseOnly (Attoparsec.signed Attoparsec.decimal) t of
     Right i -> i
     Left _ -> error ("Cannot parse Int16 from text: " <> cs t)
 toInt16 v = error ("Cannot convert to Int16: " <> show v)
 
-toBool :: DynamicValue -> Bool
-toBool (BoolValue b) = b
-toBool (TextValue "true") = True
-toBool (TextValue "false") = False
-toBool (TextValue "t") = True
-toBool (TextValue "f") = False
-toBool (IntValue 0) = False
-toBool (IntValue _) = True
+toBool :: Value -> Bool
+toBool (Bool b) = b
+toBool (String "true") = True
+toBool (String "false") = False
+toBool (String "t") = True
+toBool (String "f") = False
+toBool (Number 0) = False
+toBool (Number _) = True
 toBool v = error ("Cannot convert to Bool: " <> show v)
 
-toUTCTime :: DynamicValue -> UTCTime
-toUTCTime (DateTimeValue t) = t
-toUTCTime (TextValue t) = case ISO8601.iso8601ParseM (cs t) of
+toUTCTime :: Value -> UTCTime
+toUTCTime (String t) = case ISO8601.iso8601ParseM (cs t) of
     Just utc -> utc
     Nothing -> error ("Cannot parse UTCTime from text: " <> cs t)
 toUTCTime v = error ("Cannot convert to UTCTime: " <> show v)
 
-toLocalTime :: DynamicValue -> LocalTime
-toLocalTime (DateTimeValue t) = utcToLocalTime utc t
-toLocalTime (TextValue t) = case ISO8601.iso8601ParseM (cs t) of
+toLocalTime :: Value -> LocalTime
+toLocalTime (String t) = case ISO8601.iso8601ParseM (cs t) of
     Just lt -> lt
     Nothing -> error ("Cannot parse LocalTime from text: " <> cs t)
 toLocalTime v = error ("Cannot convert to LocalTime: " <> show v)
 
-toDay :: DynamicValue -> Day
-toDay (DateTimeValue t) = utctDay t
-toDay (TextValue t) = case ISO8601.iso8601ParseM (cs t) of
+toDay :: Value -> Day
+toDay (String t) = case ISO8601.iso8601ParseM (cs t) of
     Just d -> d
     Nothing -> error ("Cannot parse Day from text: " <> cs t)
 toDay v = error ("Cannot convert to Day: " <> show v)
 
-toDouble :: DynamicValue -> Double
-toDouble (DoubleValue d) = d
-toDouble (IntValue i) = fromIntegral i
-toDouble (TextValue t) = case Attoparsec.parseOnly Attoparsec.double t of
+toDouble :: Value -> Double
+toDouble (Number n) = Scientific.toRealFloat n
+toDouble (String t) = case Attoparsec.parseOnly Attoparsec.double t of
     Right d -> d
     Left _ -> error ("Cannot parse Double from text: " <> cs t)
 toDouble v = error ("Cannot convert to Double: " <> show v)
 
-toFloat :: DynamicValue -> Float
-toFloat (DoubleValue d) = realToFrac d
-toFloat (IntValue i) = fromIntegral i
-toFloat (TextValue t) = case Attoparsec.parseOnly Attoparsec.double t of
+toFloat :: Value -> Float
+toFloat (Number n) = Scientific.toRealFloat n
+toFloat (String t) = case Attoparsec.parseOnly Attoparsec.double t of
     Right d -> realToFrac d
     Left _ -> error ("Cannot parse Float from text: " <> cs t)
 toFloat v = error ("Cannot convert to Float: " <> show v)
 
-toScientific :: DynamicValue -> Scientific.Scientific
-toScientific (DoubleValue d) = Scientific.fromFloatDigits d
-toScientific (IntValue i) = fromIntegral i
-toScientific (TextValue t) = case Attoparsec.parseOnly Attoparsec.scientific t of
+toScientific :: Value -> Scientific.Scientific
+toScientific (Number n) = n
+toScientific (String t) = case Attoparsec.parseOnly Attoparsec.scientific t of
     Right s -> s
     Left _ -> error ("Cannot parse Scientific from text: " <> cs t)
 toScientific v = error ("Cannot convert to Scientific: " <> show v)
 
-toJSON :: DynamicValue -> Aeson.Value
-toJSON (TextValue t) = Aeson.String t
-toJSON (IntValue i) = Aeson.Number (fromIntegral i)
-toJSON (DoubleValue d) = Aeson.Number (Scientific.fromFloatDigits d)
-toJSON (BoolValue b) = Aeson.Bool b
-toJSON Null = Aeson.Null
-toJSON v = Aeson.String (toText v)
-
-toByteString :: DynamicValue -> ByteString
-toByteString (TextValue t) = cs t
+toByteString :: Value -> ByteString
+toByteString (String t) = cs t
 toByteString v = cs (toText v)

--- a/ihp-datasync/Test/DataSync/DynamicQueryCompiler.hs
+++ b/ihp-datasync/Test/DataSync/DynamicQueryCompiler.hs
@@ -13,6 +13,7 @@ import qualified Hasql.DynamicStatements.Statement as DynStatement
 import qualified Hasql.Decoders as Decoders
 import Hasql.DynamicStatements.Snippet (Snippet)
 import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Aeson as Aeson
 
 -- | Convert a Snippet to its SQL text representation for testing purposes.
 snippetToSql :: Snippet -> ByteString
@@ -92,7 +93,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (TextValue "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (Aeson.String "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Nothing
@@ -106,7 +107,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (TextValue "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (Aeson.String "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
                         , orderByClause = [ OrderByClause { orderByColumn = "createdAt", orderByDirection = Desc } ]
                         , distinctOnColumn = Nothing
                         , limit = Nothing
@@ -120,7 +121,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (TextValue "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (Aeson.String "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
                         , distinctOnColumn = Nothing
                         , orderByClause = []
                         , limit = Just 50
@@ -134,7 +135,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (TextValue "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (Aeson.String "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Nothing
@@ -148,7 +149,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (TextValue "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression (Aeson.String "b8553ce9-6a42-4a68-b5fc-259be3e2acdc"))
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Just 25
@@ -162,7 +163,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression Null)
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpEqual (LiteralExpression Aeson.Null)
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Nothing
@@ -176,7 +177,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpNotEqual (LiteralExpression Null)
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "userId") OpNotEqual (LiteralExpression Aeson.Null)
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Nothing
@@ -190,7 +191,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "a") OpIn (ListExpression { values = [Null] })
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "a") OpIn (ListExpression { values = [Aeson.Null] })
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Nothing
@@ -204,7 +205,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "a") OpIn (ListExpression { values = [Null, TextValue "test" ] })
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "a") OpIn (ListExpression { values = [Aeson.Null, Aeson.String "test" ] })
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Nothing
@@ -246,7 +247,7 @@ tests = do
                 let query = DynamicSQLQuery
                         { table = "posts"
                         , selectedColumns = SelectAll
-                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "id") OpIn (ListExpression { values = [UUIDValue "a5d7772f-c63f-4444-be69-dd9afd902e9b", UUIDValue "bb88d55a-1ed0-44ad-be13-d768f4b3f9ca"] })
+                        , whereCondition = Just $ InfixOperatorExpression (ColumnExpression "id") OpIn (ListExpression { values = [Aeson.String "a5d7772f-c63f-4444-be69-dd9afd902e9b", Aeson.String "bb88d55a-1ed0-44ad-be13-d768f4b3f9ca"] })
                         , orderByClause = []
                         , distinctOnColumn = Nothing
                         , limit = Nothing

--- a/ihp-datasync/data/DataSync/ihp-querybuilder.js
+++ b/ihp-datasync/data/DataSync/ihp-querybuilder.js
@@ -51,7 +51,7 @@ function infixColumnLiteral(field, op, value) {
         op,
         right: {
             tag: 'LiteralExpression',
-            value: jsValueToDynamicValue(value),
+            value: value,
         },
     }
 }
@@ -224,7 +224,7 @@ class ConditionBuildable {
             op: 'OpIn',
             right: {
                 tag: 'ListExpression',
-                values: values.map(jsValueToDynamicValue),
+                values: values,
             },
         };
         this._addCondition('OpAnd', expression);
@@ -236,7 +236,7 @@ class ConditionBuilder extends ConditionBuildable {
     constructor() {
         super({
             tag: 'LiteralExpression',
-            value: jsValueToDynamicValue(true),
+            value: true,
         })
         this.type = 'ConditionBuilder';
     }
@@ -384,24 +384,7 @@ function query(table, columns) {
     return new QueryBuilder(table, columns);
 }
 
-function jsValueToDynamicValue(value) {
-    if (typeof value === "string") {
-        return { tag: 'TextValue', contents: value };
-    } else if (typeof value === "number") {
-        return { tag: Number.isInteger(value) ? 'IntValue' : 'DoubleValue', contents: value };
-    } else if (typeof value === "boolean") {
-        return { tag: 'BoolValue', contents: value };
-    } else if (value === null || value === undefined) {
-        return { tag: 'Null' };
-    }
-
-    throw new Error('Could no transform JS value to DynamicValue. Supported types: string, number, boolean, null, undefined');
-}
-
 export function recordMatchesQuery(query, record) {
-    function evaluateDynamicValue(value) {
-        return (value.tag === 'Null' ? null : value.contents);
-    }
     function evaluate(expression) {
         switch (expression.tag) {
             case 'ColumnExpression': return (expression.field in record) ? record[expression.field] : null;
@@ -425,8 +408,8 @@ export function recordMatchesQuery(query, record) {
                     default: throw new Error('Unsupported operator ' + expression.op);
                 }
             }
-            case 'LiteralExpression': return evaluateDynamicValue(expression.value);
-            case 'ListExpression': return expression.values.map(value => evaluateDynamicValue(value));
+            case 'LiteralExpression': return expression.value;
+            case 'ListExpression': return expression.values;
             default: throw new Error('Unsupported expression in evaluate: ' + expression.tag);
         }
     }

--- a/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
+++ b/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
@@ -23,13 +23,6 @@ const tags = {
 	column: 'ColumnExpression',
 	literal: 'LiteralExpression',
     },
-    value: {
-	'text': 'TextValue',
-	'integer': 'IntValue',
-	'double': 'DoubleValue',
-	'bool': 'BoolValue',
-	'null': 'Null',
-    },
 }
 
 const operators = {
@@ -67,10 +60,7 @@ const expression = {
     literalInt: (value) => {
 	return {
 	    tag: tags.expression.literal,
-	    value: {
-		tag: tags.value.integer,
-		contents: value,
-	    },
+	    value,
 	}
     }
 }
@@ -79,41 +69,41 @@ describe('Value Transformations and basic use', () => {
     const suite = ([fnName, extractor, operator, where]) => {
 	describe(fnName, () => {
 
-	    function expectValueTransformsTo(jsVal, literal) {
+	    function expectValueTransformsTo(jsVal, expectedValue) {
 		const builder = where('column', jsVal)
 		expect(extractor(builder)).toStrictEqual(expression.infixOperator(
 		    expression.column('column'),
 		    operator,
-		    expression.literal(literal),
+		    expression.literal(expectedValue),
 		))
 	    }
 
 	    it('string/text', () => {
-		expectValueTransformsTo('value', { tag: tags.value.text, contents: 'value' })
+		expectValueTransformsTo('value', 'value')
 	    })
 
 	    it('number/integer', () => {
-		expectValueTransformsTo(1, { tag: tags.value.integer, contents: 1 })
+		expectValueTransformsTo(1, 1)
 	    })
 
 	    it('number/double', () => {
-		expectValueTransformsTo(3.141, { tag: tags.value.double, contents: 3.141 })
+		expectValueTransformsTo(3.141, 3.141)
 	    })
 
 	    it('true/bool', () => {
-		expectValueTransformsTo(true, { tag: tags.value.bool, contents: true })
+		expectValueTransformsTo(true, true)
 	    })
 
 	    it('false/bool', () => {
-		expectValueTransformsTo(false, { tag: tags.value.bool, contents: false })
+		expectValueTransformsTo(false, false)
 	    })
 
 	    it('null/null', () => {
-		expectValueTransformsTo(null, { tag: tags.value['null'] })
+		expectValueTransformsTo(null, null)
 	    })
 
 	    it('undefined/null', () => {
-		expectValueTransformsTo(undefined, { tag: tags.value['null'] })
+		expectValueTransformsTo(undefined, undefined)
 	    })
 
 	})
@@ -225,10 +215,7 @@ describe('QueryBuilder', () => {
 	expect(builder.query.whereCondition).toStrictEqual(expression.infixOperator(
 	    expression.column('a'),
 	    operators.notEqual,
-	    expression.literal({
-		tag: tags.value.integer,
-		contents: 1,
-	    })
+	    expression.literal(1)
 	))
     })
 
@@ -240,19 +227,13 @@ describe('QueryBuilder', () => {
 	    expression.infixOperator(
 		expression.column('a'),
 		operators.equal,
-		expression.literal({
-		    tag: tags.value.integer,
-		    contents: 1,
-		}),
+		expression.literal(1),
 	    ),
 	    operators.and,
 	    expression.infixOperator(
 		expression.column('b'),
 		operators.equal,
-		expression.literal({
-		    tag: tags.value.integer,
-		    contents: 2,
-		}),
+		expression.literal(2),
 	    ),
 	))
     })
@@ -265,19 +246,13 @@ describe('QueryBuilder', () => {
 	    expression.infixOperator(
 		expression.column('a'),
 		operators.equal,
-		expression.literal({
-		    tag: tags.value.integer,
-		    contents: 1,
-		}),
+		expression.literal(1),
 	    ),
 	    operators.or,
 	    expression.infixOperator(
 		expression.column('b'),
 		operators.equal,
-		expression.literal({
-		    tag: tags.value.integer,
-		    contents: 2,
-		})
+		expression.literal(2),
 	    ),
 	))
     })


### PR DESCRIPTION
## Summary

- Remove `DynamicValue` intermediate type from DataSync, using `Aeson.Value` directly throughout
- Simplify the JS wire protocol — values are now plain JSON (no more tagged objects like `{ tag: "TextValue", contents: "hello" }`)
- Eliminate lossy conversion where JSONB objects were being stringified through `aesonToDynamicValue`
- Reduce ~150 lines of boilerplate conversion code

The typed encoder already looks up column types from `pg_attribute`/`pg_type` to pick the correct Hasql encoder, so the `DynamicValue` constructor (e.g. `UUIDValue` vs `TextValue`) was redundant.

## Test plan

- [x] `nix build .#checks.aarch64-darwin.ihp-datasync` — Haskell compilation and tests pass
- [x] `nix build .#checks.aarch64-darwin.datasync-js` — JavaScript tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)