### PR TITLE
Fix hasql type mismatch for information_schema queries

### DIFF
--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -219,7 +219,7 @@ fetchTableNames =
 fetchTableCols :: (?modelContext :: ModelContext) => Text -> IO [ColumnDefinition]
 fetchTableCols tableName =
     runSnippetQuery
-        (Snippet.sql "SELECT column_name, data_type, column_default, CASE WHEN is_nullable='YES' THEN true ELSE false END FROM information_schema.columns WHERE table_name = " <> Snippet.param tableName <> Snippet.sql " ORDER BY ordinal_position")
+        (Snippet.sql "SELECT column_name::text, data_type::text, column_default::text, CASE WHEN is_nullable='YES' THEN true ELSE false END FROM information_schema.columns WHERE table_name = " <> Snippet.param tableName <> Snippet.sql " ORDER BY ordinal_position")
         columnDefinitionDecoder
 
 fetchRow :: (?modelContext :: ModelContext) => Text -> [Text] -> IO [[DynamicField]]
@@ -315,7 +315,7 @@ isQuery sql = T.isInfixOf "SELECT" u
 fetchForeignKeyInfo :: (?modelContext :: ModelContext) => Text -> Text -> IO (Maybe (Text, Text))
 fetchForeignKeyInfo tableName columnName = do
     let snippet =
-            Snippet.sql "SELECT ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name FROM information_schema.table_constraints AS tc JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = "
+            Snippet.sql "SELECT ccu.table_name::text AS foreign_table_name, ccu.column_name::text AS foreign_column_name FROM information_schema.table_constraints AS tc JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = "
             <> Snippet.param tableName
             <> Snippet.sql " AND kcu.column_name = "
             <> Snippet.param columnName

--- a/ihp-job-dashboard/IHP/Job/Dashboard.hs
+++ b/ihp-job-dashboard/IHP/Job/Dashboard.hs
@@ -175,7 +175,7 @@ instance JobsDashboard '[] where
         render $ SomeView tables
         where
             getAllTableNames = sqlQueryHasql getHasqlPool
-                (Snippet.sql "SELECT table_name FROM information_schema.tables WHERE table_name LIKE '%_jobs'")
+                (Snippet.sql "SELECT table_name::text FROM information_schema.tables WHERE table_name LIKE '%_jobs'")
                 (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
 
     listJob = error "listJob: Requested job type not in JobsDashboard Type"
@@ -378,7 +378,7 @@ baseJobDecoder = BaseJob
 
 getNotIncludedTableNames :: (?modelContext :: ModelContext) => [Text] -> IO [Text]
 getNotIncludedTableNames includedNames = sqlQueryHasql getHasqlPool
-    (Snippet.sql "SELECT table_name FROM information_schema.tables WHERE table_name LIKE '%_jobs' AND NOT (table_name = ANY(" <> Snippet.param includedNames <> Snippet.sql "))")
+    (Snippet.sql "SELECT table_name::text FROM information_schema.tables WHERE table_name LIKE '%_jobs' AND NOT (table_name = ANY(" <> Snippet.param includedNames <> Snippet.sql "))")
     (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
 
 buildBaseJobTable :: (?modelContext :: ModelContext, ?context :: ControllerContext, ?request :: Request) => Text -> IO SomeView


### PR DESCRIPTION
## Summary
- The `information_schema` views return columns with PostgreSQL `name` type (OID 19), but hasql decoders expect `text` (OID 25), causing a runtime crash on the ShowDatabase page
- Added `::text` casts to all `information_schema` column references in `ihp-ide` and `ihp-job-dashboard`, matching the existing pattern already used in `pg_catalog` queries (e.g. `tablename::text`, `a.attname::text`)

## Affected queries
- `fetchTableCols` — `column_name`, `data_type`, `column_default`
- `fetchForeignKeyInfo` — `ccu.table_name`, `ccu.column_name`
- `getAllTableNames` / `getNotIncludedTableNames` — `table_name`

## Test plan
- [ ] Open ShowDatabase page in IHP IDE — should display table columns without crashing
- [ ] Verify foreign key info displays correctly in data editor
- [ ] Verify job dashboard lists job tables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)