### PR TITLE
Fix enum column decoder OID mismatch with hasql 1.10

### DIFF
--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -1144,7 +1144,7 @@ hasqlValueDecoder = \case
     PInet -> "(Decoders.refine (\\t -> maybe (Left \"Invalid IP\") Right (Net.IP.decode t)) Decoders.text)"
     PTSVector -> "(Decoders.refine parseTSVectorText Decoders.bytea)"
     PArray innerType -> "(Decoders.listArray (" <> hasqlArrayElementDecoder innerType <> "))"
-    PCustomType typeName -> "(Decoders.refine (\\t -> maybe (Left (\"Invalid enum value: \" <> t)) Right (textToEnum" <> tableNameToModelName typeName <> " t)) Decoders.text)"
+    PCustomType typeName -> "(Decoders.enum (Just \"public\") " <> tshow typeName <> " textToEnum" <> tableNameToModelName typeName <> ")"
     PSingleChar -> "Decoders.char"
     PTrigger -> "Decoders.text"  -- Trigger types shouldn't appear in table columns
     PEventTrigger -> "Decoders.text"  -- Event trigger types shouldn't appear in table columns


### PR DESCRIPTION
## Summary
- hasql 1.10 validates column type OIDs when decoding
- Enum columns were decoded with `Decoders.text` (expects OID 25/text), but enum columns have custom OIDs (e.g. 16550), causing `UnexpectedColumnTypeStatementError`
- Changed `hasqlValueDecoder` for `PCustomType` to use `Decoders.enum` which resolves the correct OID for the enum type, matching the `Encoders.enum` approach already used on the encoder side

## Test plan
- [x] SchemaCompiler compiles
- [x] All 359 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)