### PR TITLE
Fix undefined values causing parse error in DataSync

### DIFF
--- a/ihp-datasync/data/DataSync/ihp-querybuilder.js
+++ b/ihp-datasync/data/DataSync/ihp-querybuilder.js
@@ -41,6 +41,10 @@ function or(...args) {
     return infixMany('OpOr', args)
 }
 
+function undefinedToNull(value) {
+    return value === undefined ? null : value;
+}
+
 function infixColumnLiteral(field, op, value) {
     return {
         tag: 'InfixOperatorExpression',
@@ -51,7 +55,7 @@ function infixColumnLiteral(field, op, value) {
         op,
         right: {
             tag: 'LiteralExpression',
-            value: value,
+            value: undefinedToNull(value),
         },
     }
 }
@@ -224,7 +228,7 @@ class ConditionBuildable {
             op: 'OpIn',
             right: {
                 tag: 'ListExpression',
-                values: values,
+                values: values.map(undefinedToNull),
             },
         };
         this._addCondition('OpAnd', expression);

--- a/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
+++ b/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
@@ -103,7 +103,7 @@ describe('Value Transformations and basic use', () => {
 	    })
 
 	    it('undefined/null', () => {
-		expectValueTransformsTo(undefined, undefined)
+		expectValueTransformsTo(undefined, null)
 	    })
 
 	})


### PR DESCRIPTION
## Summary

- Add `undefinedToNull` helper to normalize `undefined` to `null` in query builder expressions
- Fixes parse error: `the key value was not present` when `undefined` is passed to `where()` or `whereIn()`

`JSON.stringify` drops `undefined` values from objects entirely, so `{ tag: "LiteralExpression", value: undefined }` serialized to `{"tag":"LiteralExpression"}` with no `"value"` key. The old `jsValueToDynamicValue` function (removed in #2268) handled this by converting `undefined` to `{ tag: "Null" }`.

## Test plan

- [x] `nix build .#checks.aarch64-darwin.datasync-js` — JS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)