### PR TITLE
Fix CSS syntax error in Schema Designer

### DIFF
--- a/ihp-ide/data/static/IDE/schema-designer.css
+++ b/ihp-ide/data/static/IDE/schema-designer.css
@@ -150,7 +150,7 @@
 
 #editor {
     min-height: 800px;
-    background-color: #33555E#33555E
+    background-color: #33555E;
 }
 
 .row-form {


### PR DESCRIPTION
## Summary
- Fixed invalid CSS syntax in `#editor` rule that had a duplicate color value and missing semicolon
- This caused the browser's CSS parser to fail, breaking subsequent style rules

## Test plan
- [ ] Open the IHP IDE Schema Designer in a browser
- [ ] Verify the UI renders correctly with proper contrast and styling
- [ ] Check browser dev tools for CSS parsing errors (should be none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)