### PR TITLE
Fix remaining Bootstrap 5 compatibility issues in IDE

### DIFF
--- a/ihp-ide/IHP/IDE/Data/View/EditRow.hs
+++ b/ihp-ide/IHP/IDE/Data/View/EditRow.hs
@@ -79,7 +79,7 @@ instance View EditRowView where
                                 id={def.columnName <> "-alt"}
                                 type="text"
                                 name={def.columnName}
-                                class="form-control text-monospace text-secondary bg-light"
+                                class="form-control font-monospace text-secondary bg-light"
                                 value="NULL"
                                 />
                             <div class="form-control" id={def.columnName <> "-boxcontainer"}>
@@ -125,7 +125,7 @@ instance View EditRowView where
                                 id={def.columnName <> "-alt"}
                                 type="text"
                                 name={def.columnName <> "-inactive"}
-                                class="form-control text-monospace text-secondary bg-light d-none"
+                                class="form-control font-monospace text-secondary bg-light d-none"
                                 />
                             <div class="form-control" id={def.columnName <> "-boxcontainer"}>
                                 <input
@@ -169,7 +169,7 @@ instance View EditRowView where
                                 id={def.columnName <> "-input"}
                                 type="text"
                                 name={def.columnName}
-                                class={classes ["form-control", ("text-monospace text-secondary bg-light", isSqlFunction_ (value val))]}
+                                class={classes ["form-control", ("font-monospace text-secondary bg-light", isSqlFunction_ (value val))]}
                                 value={value val}
                                 oninput={"stopSqlModeOnInput('" <> def.columnName <> "')"}
                                 />

--- a/ihp-ide/IHP/IDE/Data/View/NewRow.hs
+++ b/ihp-ide/IHP/IDE/Data/View/NewRow.hs
@@ -71,7 +71,7 @@ instance View NewRowView where
                                 id={col.columnName <> "-alt"}
                                 type="text"
                                 name={col.columnName <> "-inactive"}
-                                class="form-control text-monospace text-secondary d-none"
+                                class="form-control font-monospace text-secondary d-none"
                                 />
                             <div class="form-control" id={col.columnName <> "-boxcontainer"}>
                                 <input
@@ -148,7 +148,7 @@ instance View NewRowView where
                                             id={col.columnName <> "-input"}
                                             type="text"
                                             name={col.columnName}
-                                            class={classes ["form-control", ("text-monospace", isSqlFunction (getColDefaultValue col)), ("is-foreign-key-column", isForeignKeyColumn)]}
+                                            class={classes ["form-control", ("font-monospace", isSqlFunction (getColDefaultValue col)), ("is-foreign-key-column", isForeignKeyColumn)]}
                                             value={renderDefaultWithoutType (getColDefaultValue col)}
                                             oninput={"stopSqlModeOnInput('" <> col.columnName <> "')"}
                                         />

--- a/ihp-ide/data/static/IDE/form.css
+++ b/ihp-ide/data/static/IDE/form.css
@@ -57,29 +57,22 @@
     background-color: hsl(192deg 100% 26% / 50%) !important;
 }
 
-.custom-control-label::before {
+.form-check-input {
     background-color: #002b36;
     border: 1px solid hsl(192deg 100% 30% / 50%);
 }
 
-.custom-checkbox .custom-control-input:checked~.custom-control-label::after {
-    top: 1px;
-}
-
-.custom-control-input:checked~.custom-control-label::before {
-    background-color:#519f98;
+.form-check-input:checked {
+    background-color: #519f98;
     border-color: #519f98;
 }
 
-.custom-control-input:focus~.custom-control-label::before {
+.form-check-input:focus {
     box-shadow: none !important;
-}
-
-.custom-control-input:focus:not(:checked)~.custom-control-label::before {
     border-color: #519f98;
 }
 
-.custom-control-label {
+.form-check-label {
     user-select: none;
     -webkit-user-select: none;
 }

--- a/ihp-ide/data/static/IDE/ihp-help.js
+++ b/ihp-ide/data/static/IDE/ihp-help.js
@@ -1,11 +1,14 @@
-$(function () {
-    $('#nav-help').popover({
+document.addEventListener('turbolinks:load', function () {
+    var navHelp = document.getElementById('nav-help');
+    if (!navHelp) return;
+
+    new bootstrap.Popover(navHelp, {
         container: '#content',
         html: true,
         content: document.getElementById('help-content').innerHTML,
     });
 
-    document.getElementById('nav-help').addEventListener('click', event => {
+    navHelp.addEventListener('click', function (event) {
         event.preventDefault();
-    })
-})
+    });
+});

--- a/ihp-ide/data/static/IDE/ihp-schemadesigner.js
+++ b/ihp-ide/data/static/IDE/ihp-schemadesigner.js
@@ -187,7 +187,11 @@ function initCodeEditor() {
 }
 
 function initTooltip() {
-    $('[data-bs-toggle="tooltip"]').tooltip('dispose').tooltip({ container: 'body'});
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+        var existing = bootstrap.Tooltip.getInstance(el);
+        if (existing) existing.dispose();
+        new bootstrap.Tooltip(el, { container: 'body' });
+    });
 }
 
 document.addEventListener('turbolinks:load', initSchemaDesigner);
@@ -249,7 +253,7 @@ function sqlModeCheckbox(id, checkbox, isBoolean) {
 function setSqlMode(id, sqlMode) {
     var inputField = document.getElementById(id + "-input");
     if (sqlMode) {
-        inputField.className = "form-control text-monospace text-secondary bg-light"
+        inputField.className = "form-control font-monospace text-secondary bg-light"
     } else {
         inputField.className = "form-control";
     }
@@ -270,7 +274,7 @@ function setCheckboxSqlMode(id, sqlMode) {
         inputField.className = "d-none";
         inputField.name = id + "-inactive";
         hiddenField.name = id + "-inactive";
-        altField.className = "form-control text-monospace text-secondary bg-light";
+        altField.className = "form-control font-monospace text-secondary bg-light";
         altField.name = id;
         checkBoxContainer.className = "d-none";
         

--- a/ihp-ide/data/static/IDE/ihp-toolserver-layout.css
+++ b/ihp-ide/data/static/IDE/ihp-toolserver-layout.css
@@ -293,7 +293,7 @@ body, .modal-content {
     color: #fdf6e3;
 }
 
-.border, .border-left, .border-bottom, .border-right, .border-top {
+.border, .border-start, .border-bottom, .border-end, .border-top {
     border-color: #0A4151 !important;
 }
 
@@ -401,6 +401,6 @@ a, a:hover {
     background-color: hsl(193deg 80% 6%);
 }
 
-.bs-popover-auto[x-placement^=right]>.arrow::after, .bs-popover-right>.arrow::after {
+.bs-popover-auto[data-popper-placement^="right"]>.popover-arrow::after, .bs-popover-end>.popover-arrow::after {
     border-right-color: #0B5163;
 }

--- a/ihp-ide/data/static/IDE/schema-designer.css
+++ b/ihp-ide/data/static/IDE/schema-designer.css
@@ -311,14 +311,10 @@
     font-size: 12px;
 }
 
-#column-options .custom-control {
+#column-options .form-check {
     display: flex;
     justify-content: center;
     align-items: center;
-}
-
-#column-options .custom-control-label::before {
-    top: 1px;
 }
 
 #editor .code-editor-container {

--- a/ihp-ide/data/static/IDE/tooltip.css
+++ b/ihp-ide/data/static/IDE/tooltip.css
@@ -12,7 +12,7 @@
 
     box-shadow: 0 1rem 3rem rgba(0,0,0,.175)!important;
 }
-.tooltip .arrow {
+.tooltip .tooltip-arrow {
     display: none;
 }
 


### PR DESCRIPTION
## Summary
- Replace Bootstrap 4 `.custom-control*` CSS selectors with Bootstrap 5 `.form-check*` equivalents, fixing unstyled/white checkboxes in the schema designer and data editor
- Migrate jQuery `.popover()` and `.tooltip()` calls to native Bootstrap 5 JS API (`new bootstrap.Popover()` / `new bootstrap.Tooltip()`)
- Update renamed CSS classes: `text-monospace` → `font-monospace`, `.arrow` → `.tooltip-arrow`/`.popover-arrow`, `.border-left`/`.border-right` → `.border-start`/`.border-end`, popover placement selectors for Popper.js v2

## Test plan
- [ ] Verify checkboxes in Schema Designer (Edit Column modal) render with solarized dark theme styling
- [ ] Verify checkboxes in Data Editor (New Row / Edit Row modals) render correctly for boolean columns
- [ ] Verify tooltips still appear on hover in schema designer
- [ ] Verify help popover opens when clicking the help nav item
- [ ] Verify SQL mode styling (monospace font) works in data editor form fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)