### PR TITLE
Tune GC settings for dev server to reduce request latency spikes

### DIFF
--- a/ihp-ide/exe/IHP/IDE/DevServer.hs
+++ b/ihp-ide/exe/IHP/IDE/DevServer.hs
@@ -149,7 +149,7 @@ ghciArguments =
     , "-package-env -" -- Do not load `~/.ghc/arch-os-version/environments/name file`, global packages interfere with our packages
     , "-ignore-dot-ghci" -- Ignore the global ~/.ghc/ghci.conf That file sometimes causes trouble (specifically `:set +c +s`)
     , "-ghci-script", ".ghci" -- Because the previous line ignored default ghci config file locations, we have to manual load our .ghci
-    , "+RTS", "-A128m", "-n2m", "-H2m", "--nonmoving-gc", "-N"
+    , "+RTS", "-A256m", "-n4m", "-H512m", "--nonmoving-gc", "-Iw60", "-N"
     ]
 
 withGHCI :: (?context :: Context) => (Handle -> Handle -> Handle -> Process.ProcessHandle -> IO a) -> IO a

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -236,9 +236,15 @@ executable RunDevServer
     build-depends: ihp, ihp-log, ihp-ide, ihp-schema-compiler
     hs-source-dirs: exe
     main-is: IHP/IDE/DevServer.hs
+    ghc-options: -rtsopts=all
     if flag(FastBuild)
         ghc-options:
             -threaded
+            -with-rtsopts=-A512m
+            -with-rtsopts=-N
+            -with-rtsopts=-n4m
+            -with-rtsopts=--nonmoving-gc
+            -with-rtsopts=-Iw60
             +RTS -A512m -n4m -H512m -G3 -qg -N -RTS
             -Wno-ambiguous-fields
             -Werror=incomplete-patterns
@@ -260,6 +266,7 @@ executable RunDevServer
             -with-rtsopts=-N
             -with-rtsopts=-n4m
             -with-rtsopts=--nonmoving-gc
+            -with-rtsopts=-Iw60
             +RTS -A256m -n4m -H512m -G3 -qg -N -RTS
             -Wno-ambiguous-fields
             -Werror=incomplete-patterns


### PR DESCRIPTION
## Summary

- **GHCi subprocess** (user's app): increase nursery (`-A256m`), chunk size (`-n4m`), heap suggestion (`-H512m`), and add `-Iw60` to prevent idle GC from causing a latency spike on the first request after a pause
- **RunDevServer FastBuild**: add `-with-rtsopts` flags (previously missing entirely, so the binary ran with GHC defaults instead of nonmoving-gc and tuned allocation)
- **RunDevServer both modes**: add `-Iw60` idle GC delay and `-rtsopts=all` for runtime tuning via `GHCRTS` env var

## Test plan

- [x] Type-check passes (`echo ':l ihp-ide/exe/IHP/IDE/DevServer.hs' | ghci` — 183 modules loaded)
- [ ] `devenv up`, make requests, let it idle >1s, make another request — first-after-idle should no longer spike
- [ ] Build with FastBuild flag, verify RunDevServer uses nonmoving-gc (`+RTS --info`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)