### PR TITLE
Fix withPGListener call in DataSync integration test

### DIFF
--- a/ihp-datasync/Test/DataSync/DataSyncIntegrationSpec.hs
+++ b/ihp-datasync/Test/DataSync/DataSyncIntegrationSpec.hs
@@ -149,7 +149,7 @@ withDataSyncController connStr testUserId action = do
                 else cs ("dbname=" <> connStr)
         logger <- Log.newLogger def { Log.level = Log.Error }
         modelContext <- createModelContext 10 4 actualConnStr logger
-        PGListener.withPGListener modelContext \pgListener -> do
+        PGListener.withPGListener actualConnStr logger \pgListener -> do
             frameworkConfig <- buildFrameworkConfig (pure ())
 
             let v = Vault.empty


### PR DESCRIPTION
## Summary
- Update `withPGListener` call in `DataSyncIntegrationSpec.hs` to match the new signature from the ihp-pglistener extraction (PR #2273), which takes `ByteString` + `Logger` instead of `ModelContext`

## Test plan
- [ ] CI passes (this fixes the current CI failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)