### PR TITLE
Fix ambiguous id in FromRowHasql for one-to-many fields

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -191,18 +191,18 @@ tests = do
                 let compileOutput = compileStatementPreview [statement] statement |> Text.strip
 
                 compileOutput `shouldBe` [trimming|
-                    data User'  = User {id :: (Id' "users"), ids :: (Maybe [UUID]), electricityUnitPrice :: Double, meta :: MetaBag} deriving (Eq, Show)
+                    data User' = User {id :: (Id' "users"), ids :: (Maybe [UUID]), electricityUnitPrice :: Double, meta :: MetaBag} deriving (Eq, Show)
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User' 
+                    type User = User'
 
-                    type instance GetTableName (User' ) = "users"
+                    type instance GetTableName (User') = "users"
                     type instance GetModelByTableName "users" = User
 
                     instance Default (Id' "users") where def = Id def
 
-                    instance () => IHP.ModelSupport.Table (User' ) where
+                    instance () => IHP.ModelSupport.Table (User') where
                         tableName = "users"
                         tableNameByteString = Data.Text.Encoding.encodeUtf8 "users"
                         columnNames = ["id","ids","electricity_unit_price"]
@@ -213,7 +213,6 @@ tests = do
 
                     instance InputValue Generated.ActualTypes.User where inputValue = IHP.ModelSupport.recordToInputValue
 
-
                     instance FromRow Generated.ActualTypes.User where
                         fromRow = do
                             id <- field
@@ -221,7 +220,6 @@ tests = do
                             electricityUnitPrice <- field
                             let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
-
 
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = do
@@ -231,8 +229,7 @@ tests = do
                             let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
 
-
-                    type instance GetModelName (User' ) = "User"
+                    type instance GetModelName (User') = "User"
 
                     instance CanCreate Generated.ActualTypes.User where
                         create :: (?modelContext :: ModelContext) => Generated.ActualTypes.User -> IO Generated.ActualTypes.User
@@ -273,18 +270,18 @@ tests = do
                 let compileOutput = compileStatementPreview [statement] statement |> Text.strip
 
                 compileOutput `shouldBe` [trimming|
-                    data User'  = User {id :: (Id' "users"), ids :: (Maybe [UUID]), electricityUnitPrice :: Double, meta :: MetaBag} deriving (Eq, Show)
+                    data User' = User {id :: (Id' "users"), ids :: (Maybe [UUID]), electricityUnitPrice :: Double, meta :: MetaBag} deriving (Eq, Show)
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User' 
+                    type User = User'
 
-                    type instance GetTableName (User' ) = "users"
+                    type instance GetTableName (User') = "users"
                     type instance GetModelByTableName "users" = User
 
                     instance Default (Id' "users") where def = Id def
 
-                    instance () => IHP.ModelSupport.Table (User' ) where
+                    instance () => IHP.ModelSupport.Table (User') where
                         tableName = "users"
                         tableNameByteString = Data.Text.Encoding.encodeUtf8 "users"
                         columnNames = ["id","ids","electricity_unit_price"]
@@ -295,7 +292,6 @@ tests = do
 
                     instance InputValue Generated.ActualTypes.User where inputValue = IHP.ModelSupport.recordToInputValue
 
-
                     instance FromRow Generated.ActualTypes.User where
                         fromRow = do
                             id <- field
@@ -303,7 +299,6 @@ tests = do
                             electricityUnitPrice <- field
                             let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
-
 
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = do
@@ -313,8 +308,7 @@ tests = do
                             let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
 
-
-                    type instance GetModelName (User' ) = "User"
+                    type instance GetModelName (User') = "User"
 
                     instance CanCreate Generated.ActualTypes.User where
                         create :: (?modelContext :: ModelContext) => Generated.ActualTypes.User -> IO Generated.ActualTypes.User
@@ -354,18 +348,18 @@ tests = do
                 let compileOutput = compileStatementPreview [statement] statement |> Text.strip
 
                 compileOutput `shouldBe` [trimming|
-                    data User'  = User {id :: (Id' "users"), ts :: (Maybe TSVector), meta :: MetaBag} deriving (Eq, Show)
+                    data User' = User {id :: (Id' "users"), ts :: (Maybe TSVector), meta :: MetaBag} deriving (Eq, Show)
 
                     type instance PrimaryKey "users" = UUID
 
-                    type User = User' 
+                    type User = User'
 
-                    type instance GetTableName (User' ) = "users"
+                    type instance GetTableName (User') = "users"
                     type instance GetModelByTableName "users" = User
 
                     instance Default (Id' "users") where def = Id def
 
-                    instance () => IHP.ModelSupport.Table (User' ) where
+                    instance () => IHP.ModelSupport.Table (User') where
                         tableName = "users"
                         tableNameByteString = Data.Text.Encoding.encodeUtf8 "users"
                         columnNames = ["id","ts"]
@@ -376,14 +370,12 @@ tests = do
 
                     instance InputValue Generated.ActualTypes.User where inputValue = IHP.ModelSupport.recordToInputValue
 
-
                     instance FromRow Generated.ActualTypes.User where
                         fromRow = do
                             id <- field
                             ts <- field
                             let theRecord = Generated.ActualTypes.User id ts def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
-
 
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = do
@@ -392,8 +384,7 @@ tests = do
                             let theRecord = Generated.ActualTypes.User id ts def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
 
-
-                    type instance GetModelName (User' ) = "User"
+                    type instance GetModelName (User') = "User"
 
                     instance CanCreate Generated.ActualTypes.User where
                         create :: (?modelContext :: ModelContext) => Generated.ActualTypes.User -> IO Generated.ActualTypes.User
@@ -501,20 +492,17 @@ tests = do
 
                     instance InputValue Generated.ActualTypes.LandingPage where inputValue = IHP.ModelSupport.recordToInputValue
 
-
                     instance FromRow Generated.ActualTypes.LandingPage where
                         fromRow = do
                             id <- field
                             let theRecord = Generated.ActualTypes.LandingPage id (QueryBuilder.filterWhere (#landingPageId, id) (QueryBuilder.query @ParagraphCta)) (QueryBuilder.filterWhere (#toLandingPageId, id) (QueryBuilder.query @ParagraphCta)) def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
 
-
                     instance FromRowHasql Generated.ActualTypes.LandingPage where
                         hasqlRowDecoder = do
                             id <- Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
                             let theRecord = Generated.ActualTypes.LandingPage id (QueryBuilder.filterWhere (#landingPageId, id) (QueryBuilder.query @ParagraphCta)) (QueryBuilder.filterWhere (#toLandingPageId, id) (QueryBuilder.query @ParagraphCta)) def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
-
 
                     type instance GetModelName (LandingPage' _ _) = "LandingPage"
 
@@ -755,18 +743,18 @@ tests = do
 
                 -- data Post' has no type parameters, no QueryBuilder field, and userId has concrete type
                 compileOutput `shouldBe` [trimming|
-                    data Post'  = Post {id :: (Id' "posts"), title :: Text, userId :: (Id' "users"), meta :: MetaBag} deriving (Eq, Show)
+                    data Post' = Post {id :: (Id' "posts"), title :: Text, userId :: (Id' "users"), meta :: MetaBag} deriving (Eq, Show)
 
                     type instance PrimaryKey "posts" = UUID
 
-                    type Post = Post' 
+                    type Post = Post'
 
-                    type instance GetTableName (Post' ) = "posts"
+                    type instance GetTableName (Post') = "posts"
                     type instance GetModelByTableName "posts" = Post
 
                     instance Default (Id' "posts") where def = Id def
 
-                    instance () => IHP.ModelSupport.Table (Post' ) where
+                    instance () => IHP.ModelSupport.Table (Post') where
                         tableName = "posts"
                         tableNameByteString = Data.Text.Encoding.encodeUtf8 "posts"
                         columnNames = ["id","title","user_id"]
@@ -777,7 +765,6 @@ tests = do
 
                     instance InputValue Generated.ActualTypes.Post where inputValue = IHP.ModelSupport.recordToInputValue
 
-
                     instance FromRow Generated.ActualTypes.Post where
                         fromRow = do
                             id <- field
@@ -785,7 +772,6 @@ tests = do
                             userId <- field
                             let theRecord = Generated.ActualTypes.Post id title userId def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
-
 
                     instance FromRowHasql Generated.ActualTypes.Post where
                         hasqlRowDecoder = do
@@ -795,8 +781,7 @@ tests = do
                             let theRecord = Generated.ActualTypes.Post id title userId def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
                             pure theRecord
 
-
-                    type instance GetModelName (Post' ) = "Post"
+                    type instance GetModelName (Post') = "Post"
 
                     instance CanCreate Generated.ActualTypes.Post where
                         create :: (?modelContext :: ModelContext) => Generated.ActualTypes.Post -> IO Generated.ActualTypes.Post


### PR DESCRIPTION
## Summary
- Fixes #2302
- Refactors hasql `FromRowHasql` instance from applicative to do-notation style

## Problem
The hasql decoder used applicative style:
```haskell
hasqlRowDecoder = Ward
    <$> Decoders.column ...
    <*> pure (QueryBuilder.filterWhere (#reportId, id) ...)  -- id is ambiguous!
```

The `id` resolved to imported field selectors from multiple tables, causing "Ambiguous occurrence 'id'" errors.

## Solution
Use do-notation (like the postgresql-simple `FromRow` instance):
```haskell
hasqlRowDecoder = do
    id <- Decoders.column ...  -- shadows imported selectors
    ...
    let theRecord = Ward id ... (QueryBuilder.filterWhere (#reportId, id) ...)
    pure theRecord
```

The local binding `id <- ...` shadows imported field selectors, allowing one-to-many QueryBuilders to properly reference the decoded primary key.

## Test plan
- [ ] Build a project with multiple tables that have foreign key relationships
- [ ] Verify no "Ambiguous occurrence 'id'" errors
- [ ] Verify one-to-many relations work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)