### PR TITLE
Migrate ihp-ide Data Controller from postgresql-simple to hasql

### DIFF
--- a/ihp-ide/default.nix
+++ b/ihp-ide/default.nix
@@ -3,7 +3,7 @@
 , blaze-markup, bytestring, classy-prelude, clientsession
 , containers, countable-inflections, cryptohash, data-default
 , directory, filepath, fsnotify, hasql, hasql-dynamic-statements
-, hasql-implicits, hspec, http-types, ihp, ihp-hsx
+, hasql-implicits, hasql-pool, hspec, http-types, ihp, ihp-hsx
 , ihp-log, ihp-migrate, ihp-modal, ihp-postgres-parser
 , ihp-schema-compiler, inflections, interpolate, lib, megaparsec
 , mono-traversable, neat-interpolation, network, network-uri
@@ -26,7 +26,7 @@ mkDerivation {
     basic-prelude blaze-html blaze-markup bytestring classy-prelude
     clientsession containers countable-inflections cryptohash
     data-default directory filepath fsnotify hasql
-    hasql-dynamic-statements hasql-implicits http-types ihp ihp-hsx
+    hasql-dynamic-statements hasql-implicits hasql-pool http-types ihp ihp-hsx
     ihp-log ihp-migrate ihp-modal ihp-postgres-parser
     ihp-schema-compiler inflections interpolate megaparsec
     mono-traversable neat-interpolation network network-uri
@@ -41,7 +41,7 @@ mkDerivation {
     base64-bytestring basic-prelude blaze-html blaze-markup bytestring
     classy-prelude clientsession containers countable-inflections
     cryptohash data-default directory filepath fsnotify hasql
-    hasql-dynamic-statements hasql-implicits http-types ihp
+    hasql-dynamic-statements hasql-implicits hasql-pool http-types ihp
     ihp-hsx ihp-log ihp-migrate ihp-postgres-parser ihp-schema-compiler
     inflections interpolate megaparsec mono-traversable
     neat-interpolation network network-uri postgresql-simple process
@@ -55,7 +55,7 @@ mkDerivation {
     basic-prelude blaze-html blaze-markup bytestring classy-prelude
     clientsession containers countable-inflections cryptohash
     data-default directory filepath fsnotify hasql
-    hasql-dynamic-statements hasql-implicits hspec http-types ihp
+    hasql-dynamic-statements hasql-implicits hasql-pool hspec http-types ihp
     ihp-hsx ihp-log ihp-migrate ihp-modal ihp-postgres-parser
     ihp-schema-compiler inflections interpolate megaparsec
     mono-traversable neat-interpolation network network-uri

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -91,6 +91,7 @@ common shared-properties
             , countable-inflections
             , ihp-migrate
             , hasql
+            , hasql-pool
             , hasql-dynamic-statements
             , hasql-implicits
     default-extensions:

--- a/ihp/IHP/QueryBuilder/HasqlHelpers.hs
+++ b/ihp/IHP/QueryBuilder/HasqlHelpers.hs
@@ -1,0 +1,37 @@
+-- | Shared helpers for building dynamic hasql queries.
+--
+-- These are used by both @ihp-datasync@ ('IHP.DataSync.DynamicQuery') and
+-- @ihp-ide@ ('IHP.IDE.Data.Controller') for executing dynamically-constructed
+-- SQL through hasql.
+module IHP.QueryBuilder.HasqlHelpers
+    ( wrapDynamicQuery
+    , quoteIdentifier
+    ) where
+
+import IHP.Prelude
+import qualified Hasql.DynamicStatements.Snippet as Snippet
+import Hasql.DynamicStatements.Snippet (Snippet)
+import qualified Data.Text as Text
+
+-- | Wraps a SQL query snippet so that each row is returned as a JSON object.
+--
+-- This is needed because hasql decoders are positional and don't provide column name metadata.
+-- By wrapping with @row_to_json@, we get column names in the JSON keys, which we can then
+-- decode into a list of fields.
+--
+-- Uses a CTE (Common Table Expression) which works for both SELECT queries
+-- and DML statements (INSERT, UPDATE, DELETE) with RETURNING:
+--
+-- @
+-- WITH _ihp_dynamic_result AS (...original query...) SELECT row_to_json(t)::jsonb FROM _ihp_dynamic_result AS t
+-- @
+wrapDynamicQuery :: Snippet -> Snippet
+wrapDynamicQuery innerQuery =
+    Snippet.sql "WITH _ihp_dynamic_result AS (" <> innerQuery <> Snippet.sql ") SELECT row_to_json(t)::jsonb FROM _ihp_dynamic_result AS t"
+
+-- | Quote a SQL identifier (table name, column name) to prevent SQL injection.
+--
+-- Wraps the identifier in double quotes and escapes any embedded double quotes
+-- by doubling them, following the SQL standard.
+quoteIdentifier :: Text -> Snippet
+quoteIdentifier name = Snippet.sql (cs ("\"" <> Text.replace "\"" "\"\"" name <> "\""))

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -213,6 +213,7 @@ library
         , IHP.QueryBuilder.Order
         , IHP.QueryBuilder.Union
         , IHP.QueryBuilder.HasqlCompiler
+        , IHP.QueryBuilder.HasqlHelpers
         , IHP.Fetch
         , IHP.RouterPrelude
         , IHP.Server


### PR DESCRIPTION
## Summary

- **Migrate the IDE Data Controller to hasql** — replaces all `postgresql-simple` usage in `IHP.IDE.Data.Controller` with hasql, using `hasql-dynamic-statements` for dynamic SQL and proper decoders for type-safe result parsing
- **Move shared helpers to `ihp` core** — `wrapDynamicQuery` and `quoteIdentifier` are extracted to `IHP.QueryBuilder.HasqlHelpers`, eliminating duplication between `ihp-datasync` and `ihp-ide`
- **Use connection pool** — wires up `modelContextMiddleware` in ToolServer so controllers use the hasql pool from `?modelContext` instead of acquiring/releasing a fresh connection per request
- **Fix unsafe partial match** — `EditRowAction` now handles missing rows safely instead of crashing with an irrefutable pattern

## Test plan

- [x] `nix flake check --impure` passes all 33 checks
- [ ] Manual: start dev server, browse Data tab, verify table listing and row display
- [ ] Manual: test SQL console with SELECT, INSERT, UPDATE queries
- [ ] Manual: test Edit Row functionality
- [ ] Verify `ihp-datasync` backward compatibility (re-exports `wrapDynamicQuery`/`quoteIdentifier`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)