### PR TITLE
Replace postgresql-simple with hasql in ihp-hspec

### DIFF
--- a/ihp-hspec/IHP/Hspec.hs
+++ b/ihp-hspec/IHP/Hspec.hs
@@ -1,8 +1,12 @@
 module IHP.Hspec (withIHPApp) where
 
 import IHP.Prelude
-import qualified Database.PostgreSQL.Simple as PG
-import qualified Database.PostgreSQL.Simple.Types as PG
+import qualified Hasql.Connection as Hasql
+import qualified Hasql.Connection.Settings as HasqlSettings
+import qualified Hasql.Session as Session
+import qualified Hasql.Statement as Statement
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
 import qualified Data.UUID.V4 as UUID
 import qualified Data.UUID as UUID
 import qualified Data.Text as Text
@@ -21,7 +25,19 @@ import IHP.Log.Types
 import qualified System.Process as Process
 import IHP.Test.Mocking (MockContext(..), runTestMiddlewares)
 
-withConnection databaseUrl = Exception.bracket (PG.connectPostgreSQL databaseUrl) PG.close
+withConnection :: ByteString -> (Hasql.Connection -> IO a) -> IO a
+withConnection databaseUrl action = do
+    connResult <- Hasql.acquire (HasqlSettings.connectionString (cs databaseUrl))
+    case connResult of
+        Right conn -> action conn `Exception.finally` Hasql.release conn
+        Left err -> error (show err)
+
+runSessionOnConnection :: Hasql.Connection -> Session.Session a -> IO ()
+runSessionOnConnection conn session = do
+    result <- Hasql.use conn session
+    case result of
+        Left err -> error (show err)
+        Right _ -> pure ()
 
 -- | Create contexts that can be used for mocking
 withIHPApp :: (InitControllerContext application) => application -> ConfigBuilder -> (MockContext application -> IO ()) -> IO ()
@@ -41,21 +57,30 @@ withIHPApp application configBuilder hspecAction = do
 
             hspecAction MockContext { .. }
 
+withTestDatabase :: ByteString -> (ByteString -> IO ()) -> IO ()
 withTestDatabase masterDatabaseUrl callback = do
     testDatabaseName <- randomDatabaseName
 
     withConnection masterDatabaseUrl \masterConnection ->
         Exception.bracket_
-            (PG.execute masterConnection "CREATE DATABASE ?" [PG.Identifier testDatabaseName])
+            (runSessionOnConnection masterConnection (execDDL ("CREATE DATABASE " <> quoteIdentifier testDatabaseName)))
             (
                 -- The WITH FORCE is required to force close open connections
-                PG.execute masterConnection "DROP DATABASE ? WITH (FORCE)" [PG.Identifier testDatabaseName]
+                runSessionOnConnection masterConnection (execDDL ("DROP DATABASE " <> quoteIdentifier testDatabaseName <> " WITH (FORCE)"))
             )
             do
                 let testDatabaseUrl = injectDatabaseName testDatabaseName masterDatabaseUrl
                 importSql testDatabaseUrl
                 callback testDatabaseUrl
     pure ()
+
+-- | Execute a DDL statement (CREATE DATABASE, DROP DATABASE, etc.)
+execDDL :: Text -> Session.Session ()
+execDDL sql = Session.statement () (Statement.unpreparable (cs sql) Encoders.noParams Decoders.noResult)
+
+-- | Quote a SQL identifier (e.g., database name) with double quotes
+quoteIdentifier :: Text -> Text
+quoteIdentifier name = "\"" <> Text.replace "\"" "\"\"" name <> "\""
 
 -- | Imports the IHP Schema.sql and Application/Schema.sql
 importSql :: ByteString -> IO ()

--- a/ihp-hspec/ihp-hspec.cabal
+++ b/ihp-hspec/ihp-hspec.cabal
@@ -28,6 +28,6 @@ library
         ImplicitParams
         RecordWildCards
     ghc-options: -Werror=incomplete-patterns
-    build-depends: base >= 4.17.0 && < 4.22, ihp, ihp-log, wai, process, text, ihp-ide, vault, uuid, postgresql-simple, wai-request-params
+    build-depends: base >= 4.17.0 && < 4.22, ihp, ihp-log, wai, process, text, ihp-ide, vault, uuid, hasql, wai-request-params
     hs-source-dirs: .
     exposed-modules: IHP.Hspec


### PR DESCRIPTION
## Summary
- Replace `Database.PostgreSQL.Simple` connection/execute calls with hasql equivalents for test database CREATE/DROP operations
- Remove `postgresql-simple` from ihp-hspec's build-depends, add `hasql`
- DDL statements use unprepared hasql statements with manually quoted identifiers, matching the existing pattern in ihp-datasync

## Test plan
- [ ] CI passes (`nix flake check`)
- [ ] Verify ihp-hspec compiles without postgresql-simple dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)