### PR TITLE
Fix hasql decoder OID mismatch for pg_tables.tablename

### DIFF
--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -216,7 +216,7 @@ runSnippetExec snippet = do
 fetchTableNames :: (?modelContext :: ModelContext) => IO [Text]
 fetchTableNames =
     runSnippetQuery
-        (Snippet.sql "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public'")
+        (Snippet.sql "SELECT tablename::text FROM pg_catalog.pg_tables WHERE schemaname = 'public'")
         (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
 
 fetchTableCols :: (?modelContext :: ModelContext) => Text -> IO [ColumnDefinition]


### PR DESCRIPTION
## Summary
- Cast `tablename` to `::text` in `fetchTableNames` query to fix OID mismatch (`name` OID 19 vs expected `text` OID 25)
- Prevents "Unexpected column type" errors when viewing the database in the IDE

## Test plan
- [ ] Start dev server, navigate to database view — tables should display without errors
- [ ] Run IDE tests: `echo -e ':l ihp-ide/Test/Main.hs\nmain' | direnv exec . ghci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)