### PR TITLE
Fix hasql OID mismatch in data tools primary key query

### DIFF
--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -266,7 +266,7 @@ jsonFieldToDynamicField (key, val) = DynamicField
 tablePrimaryKeyFields :: (?modelContext :: ModelContext) => Text -> IO [Text]
 tablePrimaryKeyFields tableName =
     runSnippetQuery
-        (Snippet.sql "SELECT a.attname FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = " <> Snippet.param tableName <> Snippet.sql "::regclass AND i.indisprimary")
+        (Snippet.sql "SELECT a.attname::text FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = " <> Snippet.param tableName <> Snippet.sql "::regclass AND i.indisprimary")
         (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
 
 fetchRows :: (?modelContext :: ModelContext) => Text -> IO [[DynamicField]]


### PR DESCRIPTION
## Summary
- `pg_attribute.attname` has PostgreSQL type `name` (OID 19), but the hasql text decoder expects OID 25
- This causes `ShowDatabaseAction` to crash with `expectedOid: 25 actualOid: 19`
- Added `::text` cast to `a.attname` in `tablePrimaryKeyFields`, matching the pattern already used in `ihp-datasync`

## Test plan
- [x] Compiles cleanly with ghci (108 modules loaded)
- [ ] Navigate to data tools in a running IHP app and verify table rows display without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)