### PR TITLE
Explain Postgres 63-char unique constraint name limit and stable nami…

### DIFF
--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -853,3 +853,21 @@ CREATE TABLE users (
     UNIQUE (email, username)
 );
 ```
+
+PostgreSQL constraint names have a **63-byte** limit.
+
+For a multi-column unique constraint, Postgres auto-generates a name from table + column names.  
+For `strategy_factor_regime_online` + `(symbol_id, timeframe, ts, version)`, this becomes a long name (truncated form: `strategy_factor_regime_online_symbol_id_timeframe_ts_version_ke`) and can trigger noisy migrations like:
+
+```sql
+ALTER TABLE strategy_factor_regime_online DROP CONSTRAINT strategy_factor_regime_online_symbol_id_timeframe_ts_version_ke;
+```
+
+Solution: use a short explicit constraint name after `CREATE TABLE strategy_factor_regime_online`:
+
+```sql
+ALTER TABLE strategy_factor_regime_online
+    ADD CONSTRAINT uq_sfr_on_main UNIQUE (symbol_id, timeframe, ts, version);
+```
+
+Alternative: use `CREATE UNIQUE INDEX ...`.


### PR DESCRIPTION
Updating doc for creating unique key which name is over 63 characters.  If needing optimize this doc further please tell me.

Solution as follow. In `Schema.sql`
```sql
CREATE TABLE strategy_factor_regime_offline (
    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
    symbol_id UUID NOT NULL,
    timeframe TEXT NOT NULL,
    ts TIMESTAMP WITHOUT TIME ZONE NOT NULL,
    label_state TEXT NOT NULL,
    lookahead_bars INT NOT NULL,
    label_method TEXT NOT NULL,
    label_type TEXT NOT NULL,
    label_version TEXT NOT NULL,
    extra JSONB DEFAULT '{}'::jsonb NOT NULL,
    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW() NOT NULL
);
ALTER TABLE strategy_factor_regime_offline ADD CONSTRAINT uq_sfr_off_main UNIQUE(symbol_id, timeframe, ts, label_type, label_version);
```

Following  solution still not work. Maybe optimize migration code?
````sql
CREATE TABLE table_name (
  will_be_long_unique_key_field_name1 INT,
  will_be_long_unique_key_field_name2 INT,
  will_be_long_unique_key_field_name3 INT,
  CONSTRAINT uq_1_2_3 UNIQUE (will_be_long_unique_key_field_name1, will_be_long_unique_key_field_name2, will_be_long_unique_key_field_name3)
);
```