### PR TITLE
Fix Schema Designer layout issues after Bootstrap 5 upgrade

### DIFF
--- a/ihp-ide/IHP/IDE/SchemaDesigner/View/Layout.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/View/Layout.hs
@@ -63,7 +63,7 @@ migrationStatus = if hasPendingMigrations
         <div id="migration-status-container">
             <div class="alert alert-primary d-flex align-items-center shadow-lg" role="alert">
                 {migrationStatusIcon}
-                <div class="user-select-none">
+                <div class="user-select-none flex-grow-1">
                     <div><strong>Unmigrated Changes</strong></div>
                     Your app database is not in sync with the Schema
                 </div>
@@ -82,7 +82,7 @@ migrationStatus = if hasPendingMigrations
         <div id="migration-status-container">
             <div class="alert alert-primary d-flex align-items-center shadow-lg" role="alert">
                 {migrationStatusIcon}
-                <div class="user-select-none">
+                <div class="user-select-none flex-grow-1">
                     <div><strong>Pending Changes</strong></div>
                     You have migrations that haven't been run yet
                 </div>

--- a/ihp-ide/data/static/IDE/schema-designer.css
+++ b/ihp-ide/data/static/IDE/schema-designer.css
@@ -261,10 +261,16 @@
 #schema-designer-viewer {
     margin-bottom: 0;
     flex-grow: 1;
+    flex-wrap: nowrap;
+    overflow: hidden;
 }
 
 .object-selector, .column-selector {
     min-height: 0 !important;
+}
+
+.object-selector {
+    min-width: 0;
 }
 
 .migration-status-visible .column-selector {
@@ -344,6 +350,7 @@
     position: sticky;
     bottom: 0;
     z-index: 10;
+    width: 100%;
 }
 
 #migration-status-container > .alert {


### PR DESCRIPTION
## Summary
- **Migration status banner:** "Migrate DB →" button not pushed to far right. The `#migration-status-container` wasn't stretching to full width inside the flex column parent. Fixed by adding `width: 100%` on the container and `flex-grow-1` on the text div.
- **Tables/columns split view:** The object-selector (tables list) was expanding to full row width, pushing the column-selector (columns panel) below it instead of side-by-side. Caused by `min-width: auto` on flex items with long table names triggering `flex-wrap: wrap`. Fixed by adding `flex-wrap: nowrap` + `overflow: hidden` on `#schema-designer-viewer` and `min-width: 0` on `.object-selector`.

## Test plan
- [ ] Open Schema Designer with a table selected — verify tables list and columns panel are side-by-side
- [ ] Verify long table names truncate with ellipsis instead of expanding the tables panel
- [ ] Check "Unmigrated Changes" banner — button should be pushed to the far right
- [ ] Check "Pending Migrations" banner — same layout fix applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)