### PR TITLE
Replace VarCondition text templates with structured ColumnCondition

### DIFF
--- a/ihp/IHP/QueryBuilder.hs
+++ b/ihp/IHP/QueryBuilder.hs
@@ -102,7 +102,7 @@ module IHP.QueryBuilder
 
 import IHP.QueryBuilder.Types
 import IHP.QueryBuilder.Compiler
-import IHP.QueryBuilder.HasqlCompiler (toSnippet, snippetToSQL)
+import IHP.QueryBuilder.HasqlCompiler (toSnippet, snippetToSQL, compileOperator)
 import IHP.QueryBuilder.Filter
 import IHP.QueryBuilder.Join
 import IHP.QueryBuilder.Order

--- a/ihp/Test/Test/QueryBuilderSpec.hs
+++ b/ihp/Test/Test/QueryBuilderSpec.hs
@@ -330,14 +330,14 @@ tests = do
                 let theQuery = query @Post
                         |> filterWherePast #createdAt
 
-                (snippetToSQL $ toSnippet theQuery) `shouldBe` ("SELECT " <> postColumns <> " FROM posts WHERE posts.created_at  <= NOW()")
+                (snippetToSQL $ toSnippet theQuery) `shouldBe` ("SELECT " <> postColumns <> " FROM posts WHERE posts.created_at <= NOW()")
 
         describe "filterWhereFuture" do
             it "should produce a SQL with the correct WHERE condition" do
                 let theQuery = query @Post
                         |> filterWhereFuture #createdAt
 
-                (snippetToSQL $ toSnippet theQuery) `shouldBe` ("SELECT " <> postColumns <> " FROM posts WHERE posts.created_at  > NOW()")
+                (snippetToSQL $ toSnippet theQuery) `shouldBe` ("SELECT " <> postColumns <> " FROM posts WHERE posts.created_at > NOW()")
 
         describe "filterWhereGreaterThan" do
             it "should produce a SQL with a WHERE > condition" do
@@ -418,8 +418,7 @@ tests = do
                 let theQuery = query @Post
                         |> filterWhereSql (#createdAt, "< current_timestamp - interval '1 day'")
 
-                -- Note: there's an extra space between column name and operator (consistent with postgresql-simple path)
-                (snippetToSQL $ toSnippet theQuery) `shouldBe` ("SELECT " <> postColumns <> " FROM posts WHERE posts.created_at  < current_timestamp - interval '1 day'")
+                (snippetToSQL $ toSnippet theQuery) `shouldBe` ("SELECT " <> postColumns <> " FROM posts WHERE posts.created_at < current_timestamp - interval '1 day'")
 
         describe "queryOr" do
             it "should merge two conditions" do


### PR DESCRIPTION
## Summary
- Replaces `VarCondition !Text !Snippet` (text template + string substitution) with `ColumnCondition !Text !FilterOperator !Snippet !(Maybe Text) !(Maybe Text)` storing structured filter data
- Eliminates `substituteSnippet` — no more `Text.break (== '?')` parsing at query time
- Moves `compileOperator` from Compiler to HasqlCompiler where it's used
- Fixes double-space bug in `filterWhereSql` output (e.g. `col  <= NOW()` → `col <= NOW()`)

Follows up on #2378.

## Test plan
- [x] All 422 IHP tests pass
- [x] All 361 IDE tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)