### PR TITLE
Truncate long database query logs

### DIFF
--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -406,7 +406,7 @@ sqlQueryHasql pool snippet decoder = do
                 end <- getCurrentTime
                 let queryTimeInMs = round (realToFrac (end `diffUTCTime` start) * 1000 :: Double)
                 let sqlText = Hasql.toSql statement
-                Log.debug ("🔍 " <> cs sqlText <> " (" <> Text.pack (show queryTimeInMs) <> "ms)")
+                Log.debug ("🔍 " <> truncateQuery (cs sqlText) <> " (" <> Text.pack (show queryTimeInMs) <> "ms)")
         else runQuery
 {-# INLINABLE sqlQueryHasql #-}
 
@@ -429,7 +429,7 @@ sqlExecHasql pool snippet = do
                 end <- getCurrentTime
                 let queryTimeInMs = round (realToFrac (end `diffUTCTime` start) * 1000 :: Double)
                 let sqlText = Hasql.toSql statement
-                Log.debug ("💾 " <> cs sqlText <> " (" <> Text.pack (show queryTimeInMs) <> "ms)")
+                Log.debug ("💾 " <> truncateQuery (cs sqlText) <> " (" <> Text.pack (show queryTimeInMs) <> "ms)")
         else runQuery
 {-# INLINABLE sqlExecHasql #-}
 
@@ -672,6 +672,11 @@ primaryKeyConditionColumnSelector =
 primaryKeyCondition :: forall record. (HasField "id" record (Id record), Table record) => record -> PG.Action
 primaryKeyCondition record = primaryKeyConditionForId @record record.id
 
+truncateQuery :: Text -> Text
+truncateQuery query
+    | Text.length query > 2000 = Text.take 2000 query <> "... (truncated)"
+    | otherwise = query
+
 logQuery :: (?modelContext :: ModelContext, PG.ToRow parameters) => Text -> PG.Connection -> Query -> parameters -> NominalDiffTime -> IO ()
 logQuery logPrefix connection query parameters time = do
         let ?context = ?modelContext
@@ -685,7 +690,7 @@ logQuery logPrefix connection query parameters time = do
                 Nothing -> ""
 
         formatted <- PG.formatQuery connection query parameters
-        Log.debug (logPrefix <> " " <> cs formatted <> rlsInfo <> " (" <> Text.pack (show queryTimeInMs) <> "ms)")
+        Log.debug (logPrefix <> " " <> truncateQuery (cs formatted) <> rlsInfo <> " (" <> Text.pack (show queryTimeInMs) <> "ms)")
 {-# INLINABLE logQuery #-}
 
 -- | Runs a @DELETE@ query for a record.


### PR DESCRIPTION
## Summary
- Queries containing binary data (e.g. bytea image uploads) produce enormous log lines that are unreadable and waste disk/terminal space
- Adds a `truncateQuery` helper that caps logged SQL text at 2000 characters, appending `... (truncated)` when exceeded
- Applied at all 3 debug logging points: pg-simple (`logQuery`), hasql SELECT (`sqlQueryHasql`), and hasql exec (`sqlExecHasql`)

## Test plan
- [x] Module compiles cleanly via `ghci`
- [ ] Verify truncation works by inserting a record with large bytea data and checking debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)