### PR TITLE
Fix test failures from vault middleware migration

### DIFF
--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -129,7 +129,7 @@ buildToolServerApplication toolServerApplication port liveReloadClients = do
             let defaultAppUrl = "http://localhost:" <> tshow toolServerApplication.appPort
             appUrl <- AppUrl <$> EnvVar.envOrDefault "IHP_BASEURL" defaultAppUrl
             databaseNeedsMigration <- DatabaseNeedsMigration <$> readIORef toolServerApplication.databaseNeedsMigration
-            let req' = req { vault = Vault.insert availableAppsVaultKey availableApps
+            let req' = req { Wai.vault = Vault.insert availableAppsVaultKey availableApps
                                    . Vault.insert webControllersVaultKey webControllers
                                    . Vault.insert appUrlVaultKey appUrl
                                    . Vault.insert databaseNeedsMigrationVaultKey databaseNeedsMigration

--- a/ihp-ide/IHP/IDE/ToolServer/Layout.hs
+++ b/ihp-ide/IHP/IDE/ToolServer/Layout.hs
@@ -159,7 +159,7 @@ toolServerLayout inner = [hsx|
                 target :: Maybe Text
                 target = if isExternal then "_blank" else Nothing
 
-appUrl :: (?context :: ControllerContext) => Text
+appUrl :: (?context :: ControllerContext, ?request :: Request) => Text
 appUrl = let (AppUrl url) = lookupRequestVault appUrlVaultKey ?request in url
 
 -- | https://github.com/encharm/Font-Awesome-SVG-PNG/blob/master/white/svg/terminal.svg

--- a/ihp/Test/Test/Controller/NotFoundSpec.hs
+++ b/ihp/Test/Test/Controller/NotFoundSpec.hs
@@ -31,6 +31,8 @@ import Unsafe.Coerce
 import qualified Network.Wai.Session as Session
 import qualified Network.Wai.Session.Map as Session
 import IHP.Controller.Layout (viewLayoutMiddleware)
+import System.IO.Unsafe (unsafePerformIO)
+import IHP.Log.Types (newLogger, LoggerSettings(..), LogLevel(..))
 
 data WebApplication = WebApplication deriving (Eq, Show, Data)
 
@@ -71,8 +73,16 @@ config = do
     option Development
     option (AppPort 8000)
 
+initApplication :: IO Application
+initApplication = do
+    frameworkConfig <- buildFrameworkConfig (pure ())
+    logger <- newLogger def { level = Warn }
+    modelContext <- createModelContext frameworkConfig.dbPoolIdleTime frameworkConfig.dbPoolMaxConnections frameworkConfig.databaseUrl logger
+    middleware <- Server.initMiddlewareStack frameworkConfig modelContext Nothing
+    pure (middleware $ Server.application handleNotFound (\app -> app))
+
 application :: Application
-application = viewLayoutMiddleware $ Server.application handleNotFound (\app -> app)
+application = unsafePerformIO initApplication
 
 assertNotFound :: SResponse -> IO ()
 assertNotFound response = do


### PR DESCRIPTION
## Summary
- Test WAI applications were using minimal middleware stacks (only `frameworkConfigMiddleware`/`viewLayoutMiddleware`) that didn't include the vault middlewares now required after the putContext-to-vault migration
- Switch all test apps (`RouterSupportSpec`, `NotFoundSpec`, `AccessDeniedSpec`, `ViewSupportSpec`) to use `Server.initMiddlewareStack` for the full middleware stack
- Fix ihp-ide `ToolServer` compilation: qualify `vault` field in record update (`Wai.vault`) and add `?request :: Request` constraint to `appUrl`

## Test plan
- [x] `ihp` tests: 441 examples, 0 failures
- [x] `ihp-ide` tests: 359 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)