### PR TITLE
Fix callActionWithParams using GET method causing empty params

### DIFF
--- a/ihp/IHP/Test/Mocking.hs
+++ b/ihp/IHP/Test/Mocking.hs
@@ -105,7 +105,8 @@ callActionWithParams controller params = do
     requestBody <- newIORef (HTTP.renderSimpleQuery False params)
     let readBody = atomicModifyIORef requestBody (\body -> ("", body))
     let baseRequest = ?request
-            { Wai.requestBody = readBody
+            { Wai.requestMethod = "POST"
+            , Wai.requestBody = readBody
             , Wai.requestHeaders = (HTTP.hContentType, "application/x-www-form-urlencoded") : filter ((/= HTTP.hContentType) . fst) (Wai.requestHeaders ?request)
             }
 


### PR DESCRIPTION
## Summary

- Fix test framework `callActionWithParams` silently discarding all params by setting request method to POST

The `requestBodyMiddleware` optimization (ec6547b2) correctly skips body parsing for GET/HEAD/DELETE/OPTIONS requests. But `callActionWithParams` in `IHP.Test.Mocking` used `defaultRequest` which has `requestMethod = "GET"`, so the middleware returned `FormBody [] []` and all test params were silently discarded.

This caused two symptoms in downstream apps (reported in thepurplepen/tpp-app#941):
1. Actions returning 200 instead of 302 (missing params → validation failures → re-render instead of redirect)
2. `RecordNotFoundException` (record IDs missing from params)

## Test plan

- [ ] Verify IHP test suite passes
- [ ] Verify downstream app (tpp-app) tests pass with this IHP revision — the 302→200 test changes in PR #941 should be reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)