### PR TITLE
Fix white background on data rows table

### DIFF
--- a/ihp-ide/data/static/IDE/table.css
+++ b/ihp-ide/data/static/IDE/table.css
@@ -9,7 +9,10 @@ thead > tr {
 }
 
 .table {
-    color:  #fff;
+    --bs-table-bg: transparent;
+    --bs-table-color: #fff;
+    --bs-table-hover-bg: hsla(192, 81%, 26%, 0.25);
+    color: #fff;
 }
 
 /* Override Bootstrap's .table>:not(caption)>*>* which resets color on cells */


### PR DESCRIPTION
## Summary
- Bootstrap 5.3 changed `--bs-table-bg` from `transparent` to `var(--bs-body-bg)` (white), causing data rows in the database view to have white backgrounds instead of the dark theme
- Override `--bs-table-bg`, `--bs-table-color`, and `--bs-table-hover-bg` CSS variables on `.table` to restore transparent backgrounds

## Test plan
- [ ] Open the IHP IDE, navigate to the Database tab
- [ ] Select a table with data rows
- [ ] Verify rows have transparent backgrounds (dark theme visible)
- [ ] Verify hover highlighting still works with the teal color

🤖 Generated with [Claude Code](https://claude.com/claude-code)