### PR TITLE
Add Hasql database patterns reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,248 @@ This is a monorepo with multiple Haskell packages:
 - The framework uses implicit parameters extensively (see `ImplicitParams` extension)
 - HSX uses quasiquotes: `[hsx|<div>content</div>|]`
 
+## Hasql Database Patterns (Reference)
+
+Based on patterns from [hasql-tutorial1](https://github.com/nikita-volkov/hasql-tutorial1). Hasql provides type-safe PostgreSQL access with a layered architecture.
+
+### Module Structure
+
+The tutorial demonstrates a library-oriented structure where database code is isolated into a reusable package:
+
+```
+my-db-library/
+├── my-db-library.cabal
+└── library/
+    └── MyDbLibrary/
+        ├── Prelude.hs      -- Re-exports (rerebase), internal
+        ├── Statement.hs    -- Raw SQL statements, internal
+        ├── Transaction.hs  -- Business logic composition, internal
+        └── Session.hs      -- PUBLIC API (only exposed module)
+```
+
+**Cabal exposure pattern:**
+```cabal
+library
+  exposed-modules:
+    MyDbLibrary.Session           -- Only public module
+  other-modules:
+    MyDbLibrary.Prelude           -- Internal
+    MyDbLibrary.Statement         -- Internal
+    MyDbLibrary.Transaction       -- Internal
+```
+
+**Why this structure?**
+- **Stable API**: Only `Session` is exposed, allowing internal refactoring without breaking consumers
+- **Encapsulation**: Statements and transactions are implementation details
+- **Reusability**: The library can be shared across multiple apps (CLI, REST API, etc.)
+- **Testability**: Each layer can be tested independently
+
+### Import Pattern
+
+```haskell
+-- In Statement.hs (internal)
+module MyDbLibrary.Statement where
+
+import MyDbLibrary.Prelude
+import qualified Hasql.Statement as Hasql
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Decoders as Decoders
+
+-- In Transaction.hs (internal)
+module MyDbLibrary.Transaction where
+
+import MyDbLibrary.Prelude
+import qualified MyDbLibrary.Statement as Statement
+import qualified Hasql.Transaction as Transaction
+
+-- In Session.hs (public API)
+module MyDbLibrary.Session where
+
+import MyDbLibrary.Prelude
+import qualified MyDbLibrary.Transaction as Transaction
+import qualified Hasql.Session as Session
+import qualified Hasql.Transaction.Sessions as Sessions
+```
+
+### Layer 1: Statements (Raw SQL + Codecs)
+
+Statements combine SQL with type-safe encoders/decoders:
+
+```haskell
+import qualified Hasql.Statement as Hasql
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Decoders as Decoders
+
+findUserByEmail :: Hasql.Statement Text (Maybe Int32)
+findUserByEmail =
+  Hasql.Statement sql encoder decoder True
+  where
+    sql = "SELECT id FROM users WHERE email = $1"
+    encoder = Encoders.param (Encoders.nonNullable Encoders.text)
+    decoder = Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.int4))
+
+insertUser :: Hasql.Statement (Text, ByteString, Text, Maybe Text) Int32
+insertUser =
+  Hasql.Statement sql encoder decoder True
+  where
+    sql = "INSERT INTO users (email, password, name, phone) VALUES ($1, $2, $3, $4) RETURNING id"
+    encoder =
+      contramap (\(a,b,c,d) -> (a,(b,(c,d)))) $
+        Encoders.param (Encoders.nonNullable Encoders.text) <>
+        Encoders.param (Encoders.nonNullable Encoders.bytea) <>
+        Encoders.param (Encoders.nonNullable Encoders.text) <>
+        Encoders.param (Encoders.nullable Encoders.text)
+    decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int4))
+
+getUserNotifications :: Hasql.Statement Int32 (Vector (Int32, Text, Bool))
+getUserNotifications =
+  Hasql.Statement sql encoder decoder True
+  where
+    sql = "SELECT id, message, read FROM notifications WHERE user_id = $1"
+    encoder = Encoders.param (Encoders.nonNullable Encoders.int4)
+    decoder = Decoders.rowVector $
+      (,,) <$>
+        Decoders.column (Decoders.nonNullable Decoders.int4) <*>
+        Decoders.column (Decoders.nonNullable Decoders.text) <*>
+        Decoders.column (Decoders.nonNullable Decoders.bool)
+```
+
+Key points:
+- `$1`, `$2` placeholders for parameters (PostgreSQL prepared statements)
+- Encoder maps Haskell tuple → PostgreSQL binary format
+- Decoder maps PostgreSQL result → Haskell type
+- Last `Bool` parameter enables statement caching
+- **Codecs stay with SQL**: Encoders/decoders defined in same module as queries
+
+### Layer 2: Transactions (Business Logic)
+
+Transactions compose statements with atomicity:
+
+```haskell
+import qualified Hasql.Transaction as Transaction
+import qualified Hasql.Transaction.Sessions as Sessions
+
+register :: Text -> ByteString -> Text -> Maybe Text -> Transaction (Bool, Int32)
+register email password name phone = do
+  existingId <- Transaction.statement email Statement.findUserByEmail
+  case existingId of
+    Just id -> pure (False, id)  -- User already existed
+    Nothing -> do
+      newId <- Transaction.statement (email, password, name, phone) Statement.insertUser
+      pure (True, newId)         -- New user created
+```
+
+The `(Bool, Int32)` return type is idempotent: callers know whether the operation created a new record.
+
+**Alternative: Applicative/Selective composition** (for independent operations):
+```haskell
+import Control.Selective (fromMaybeS)
+
+register' :: Text -> ByteString -> Text -> Maybe Text -> Transaction (Bool, Int32)
+register' email password name phone =
+  fromMaybeS
+    (fmap (\newId -> (True, newId)) $
+      Transaction.statement (email, password, name, phone) Statement.insertUser)
+    (fmap (\existingId -> (False, existingId)) $
+      Transaction.statement email Statement.findUserByEmail)
+```
+
+### Layer 3: Sessions (Public API)
+
+Sessions wrap transactions and manage connections:
+
+```haskell
+import qualified Hasql.Session as Session
+import qualified Hasql.Transaction.Sessions as Sessions
+
+-- Using transactions (for multi-statement operations)
+registerUser :: Text -> ByteString -> Text -> Maybe Text -> Session (Bool, Int32)
+registerUser email password name phone =
+  Sessions.transaction Sessions.Write Sessions.Serializable $
+    Transaction.register email password name phone
+
+-- Direct statement (for single-statement operations)
+authenticate :: Text -> ByteString -> Session (Maybe (Bool, Int32))
+authenticate email password =
+  Session.statement (email, password) Statement.authenticateUser
+
+getUserDetails :: Int32 -> Session (Maybe (Text, Text, Maybe Text, Bool))
+getUserDetails userId =
+  Session.statement userId Statement.getUserDetails
+
+getNotifications :: Int32 -> Session (Vector (Int32, Text, Bool))
+getNotifications userId =
+  Session.statement userId Statement.getUserNotifications
+```
+
+Transaction modes:
+- `Write Serializable`: For critical operations (registration, payments) - full isolation
+- `Read ReadCommitted`: For queries - weaker isolation, better concurrency
+
+### Result Type Conventions
+
+| Pattern | Type | Use Case |
+|---------|------|----------|
+| Optional row | `Maybe a` | `SELECT` returning 0 or 1 row |
+| Multiple rows | `Vector a` | `SELECT` returning many rows |
+| Multi-column | `(a, b, c)` | Tuples, not custom wrapper types |
+| Success flag | `Bool` | `UPDATE`/`DELETE` success |
+| Idempotent | `(Bool, a)` | Indicates if operation was performed |
+
+**Why tuples over custom types?**
+- Less boilerplate
+- Results are internal to the library anyway
+- Consumers see semantic Session API, not raw tuples
+
+### Encoder Composition
+
+For multi-parameter statements, compose encoders with `<>`:
+
+```haskell
+-- For (Text, ByteString, Int32)
+encoder =
+  contramap (\(a,b,c) -> (a,(b,c))) $
+    Encoders.param (Encoders.nonNullable Encoders.text) <>
+    Encoders.param (Encoders.nonNullable Encoders.bytea) <>
+    Encoders.param (Encoders.nonNullable Encoders.int4)
+```
+
+The `contramap` restructures the flat tuple into nested pairs for the `<>` combinator.
+
+### Decoder Composition
+
+```haskell
+-- Single optional row with multiple columns
+Decoders.rowMaybe $
+  (,,,) <$>
+    Decoders.column (Decoders.nonNullable Decoders.text) <*>
+    Decoders.column (Decoders.nonNullable Decoders.text) <*>
+    Decoders.column (Decoders.nullable Decoders.text) <*>
+    Decoders.column (Decoders.nonNullable Decoders.bool)
+
+-- Vector of rows (multiple results)
+Decoders.rowVector $
+  (,,) <$>
+    Decoders.column (Decoders.nonNullable Decoders.int4) <*>
+    Decoders.column (Decoders.nonNullable Decoders.text) <*>
+    Decoders.column (Decoders.nonNullable Decoders.bool)
+
+-- Single required row
+Decoders.singleRow $
+  Decoders.column (Decoders.nonNullable Decoders.int4)
+```
+
+### Dependencies
+
+```cabal
+build-depends:
+    hasql >= 1.4 && < 1.5
+  , hasql-transaction >= 0.10 && < 0.11
+  , rerebase >= 1.4 && < 1.5  -- Enhanced prelude with Text, Vector, etc.
+```
+
+Note: `hasql-transaction` is marked experimental but widely used.
+
 ## Key Language Extensions
 
 The codebase uses GHC2021 with these notable extensions:


### PR DESCRIPTION
## Summary
- Add comprehensive Hasql patterns documentation based on hasql-tutorial1
- Document the layered architecture: Statement → Transaction → Session
- Include encoder/decoder composition examples
- Cover transaction modes and result type conventions

## Test plan
- [x] Verify markdown renders correctly
- [x] Code examples are syntactically valid Haskell

🤖 Generated with [Claude Code](https://claude.com/claude-code)