### PR TITLE
Fix devserver crash: Add viewLayoutMiddleware to ToolServer

### DIFF
--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -85,6 +85,7 @@ data ToolServerApplicationWithConfig = ToolServerApplicationWithConfig
 -- - methodOverridePost (for PUT/DELETE via POST)
 -- - sessionMiddleware (for session handling)
 -- - approotMiddleware (for app root path)
+-- - viewLayoutMiddleware (for setLayout/getLayout support)
 -- - frameworkConfigMiddleware (for framework config in request vault)
 -- - requestBodyMiddleware (for parsing form params - required for controllers)
 -- - websocket support (for live reload)
@@ -112,6 +113,7 @@ buildToolServerApplication toolServerApplication port liveReloadClients = do
 
     let application =
             methodOverridePost $ sessionMiddleware $ approotMiddleware
+                $ viewLayoutMiddleware
                 $ frameworkConfigMiddleware frameworkConfig
                 $ requestBodyMiddleware frameworkConfig.parseRequestBodyOptions
                 $ Websocket.websocketsOr


### PR DESCRIPTION
## Summary
- Fixes #2299
- Adds `viewLayoutMiddleware` to the ToolServer middleware stack

The ToolServer calls `setLayout` in its `InitControllerContext`, but was missing the `viewLayoutMiddleware` that was added in 6b83d680. This caused the devserver to crash with "viewLayoutMiddleware not installed" when running TablesAction.

## Test plan
- [ ] Start devserver with an IHP project on latest master
- [ ] Verify the Schema Designer loads without crashing

🤖 Generated with [Claude Code](https://claude.ai/code)