### PR TITLE
Optimize GHCi loading speed with RTS flags

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -387,6 +387,9 @@ ihpFlake:
 
                 env.IHP_RELATION_SUPPORT = if cfg.relationSupport then "1" else "0";
 
+                # Optimized RTS flags for GHCi: reduces GC overhead during module loading
+                env.GHCRTS = "-A256m -n4m -H256m -I0 --nonmoving-gc -N";
+
                 scripts.deploy-to-nixos.exec = ''
                     if [[ $# -eq 0 || $1 == "--help" ]]; then
                         echo "usage: deploy-to-nixos <target-host>"

--- a/ihp-ide/data/lib/IHP/applicationGhciConfig
+++ b/ihp-ide/data/lib/IHP/applicationGhciConfig
@@ -41,6 +41,7 @@
 :set -XFunctionalDependencies
 :set -package ihp
 :set -fbyte-code
+:set -j
 :set -Wno-partial-type-signatures
 :set -XPartialTypeSignatures
 :set -XStandaloneDeriving


### PR DESCRIPTION
## Summary
- Set `GHCRTS` env var in the devenv shell so every `ghci` invocation automatically gets tuned RTS flags
- Enable parallel module compilation (`:set -j`) in `applicationGhciConfig`

## Problem
When running `ghci` directly in an IHP project, no RTS tuning is applied — modules load with GHC's defaults (256KB allocation area, tiny heap). This causes excessive GC during module loading, making `ghci` startup slow on larger projects.

The IHP dev server already passes RTS flags via the command line, but these don't apply when running `ghci` directly for type checking.

## Changes

**`flake-module.nix`** — Added `env.GHCRTS = "-A256m -n4m -H256m -I0 --nonmoving-gc -N"` to `devenv.shells.default`:
- **`-A256m`**: 256MB allocation area — dramatically reduces GC frequency during module loading
- **`-n4m`**: 4MB nursery chunks for better memory utilization with parallel RTS
- **`-H256m`**: Pre-allocate 256MB heap to avoid repeated heap growth/GC during initial load
- **`-I0`**: Disable idle GC — GHCi spends most time idle at the prompt
- **`--nonmoving-gc`**: Low-latency concurrent GC (matches what the IHP dev server uses)
- **`-N`**: Use all available cores for parallel GC

**`ihp-ide/data/lib/IHP/applicationGhciConfig`** — Added `:set -j` for parallel module compilation during `:load`/`:reload`.

## Test plan
- [ ] Run `direnv allow` to reload environment
- [ ] Verify `echo $GHCRTS` outputs `-A256m -n4m -H256m -I0 --nonmoving-gc -N`
- [ ] Run `ghci` and confirm modules load faster
- [ ] Optionally run `ghci +RTS -s -RTS` to confirm reduced GC cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)