### PR TITLE
Switch default PostgreSQL from 17 to 18

### DIFF
--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -34,7 +34,7 @@ Once you have created your project, the first step is to define a database schem
 
 In a new project, this file will be empty.
 
-If you are using PostgreSQL 18 or newer, you can set the environment variable `IHP_POSTGRES_VERSION=18` to use the native `uuidv7()` function as the default for new tables and jobs instead of `uuid_generate_v4()`. UUIDv7 provides time-ordered UUIDs that are better for database indexing.
+IHP uses PostgreSQL 18 by default, which provides the native `uuidv7()` function for time-ordered UUIDs that are better for database indexing. New tables and jobs will use `uuidv7()` as the default UUID function. If you need to use PostgreSQL 17, set the environment variable `IHP_POSTGRES_VERSION=17` to fall back to `uuid_generate_v4()`.
 
 To define your database schema add your `CREATE TABLE ...` statements to the `Schema.sql`. For a users table this can look like this:
 

--- a/NixSupport/nixosModules/appWithPostgres.nix
+++ b/NixSupport/nixosModules/appWithPostgres.nix
@@ -63,6 +63,7 @@ in
     # Postgres
     services.postgresql = {
         enable = true;
+        package = pkgs.postgresql_18;
         initialScript = pkgs.writeText "ihp-initScript" ''
             CREATE USER ${cfg.databaseUser};
             CREATE DATABASE ${cfg.databaseName} OWNER ${cfg.databaseUser};

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,39 @@
 This document describes breaking changes, as well as how to fix them, that have occured at given releases.
 After updating your project, please consult the segments from your current release until now.
 
+# PostgreSQL 18 Upgrade
+
+IHP now defaults to PostgreSQL 18, which provides the native `uuidv7()` function for time-ordered UUIDs. New tables and jobs created by the code generators will use `uuidv7()` instead of `uuid_generate_v4()`.
+
+Existing `Schema.sql` files using `uuid_generate_v4()` continue to work — the `uuid-ossp` extension is still loaded.
+
+### Upgrading your dev database
+
+1. Save your local data (if needed):
+   ```bash
+   make dumpdb
+   ```
+
+2. Remove the old database files:
+   ```bash
+   # devenv users:
+   rm -rf .devenv/state/postgres/
+
+   # non-devenv users:
+   rm -rf build/db
+   ```
+
+3. Start the dev server — the database will be recreated with PG 18:
+   ```bash
+   devenv up
+   ```
+
+If you need to stay on PostgreSQL 17, set `IHP_POSTGRES_VERSION=17` in your environment.
+
+### Upgrading production (NixOS)
+
+If your production server uses the IHP `appWithPostgres` NixOS module, deploying will automatically use PG 18. Follow the [PostgreSQL upgrade guide on the NixOS wiki](https://wiki.nixos.org/wiki/PostgreSQL#Upgrading) to migrate your production data.
+
 # Upgrade to 1.5.0 from 1.4.0
 
 ## 1. Switch IHP version

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -19,7 +19,7 @@ that is defined in flake-module.nix
 
                     # Wrap a package's check phase with a temporary PostgreSQL server
                     withTestPostgres = pkg: pkg.overrideAttrs (old: {
-                        nativeCheckInputs = (old.nativeCheckInputs or []) ++ [ pkgs.postgresql ];
+                        nativeCheckInputs = (old.nativeCheckInputs or []) ++ [ pkgs.postgresql_18 ];
                         preCheck = ''
                             ${old.preCheck or ""}
                             export PGDATA="$TMPDIR/pgdata"
@@ -105,7 +105,7 @@ that is defined in flake-module.nix
                             hspec
                         ]))
                         pkgs.gnumake
-                        pkgs.postgresql
+                        pkgs.postgresql_18
                     ];
                     buildPhase = ''
                         export IHP_LIB=${hsDataDir pkgs.ghc.ihp-ide.data}

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -357,6 +357,7 @@ ihpFlake:
                 # As the devenv postgres uses a different location for the socket
                 # this would break lots of known commands such as `make db`
                 services.postgres.enable = true;
+                services.postgres.package = pkgs.postgresql_18;
                 services.postgres.initialDatabases = [
                     {
                     name = "app";

--- a/ihp/IHP/PGVersion.hs
+++ b/ihp/IHP/PGVersion.hs
@@ -9,6 +9,6 @@ import Text.Read (readMaybe)
 -- Otherwise returns @"uuid_generate_v4"@ (requires uuid-ossp extension).
 defaultUuidFunction :: IO Text
 defaultUuidFunction = do
-    pgVersion <- fromMaybe "17" <$> Env.lookupEnv "IHP_POSTGRES_VERSION"
-    let version = fromMaybe 17 (readMaybe pgVersion :: Maybe Int)
+    pgVersion <- fromMaybe "18" <$> Env.lookupEnv "IHP_POSTGRES_VERSION"
+    let version = fromMaybe 18 (readMaybe pgVersion :: Maybe Int)
     pure if version >= 18 then "uuidv7" else "uuid_generate_v4"


### PR DESCRIPTION
## Summary

- Switches IHP's default PostgreSQL version from 17 to 18
- PG 18 provides the native `uuidv7()` function, making time-ordered UUIDs the out-of-the-box experience
- Pins `postgresql_18` in devenv service, nix test environments, and NixOS deployment module
- Updates `PGVersion.hs` default so `uuidv7()` is used without needing `IHP_POSTGRES_VERSION=18`
- Adds upgrade instructions to `UPGRADE.md`

## Test plan

- [x] `defaultUuidFunction` returns `"uuidv7"` with no env var set
- [x] All 361 ihp-ide tests pass
- [x] No remaining hardcoded `postgresql_17` references
- [ ] `nix flake check --impure` passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)