### PR TITLE
Fix typos for Guide

### DIFF
--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -822,7 +822,7 @@ withTransaction do
 In this example, when the creation of the User fails, the creation of the company will be rolled back. So that no
 incomplete data is left in the database when there's an error.
 
-The [`withTransaction`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:withTransaction) function will automatically commit after it succesfully executed the passed do-block. When any exception is thrown, it will automatically rollback.
+The [`withTransaction`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:withTransaction) function will automatically commit after it successfully executed the passed do-block. When any exception is thrown, it will automatically rollback.
 
 Keep in mind that some IHP functions like [`redirectTo`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Redirect.html#v:redirectTo) or [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:render) throw a [`ResponseException`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:ResponseException). So code like below will not work as expected:
 

--- a/Guide/deployment.markdown
+++ b/Guide/deployment.markdown
@@ -39,7 +39,7 @@ The EC2 instance, RDS database, VPS, subnets, security groups, etc, can be setup
    ```
 6. Important data like the RDS endpoint and the EC2 instance URL is written to the file `db_info.txt`
 
-Now the NixOS instance and Postgres database is setup and an SSH conncetion can be established to it.
+Now the NixOS instance and Postgres database is setup and an SSH connection can be established to it.
 
 #### Creating a new EC2 Instance
 
@@ -416,9 +416,9 @@ $ docker run \
 
 ##### `IHP_ASSET_VERSION`
 
-**As of IHP v0.16 this env variable is automatically set to a unqiue build hash.**
+**As of IHP v0.16 this env variable is automatically set to a unique build hash.**
 
-If you use [`assetPath` helpers](assets.html) in your app, specifiy the `IHP_ASSET_VERSION` env var. Set it e.g. to your commit hash or to the release timestamp.
+If you use [`assetPath` helpers](assets.html) in your app, specify the `IHP_ASSET_VERSION` env var. Set it e.g. to your commit hash or to the release timestamp.
 
 ```bash
 $ docker run \
@@ -443,7 +443,7 @@ $ docker run \
 
 Without specifying this env var, the app will always use `http://localhost:8000/` in absolute URLs it's generating (e.g. when redirecting or sending out emails).
 
-It's therefore important to set it to the external user-facing web addresss. E.g. if your IHP app is available at `https://example.com/`, the variable should be set to that:
+It's therefore important to set it to the external user-facing web address. E.g. if your IHP app is available at `https://example.com/`, the variable should be set to that:
 
 ```bash
 $ docker run \
@@ -800,7 +800,7 @@ You can also use `IHP_ENV=Development` to force dev mode.
 
 Without specifying this env var, the app will always use `http://localhost:8000/` in absolute URLs it's generating (e.g. when redirecting or sending out emails).
 
-It's therefore important to set it to the external user-facing web addresss. E.g. if your IHP app is available at `https://example.com/`, the variable should be set to that:
+It's therefore important to set it to the external user-facing web address. E.g. if your IHP app is available at `https://example.com/`, the variable should be set to that:
 
 ```bash
 $ export IHP_BASEURL=https://example.com
@@ -872,7 +872,7 @@ $ ./build/bin/RunProdServer
 
 As of IHP v0.16 this env variable is automatically set to a unique build hash.
 
-If you use [`assetPath` helpers](assets.html) in your app, specifiy the `IHP_ASSET_VERSION` env var. Set it e.g. to your commit hash or to the release timestamp.
+If you use [`assetPath` helpers](assets.html) in your app, specify the `IHP_ASSET_VERSION` env var. Set it e.g. to your commit hash or to the release timestamp.
 
 ```bash
 $ export IHP_ASSET_VERSION=af5f389ef7a64a04c9fa275111e4739c0d4a78d0

--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -408,7 +408,7 @@ uploadOrRemoveMaybeImage imageProperty isRemove record = do
 
 Note that the above function doesn't actually remove the file from the storage. It just removes the reference to the file from the record. To remove the file from storage you would need to call [`removeFileFromStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:removeFileFromStorage).
 
-Finally, let's add some Javacript, that would take care of removing the image from the file input, as well as hiding the "Remove image" checkbox when there's no image to remove.
+Finally, let's add some Javascript, that would take care of removing the image from the file input, as well as hiding the "Remove image" checkbox when there's no image to remove.
 
 ```javascript
 # app.js

--- a/Guide/form.markdown
+++ b/Guide/form.markdown
@@ -571,7 +571,7 @@ If you want a certain value to be preselected, set the value in the controller. 
         render NewView { .. }
 ```
 
-In your `Show.hs` file you can re-use the `selectLabel` to render the user name, the same it did on the select list.
+In your `Show.hs` file you can reuse the `selectLabel` to render the user name, the same it did on the select list.
 
 ```haskell
 instance View ShowView where
@@ -635,7 +635,7 @@ view to generate the list of select fields:
       allContentTypes = allEnumValues @ContentType
 ```
 
-In your `Show.hs` file you can re-use the `selectLabel` to render the content type, the same it did on the select list.
+In your `Show.hs` file you can reuse the `selectLabel` to render the content type, the same it did on the select list.
 
 ```haskell
 instance View ShowView where
@@ -808,7 +808,7 @@ The generated HTML will look like this:
 
 ### Custom Form Attributes
 
-You can specifiy custom HTML attributes using [`formForWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formForWithOptions):
+You can specify custom HTML attributes using [`formForWithOptions`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formForWithOptions):
 
 ```haskell
 renderForm :: Post -> Html

--- a/Guide/helpful-tips.markdown
+++ b/Guide/helpful-tips.markdown
@@ -103,7 +103,7 @@ ShowPostAction { postId :: !(Id Post) }
 
 The `!` marks the `postId` field as strict. Strict means that the value of `postId` is not stored as a lazy value. So instead of only computing the `postId` field when needed, it will already be fully computed when the `ShowPostAction` value is constructed. Basically we tell haskell that we're sure that this field is always needed. This makes the action data structures more memory efficient.
 
-[You can learn more about strictness and lazyness in haskell in this blog post.](https://www.fpcomplete.com/blog/2017/09/all-about-strictness/)
+[You can learn more about strictness and laziness in haskell in this blog post.](https://www.fpcomplete.com/blog/2017/09/all-about-strictness/)
 
 ### The `\case`
 

--- a/Guide/hsx.markdown
+++ b/Guide/hsx.markdown
@@ -78,7 +78,7 @@ This will not render the attribute, [as specified in the HTML standard](https://
 
 #### Boolean data attributes
 
-This behavior of omiting a attribute when it's set to `False` does not apply to `data-` attributes.
+This behavior of omitting a attribute when it's set to `False` does not apply to `data-` attributes.
 
 You can write
 
@@ -471,7 +471,7 @@ html = [hsx|
         style = "someClassName&" :: Text
 ```
 
-The above code will generate the following HTML, where the `&` symbol has been replaced with it's escpaed form `&amp;`:
+The above code will generate the following HTML, where the `&` symbol has been replaced with it's escaped form `&amp;`:
 
 ```html
 <div class="someClassName&amp;">Hello World</div>

--- a/Guide/htmx-and-hyperscript.markdown
+++ b/Guide/htmx-and-hyperscript.markdown
@@ -29,7 +29,7 @@ This makes sure that htmx and hyperscript code does not stop working after a Tur
 
 ## htmx
 
-htmx gives you access to AJAX, as a way to update views locally with an API conviently residing in HTML attributes.
+htmx gives you access to AJAX, as a way to update views locally with an API conveniently residing in HTML attributes.
 
 Instead of the typical Single Page Application pattern parsing JSON and turning into html in the DOM, the API endpoints simply just return HTML to be patched into the DOM.
 
@@ -65,7 +65,7 @@ data CounterController
 
 Add `parseRoute @CounterController` to the list of `instance FrontController WebApplication` in `FrontController.hs` (or you'll get a 404 on calling it), and add an `instance AutoRoute CounterController` to `Routes.hs` (or you'll get a compilation error about it not being an instance of AutoRoute).
 
-Instead of using the `render` function, htmx routes are better used with `respondHtml` to avoid the layout being shipped as part of the response. The same function can be used for initializing the view as well as upating.
+Instead of using the `render` function, htmx routes are better used with `respondHtml` to avoid the layout being shipped as part of the response. The same function can be used for initializing the view as well as updating.
 
 ```haskell
 module Web.Controller.Counter where

--- a/Guide/jobs.markdown
+++ b/Guide/jobs.markdown
@@ -267,7 +267,7 @@ The third type parameter to [`JobsDashboardController`](https://ihp.digitallyind
 ### Customize views
 
 Most views in the dashboard can be customized by providing a custom implementation of [`DisplayableJob`](https://ihp.digitallyinduced.com/api-docs/IHP-Job-Dashboard.html#t:DisplayableJob) for your job type.
-These methods can be overriden to allow for custom behavior:
+These methods can be overridden to allow for custom behavior:
 
 ```haskell
 makeDashboardSection :: (?context::ControllerContext, ?modelContext::ModelContext) => IO SomeView
@@ -292,7 +292,7 @@ Can be defined as any arbitrary view:
 makeNewJobView :: (?context::ControllerContext, ?modelContext::ModelContext) => IO SomeView
 ```
 The content of the page that will be displayed for the "new job" form of this job.
-By default, only the submit button is rendered. For additonal form data, define your own implementation.
+By default, only the submit button is rendered. For additional form data, define your own implementation.
 See `GenericNewJobView` for a guide on how it can look like.
 It can be defined as any arbitrary view, but it should be a form:
 

--- a/Guide/oauth.markdown
+++ b/Guide/oauth.markdown
@@ -128,7 +128,7 @@ import IHP.ViewPrelude
 import IHP.OAuth.Google.Types  -- <---- ADD THIS
 ```
 
-This ensures that we can write `pathTo NewSessionWithGoogleAction` and similiar calls without always manually needing to add import statements.
+This ensures that we can write `pathTo NewSessionWithGoogleAction` and similar calls without always manually needing to add import statements.
 
 ### Config
 
@@ -394,7 +394,7 @@ import IHP.ViewPrelude
 import IHP.OAuth.Github.Types  -- <---- ADD THIS
 ```
 
-This ensures that we can write [`pathTo NewSessionWithGithubAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo) and similiar calls without always manually needing to add import statements.
+This ensures that we can write [`pathTo NewSessionWithGithubAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo) and similar calls without always manually needing to add import statements.
 
 
 ### Config

--- a/Guide/realtime-spas.markdown
+++ b/Guide/realtime-spas.markdown
@@ -151,7 +151,7 @@ Now open the view in the browser. You should see `Hello from react!` on the page
 
 ### Building a Realtime SPA with IHP DataSync
 
-*The following section asumes that your app already has a login as described in the [Authentication](https://ihp.digitallyinduced.com/Guide/authentication.html#setup) section.*
+*The following section assumes that your app already has a login as described in the [Authentication](https://ihp.digitallyinduced.com/Guide/authentication.html#setup) section.*
 
 IHP DataSync is an IHP API that allows your to query your app's database from within JS. Basically it provides functions like `query`, `fetchOne` or `createRecord`, which you're already familiar with from the Haskell side, but makes them available in JavaScript land.
 
@@ -163,7 +163,7 @@ const posts = await query('posts')
     .fetch()
 ```
 
-This is very similiar to how you would do it on the Haskell backend side:
+This is very similar to how you would do it on the Haskell backend side:
 
 ```haskell
 posts <- query @Post
@@ -473,7 +473,7 @@ Next we're going to add a todo form to create new todos:
 
 Our todo app is already realtime. Open the app again and enter a new todo. You will now see it showing up instantly. You can also open a second browser window (keep in mind that you need to be logged in), and changes will appear in both windows at the same time.
 
-The `useQuery(query('todos'))` call in our `TodoList` has set up a subscription behind the scences. Whenever the result set of our `query('todos')` we fired here changes, it will trigger a re-render of our component.
+The `useQuery(query('todos'))` call in our `TodoList` has set up a subscription behind the scenes. Whenever the result set of our `query('todos')` we fired here changes, it will trigger a re-render of our component.
 
 ##### Checking off Todos
 
@@ -498,7 +498,7 @@ function TodoItem({ todo }) {
 }
 ```
 
-This displays a checkbox next to the todo title. When the checkbox is toggled it will call `updateRecord('todos', todo.id, { isCompleted: !todo.isCompleted })`. This function is similiar to the `updateRecord` on the Haskell side, but only takes a patch object as a argument.
+This displays a checkbox next to the todo title. When the checkbox is toggled it will call `updateRecord('todos', todo.id, { isCompleted: !todo.isCompleted })`. This function is similar to the `updateRecord` on the Haskell side, but only takes a patch object as a argument.
 
 Now we need to use this new `TodoItem` component inside our `TodoList`. Change the `render()` function of the `TodoList` to this:
 

--- a/Guide/relationships.markdown
+++ b/Guide/relationships.markdown
@@ -59,7 +59,7 @@ The `post.comments` returns a list of the comments belonging to the post.
 
 The type of `post` is [`Include "comments" Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) instead of the usual `Post`. This way the state of a fetched nested resource is tracked at the type level.
 
-It is possible to have multiple nested resources. For example, if Post had a list of comments and tags related to it, it can be defined as [`Include "comments" (Include "tags" Post)`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) or with the more convinient way as [`Include' ["comments", "tags"] Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include-39-).
+It is possible to have multiple nested resources. For example, if Post had a list of comments and tags related to it, it can be defined as [`Include "comments" (Include "tags" Post)`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) or with the more convenient way as [`Include' ["comments", "tags"] Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include-39-).
 
 Note that for the above example, it is expected that the query will change as-well:
 
@@ -260,7 +260,7 @@ To add `WHERE` clauses involving a joined table, there is a family of functions 
 
 ### Many-to-many relationships and labeled results
 
-Joins are also useful when it comes to many-to-many relationships. An example is the realationship between blog posts and tags: each post can have multiple tags and each tag can be attached to any number of posts. The following code could be used to obtain all posts with the tag 'haskell' or 'ihp'.
+Joins are also useful when it comes to many-to-many relationships. An example is the relationship between blog posts and tags: each post can have multiple tags and each tag can be attached to any number of posts. The following code could be used to obtain all posts with the tag 'haskell' or 'ihp'.
 
 ```haskell
 query @Post
@@ -383,7 +383,7 @@ fetchPostWithRecords postId = do
     post <- fetch postId
 
     -- Fetch Comments referencing the post ID.
-    -- Eventhough we haven't used `fetchRelated` on the Post we still have the `post.comments` field.
+    -- Even though we haven't used `fetchRelated` on the Post we still have the `post.comments` field.
     -- This field field is a query builder with the right `WHERE` condition already applied (referencing the Post ID),
     -- so we only need to `fetch` and don't have to use the more verbose `query`:
     -- comments <- query @Comment

--- a/Guide/server-side-components.markdown
+++ b/Guide/server-side-components.markdown
@@ -80,7 +80,7 @@ Inside the [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideCo
 
 When the `callServerAction('IncrementCounterAction')` is called, it will trigger the [`action state IncrementCounterAction = do`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:action) haskell block to be called on the server.
 
-You can see that the [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:action) handler get's passed the current state and will return a new state based on the action and the current state.
+You can see that the [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:action) handler gets passed the current state and will return a new state based on the action and the current state.
 
 ### FrontController
 
@@ -170,7 +170,7 @@ To call the `SetSearchQuery` action with a specific `searchQuery` value, we can 
 
 You can use the typical IHP database operations like [`query @Post`](https://ihp.digitallyinduced.com/api-docs/IHP-QueryBuilder.html#v:query) or [`createRecord`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) from your actions.
 
-To fill the inital data you can use the [`componentDidMount`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) lifecycle function:
+To fill the initial data you can use the [`componentDidMount`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) lifecycle function:
 
 ```haskell
 data PostsTable = PostsTable
@@ -195,7 +195,7 @@ instance Component PostsTable PostsTableController where
     |]
 ```
 
-The [`componentDidMount`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) get's passed the initial state and returns a new state. It's called right after the first render once the client has wired up the WebSocket connection.
+The [`componentDidMount`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:createRecord) gets passed the initial state and returns a new state. It's called right after the first render once the client has wired up the WebSocket connection.
 
 When the `posts` field is set to `Nothing` we know that the data is still being fetched. In that case we render a loading spinner inside our [`render`](https://ihp.digitallyinduced.com/api-docs/IHP-ServerSideComponent-Types.html#v:render) function.
 

--- a/Guide/session.markdown
+++ b/Guide/session.markdown
@@ -75,7 +75,7 @@ Use [`setSuccessMessage`](https://ihp.digitallyinduced.com/api-docs/IHP-FlashMes
 ```haskell
 action CreatePostAction = do
     ...
-    setSuccessMessage "Your Post has been created succesfully"
+    setSuccessMessage "Your Post has been created successfully"
     redirectTo ShowPostAction { .. }
 ```
 

--- a/Guide/stripe.markdown
+++ b/Guide/stripe.markdown
@@ -10,7 +10,7 @@ You can use the IHP Stripe Integration to accept payments within your IHP applic
 
 The IHP Stripe integration is available [with IHP Pro and IHP Business](ihp-pro.html). If you're not on IHP Pro yet, now is a good time to try it out. By switching to Pro, you're supporting the sustainable development of IHP.
 
-This guide asumes you've read through the basics of the stripe documentation to get a gist of how the stripe api works.
+This guide assumes you've read through the basics of the stripe documentation to get a gist of how the stripe api works.
 
 ## Setup
 
@@ -81,7 +81,7 @@ Replace the `whsec_...` and `pk_test_...` with your stripe api keys. It's best t
 
 ## Subscriptions
 
-In this guide we'll deal with how to set up a typical SaaS subscription. We also asume you're using [stripe tax to collect VAT](https://stripe.com/en-de/tax).
+In this guide we'll deal with how to set up a typical SaaS subscription. We also assume you're using [stripe tax to collect VAT](https://stripe.com/en-de/tax).
 
 ### Plans
 

--- a/Guide/updating.markdown
+++ b/Guide/updating.markdown
@@ -12,7 +12,7 @@ A new version is usually announced first via the [IHP Newsletter](http://eepurl.
 
 ## Upgrade Instructions
 
-[See UPGRADE.md](https://github.com/digitallyinduced/ihp/blob/master/UPGRADE.md) for intructions on how to upgrade your IHP project to a newer version of IHP.
+[See UPGRADE.md](https://github.com/digitallyinduced/ihp/blob/master/UPGRADE.md) for instructions on how to upgrade your IHP project to a newer version of IHP.
 
 ## Updating to the Latest Release
 

--- a/Guide/validation.markdown
+++ b/Guide/validation.markdown
@@ -341,7 +341,7 @@ buildComment comment = comment
     |> fill @'["postId", "body", "commentModeration"]
 ```
 
-We'll start with the `postId`. Once a comment is refernecing a post it will never have the reference change. So it means we should fill it only upon creation.
+We'll start with the `postId`. Once a comment is referencing a post it will never have the reference change. So it means we should fill it only upon creation.
 
 ```haskell
 buildComment comment = comment

--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -344,7 +344,7 @@ WRONG:
 
 RIGHT:
 <head>
-    <title>{pageTitleOrDefault "The default page title, can be overriden in views"}</title>
+    <title>{pageTitleOrDefault "The default page title, can be overridden in views"}</title>
 </head>
 ```
 

--- a/Guide/websockets.markdown
+++ b/Guide/websockets.markdown
@@ -10,7 +10,7 @@ IHP has first class support for WebSockets.
 
 **When you only want to use WebSockets to update the UI:** Check out [Auto Refresh](https://ihp.digitallyinduced.com/Guide/auto-refresh.html). The Auto Refresh API provides a high-level approach for pushing HTML/UI updates from the server-side build on top of WebSockets.
 
-The entry points for your WebSocket servers are similiar to the typical IHP controllers, and are also stored in the `Web/Controller/` directory. Similiar to normal IHP controllers, the WebSocket servers are also added to the [`FrontController`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:FrontController) later on.
+The entry points for your WebSocket servers are similar to the typical IHP controllers, and are also stored in the `Web/Controller/` directory. Similar to normal IHP controllers, the WebSocket servers are also added to the [`FrontController`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#t:FrontController) later on.
 
 ## Creating a WebSocket Controller
 


### PR DESCRIPTION
Found via `codespell Guide/ -L shouldbe,optiona,foto,doubleclick`