### PR TITLE
Add regression tests for callActionWithParams param delivery

### DIFF
--- a/ihp/Test/Test/Main.hs
+++ b/ihp/Test/Test/Main.hs
@@ -19,6 +19,7 @@ import qualified Test.RouterSupportSpec
 import qualified Test.ViewSupportSpec
 import qualified Test.FileStorage.ControllerFunctionsSpec
 import qualified Test.PGListenerSpec
+import qualified Test.MockingSpec
 
 main :: IO ()
 main = hspec do
@@ -38,3 +39,4 @@ main = hspec do
     Test.FileStorage.ControllerFunctionsSpec.tests
     Test.Controller.CookieSpec.tests
     Test.PGListenerSpec.tests
+    Test.MockingSpec.tests

--- a/ihp/Test/Test/MockingSpec.hs
+++ b/ihp/Test/Test/MockingSpec.hs
@@ -1,0 +1,72 @@
+{-|
+Module: Test.MockingSpec
+Tests for IHP.Test.Mocking, ensuring callActionWithParams correctly
+delivers params through the middleware stack and that redirect responses
+preserve their status codes.
+-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module Test.MockingSpec where
+import qualified Prelude
+import ClassyPrelude
+import Test.Hspec
+import IHP.Test.Mocking
+import IHP.Prelude
+import IHP.Environment
+import IHP.FrameworkConfig
+import IHP.Job.Types
+import IHP.ControllerPrelude hiding (get, request)
+import Text.Blaze.Html (Html)
+import Network.Wai
+import Network.HTTP.Types
+
+data WebApplication = WebApplication deriving (Eq, Show, Data)
+
+data TestController
+    = EchoParamAction
+    | RedirectAction
+  deriving (Eq, Show, Data)
+
+instance Controller TestController where
+    action EchoParamAction = do
+        let value = param @Text "message"
+        renderPlain (cs value)
+    action RedirectAction = do
+        redirectToPath "/target"
+
+instance AutoRoute TestController
+
+instance FrontController WebApplication where
+  controllers = [ parseRoute @TestController ]
+
+defaultLayout :: Html -> Html
+defaultLayout inner = inner
+
+instance InitControllerContext WebApplication where
+  initContext = do
+    setLayout defaultLayout
+
+instance FrontController RootApplication where
+    controllers = [ mountFrontController WebApplication ]
+
+config = do
+    option Development
+    option (AppPort 8000)
+
+tests :: Spec
+tests = beforeAll (mockContextNoDatabase WebApplication config) do
+    describe "IHP.Test.Mocking" do
+        describe "callActionWithParams" do
+            it "should deliver params to the controller action" $ withContext do
+                response <- callActionWithParams EchoParamAction [("message", "hello world")]
+                body <- responseBody response
+                cs body `shouldBe` ("hello world" :: Text)
+
+            it "should return status 200 for rendered responses" $ withContext do
+                response <- callActionWithParams EchoParamAction [("message", "test")]
+                responseStatus response `shouldBe` status200
+
+        describe "redirectTo" do
+            it "should return status 302" $ withContext do
+                response <- callAction RedirectAction
+                responseStatus response `shouldBe` status302

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -274,3 +274,4 @@ test-suite tests
         Test.FileStorage.ControllerFunctionsSpec
         Test.Controller.CookieSpec
         Test.PGListenerSpec
+        Test.MockingSpec


### PR DESCRIPTION
## Summary

- Add `Test.MockingSpec` with tests for `callActionWithParams` and redirect status codes

These tests verify that:
1. `callActionWithParams` correctly delivers params to controllers (the param value is echoed back in the response body)
2. Controllers that render return status 200
3. Controllers that call `redirectToPath` return status 302

This is a regression test for the bug fixed in #2282, where the `requestBodyMiddleware` optimization silently discarded all params because the mock request used GET method.

## Test plan

- [ ] CI passes (nix flake check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)