### PR TITLE
Migrate ihp-ide Data Controller from postgresql-simple to hasql

### DIFF
--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -10,14 +10,20 @@ import IHP.IDE.Data.View.EditRow
 import IHP.IDE.Data.View.EditValue
 import IHP.IDE.Data.View.ShowForeignKeyHoverCard
 
-import qualified Database.PostgreSQL.Simple as PG
-import qualified Database.PostgreSQL.Simple.FromField as PG
-import qualified Database.PostgreSQL.Simple.FromRow as PG
-import qualified Database.PostgreSQL.Simple.ToField as PG
-import qualified Database.PostgreSQL.Simple.Types as PG
+import qualified Hasql.Connection as Hasql
+import qualified Hasql.Connection.Settings as HasqlSettings
+import qualified Hasql.Session as Session
+import qualified Hasql.Errors as HasqlErrors
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.DynamicStatements.Snippet as Snippet
+import Hasql.DynamicStatements.Snippet (Snippet)
 import qualified Data.Text as T
-import qualified Data.ByteString.Builder
-import Control.Exception (bracket)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.List as List
+import qualified Control.Exception.Safe as Exception
+import Data.Int (Int64)
 
 instance Controller DataController where
     action ShowDatabaseAction = do
@@ -48,23 +54,33 @@ instance Controller DataController where
         when (isEmpty queryText) do
             redirectTo NewQueryAction
 
-        let query = fromString $ cs queryText
-
-        queryResult :: Maybe (Either PG.SqlError SqlConsoleResult) <- withAppDb \connection ->
-            Just <$> if isQuery queryText then
-                    (Right . SelectQueryResult <$> PG.query_ connection query) `catch` (pure . Left)
-                else
-                    (Right . InsertOrUpdateResult <$> PG.execute_ connection query) `catch` (pure . Left)
+        queryResult :: Maybe (Either SqlConsoleError SqlConsoleResult) <- withAppDb \connection ->
+            Just <$> if isQuery queryText then do
+                    let snippet = wrapDynamicQuery (Snippet.sql (cs queryText))
+                    let statement = Snippet.toStatement snippet dynamicFieldDecoder
+                    let session = Session.statement () statement
+                    result <- Hasql.use connection session
+                    case result of
+                        Right rows -> pure (Right (SelectQueryResult rows))
+                        Left err -> pure (Left (sessionErrorToConsoleError err))
+                else do
+                    let statement = Snippet.toStatement (Snippet.sql (cs queryText)) Decoders.rowsAffected
+                    let session = Session.statement () statement
+                    result <- Hasql.use connection session
+                    case result of
+                        Right count -> pure (Right (InsertOrUpdateResult count))
+                        Left err -> pure (Left (sessionErrorToConsoleError err))
 
         render ShowQueryView { .. }
 
     action DeleteEntryAction { primaryKey, tableName } = do
         withAppDb \connection -> do
-            tableNames <- fetchTableNames connection
             primaryKeyFields <- tablePrimaryKeyFields connection tableName
             let primaryKeyValues = T.splitOn "---" primaryKey
-            let query = "DELETE FROM " <> tableName <> " WHERE " <> intercalate " AND " ((<> " = ?") <$> primaryKeyFields)
-            PG.execute connection (PG.Query . cs $! query) primaryKeyValues
+            let whereClause = mconcat $ List.intersperse (Snippet.sql " AND ") $
+                    zipWith (\field val -> quoteIdentifier field <> Snippet.sql " = " <> Snippet.param val) primaryKeyFields primaryKeyValues
+            let snippet = Snippet.sql "DELETE FROM " <> quoteIdentifier tableName <> Snippet.sql " WHERE " <> whereClause
+            runSnippetExec connection snippet
         redirectTo ShowTableRowsAction { .. }
 
     action NewRowAction { tableName } = do
@@ -78,11 +94,10 @@ instance Controller DataController where
     action CreateRowAction = do
         let tableName = param "tableName"
         withAppDb \connection -> do
-            tableNames <- fetchTableNames connection
             tableCols <- fetchTableCols connection tableName
-            let values :: [PG.Action] = map (\col -> parseValues (param @Bool (cs (col.columnName) <> "_")) (param @Bool (cs (col.columnName) <> "-isBoolean")) (param @Text (cs (col.columnName)))) tableCols
-            let query = "INSERT INTO " <> tableName <> " VALUES (" <> intercalate "," (map (const "?") values) <> ")"
-            PG.execute connection (PG.Query . cs $! query) values
+            let values :: [Snippet] = map (\col -> parseValues (param @Bool (cs (col.columnName) <> "_")) (param @Bool (cs (col.columnName) <> "-isBoolean")) (param @Text (cs (col.columnName)))) tableCols
+            let snippet = Snippet.sql "INSERT INTO " <> quoteIdentifier tableName <> Snippet.sql " VALUES (" <> (mconcat $ List.intersperse (Snippet.sql ", ") values) <> Snippet.sql ")"
+            runSnippetExec connection snippet
         redirectTo ShowTableRowsAction { .. }
 
     action EditRowAction { tableName, targetPrimaryKey } = do
@@ -92,7 +107,7 @@ instance Controller DataController where
             rows <- fetchRows connection tableName
             tableCols <- fetchTableCols connection tableName
             let targetPrimaryKeyValues = T.splitOn "---" targetPrimaryKey
-            values <- fetchRow connection (cs tableName) targetPrimaryKeyValues
+            values <- fetchRow connection tableName targetPrimaryKeyValues
             let (Just rowValues) = head values
             pure (tableNames, primaryKeyFields, rows, tableCols, rowValues)
         render EditRowView { .. }
@@ -100,16 +115,19 @@ instance Controller DataController where
     action UpdateRowAction = do
         let tableName = param "tableName"
         withAppDb \connection -> do
-            tableNames <- fetchTableNames connection
             tableCols <- fetchTableCols connection tableName
             primaryKeyFields <- tablePrimaryKeyFields connection tableName
 
-            let values :: [PG.Action] = map (\col -> parseValues (param @Bool (cs (col.columnName) <> "_")) (param @Bool (cs (col.columnName) <> "-isBoolean")) (param @Text (cs (col.columnName)))) tableCols
-            let columns :: [Text] = map (\col -> cs (col.columnName)) tableCols
-            let primaryKeyValues = map (\pkey -> "'" <> (param @Text (cs pkey <> "-pk")) <> "'") primaryKeyFields
+            let values :: [Snippet] = map (\col -> parseValues (param @Bool (cs (col.columnName) <> "_")) (param @Bool (cs (col.columnName) <> "-isBoolean")) (param @Text (cs (col.columnName)))) tableCols
+            let columns :: [Text] = map (\col -> col.columnName) tableCols
 
-            let query = "UPDATE " <> tableName <> " SET " <> intercalate ", " (updateValues (zip columns (map (const "?") values))) <> " WHERE " <> intercalate " AND " (updateValues (zip primaryKeyFields primaryKeyValues))
-            PG.execute connection (PG.Query . cs $! query) values
+            let setClause = mconcat $ List.intersperse (Snippet.sql ", ") $
+                    zipWith (\col val -> quoteIdentifier col <> Snippet.sql " = " <> val) columns values
+            let whereClause = mconcat $ List.intersperse (Snippet.sql " AND ") $
+                    map (\pkey -> quoteIdentifier pkey <> Snippet.sql " = " <> Snippet.param (param @Text (cs pkey <> "-pk"))) primaryKeyFields
+
+            let snippet = Snippet.sql "UPDATE " <> quoteIdentifier tableName <> Snippet.sql " SET " <> setClause <> Snippet.sql " WHERE " <> whereClause
+            runSnippetExec connection snippet
         redirectTo ShowTableRowsAction { .. }
 
     action EditRowValueAction { tableName, targetName, id } = do
@@ -124,29 +142,28 @@ instance Controller DataController where
         let id :: String = cs (param @Text "id")
         let tableName = param "tableName"
         withAppDb \connection -> do
-            tableNames <- fetchTableNames connection
-            tableCols <- fetchTableCols connection tableName
             primaryKeyFields <- tablePrimaryKeyFields connection tableName
-            let targetPrimaryKeyValues = PG.Escape . cs <$> T.splitOn "---" targetPrimaryKey
-            let query = PG.Query . cs $! "UPDATE ? SET ? = NOT ? WHERE " <> intercalate " AND " ((<> " = ?") <$> primaryKeyFields)
-            let params = [PG.toField $ PG.Identifier tableName, PG.toField $ PG.Identifier targetName, PG.toField $ PG.Identifier targetName] <> targetPrimaryKeyValues
-            PG.execute connection query params
+            let targetPrimaryKeyValues = T.splitOn "---" targetPrimaryKey
+            let whereClause = mconcat $ List.intersperse (Snippet.sql " AND ") $
+                    zipWith (\field val -> quoteIdentifier field <> Snippet.sql " = " <> Snippet.param val) primaryKeyFields targetPrimaryKeyValues
+            let snippet = Snippet.sql "UPDATE " <> quoteIdentifier tableName <> Snippet.sql " SET " <> quoteIdentifier targetName <> Snippet.sql " = NOT " <> quoteIdentifier targetName <> Snippet.sql " WHERE " <> whereClause
+            runSnippetExec connection snippet
         redirectTo ShowTableRowsAction { .. }
 
     action UpdateValueAction = do
         let id :: String = cs (param @Text "id")
         let tableName = param "tableName"
-        let targetCol = param "targetName"
-        let targetValue = param "targetValue"
-        let query = "UPDATE " <> tableName <> " SET " <> targetCol <> " = '" <> targetValue <> "' WHERE id = '" <> cs id <> "'"
+        let targetCol = param @Text "targetName"
+        let targetValue = param @Text "targetValue"
+        let snippet = Snippet.sql "UPDATE " <> quoteIdentifier tableName <> Snippet.sql " SET " <> quoteIdentifier targetCol <> Snippet.sql " = " <> Snippet.param targetValue <> Snippet.sql " WHERE id = " <> Snippet.param (cs id :: Text)
         withAppDb \connection ->
-            PG.execute_ connection (PG.Query . cs $! query)
+            runSnippetExec connection snippet
         redirectTo ShowTableRowsAction { .. }
 
     action DeleteTableRowsAction { tableName } = do
-        let query = "TRUNCATE TABLE " <> tableName
+        let snippet = Snippet.sql "TRUNCATE TABLE " <> quoteIdentifier tableName
         withAppDb \connection ->
-            PG.execute_ connection (PG.Query . cs $! query)
+            runSnippetExec connection snippet
         redirectTo ShowTableRowsAction { .. }
 
     action AutocompleteForeignKeyColumnAction { tableName, columnName, term } = do
@@ -163,125 +180,188 @@ instance Controller DataController where
 
     action ShowForeignKeyHoverCardAction { tableName, id, columnName } = do
         hovercardData <- withAppDb \connection -> do
-            [Only (foreignId :: UUID)] <- PG.query connection "SELECT ? FROM ? WHERE id = ?" (PG.Identifier columnName, PG.Identifier tableName, id)
+            let fetchIdSnippet = Snippet.sql "SELECT " <> quoteIdentifier columnName <> Snippet.sql "::text FROM " <> quoteIdentifier tableName <> Snippet.sql " WHERE id = " <> Snippet.param id
+            foreignIdResult <- runSnippetQuery connection fetchIdSnippet (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
 
-            foreignKeyInfo <- fetchForeignKeyInfo connection tableName columnName
+            case foreignIdResult of
+                [foreignId] -> do
+                    foreignKeyInfo <- fetchForeignKeyInfo connection tableName columnName
 
-            case foreignKeyInfo of
-                Just (foreignTable, foreignColumn) -> do
-                    [record] <- PG.query connection "SELECT * FROM ? WHERE ? = ? LIMIT 1" (PG.Identifier foreignTable, PG.Identifier foreignColumn, foreignId)
-                    pure $ Just (record, foreignTable)
-                Nothing -> pure Nothing
+                    case foreignKeyInfo of
+                        Just (foreignTable, foreignColumn) -> do
+                            let fetchRecordSnippet = wrapDynamicQuery (Snippet.sql "SELECT * FROM " <> quoteIdentifier foreignTable <> Snippet.sql " WHERE " <> quoteIdentifier foreignColumn <> Snippet.sql " = " <> Snippet.param foreignId <> Snippet.sql "::uuid LIMIT 1")
+                            records <- runSnippetQuery connection fetchRecordSnippet dynamicFieldDecoder
+                            case records of
+                                [record] -> pure $ Just (record, foreignTable)
+                                _ -> pure Nothing
+                        Nothing -> pure Nothing
+                _ -> pure Nothing
 
         case hovercardData of
             Just (record, foreignTableName) -> render ShowForeignKeyHoverCardView { record, foreignTableName }
             Nothing -> renderNotFound
 
-connectToAppDb :: (?context :: ControllerContext) => IO PG.Connection
-connectToAppDb = PG.connectPostgreSQL ?context.frameworkConfig.databaseUrl
+withAppDb :: (?context :: ControllerContext) => (Hasql.Connection -> IO a) -> IO a
+withAppDb action = do
+    let databaseUrl = ?context.frameworkConfig.databaseUrl
+    connResult <- Hasql.acquire (HasqlSettings.connectionString (cs databaseUrl))
+    case connResult of
+        Right conn -> action conn `Exception.finally` Hasql.release conn
+        Left err -> error (HasqlErrors.toDetailedText err)
 
-withAppDb :: (?context :: ControllerContext) => (PG.Connection -> IO a) -> IO a
-withAppDb = bracket connectToAppDb PG.close
+runSnippetQuery :: Hasql.Connection -> Snippet -> Decoders.Result a -> IO a
+runSnippetQuery conn snippet decoder = do
+    let statement = Snippet.toStatement snippet decoder
+    let session = Session.statement () statement
+    result <- Hasql.use conn session
+    case result of
+        Right a -> pure a
+        Left err -> error (HasqlErrors.toDetailedText err)
 
-fetchTableNames :: PG.Connection -> IO [Text]
-fetchTableNames connection = do
-    values :: [[Text]] <- PG.query_ connection "SELECT tablename FROM pg_catalog.pg_tables where schemaname = 'public'"
-    pure (join values)
+runSnippetExec :: Hasql.Connection -> Snippet -> IO ()
+runSnippetExec conn snippet = do
+    let statement = Snippet.toStatement snippet Decoders.noResult
+    let session = Session.statement () statement
+    result <- Hasql.use conn session
+    case result of
+        Right () -> pure ()
+        Left err -> error (HasqlErrors.toDetailedText err)
 
-fetchTableCols :: PG.Connection -> Text -> IO [ColumnDefinition]
-fetchTableCols connection tableName = do
-    PG.query connection "SELECT column_name,data_type,column_default,CASE WHEN is_nullable='YES' THEN true ELSE false END FROM information_schema.columns where table_name = ? ORDER BY ordinal_position" (PG.Only tableName)
+fetchTableNames :: Hasql.Connection -> IO [Text]
+fetchTableNames connection =
+    runSnippetQuery connection
+        (Snippet.sql "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public'")
+        (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
 
-fetchRow :: PG.Connection -> Text -> [Text] -> IO [[DynamicField]]
+fetchTableCols :: Hasql.Connection -> Text -> IO [ColumnDefinition]
+fetchTableCols connection tableName =
+    runSnippetQuery connection
+        (Snippet.sql "SELECT column_name, data_type, column_default, CASE WHEN is_nullable='YES' THEN true ELSE false END FROM information_schema.columns WHERE table_name = " <> Snippet.param tableName <> Snippet.sql " ORDER BY ordinal_position")
+        columnDefinitionDecoder
+
+fetchRow :: Hasql.Connection -> Text -> [Text] -> IO [[DynamicField]]
 fetchRow connection tableName primaryKeyValues = do
     pkFields <- tablePrimaryKeyFields connection tableName
-    let query = "SELECT * FROM " <> tableName <> " WHERE " <> intercalate " AND " ((<> " = ?") <$> pkFields)
-    PG.query connection (PG.Query . cs $! query) primaryKeyValues
+    let whereClause = mconcat $ List.intersperse (Snippet.sql " AND ") $
+            zipWith (\field val -> quoteIdentifier field <> Snippet.sql " = " <> Snippet.param val) pkFields primaryKeyValues
+    let snippet = wrapDynamicQuery (Snippet.sql "SELECT * FROM " <> quoteIdentifier tableName <> Snippet.sql " WHERE " <> whereClause)
+    runSnippetQuery connection snippet dynamicFieldDecoder
 
-instance PG.FromField DynamicField where
-    fromField field fieldValue = pure DynamicField { .. }
-        where
-            fieldName = fromMaybe "" (PG.name field)
+columnDefinitionDecoder :: Decoders.Result [ColumnDefinition]
+columnDefinitionDecoder = Decoders.rowList $
+    ColumnDefinition
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.bool)
 
-instance PG.FromRow ColumnDefinition where
-    fromRow = ColumnDefinition <$> PG.field <*> PG.field <*> PG.field <*> PG.field
+-- | Decoder for dynamic query results wrapped with 'wrapDynamicQuery'.
+-- Each row comes back as a single JSONB column (from row_to_json), which is then
+-- parsed into a list of DynamicField values.
+dynamicFieldDecoder :: Decoders.Result [[DynamicField]]
+dynamicFieldDecoder = Decoders.rowList $
+    Decoders.column (Decoders.nonNullable Decoders.jsonb)
+    |> fmap (\case
+        Aeson.Object obj -> map jsonFieldToDynamicField (Aeson.toList obj)
+        _ -> error "Expected JSON object from row_to_json"
+    )
 
-tablePrimaryKeyFields :: PG.Connection -> Text -> IO [Text]
-tablePrimaryKeyFields connection tableName = do
-    fields <- PG.query connection "SELECT a.attname FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = ?::regclass AND i.indisprimary" (PG.Only tableName) :: IO [PG.Only Text]
-    pure $ PG.fromOnly <$> fields
+jsonFieldToDynamicField :: (Aeson.Key, Aeson.Value) -> DynamicField
+jsonFieldToDynamicField (key, val) = DynamicField
+    { fieldValue = case val of
+        Aeson.Null -> Nothing
+        Aeson.String t -> Just (cs t)
+        Aeson.Bool True -> Just "true"
+        Aeson.Bool False -> Just "false"
+        other -> Just (cs (Aeson.encode other))
+    , fieldName = cs (Aeson.toText key)
+    }
 
-fetchRows :: FromRow r => PG.Connection -> Text -> IO [r]
+tablePrimaryKeyFields :: Hasql.Connection -> Text -> IO [Text]
+tablePrimaryKeyFields connection tableName =
+    runSnippetQuery connection
+        (Snippet.sql "SELECT a.attname FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = " <> Snippet.param tableName <> Snippet.sql "::regclass AND i.indisprimary")
+        (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
+
+fetchRows :: Hasql.Connection -> Text -> IO [[DynamicField]]
 fetchRows connection tableName = do
     pkFields <- tablePrimaryKeyFields connection tableName
 
-    let query = "SELECT * FROM "
-            <> tableName
-            <> (if null pkFields
-                    then ""
-                    else " ORDER BY " <> intercalate ", " pkFields
-                )
+    let orderBy = if null pkFields
+            then mempty
+            else Snippet.sql " ORDER BY " <> (mconcat $ List.intersperse (Snippet.sql ", ") (map quoteIdentifier pkFields))
 
-    PG.query_ connection (PG.Query . cs $! query)
+    let snippet = wrapDynamicQuery (Snippet.sql "SELECT * FROM " <> quoteIdentifier tableName <> orderBy)
+    runSnippetQuery connection snippet dynamicFieldDecoder
 
-fetchRowsPage :: FromRow r => PG.Connection -> Text -> Int -> Int -> IO [r]
+fetchRowsPage :: Hasql.Connection -> Text -> Int -> Int -> IO [[DynamicField]]
 fetchRowsPage connection tableName page rows = do
     pkFields <- tablePrimaryKeyFields connection tableName
-    let slice = " OFFSET " <> show (page * rows - rows) <> " ROWS FETCH FIRST " <> show rows <> " ROWS ONLY"
-    let query = "SELECT * FROM "
-            <> tableName
-            <> (if null pkFields
-                    then ""
-                    else " ORDER BY " <> intercalate ", " pkFields
-                )
-            <> slice
 
-    PG.query_ connection (PG.Query . cs $! query)
+    let orderBy = if null pkFields
+            then mempty
+            else Snippet.sql " ORDER BY " <> (mconcat $ List.intersperse (Snippet.sql ", ") (map quoteIdentifier pkFields))
 
-tableLength :: PG.Connection -> Text -> IO Int
+    let snippet = wrapDynamicQuery (
+            Snippet.sql "SELECT * FROM " <> quoteIdentifier tableName
+            <> orderBy
+            <> Snippet.sql " OFFSET " <> Snippet.param (fromIntegral (page * rows - rows) :: Int64)
+            <> Snippet.sql " ROWS FETCH FIRST " <> Snippet.param (fromIntegral rows :: Int64)
+            <> Snippet.sql " ROWS ONLY"
+            )
+    runSnippetQuery connection snippet dynamicFieldDecoder
+
+tableLength :: Hasql.Connection -> Text -> IO Int
 tableLength connection tableName = do
-    [Only count] <- PG.query connection "SELECT COUNT(*) FROM ?" [PG.Identifier tableName]
-    pure count
-
+    count <- runSnippetQuery connection
+        (Snippet.sql "SELECT COUNT(*) FROM " <> quoteIdentifier tableName)
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8)))
+    pure (fromIntegral count)
 
 -- parseValues sqlMode isBoolField input
-parseValues :: Bool -> Bool -> Text -> PG.Action
-parseValues _ True "on" = PG.toField True
-parseValues _ True "off" = PG.toField False
-parseValues False _ text = PG.toField text
-parseValues _ _ text = PG.Plain (Data.ByteString.Builder.byteString (cs text))
+parseValues :: Bool -> Bool -> Text -> Snippet
+parseValues _ True "on" = Snippet.param True
+parseValues _ True "off" = Snippet.param False
+parseValues False _ text = Snippet.param text
+parseValues _ _ text = Snippet.sql (cs text)  -- raw SQL mode (for expressions like now(), DEFAULT, NULL)
 
-updateValues list = map (\elem -> fst elem <> " = " <> snd elem) list
-
+isQuery :: Text -> Bool
 isQuery sql = T.isInfixOf "SELECT" u
     where u = T.toUpper sql
 
+-- | Quote a SQL identifier (table name, column name) to prevent SQL injection.
+-- Duplicated from IHP.DataSync.DynamicQuery to avoid ihp-datasync dependency.
+quoteIdentifier :: Text -> Snippet
+quoteIdentifier name = Snippet.sql (cs ("\"" <> T.replace "\"" "\"\"" name <> "\""))
 
+-- | Wraps a SQL query snippet so that each row is returned as a JSON object.
+-- Duplicated from IHP.DataSync.DynamicQuery to avoid ihp-datasync dependency.
+wrapDynamicQuery :: Snippet -> Snippet
+wrapDynamicQuery innerQuery =
+    Snippet.sql "WITH _ihp_dynamic_result AS (" <> innerQuery <> Snippet.sql ") SELECT row_to_json(t)::jsonb FROM _ihp_dynamic_result AS t"
 
-fetchForeignKeyInfo :: PG.Connection -> Text -> Text -> IO (Maybe (Text, Text))
+fetchForeignKeyInfo :: Hasql.Connection -> Text -> Text -> IO (Maybe (Text, Text))
 fetchForeignKeyInfo connection tableName columnName = do
-    let sql = [plain|
-        SELECT
-            ccu.table_name AS foreign_table_name,
-            ccu.column_name AS foreign_column_name
-        FROM
-            information_schema.table_constraints AS tc
-            JOIN information_schema.key_column_usage AS kcu
-              ON tc.constraint_name = kcu.constraint_name
-              AND tc.table_schema = kcu.table_schema
-            JOIN information_schema.constraint_column_usage AS ccu
-              ON ccu.constraint_name = tc.constraint_name
-              AND ccu.table_schema = tc.table_schema
-        WHERE
-            tc.constraint_type = 'FOREIGN KEY'
-            AND tc.table_name = ?
-            AND kcu.column_name = ?
-    |]
-    let args = (tableName, columnName)
-    result <- PG.query connection (PG.Query $ cs sql) args
+    let snippet =
+            Snippet.sql "SELECT ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name FROM information_schema.table_constraints AS tc JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = "
+            <> Snippet.param tableName
+            <> Snippet.sql " AND kcu.column_name = "
+            <> Snippet.param columnName
+    let decoder = Decoders.rowList $
+            (,) <$> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+    result <- runSnippetQuery connection snippet decoder
     case result of
         [(foreignTableName, foreignColumnName)] -> pure $ Just (foreignTableName, foreignColumnName)
-        otherwise -> pure $ Nothing
+        _ -> pure Nothing
+
+sessionErrorToConsoleError :: HasqlErrors.SessionError -> SqlConsoleError
+sessionErrorToConsoleError (HasqlErrors.StatementSessionError _ _ _ _ _ (HasqlErrors.ServerStatementError (HasqlErrors.ServerError code message detail hint _))) =
+    SqlConsoleError { errorMessage = message, errorDetail = fromMaybe "" detail, errorHint = fromMaybe "" hint, errorState = code }
+sessionErrorToConsoleError (HasqlErrors.ScriptSessionError _ (HasqlErrors.ServerError code message detail hint _)) =
+    SqlConsoleError { errorMessage = message, errorDetail = fromMaybe "" detail, errorHint = fromMaybe "" hint, errorState = code }
+sessionErrorToConsoleError err =
+    SqlConsoleError { errorMessage = cs (show err), errorDetail = "", errorHint = "", errorState = "" }
 
 instance {-# OVERLAPS #-} ToJSON [DynamicField] where
     toJSON fields = object (map (\DynamicField { fieldName, fieldValue } -> (cs fieldName) .= (fieldValueToJSON fieldValue)) fields)

--- a/ihp-ide/IHP/IDE/Data/View/EditRow.hs
+++ b/ihp-ide/IHP/IDE/Data/View/EditRow.hs
@@ -88,7 +88,7 @@ instance View EditRowView where
                                     type="checkbox"
                                     class="d-none"
                                     name={def.columnName <> "-inactive"}
-                                    checked={(value val) == "t"}
+                                    checked={(value val) == "true"}
                                     />
                             </div>
                             <input
@@ -132,7 +132,7 @@ instance View EditRowView where
                                     id={def.columnName <> "-input"}
                                     type="checkbox"
                                     name={def.columnName}
-                                    checked={(value val) == "t"}
+                                    checked={(value val) == "true"}
                                     />
                             </div>
                             <input

--- a/ihp-ide/IHP/IDE/Data/View/NewRow.hs
+++ b/ihp-ide/IHP/IDE/Data/View/NewRow.hs
@@ -33,7 +33,7 @@ instance View NewRowView where
                 where
                     id = (cs (fromMaybe "" ((fromJust (headMay fields)).fieldValue)))
             renderField id DynamicField { .. } | fieldName == "id" = [hsx|<td><span data-fieldname={fieldName}><a class="no-link border rounded p-1" href={EditRowValueAction tableName (cs fieldName) id}>{renderId (sqlValueToText fieldValue)}</a></span></td>|]
-            renderField id DynamicField { .. } | isBoolField fieldName tableCols && not (isNothing fieldValue) = [hsx|<td><span data-fieldname={fieldName}><input type="checkbox" onclick={onClick tableName fieldName id} checked={sqlValueToText fieldValue == "t"} /></span></td>|]
+            renderField id DynamicField { .. } | isBoolField fieldName tableCols && not (isNothing fieldValue) = [hsx|<td><span data-fieldname={fieldName}><input type="checkbox" onclick={onClick tableName fieldName id} checked={sqlValueToText fieldValue == "true"} /></span></td>|]
             renderField id DynamicField { .. } = [hsx|<td><span data-fieldname={fieldName}><a class="no-link" href={EditRowValueAction tableName (cs fieldName) id}>{sqlValueToText fieldValue}</a></span></td>|]
 
             modalContent = [hsx|

--- a/ihp-ide/IHP/IDE/Data/View/ShowQuery.hs
+++ b/ihp-ide/IHP/IDE/Data/View/ShowQuery.hs
@@ -1,12 +1,11 @@
 module IHP.IDE.Data.View.ShowQuery where
 
-import qualified Database.PostgreSQL.Simple as PG
 import IHP.ViewPrelude
 import IHP.IDE.ToolServer.Types
 import IHP.IDE.Data.View.Layout
 
 data ShowQueryView = ShowQueryView
-    { queryResult :: Maybe (Either PG.SqlError SqlConsoleResult)
+    { queryResult :: Maybe (Either SqlConsoleError SqlConsoleResult)
     , queryText :: Text
     }
 
@@ -55,11 +54,11 @@ instance View ShowQueryView where
                 |]
                 Just (Left sqlError) -> [hsx|
                     <div class="alert alert-danger" role="alert">
-                        <h4 class="alert-heading">SQL Error - {sqlError.sqlExecStatus}</h4>
-                        {showIfNotEmpty "Message" (sqlError.sqlErrorMsg)}
-                        {showIfNotEmpty "Details" (sqlError.sqlErrorDetail)}
-                        {showIfNotEmpty "Hint" (sqlError.sqlErrorHint)}
-                        {showIfNotEmpty "State" (sqlError.sqlState)}
+                        <h4 class="alert-heading">SQL Error</h4>
+                        {showIfNotEmpty "Message" (sqlError.errorMessage)}
+                        {showIfNotEmpty "Details" (sqlError.errorDetail)}
+                        {showIfNotEmpty "Hint" (sqlError.errorHint)}
+                        {showIfNotEmpty "State" (sqlError.errorState)}
                     </div>
                 |]
                 Nothing -> mempty
@@ -73,7 +72,7 @@ instance View ShowQueryView where
 
             columnNames rows = maybe [] (map (.fieldName)) (head rows)
 
-            showIfNotEmpty :: Text -> ByteString -> Html
+            showIfNotEmpty :: Text -> Text -> Html
             showIfNotEmpty title = \case
                 "" -> mempty
                 text -> [hsx|<div><strong>{title}:</strong> {text}</div>|]

--- a/ihp-ide/IHP/IDE/Data/View/ShowTableRows.hs
+++ b/ihp-ide/IHP/IDE/Data/View/ShowTableRows.hs
@@ -52,7 +52,7 @@ instance View ShowTableRowsView where
                     primaryKey = intercalate "---" . map (cs . fromMaybe "" . (.fieldValue)) $ filter ((`elem` primaryKeyFields) . cs . (.fieldName)) fields
             renderField primaryKey DynamicField { .. }
                 | fieldName == "id" = [hsx|<td><span data-fieldname={fieldName}><a class="border rounded p-1" href={EditRowValueAction tableName (cs fieldName) primaryKey}>{renderId (sqlValueToText fieldValue)}</a></span></td>|]
-                | isBoolField fieldName tableCols && not (isNothing fieldValue) = [hsx|<td><span data-fieldname={fieldName}><input type="checkbox" onclick={onClick tableName fieldName primaryKey} checked={sqlValueToText fieldValue == "t"} /></span></td>|]
+                | isBoolField fieldName tableCols && not (isNothing fieldValue) = [hsx|<td><span data-fieldname={fieldName}><input type="checkbox" onclick={onClick tableName fieldName primaryKey} checked={sqlValueToText fieldValue == "true"} /></span></td>|]
                 | otherwise = renderNormalField primaryKey DynamicField { .. }
 
             renderNormalField primaryKey DynamicField { .. } = [hsx|

--- a/ihp-ide/IHP/IDE/ToolServer/Types.hs
+++ b/ihp-ide/IHP/IDE/ToolServer/Types.hs
@@ -165,3 +165,10 @@ newtype DatabaseNeedsMigration = DatabaseNeedsMigration Bool
 data SqlConsoleResult
     = SelectQueryResult ![[DynamicField]]
     | InsertOrUpdateResult !Int64
+
+data SqlConsoleError = SqlConsoleError
+    { errorMessage :: Text
+    , errorDetail :: Text
+    , errorHint :: Text
+    , errorState :: Text
+    }

--- a/ihp-ide/default.nix
+++ b/ihp-ide/default.nix
@@ -2,7 +2,8 @@
 , base16-bytestring, base64-bytestring, basic-prelude, blaze-html
 , blaze-markup, bytestring, classy-prelude, clientsession
 , containers, countable-inflections, cryptohash, data-default
-, directory, filepath, fsnotify, hspec, http-types, ihp, ihp-hsx
+, directory, filepath, fsnotify, hasql, hasql-dynamic-statements
+, hasql-implicits, hspec, http-types, ihp, ihp-hsx
 , ihp-log, ihp-migrate, ihp-modal, ihp-postgres-parser
 , ihp-schema-compiler, inflections, interpolate, lib, megaparsec
 , mono-traversable, neat-interpolation, network, network-uri
@@ -24,7 +25,8 @@ mkDerivation {
     aeson async attoparsec auto-update base base16-bytestring
     basic-prelude blaze-html blaze-markup bytestring classy-prelude
     clientsession containers countable-inflections cryptohash
-    data-default directory filepath fsnotify http-types ihp ihp-hsx
+    data-default directory filepath fsnotify hasql
+    hasql-dynamic-statements hasql-implicits http-types ihp ihp-hsx
     ihp-log ihp-migrate ihp-modal ihp-postgres-parser
     ihp-schema-compiler inflections interpolate megaparsec
     mono-traversable neat-interpolation network network-uri
@@ -38,7 +40,8 @@ mkDerivation {
     aeson async attoparsec auto-update base base16-bytestring
     base64-bytestring basic-prelude blaze-html blaze-markup bytestring
     classy-prelude clientsession containers countable-inflections
-    cryptohash data-default directory filepath fsnotify http-types ihp
+    cryptohash data-default directory filepath fsnotify hasql
+    hasql-dynamic-statements hasql-implicits http-types ihp
     ihp-hsx ihp-log ihp-migrate ihp-postgres-parser ihp-schema-compiler
     inflections interpolate megaparsec mono-traversable
     neat-interpolation network network-uri postgresql-simple process
@@ -51,7 +54,8 @@ mkDerivation {
     aeson async attoparsec auto-update base base16-bytestring
     basic-prelude blaze-html blaze-markup bytestring classy-prelude
     clientsession containers countable-inflections cryptohash
-    data-default directory filepath fsnotify hspec http-types ihp
+    data-default directory filepath fsnotify hasql
+    hasql-dynamic-statements hasql-implicits hspec http-types ihp
     ihp-hsx ihp-log ihp-migrate ihp-modal ihp-postgres-parser
     ihp-schema-compiler inflections interpolate megaparsec
     mono-traversable neat-interpolation network network-uri

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -90,6 +90,9 @@ common shared-properties
             , safe-exceptions
             , countable-inflections
             , ihp-migrate
+            , hasql
+            , hasql-dynamic-statements
+            , hasql-implicits
     default-extensions:
         OverloadedStrings
         , NoImplicitPrelude


### PR DESCRIPTION
## Summary
- Replace all postgresql-simple usage in the IDE's data browser (`IHP.IDE.Data.Controller`) with hasql, using `Snippet` for safe parameterized queries and `row_to_json` for dynamic result decoding
- Brings ihp-ide in line with ihp-datasync and ihp-pglistener which already use hasql
- Fixes SQL injection vulnerability in `UpdateValueAction` (previously string-interpolated user input, now uses `Snippet.param`)
- Fixes boolean display in data browser views (`"t"`/`"f"` → `"true"`/`"false"` to match `row_to_json` output format)

## Changes
- **`IHP/IDE/Data/Controller.hs`**: Complete rewrite — all queries use `Hasql.DynamicStatements.Snippet`, dynamic rows decoded via `wrapDynamicQuery` (CTE + `row_to_json`), table/column names quoted via `quoteIdentifier`
- **`IHP/IDE/ToolServer/Types.hs`**: Added `SqlConsoleError` type with `Text` fields (replaces `PG.SqlError`)
- **`IHP/IDE/Data/View/ShowQuery.hs`**: Updated to use `SqlConsoleError`
- **`IHP/IDE/Data/View/ShowTableRows.hs`**, **`EditRow.hs`**, **`NewRow.hs`**: Boolean check `"t"` → `"true"`
- **`ihp-ide.cabal`**, **`default.nix`**: Added `hasql`, `hasql-dynamic-statements`, `hasql-implicits` deps

## Test plan
- [x] `nix flake check --impure` passes (all 27 checks)
- [ ] Manual test: start dev server, browse Data tab — verify table listing, row display, pagination, SQL console, row editing, boolean toggles, foreign key hover cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)