### PR TITLE
Lazy session middleware: skip decrypt/encrypt when session is unused

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -64,6 +64,14 @@ let
             ihp-hspec = localPackage "ihp-hspec";
             ihp-welcome = localPackage "ihp-welcome";
 
+            # Lazy session middleware: defer cookie decryption until first access,
+            # skip Set-Cookie when session is unmodified.
+            # See: https://github.com/singpolyma/wai-session/issues/15
+            wai-session = final.haskell.lib.appendPatch super.wai-session
+                "${flakeRoot}/NixSupport/patches/wai-session-lazy.patch";
+            wai-session-clientsession = final.haskell.lib.appendPatch super.wai-session-clientsession
+                "${flakeRoot}/NixSupport/patches/wai-session-clientsession-lazy.patch";
+
             # Can be removed after v0.3.2 is on hackage
             countable-inflections = final.haskell.lib.overrideSrc super.countable-inflections {
                 version = "0.3.2";

--- a/NixSupport/patches/wai-session-clientsession-lazy.patch
+++ b/NixSupport/patches/wai-session-clientsession-lazy.patch
@@ -1,0 +1,82 @@
+Lazy session decryption and conditional cookie encryption
+
+Defers cookie decryption until the session is first read or written.
+
+When the session is read but not modified, the original encrypted cookie
+bytes are returned without re-encrypting. This refreshes the browser's
+max-age timer (preventing expiry 30 days from login rather than 30 days
+from last visit) with zero crypto cost.
+
+When the session is never accessed, Nothing is returned, signaling to
+wai-session's withSession to skip the Set-Cookie header entirely.
+
+diff -ruN a/Network/Wai/Session/ClientSession.hs b/Network/Wai/Session/ClientSession.hs
+--- a/Network/Wai/Session/ClientSession.hs
++++ b/Network/Wai/Session/ClientSession.hs
+@@ -10,25 +10,52 @@
+ import Web.ClientSession (Key, encryptIO, decrypt)
+ import Data.Serialize (encode, decode, Serialize) -- Use cereal because clientsession does
+
++-- | Lazy session state: defers decryption until first access
++data SessionState k v
++	= Unloaded                     -- ^ Cookie present, not yet decrypted
++	| Loaded ![(k, v)] !Bool       -- ^ Decrypted pairs + dirty flag
++	| NoCookie                     -- ^ No cookie was present
++
+ -- | Session store that keeps all content in a 'Serialize'd cookie encrypted
+ -- with 'Web.ClientSession'
+ --
++-- Decryption is deferred until the session is first read or written.
++-- The Set-Cookie header is skipped when the session is never accessed.
++--
+ -- WARNING: This session is vulnerable to sidejacking,
+ -- use with TLS for security.
+ clientsessionStore :: (Serialize k, Serialize v, Eq k, MonadIO m) => Key -> SessionStore m k v
+-clientsessionStore cryptKey (Just encoded) =
+-	case hush . decode =<< decrypt cryptKey encoded of
+-		Just sessionData -> backend cryptKey sessionData
+-		-- Bad cookie is the same as no cookie
+-		Nothing -> clientsessionStore cryptKey Nothing
+-clientsessionStore cryptKey Nothing = backend cryptKey []
++clientsessionStore cryptKey maybeCookie = do
++	stateRef <- newIORef $ case maybeCookie of
++		Nothing -> NoCookie
++		Just _  -> Unloaded
++
++	let decryptSession = case maybeCookie of
++		Nothing -> return []
++		Just encoded -> case hush . decode =<< decrypt cryptKey encoded of
++			Just sessionData -> return sessionData
++			Nothing -> return []
++
++	let ensureLoaded = do
++		state <- readIORef stateRef
++		case state of
++			Unloaded -> do
++				pairs <- decryptSession
++				writeIORef stateRef (Loaded pairs False)
++				return pairs
++			Loaded pairs _ -> return pairs
++			NoCookie -> return []
+
+-backend :: (Serialize k, Serialize v, Eq k, MonadIO m) => Key -> [(k, v)] -> IO (Session m k v, IO ByteString)
+-backend cryptKey sessionData = do
+-	-- Don't need threadsafety because we only hand this IORef to an Application
+-	-- through a single Request.
+-	ref <- newIORef sessionData
+ 	return ((
+-			(\k -> lookup k `liftM` liftIO (readIORef ref)),
+-			(\k v -> liftIO (modifyIORef ref (((k,v):) . filter ((/=k) . fst))))
+-		), encryptIO cryptKey =<< encode `fmap` readIORef ref)
++			(\k -> lookup k `liftM` liftIO ensureLoaded),
++			(\k v -> liftIO $ do
++				pairs <- ensureLoaded
++				writeIORef stateRef (Loaded (((k,v):) . filter ((/=k) . fst) $ pairs) True))
++		), do
++			state <- readIORef stateRef
++			case state of
++				Loaded pairs True ->
++					Just <$> (encryptIO cryptKey $ encode pairs)
++				Loaded _     False -> return maybeCookie
++				_                  -> return Nothing
++		)

--- a/NixSupport/patches/wai-session-lazy.patch
+++ b/NixSupport/patches/wai-session-lazy.patch
@@ -1,0 +1,66 @@
+Allow SessionStore to return Nothing for "contents of new cookie"
+
+When getNewCookie returns Nothing, withSession skips the Set-Cookie header.
+This enables session stores to signal "no change" and avoid unnecessary
+cookie updates on every response.
+
+See: https://github.com/singpolyma/wai-session/issues/15
+
+diff -ruN a/Network/Wai/Session.hs b/Network/Wai/Session.hs
+--- a/Network/Wai/Session.hs
++++ b/Network/Wai/Session.hs
+@@ -32,7 +32,7 @@
+
+ -- | A 'SessionStore' takes in the contents of the cookie (if there was one)
+ -- and returns a ('Session', 'IO' action to get new contents for cookie) pair
+-type SessionStore m k v = (Maybe ByteString -> IO (Session m k v, IO ByteString))
++type SessionStore m k v = (Maybe ByteString -> IO (Session m k v, IO (Maybe ByteString)))
+
+ -- | Fully parameterised middleware for cookie-based sessions
+ withSession ::
+@@ -53,13 +53,21 @@
+ 	(session, getNewCookie) <- liftIO $ sessions $ lookup cookieName =<< cookies
+ #if MIN_VERSION_wai(3,0,0)
+ 	app (req {vault = Vault.insert vkey session (vault req)}) (\r -> do
+-			newCookieVal <- liftIO getNewCookie
+-			respond $ mapHeader (\hs -> (setCookie, newCookie newCookieVal):hs) r
++			mNewCookieVal <- liftIO getNewCookie
++			case mNewCookieVal of
++				Just newCookieVal ->
++					respond $ mapHeader (\hs -> (setCookie, newCookie newCookieVal):hs) r
++				Nothing ->
++					respond r
+ 		)
+ #else
+ 	resp <- app (req {vault = Vault.insert vkey session (vault req)})
+-	newCookieVal <- liftIO getNewCookie
+-	return $ mapHeader (\hs -> (setCookie, newCookie newCookieVal):hs) resp
++	mNewCookieVal <- liftIO getNewCookie
++	case mNewCookieVal of
++		Just newCookieVal ->
++			return $ mapHeader (\hs -> (setCookie, newCookie newCookieVal):hs) resp
++		Nothing ->
++			return resp
+ #endif
+ 	where
+ 	newCookie v = Builder.toByteString $ renderSetCookie $ cookieDefaults {
+diff -ruN a/Network/Wai/Session/Map.hs b/Network/Wai/Session/Map.hs
+--- a/Network/Wai/Session/Map.hs
++++ b/Network/Wai/Session/Map.hs
+@@ -28,14 +28,14 @@
+ 	mapStore' _ ssv (Just k) = do
+ 		m <- get ssv
+ 		case Map.lookup k m of
+-			Just sv -> return (sessionFromMapStateVar sv, return k)
++			Just sv -> return (sessionFromMapStateVar sv, return (Just k))
+ 			-- Could not find key, so it's as if we were not sent one
+ 			Nothing -> mapStore' gen ssv Nothing
+ 	mapStore' genNewKey ssv Nothing = do
+ 		newKey <- genNewKey
+ 		sv <- newThreadSafeStateVar Map.empty
+ 		ssv $~ Map.insert newKey sv
+-		return (sessionFromMapStateVar sv, return newKey)
++		return (sessionFromMapStateVar sv, return (Just newKey))
+
+ -- | Store using simple session ID generator based on time and 'Data.Unique'
+ mapStore_ :: (Ord k, MonadIO m) => IO (SessionStore m k v)


### PR DESCRIPTION
## Summary

- Patch `wai-session` to allow `SessionStore` to return `Nothing` for the cookie value, signaling "no change" — `withSession` then skips the `Set-Cookie` header entirely ([upstream issue](https://github.com/singpolyma/wai-session/issues/15))
- Patch `wai-session-clientsession` to defer cookie decryption until the session is first read/written, and only encrypt+return `Just` when the session was actually modified (dirty flag)
- Read-only sessions (e.g. auth checks) echo back the original encrypted cookie bytes — this refreshes the browser's `max-age` timer with zero crypto cost
- Both patches applied via nix overlay (`appendPatch`) — zero IHP source changes needed

## Benchmark Results

Tested with a minimal WAI app using `withSession`+`clientsessionStore` and a handler that never accesses the session (the common case for most routes):

| Scenario | Before | After | Improvement |
|---|---|---|---|
| No cookie (new visitor) | 43,858 req/s, p50=2.2ms | 128,990 req/s, p50=0.4ms | **2.9x throughput, 5.5x lower p50** |
| With cookie (read-only) | 39,533 req/s, p50=2.5ms | 123,160 req/s, p50=0.4ms | **3.1x throughput, 6.3x lower p50** |

## How it works

The patched `clientsessionStore` uses a three-state `IORef`:
- **`Unloaded`** — cookie present but not yet decrypted
- **`Loaded pairs dirty`** — decrypted pairs with a dirty flag
- **`NoCookie`** — no cookie was present

Decryption only happens when `ensureLoaded` is called (on first session read/write). Encryption only happens when the dirty flag is `True`. For routes that never touch the session, both AES decrypt and encrypt are completely skipped.

## Cookie expiry handling

| Scenario | Decrypt | Encrypt | Set-Cookie |
|---|---|---|---|
| Never accessed (most routes) | No | No | No |
| Read-only (auth check) | Yes | **No** | Yes (original bytes) |
| Written (login/logout/flash) | Yes | Yes | Yes (new ciphertext) |

Read-only sessions return the original encrypted cookie bytes (`maybeCookie`) instead of re-encrypting. This refreshes the browser's `max-age` timer so the cookie expiry is 30 days from last visit, not 30 days from login — with zero encryption cost.

## Test plan

- [x] Both patches apply cleanly to actual Hackage tarballs
- [x] `IHP.Server` compiles (89 modules)
- [x] `IHP.IDE.ToolServer` compiles (178 modules)
- [x] `wai-flash-messages` compiles
- [x] ihp tests pass (441 examples, 0 failures)
- [x] ihp-ide tests pass (359 examples, 0 failures)
- [x] `nix build .#checks.aarch64-darwin.ihp-new` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)