### PR TITLE
Extract IHP.PGListener into ihp-pglistener package

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -3,6 +3,7 @@
 :set -iihp-context
 :set -iihp-pagehead
 :set -iihp-log
+:set -iihp-pglistener
 :set -iihp-modal
 :set -iihp
 :set -iihp/Test

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -42,6 +42,7 @@ final: prev: {
             ihp-context = localPackage "ihp-context";
             ihp-pagehead = localPackage "ihp-pagehead";
             ihp-log = localPackage "ihp-log";
+            ihp-pglistener = localPackage "ihp-pglistener";
             ihp-modal = localPackage "ihp-modal";
             ihp-ide = localPackage "ihp-ide";
             ihp-schema-compiler = localPackage "ihp-schema-compiler";

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -73,6 +73,7 @@ that is defined in flake-module.nix
                         hasql
                         hasql-notifications
                         hasql-pool
+                        ihp-pglistener
                         hasql-dynamic-statements
                         hasql-implicits
                         hasql-transaction

--- a/ihp-pglistener/LICENSE
+++ b/ihp-pglistener/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 digitally induced GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ihp-pglistener/default.nix
+++ b/ihp-pglistener/default.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, aeson, async, base, bytestring, containers, hashable
+, hasql, hasql-notifications, ihp-log, lib, safe-exceptions
+, string-conversions, text, unagi-chan, unordered-containers, uuid
+}:
+mkDerivation {
+  pname = "ihp-pglistener";
+  version = "1.4.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson async base bytestring containers hashable hasql
+    hasql-notifications ihp-log safe-exceptions string-conversions
+    text unagi-chan unordered-containers uuid
+  ];
+  homepage = "https://ihp.digitallyinduced.com/";
+  description = "PostgreSQL LISTEN/NOTIFY channel manager for IHP";
+  license = lib.licenses.mit;
+}

--- a/ihp-pglistener/ihp-pglistener.cabal
+++ b/ihp-pglistener/ihp-pglistener.cabal
@@ -1,0 +1,49 @@
+cabal-version:       2.2
+name:                ihp-pglistener
+version:             1.4.0
+synopsis:            PostgreSQL LISTEN/NOTIFY channel manager for IHP
+description:         Manages PostgreSQL LISTEN/NOTIFY subscriptions over a single shared connection
+                     with automatic reconnection and exponential backoff.
+license:             MIT
+license-file:        LICENSE
+author:              digitally induced GmbH
+maintainer:          hello@digitallyinduced.com
+homepage:            https://ihp.digitallyinduced.com/
+bug-reports:         https://github.com/digitallyinduced/ihp/issues
+copyright:           (c) digitally induced GmbH
+category:            Web, Database, IHP
+
+common shared-properties
+    default-language: GHC2021
+    build-depends:
+          base >= 4.17.0 && < 4.22
+        , bytestring
+        , text
+        , string-conversions
+        , aeson
+        , uuid
+        , async
+        , hasql
+        , hasql-notifications
+        , unagi-chan
+        , safe-exceptions
+        , containers
+        , unordered-containers
+        , hashable
+        , ihp-log
+    default-extensions:
+        OverloadedStrings
+        , ImplicitParams
+        , DataKinds
+        , RecordWildCards
+        , OverloadedRecordDot
+        , DuplicateRecordFields
+        , BlockArguments
+        , LambdaCase
+    ghc-options: -Werror=incomplete-patterns
+
+library
+    import: shared-properties
+    hs-source-dirs: .
+    exposed-modules:
+        IHP.PGListener

--- a/ihp/default.nix
+++ b/ihp/default.nix
@@ -2,11 +2,11 @@
 , binary, blaze-html, blaze-markup, bytestring, case-insensitive
 , cereal, cereal-text, classy-prelude, clientsession, conduit-extra
 , containers, cookie, countable-inflections, data-default, deepseq
-, directory, fast-logger, filepath, ghc-prim, hashable, hasql
-, hasql-notifications
+, directory, fast-logger, filepath, ghc-prim, hashable
 , haskell-src-exts, haskell-src-meta, hspec, http-client
 , http-client-tls, http-media, http-types, ihp-context, ihp-hsx
 , ihp-imagemagick, ihp-log, ihp-modal, ihp-pagehead
+, ihp-pglistener
 , ihp-postgresql-simple-extra, inflections, interpolate, ip, lens
 , lib, mime-types, minio-hs, mono-traversable, mtl
 , neat-interpolation, network, network-uri, parser-combinators
@@ -30,10 +30,11 @@ mkDerivation {
     blaze-markup bytestring case-insensitive cereal cereal-text
     classy-prelude clientsession conduit-extra containers cookie
     countable-inflections data-default deepseq directory fast-logger
-    filepath ghc-prim hashable hasql hasql-notifications
+    filepath ghc-prim hashable
     haskell-src-exts haskell-src-meta hspec
     http-client http-client-tls http-media http-types ihp-context
     ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
+    ihp-pglistener
     ihp-postgresql-simple-extra inflections interpolate ip lens
     mime-types minio-hs mono-traversable mtl neat-interpolation network
     network-uri parser-combinators postgresql-simple process
@@ -51,10 +52,11 @@ mkDerivation {
     blaze-markup bytestring case-insensitive cereal cereal-text
     classy-prelude clientsession conduit-extra containers cookie
     countable-inflections data-default deepseq directory fast-logger
-    filepath ghc-prim hashable hasql hasql-notifications
+    filepath ghc-prim hashable
     haskell-src-exts haskell-src-meta hspec
     http-client http-client-tls http-media http-types ihp-context
     ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
+    ihp-pglistener
     ihp-postgresql-simple-extra inflections interpolate ip lens
     mime-types minio-hs mono-traversable mtl neat-interpolation network
     network-uri parser-combinators postgresql-simple process

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -53,8 +53,7 @@ common shared-properties
             , inflections
             , text
             , postgresql-simple
-            , hasql
-            , hasql-notifications
+            , ihp-pglistener
             , wai-app-static
             , wai-util
             , bytestring
@@ -243,8 +242,8 @@ library
         , IHP.Pagination.ViewFunctions
         , IHP.Pagination.Types
         , IHP.Pagination.Helpers
-        , IHP.PGListener
         , IHP.EnvVar
+    reexported-modules: IHP.PGListener
     autogen-modules: Paths_ihp
     other-modules: Paths_ihp
 


### PR DESCRIPTION
## Summary
- Extracts `IHP.PGListener` from the `ihp` package into a standalone `ihp-pglistener` package
- The module only depends on `ihp-log` and standard external packages — no dependency on the main `ihp` package
- The `ihp` package re-exports `IHP.PGListener` via `reexported-modules` for full backward compatibility

## Test plan
- [x] `ihp-pglistener/IHP/PGListener.hs` compiles standalone via ghci
- [x] `ihp/IHP/Server.hs` compiles (all 86 modules loaded)
- [x] Full test suite passes: 401 examples, 0 failures (including PGListener tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)