### PR TITLE
Revert CI workaround for macOS case-sensitivity issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, ARM64]
     runs-on: ${{ matrix.os }}
     steps:
-    # On macOS case-insensitive filesystem, directory names from previous
-    # workflows can persist with wrong case (e.g. IHP/ instead of ihp/).
-    # Git won't rename them because core.ignorecase=true.
-    # Delete and let checkout recreate with correct case from the git index.
-    - run: rm -rf ihp
-      if: matrix.os == 'ARM64'
     - uses: actions/checkout@v6
     - uses: wimpysworld/nothing-but-nix@main
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,5 @@ jobs:
   nix-flake-check:
     runs-on: ARM64
     steps:
-    # On macOS case-insensitive filesystem, directory names from previous
-    # workflows can persist with wrong case (e.g. IHP/ instead of ihp/).
-    # Git won't rename them because core.ignorecase=true.
-    # Delete and let checkout recreate with correct case from the git index.
-    - run: rm -rf ihp
     - uses: actions/checkout@v6
     - run: nix flake check --impure --override-input ihp-boilerplate/ihp "github:${{ github.event.repository.full_name }}/${{ github.sha }}" -L


### PR DESCRIPTION
## Summary
- Reverts the `rm -rf ihp/` workaround from 6bb309f now that the runner is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)