### PR TITLE
Remove global GHCRTS env var that crashes non-threaded CLI tools

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -387,9 +387,6 @@ ihpFlake:
 
                 env.IHP_RELATION_SUPPORT = if cfg.relationSupport then "1" else "0";
 
-                # Optimized RTS flags for GHCi: reduces GC overhead during module loading
-                env.GHCRTS = "-A256m -n4m -H256m -I0 --nonmoving-gc -N";
-
                 scripts.deploy-to-nixos.exec = ''
                     if [[ $# -eq 0 || $1 == "--help" ]]; then
                         echo "usage: deploy-to-nixos <target-host>"

--- a/ihp-datasync-typescript/ihp-datasync-typescript.cabal
+++ b/ihp-datasync-typescript/ihp-datasync-typescript.cabal
@@ -49,7 +49,6 @@ executable generate-datasync-types
     build-depends: ihp-datasync-typescript, ihp, ihp-postgres-parser, neat-interpolation, with-utf8, text
     hs-source-dirs: .
     main-is: exe/GenerateDataSyncTypes.hs
-    ghc-options: -rtsopts
 
 test-suite spec
     import: shared-properties

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -282,42 +282,36 @@ executable new-application
     build-depends: ihp, ihp-ide
     hs-source-dirs: exe
     main-is: IHP/CLI/NewApplication.hs
-    ghc-options: -rtsopts
 
 executable new-controller
     import: shared-properties
     build-depends: ihp, ihp-ide
     hs-source-dirs: exe
     main-is: IHP/CLI/NewController.hs
-    ghc-options: -rtsopts
 
 executable delete-controller
     import: shared-properties
     build-depends: ihp, ihp-ide
     hs-source-dirs: exe
     main-is: IHP/CLI/DeleteController.hs
-    ghc-options: -rtsopts
 
 executable new-script
     import: shared-properties
     build-depends: ihp, ihp-ide
     hs-source-dirs: exe
     main-is: IHP/CLI/NewScript.hs
-    ghc-options: -rtsopts
 
 executable new-migration
     import: shared-properties
     build-depends: ihp, ihp-ide
     hs-source-dirs: exe
     main-is: IHP/CLI/NewMigration.hs
-    ghc-options: -rtsopts
 
 executable hash-password
     import: shared-properties
     build-depends: ihp, ihp-ide
     hs-source-dirs: exe
     main-is: IHP/CLI/HashPassword.hs
-    ghc-options: -rtsopts
 
 executable new-session-secret
     default-language: Haskell2010
@@ -325,7 +319,7 @@ executable new-session-secret
     build-depends: base >= 4.17.0 && < 4.22, clientsession, bytestring, with-utf8, base64-bytestring
     hs-source-dirs: exe
     main-is: IHP/CLI/NewSessionSecret.hs
-    ghc-options: -fsplit-sections -rtsopts
+    ghc-options: -fsplit-sections
 
 source-repository head
     type:     git

--- a/ihp-migrate/ihp-migrate.cabal
+++ b/ihp-migrate/ihp-migrate.cabal
@@ -40,7 +40,6 @@ executable migrate
     build-depends: base >= 4.17.0 && < 4.22, ihp, ihp-log, with-utf8, text, directory >= 1.3.8.0, filepath >= 1.5, ihp-migrate
     hs-source-dirs: .
     main-is: Migrate.hs
-    ghc-options: -rtsopts
 
 test-suite tests
     import: ihp-std

--- a/ihp-schema-compiler/ihp-schema-compiler.cabal
+++ b/ihp-schema-compiler/ihp-schema-compiler.cabal
@@ -86,7 +86,6 @@ executable build-generated-code
     build-depends: ihp-schema-compiler
     hs-source-dirs: exe
     main-is: IHP/CLI/BuildGeneratedCode.hs
-    ghc-options: -rtsopts
 
 source-repository head
     type:     git


### PR DESCRIPTION
## Summary
- Remove the `GHCRTS` env var from `flake-module.nix` that was crashing `build-generated-code`, `migrate`, and other CLI tools
- Revert the `-rtsopts` band-aid additions from #2351

## Problem
The `GHCRTS` env var added in #2347 sets RTS flags globally for all Haskell binaries in the devenv shell. The flags `--nonmoving-gc` and `-N` require the threaded runtime, but CLI tools like `build-generated-code` and `migrate` are not compiled with `-threaded`. This causes them to print RTS usage and exit with an error.

This broke CI for projects using IHP (e.g. https://github.com/amitaibu/ihp-sensors/pull/2#issuecomment-3867450032).

## Why this is safe
The `GHCRTS` was redundant — both the DevServer and its GHCi subprocess already have their own RTS flags:
- **DevServer**: `-with-rtsopts=-A512m -N -n4m --nonmoving-gc -Iw60` in `ihp-ide.cabal`
- **GHCi subprocess**: `+RTS -A256m -n4m -H512m --nonmoving-gc -Iw60 -N` passed directly in `DevServer.hs:152`

## Test plan
- [ ] `nix flake check --impure` passes
- [ ] `build-generated-code` works without crashing in a devenv shell
- [ ] Dev server still starts with optimized RTS flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)