### PR TITLE
Fix lazy IO crash in FileWatcher

### DIFF
--- a/ihp-ide/IHP/IDE/FileWatcher.hs
+++ b/ihp-ide/IHP/IDE/FileWatcher.hs
@@ -107,6 +107,7 @@ filterGitIgnored dirs = do
                 }
         Process.withCreateProcess process \_ (Just stdout) _ processHandle -> do
             output <- IO.hGetContents stdout
+            _ <- evaluate (length output)
             let ignored = List.lines output
             _ <- Process.waitForProcess processHandle
             pure ignored


### PR DESCRIPTION
## Summary
- `filterGitIgnored` in `FileWatcher.hs` uses `hGetContents` (lazy IO) inside a `withCreateProcess` bracket
- The bracket closes the handle on exit, but the lazy string hasn't been fully evaluated yet
- When the result is consumed later, the read hits a closed handle: `hGetContents: illegal operation (delayed read on closed handle)`
- This crashes the dev server on startup

## Fix
Force strict evaluation with `evaluate (length output)` before the `withCreateProcess` bracket exits.

## Test plan
- [x] Verified `devenv up` starts without the `hGetContents` crash
- [x] Verified the server serves requests normally after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)