### PR TITLE
Fix hasqlRowDecoder for hasql 1.10 (Applicative, not Monad)

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -218,12 +218,10 @@ tests = do
                             pure theRecord
 
                     instance FromRowHasql Generated.ActualTypes.User where
-                        hasqlRowDecoder = do
-                            id <- Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
-                            ids <- Decoders.column (Decoders.nullable (Decoders.listArray (Decoders.nonNullable Decoders.uuid)))
-                            electricityUnitPrice <- Decoders.column (Decoders.nonNullable Decoders.float8)
-                            let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
-                            pure theRecord
+                        hasqlRowDecoder = (\id ids electricityUnitPrice -> let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            <$> Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
+                            <*> Decoders.column (Decoders.nullable (Decoders.listArray (Decoders.nonNullable Decoders.uuid)))
+                            <*> Decoders.column (Decoders.nonNullable Decoders.float8)
 
                     type instance GetModelName (User') = "User"
 
@@ -350,12 +348,10 @@ tests = do
                             pure theRecord
 
                     instance FromRowHasql Generated.ActualTypes.User where
-                        hasqlRowDecoder = do
-                            id <- Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
-                            ids <- Decoders.column (Decoders.nullable (Decoders.listArray (Decoders.nonNullable Decoders.uuid)))
-                            electricityUnitPrice <- Decoders.column (Decoders.nonNullable Decoders.float8)
-                            let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
-                            pure theRecord
+                        hasqlRowDecoder = (\id ids electricityUnitPrice -> let theRecord = Generated.ActualTypes.User id ids electricityUnitPrice def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            <$> Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
+                            <*> Decoders.column (Decoders.nullable (Decoders.listArray (Decoders.nonNullable Decoders.uuid)))
+                            <*> Decoders.column (Decoders.nonNullable Decoders.float8)
 
                     type instance GetModelName (User') = "User"
 
@@ -480,11 +476,9 @@ tests = do
                             pure theRecord
 
                     instance FromRowHasql Generated.ActualTypes.User where
-                        hasqlRowDecoder = do
-                            id <- Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
-                            ts <- Decoders.column (Decoders.nullable (Decoders.refine parseTSVectorText Decoders.bytea))
-                            let theRecord = Generated.ActualTypes.User id ts def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
-                            pure theRecord
+                        hasqlRowDecoder = (\id ts -> let theRecord = Generated.ActualTypes.User id ts def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            <$> Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
+                            <*> Decoders.column (Decoders.nullable (Decoders.refine parseTSVectorText Decoders.bytea))
 
                     type instance GetModelName (User') = "User"
 
@@ -646,10 +640,8 @@ tests = do
                             pure theRecord
 
                     instance FromRowHasql Generated.ActualTypes.LandingPage where
-                        hasqlRowDecoder = do
-                            id <- Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
-                            let theRecord = Generated.ActualTypes.LandingPage id (QueryBuilder.filterWhere (#landingPageId, id) (QueryBuilder.query @ParagraphCta)) (QueryBuilder.filterWhere (#toLandingPageId, id) (QueryBuilder.query @ParagraphCta)) def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
-                            pure theRecord
+                        hasqlRowDecoder = (\id -> let theRecord = Generated.ActualTypes.LandingPage id (QueryBuilder.filterWhere (#landingPageId, id) (QueryBuilder.query @ParagraphCta)) (QueryBuilder.filterWhere (#toLandingPageId, id) (QueryBuilder.query @ParagraphCta)) def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            <$> Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
 
                     type instance GetModelName (LandingPage' _ _) = "LandingPage"
 
@@ -952,12 +944,10 @@ tests = do
                             pure theRecord
 
                     instance FromRowHasql Generated.ActualTypes.Post where
-                        hasqlRowDecoder = do
-                            id <- Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
-                            title <- Decoders.column (Decoders.nonNullable Decoders.text)
-                            userId <- Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
-                            let theRecord = Generated.ActualTypes.Post id title userId def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }
-                            pure theRecord
+                        hasqlRowDecoder = (\id title userId -> let theRecord = Generated.ActualTypes.Post id title userId def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            <$> Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
+                            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                            <*> Decoders.column (Decoders.nonNullable (Id <$> Decoders.uuid))
 
                     type instance GetModelName (Post') = "Post"
 


### PR DESCRIPTION
## Summary
- hasql 1.10's `Decoders.Row` is `Applicative` but not `Monad`, so the generated do-notation (which desugars to `>>=`) fails with `No instance for 'Monad Decoders.Row'`
- Switch `compileFromRowHasqlInstance` code generation from do-notation to applicative style using `<$>`/`<*>` with a lambda to bind column values
- Update all test expectations to match the new applicative output

## Test plan
- [x] `SchemaCompiler.hs` compiles with hasql 1.10.2
- [x] All 359 tests pass (0 failures)
- [x] Key modules compile: `Job/Queue.hs`, `QueryBuilder/Filter.hs`, `ModelSupport.hs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)