### PR TITLE
Add INLINE pragma to insertNewIORefVaultMiddleware

### DIFF
--- a/ihp/IHP/RequestVault/Helper.hs
+++ b/ihp/IHP/RequestVault/Helper.hs
@@ -29,6 +29,7 @@ lookupRequestVault key req =
 -- | Like 'insertVaultMiddleware', but creates a fresh 'IORef' with the given
 -- default value on each request. Use this for mutable per-request state
 -- (e.g. response headers, modal containers).
+{-# INLINE insertNewIORefVaultMiddleware #-}
 insertNewIORefVaultMiddleware :: Vault.Key (IORef value) -> value -> Middleware
 insertNewIORefVaultMiddleware key defaultValue app req respond = do
     ref <- newIORef defaultValue


### PR DESCRIPTION
## Summary

- `insertNewIORefVaultMiddleware` is called 4 times in `initMiddlewareStack` but GHC was not inlining it — the worker's 87-term unfolding exceeds the default 80-term threshold
- Adding the `INLINE` pragma produces a `StableUser` unfolding in the `.hi` file, matching the behavior of `insertVaultMiddleware` and other helpers in the same module
- Verified with `nix build` — all tests pass

## Test plan

- [x] `nix build` in ihp-pro passes
- [x] Confirmed via `-ddump-simpl` / `.hi` inspection that without INLINE, GHC does not inline this function (87 terms > 80-term default threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)