### PR TITLE
docs(hsx): use {component @Counter} in SSC guide

### DIFF
--- a/Guide/server-side-components.markdown
+++ b/Guide/server-side-components.markdown
@@ -125,13 +125,11 @@ instance View WelcomeView where
     html WelcomeView = [hsx|
         <h1>Counter</h1>
 
-        {counter}
+        {component @Counter}
     |]
-        where
-            counter = component @Counter
 ```
 
-If you wonder why we're using the `where` instead of writing [`{component @Counter}`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-ViewFunctions.html#v:component): Currently the at-symbol `@` is not supported in HSX expressions.
+If this does not compile in your project, make sure `TypeApplications` is enabled for the module (e.g. add `{-# LANGUAGE TypeApplications #-}` at the top). In current IHP versions, HSX splices support type applications like `@Counter`.
 
 We also need to load the `ihp-ssc.js` from our `Layout.hs`. Open the `Web/View/Layout.hs` and add `<script src="/vendor/ihp-ssc.js"></script>` inside your `scripts` section:
 

--- a/ihp-hsx/Test/IHP/HSX/QQSpec.hs
+++ b/ihp-hsx/Test/IHP/HSX/QQSpec.hs
@@ -40,6 +40,9 @@ tests = do
             let project = Project { name = "Testproject" }
             [hsx|<h1>Project: {project.name}</h1>|] `shouldBeSameHtml` "<h1>Project: Testproject</h1>"
 
+        it "should support TypeApplications inside spliced expressions" do
+            [hsx|<h1>{show (id @Int 1)}</h1>|] `shouldBeSameHtml` "<h1>1</h1>"
+
         it "should support lambdas and pattern matching on constructors" do
             let placeData = PlaceId "Punches Cross"
             [hsx|<h1>{(\(PlaceId x) -> x)(placeData)}</h1>|] `shouldBeSameHtml` "<h1>Punches Cross</h1>"


### PR DESCRIPTION
The SSC guide currently claims that HSX splices cannot use type applications (e.g. {component @Counter}).

This PR updates Guide/server-side-components.markdown to use {component @Counter} directly and adds a regression test to ihp-hsx to ensure TypeApplications inside HSX splices work (e.g. {show (id @Int 1)}).

If users still hit compile errors, they likely need to enable the TypeApplications extension in their module.