### PR TITLE
Fix migrate crash: cannot enter pipeline mode

### DIFF
--- a/ihp-migrate/Test/SchemaMigrationSpec.hs
+++ b/ihp-migrate/Test/SchemaMigrationSpec.hs
@@ -28,6 +28,36 @@ tests = do
                             , Migration { revision = 1605721940, migrationFile = "1605721940-create-users.sql" }
                             ]
 
+        describe "splitStatements" do
+            it "should split simple statements" do
+                splitStatements "CREATE TABLE a (id INT); CREATE TABLE b (id INT);"
+                    `shouldBe` ["CREATE TABLE a (id INT)", "CREATE TABLE b (id INT)"]
+
+            it "should handle statements without trailing semicolon" do
+                splitStatements "CREATE TABLE a (id INT); CREATE TABLE b (id INT)"
+                    `shouldBe` ["CREATE TABLE a (id INT)", "CREATE TABLE b (id INT)"]
+
+            it "should ignore semicolons inside single-quoted strings" do
+                splitStatements "INSERT INTO t (v) VALUES ('hello; world'); SELECT 1"
+                    `shouldBe` ["INSERT INTO t (v) VALUES ('hello; world')", "SELECT 1"]
+
+            it "should handle escaped quotes in strings" do
+                splitStatements "INSERT INTO t (v) VALUES ('it''s a test'); SELECT 1"
+                    `shouldBe` ["INSERT INTO t (v) VALUES ('it''s a test')", "SELECT 1"]
+
+            it "should ignore semicolons in line comments" do
+                splitStatements "SELECT 1; -- this; is a comment\nSELECT 2"
+                    `shouldBe` ["SELECT 1", "-- this; is a comment\nSELECT 2"]
+
+            it "should handle empty input" do
+                splitStatements "" `shouldBe` []
+
+            it "should filter blank statements from extra semicolons" do
+                splitStatements "SELECT 1;; SELECT 2;" `shouldBe` ["SELECT 1", "SELECT 2"]
+
+            it "should handle a single statement" do
+                splitStatements "CREATE TABLE users (id INT)" `shouldBe` ["CREATE TABLE users (id INT)"]
+
 withTempApp :: IO a -> IO a
 withTempApp action =
     withSystemTempDirectory "ihp-migrate-test" \tmp -> do


### PR DESCRIPTION
## Summary
- hasql 1.10's `Session.script` (used by `Transaction.sql`) uses `PQsendQuery` + `singleResult` internally, which only handles a single SQL result. Multi-statement migration files produce multiple results via `PQsendQuery`, leaving unconsumed results on the connection. The transaction error handler then tries to ROLLBACK via pipeline mode, which fails with `"cannot enter pipeline mode, connection not idle"`.
- Fix by splitting migration SQL into individual statements (respecting quoted strings and `--` comments) and executing each one separately via `Session.script` in a single session with manual `BEGIN`/`COMMIT`.
- Adds 8 tests for the new `splitStatements` function.

## Test plan
- [x] Existing `findAllMigrations` test passes
- [x] New `splitStatements` tests pass (simple split, quoted strings, escaped quotes, line comments, empty input, extra semicolons, single statement)
- [ ] Deploy and verify migration service starts without `ConnectionSessionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)