### PR TITLE
Fix enum hasql queries with explicit SQL type casts

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -45,9 +45,11 @@ tests = do
                     textToEnumMood :: Text -> Maybe Mood
                     textToEnumMood t = HashMap.lookup t textToEnumMoodMap
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder Mood where
-                        defaultParam = Hasql.Encoders.nonNullable (Data.Functor.Contravariant.contramap (Data.Text.Encoding.encodeUtf8 . inputValue) Hasql.Encoders.unknown)
+                        defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum inputValue)
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe Mood) where
-                        defaultParam = Hasql.Encoders.nullable (Data.Functor.Contravariant.contramap (Data.Text.Encoding.encodeUtf8 . inputValue) Hasql.Encoders.unknown)
+                        defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum inputValue)
+                    instance PgEnumCast Mood where pgEnumCast = Snippet.sql "::mood"
+                    instance PgEnumCast (Maybe Mood) where pgEnumCast = Snippet.sql "::mood"
                 |]
             it "should deal with enums that have no values" do
                 -- https://github.com/digitallyinduced/ihp/issues/1026
@@ -108,9 +110,11 @@ tests = do
                     textToEnumProvince :: Text -> Maybe Province
                     textToEnumProvince t = HashMap.lookup t textToEnumProvinceMap
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder Province where
-                        defaultParam = Hasql.Encoders.nonNullable (Data.Functor.Contravariant.contramap (Data.Text.Encoding.encodeUtf8 . inputValue) Hasql.Encoders.unknown)
+                        defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum inputValue)
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe Province) where
-                        defaultParam = Hasql.Encoders.nullable (Data.Functor.Contravariant.contramap (Data.Text.Encoding.encodeUtf8 . inputValue) Hasql.Encoders.unknown)
+                        defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum inputValue)
+                    instance PgEnumCast Province where pgEnumCast = Snippet.sql "::Province"
+                    instance PgEnumCast (Maybe Province) where pgEnumCast = Snippet.sql "::Province"
                 |]
             it "should deal with duplicate enum values" do
                 let enum1 = CreateEnumType { name = "property_type", values = ["APARTMENT", "HOUSE"] }
@@ -138,9 +142,11 @@ tests = do
                     textToEnumPropertyType :: Text -> Maybe PropertyType
                     textToEnumPropertyType t = HashMap.lookup t textToEnumPropertyTypeMap
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder PropertyType where
-                        defaultParam = Hasql.Encoders.nonNullable (Data.Functor.Contravariant.contramap (Data.Text.Encoding.encodeUtf8 . inputValue) Hasql.Encoders.unknown)
+                        defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum inputValue)
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe PropertyType) where
-                        defaultParam = Hasql.Encoders.nullable (Data.Functor.Contravariant.contramap (Data.Text.Encoding.encodeUtf8 . inputValue) Hasql.Encoders.unknown)
+                        defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum inputValue)
+                    instance PgEnumCast PropertyType where pgEnumCast = Snippet.sql "::property_type"
+                    instance PgEnumCast (Maybe PropertyType) where pgEnumCast = Snippet.sql "::property_type"
                 |]
         describe "compileCreate" do
             let statement = StatementCreateTable $ (table "users") {

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -1037,6 +1037,22 @@ withTableReadTracker trackedSection = do
     trackedSection
 
 
+-- | Typeclass for appending SQL type casts to enum parameters in hasql snippets.
+--
+-- PostgreSQL enum types need explicit @::type_name@ casts when parameters are sent as text OID.
+-- Non-enum types use the default instance which appends nothing (mempty).
+--
+-- Generated code produces instances like:
+--
+-- > instance PgEnumCast MyStatus where pgEnumCast = Snippet.sql "::my_status"
+-- > instance PgEnumCast (Maybe MyStatus) where pgEnumCast = Snippet.sql "::my_status"
+class PgEnumCast a where
+    pgEnumCast :: Snippet.Snippet
+    pgEnumCast = mempty
+
+instance {-# OVERLAPPABLE #-} PgEnumCast a where
+    pgEnumCast = mempty
+
 -- | Shorthand filter function
 --
 -- In IHP code bases you often write filter functions such as these:

--- a/ihp/IHP/QueryBuilder/Filter.hs
+++ b/ihp/IHP/QueryBuilder/Filter.hs
@@ -90,8 +90,8 @@ import IHP.Hasql.Encoders () -- Import for DefaultParamEncoder instances
 -- For case-insensitive versions of these operators, see 'filterWhereILike' and 'filterWhereIMatches'.
 --
 -- When your condition is too complex, use a raw sql query with 'IHP.ModelSupport.sqlQuery'.
-filterWhere :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, Table model) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
-filterWhere (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value), applyLeft = Nothing, applyRight = Nothing }
+filterWhere :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, Table model, PgEnumCast value) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhere (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value <> pgEnumCast @value), applyLeft = Nothing, applyRight = Nothing }
     where
         columnName = tableNameByteString @model <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
@@ -107,8 +107,8 @@ filterWhere (name, value) queryBuilderProvider = injectQueryBuilder FilterByQuer
 -- >                    |> fetch
 -- > -- SELECT posts.* FROM posts INNER JOIN users ON posts.created_by = users.id WHERE users.name = 'Tom'
 --
-filterWhereJoinedTable :: forall model name table value queryBuilderProvider joinRegister table'. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister, IsJoined model joinRegister, Table model) => (Proxy name, value) -> queryBuilderProvider table' -> queryBuilderProvider table'
-filterWhereJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value), applyLeft = Nothing, applyRight = Nothing }
+filterWhereJoinedTable :: forall model name table value queryBuilderProvider joinRegister table'. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister, IsJoined model joinRegister, Table model, PgEnumCast value) => (Proxy name, value) -> queryBuilderProvider table' -> queryBuilderProvider table'
+filterWhereJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value <> pgEnumCast @value), applyLeft = Nothing, applyRight = Nothing }
     where
         columnName = tableNameByteString @model <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
@@ -124,8 +124,8 @@ filterWhereJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder F
 -- >                    |> fetch
 -- > -- SELECT posts.* FROM posts INNER JOIN users ON posts.created_by = users.id WHERE LOWER(users.name) = LOWER('Tom')
 --
-filterWhereCaseInsensitiveJoinedTable :: forall model name table value queryBuilderProvider joinRegister table'. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister, IsJoined model joinRegister, Table model) => (Proxy name, value) -> queryBuilderProvider table' -> queryBuilderProvider table'
-filterWhereCaseInsensitiveJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value), applyLeft = Just "LOWER", applyRight = Just "LOWER" }
+filterWhereCaseInsensitiveJoinedTable :: forall model name table value queryBuilderProvider joinRegister table'. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister, IsJoined model joinRegister, Table model, PgEnumCast value) => (Proxy name, value) -> queryBuilderProvider table' -> queryBuilderProvider table'
+filterWhereCaseInsensitiveJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value <> pgEnumCast @value), applyLeft = Just "LOWER", applyRight = Just "LOWER" }
     where
         columnName = tableNameByteString @model <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
@@ -140,8 +140,8 @@ filterWhereCaseInsensitiveJoinedTable (name, value) queryBuilderProvider = injec
 -- >     |> fetch
 -- > -- SELECT * FROM projects WHERE user_id != '23d5ea33-b28e-4f0a-99b3-77a3564a2546'
 --
-filterWhereNot :: forall name table model value. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
-filterWhereNot (name, value) queryBuilder = FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, negateFilterOperator (toEqOrIsOperator value), toField value, Snippet.param value), applyLeft = Nothing, applyRight = Nothing }
+filterWhereNot :: forall name table model value. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, Table model, PgEnumCast value) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereNot (name, value) queryBuilder = FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, negateFilterOperator (toEqOrIsOperator value), toField value, Snippet.param value <> pgEnumCast @value), applyLeft = Nothing, applyRight = Nothing }
     where
         columnName = tableNameByteString @model <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
 {-# INLINE filterWhereNot #-}
@@ -156,8 +156,8 @@ filterWhereNot (name, value) queryBuilder = FilterByQueryBuilder { queryBuilder,
 -- >                    |> fetch
 -- > -- SELECT posts.* FROM posts INNER JOIN users ON posts.created_by = users.id WHERE users.name = 'Tom'
 --
-filterWhereNotJoinedTable :: forall model name table value queryBuilderProvider joinRegister table'. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister, IsJoined model joinRegister, Table model) => (Proxy name, value) -> queryBuilderProvider table' -> queryBuilderProvider table'
-filterWhereNotJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, negateFilterOperator (toEqOrIsOperator value), toField value, Snippet.param value), applyLeft = Nothing, applyRight = Nothing }
+filterWhereNotJoinedTable :: forall model name table value queryBuilderProvider joinRegister table'. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, table ~ GetTableName model, HasQueryBuilder queryBuilderProvider joinRegister, IsJoined model joinRegister, Table model, PgEnumCast value) => (Proxy name, value) -> queryBuilderProvider table' -> queryBuilderProvider table'
+filterWhereNotJoinedTable (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, negateFilterOperator (toEqOrIsOperator value), toField value, Snippet.param value <> pgEnumCast @value), applyLeft = Nothing, applyRight = Nothing }
     where
         columnName = tableNameByteString @model <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider
@@ -613,8 +613,8 @@ filterWhereSql (name, sqlCondition) queryBuilderProvider = injectQueryBuilder Fi
 --
 -- >>> CREATE UNIQUE INDEX users_email_index ON users ((LOWER(email)));
 --
-filterWhereCaseInsensitive :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, Table model) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
-filterWhereCaseInsensitive (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value), applyLeft = Just "LOWER", applyRight = Just "LOWER" }
+filterWhereCaseInsensitive :: forall name table model value queryBuilderProvider joinRegister. (KnownSymbol table, KnownSymbol name, ToField value, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, HasQueryBuilder queryBuilderProvider joinRegister, Table model, PgEnumCast value) => (Proxy name, value) -> queryBuilderProvider table -> queryBuilderProvider table
+filterWhereCaseInsensitive (name, value) queryBuilderProvider = injectQueryBuilder FilterByQueryBuilder { queryBuilder, queryFilter = (columnName, toEqOrIsOperator value, toField value, Snippet.param value <> pgEnumCast @value), applyLeft = Just "LOWER", applyRight = Just "LOWER" }
     where
         columnName = tableNameByteString @model <> "." <> Text.encodeUtf8 (fieldNameToColumnName (symbolToText @name))
         queryBuilder = getQueryBuilder queryBuilderProvider


### PR DESCRIPTION
## Summary

- Fixes `operator does not exist: job_status = text` errors when using hasql prepared statements with PostgreSQL enum columns
- Adds `PgEnumCast` typeclass that appends `::type_name` SQL casts to enum parameters, with an overlappable default instance (mempty) for non-enum types
- Generates `PgEnumCast` and `PgEnumCast (Maybe _)` instances for user-defined enums in `SchemaCompiler`
- Adds `::job_status` casts to all 5 hardcoded `Snippet.param JobStatus*` sites in `Queue.hs`
- Switches enum `DefaultParamEncoder` from `Encoders.unknown` to cleaner `Encoders.enum inputValue`

## Test plan

- [x] All modified modules compile in ghci
- [x] Test expectations updated in `SchemaCompilerSpec.hs`
- [ ] Run full test suite (`echo -e ':l ihp-ide/Test/Main.hs\nmain' | ghci` — blocked by pre-existing `hasql-notifications` missing package)
- [ ] Manual test: create an IHP app with an enum column, verify `filterWhere (#status, MyEnum)` works via hasql

🤖 Generated with [Claude Code](https://claude.com/claude-code)