### PR TITLE
Fix context menu width in Schema Designer

### DIFF
--- a/ihp-ide/data/static/IDE/ihp-toolserver-layout.css
+++ b/ihp-ide/data/static/IDE/ihp-toolserver-layout.css
@@ -184,6 +184,7 @@ body, .modal-content {
 .context-menu-open {
     display: block;
     position: fixed;
+    width: fit-content;
 }
 
 /* slightly transparent fallback */


### PR DESCRIPTION
## Summary
- Fix context menu stretching too wide after Bootstrap 5 upgrade
- Add `width: fit-content` to `.context-menu-open` class

## Test plan
- [ ] Open Schema Designer
- [ ] Right-click to open context menu
- [ ] Verify menu fits content width

🤖 Generated with [Claude Code](https://claude.com/claude-code)