### PR TITLE
Add setup instructions to Auto Refresh documentation

### DIFF
--- a/Guide/auto-refresh.markdown
+++ b/Guide/auto-refresh.markdown
@@ -4,6 +4,49 @@
 
 ```
 
+## Setup
+
+Auto Refresh is enabled by default in new IHP applications. If you've disabled it or are setting it up manually, you need these three components:
+
+### 1. Initialize Auto Refresh in FrontController
+
+In your `Web/FrontController.hs`, add `initAutoRefresh` to the `InitControllerContext` instance:
+
+```haskell
+instance InitControllerContext WebApplication where
+    initContext = do
+        setLayout defaultLayout
+        initAutoRefresh  -- Add this line
+```
+
+### 2. Add Meta Tag to Layout
+
+In your `Web/View/Layout.hs`, add `{autoRefreshMeta}` inside the `<head>` section:
+
+```haskell
+metaTags :: Html
+metaTags = [hsx|
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+    {autoRefreshMeta}
+|]
+```
+
+### 3. Include Required JavaScript
+
+In your `Web/View/Layout.hs`, ensure these scripts are included (order matters - morphdom must come before ihp-auto-refresh):
+
+```haskell
+scripts :: Html
+scripts = [hsx|
+        <script src={assetPath "/vendor/morphdom-umd.min.js"}></script>
+        <script src={assetPath "/ihp-auto-refresh.js"}></script>
+        <!-- ... other scripts ... -->
+    |]
+```
+
+Once these three components are in place, you can use `autoRefresh` on your actions.
+
 ## Introduction
 
 Auto Refresh offers a way to re-render views of your application when the underlying data changes. This is useful when you want your views to always reflect the live database state. Auto Refresh can be an easy replacement for manually polling for changes using AJAX.


### PR DESCRIPTION
## Summary
- Add a "Setup" section to the Auto Refresh documentation explaining the three required components:
  1. `initAutoRefresh` in FrontController
  2. `{autoRefreshMeta}` in layout head
  3. `morphdom-umd.min.js` and `ihp-auto-refresh.js` scripts

## Motivation
Auto Refresh is enabled by default in new IHP apps via the boilerplate. However, if someone disables it and later wants to re-enable it, or is setting up an app manually, the documentation didn't explain what components are needed.

This came up when debugging why Auto Refresh wasn't working in an app - it turned out the setup was incomplete because the required steps weren't documented.

## Test plan
- [ ] Review the documentation at Guide/auto-refresh.markdown
- [ ] Verify the setup instructions match what the ApplicationGenerator produces

🤖 Generated with [Claude Code](https://claude.com/claude-code)