### PR TITLE
Fix enum hasql queries failing with operator type mismatch

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -45,9 +45,9 @@ tests = do
                     textToEnumMood :: Text -> Maybe Mood
                     textToEnumMood t = HashMap.lookup t textToEnumMoodMap
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder Mood where
-                        defaultParam = Hasql.Encoders.nonNullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)
+                        defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum inputValue)
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe Mood) where
-                        defaultParam = Hasql.Encoders.nullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)
+                        defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum inputValue)
                 |]
             it "should deal with enums that have no values" do
                 -- https://github.com/digitallyinduced/ihp/issues/1026
@@ -108,9 +108,9 @@ tests = do
                     textToEnumProvince :: Text -> Maybe Province
                     textToEnumProvince t = HashMap.lookup t textToEnumProvinceMap
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder Province where
-                        defaultParam = Hasql.Encoders.nonNullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)
+                        defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum inputValue)
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe Province) where
-                        defaultParam = Hasql.Encoders.nullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)
+                        defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum inputValue)
                 |]
             it "should deal with duplicate enum values" do
                 let enum1 = CreateEnumType { name = "property_type", values = ["APARTMENT", "HOUSE"] }
@@ -138,9 +138,9 @@ tests = do
                     textToEnumPropertyType :: Text -> Maybe PropertyType
                     textToEnumPropertyType t = HashMap.lookup t textToEnumPropertyTypeMap
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder PropertyType where
-                        defaultParam = Hasql.Encoders.nonNullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)
+                        defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum inputValue)
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe PropertyType) where
-                        defaultParam = Hasql.Encoders.nullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)
+                        defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum inputValue)
                 |]
         describe "compileCreate" do
             let statement = StatementCreateTable $ (table "users") {

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -343,7 +343,6 @@ defaultImports = [trimming|
     import qualified Hasql.Decoders as Decoders
     import qualified Hasql.Encoders
     import qualified Hasql.Implicits.Encoders
-    import qualified Data.Functor.Contravariant
     import qualified Hasql.DynamicStatements.Snippet as Snippet
     import qualified Hasql.Pool as HasqlPool
     import IHP.Hasql.Encoders ()
@@ -376,7 +375,6 @@ compileEnums options schema@(Schema statements) = Text.unlines
             import qualified Control.DeepSeq as DeepSeq
             import qualified Hasql.Encoders
             import qualified Hasql.Implicits.Encoders
-            import qualified Data.Functor.Contravariant
             import qualified Data.HashMap.Strict as HashMap
         |]
 
@@ -604,9 +602,9 @@ compileEnumDataDefinitions enum@(CreateEnumType { name, values }) =
         <> "textToEnum" <> modelName <> " t = HashMap.lookup t textToEnum" <> modelName <> "Map\n"
         -- DefaultParamEncoder for hasql queries
         <> "instance Hasql.Implicits.Encoders.DefaultParamEncoder " <> modelName <> " where\n"
-        <> "    defaultParam = Hasql.Encoders.nonNullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)\n"
+        <> "    defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum inputValue)\n"
         <> "instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe " <> modelName <> ") where\n"
-        <> "    defaultParam = Hasql.Encoders.nullable (Data.Functor.Contravariant.contramap inputValue Hasql.Encoders.text)\n"
+        <> "    defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum inputValue)\n"
     where
         modelName = tableNameToModelName name
         valueConstructors = map enumValueToConstructorName values

--- a/ihp/IHP/Job/Queue.hs
+++ b/ihp/IHP/Job/Queue.hs
@@ -20,7 +20,7 @@ import Control.Monad.Trans.Resource
 import IHP.Hasql.FromRow (FromRowHasql(..))
 import qualified Hasql.Encoders as Encoders
 import Hasql.Implicits.Encoders (DefaultParamEncoder(..))
-import Data.Functor.Contravariant (contramap)
+
 import qualified Data.HashMap.Strict as HashMap
 import qualified Hasql.Pool as HasqlPool
 import qualified Hasql.Session as HasqlSession
@@ -304,7 +304,7 @@ textToEnumJobStatus t = HashMap.lookup t textToEnumJobStatusMap
 
 -- | DefaultParamEncoder for hasql queries using JobStatus in filterWhere
 instance DefaultParamEncoder JobStatus where
-    defaultParam = Encoders.nonNullable (contramap inputValue Encoders.text)
+    defaultParam = Encoders.nonNullable (Encoders.enum inputValue)
 
 getHasqlPool :: (?modelContext :: ModelContext) => IO HasqlPool.Pool
 getHasqlPool = case ?modelContext.hasqlPool of


### PR DESCRIPTION
## Summary
- Enum parameters sent via hasql used `Encoders.text`, which tells PostgreSQL the parameter type is `text`. PostgreSQL has no `enum_col = text` operator, so all hasql queries filtering by enum columns fail with "operator does not exist: job_status = text".
- Switched to `Encoders.enum` which sends the value as an untyped string literal, letting PostgreSQL infer the correct enum type from context.
- Applied the fix in both the hardcoded `JobStatus` encoder and the schema compiler's generated `DefaultParamEncoder` instances for all user-defined enums.

## Test plan
- [ ] Verify `SchemaCompilerSpec` tests pass (generated enum code uses `Encoders.enum`)
- [ ] Verify job worker queries with `filterWhere` on `JobStatus` no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)