### PR TITLE
Remove unused postgresql-simple dependency from ihp-datasync

### DIFF
--- a/ihp-datasync/ihp-datasync.cabal
+++ b/ihp-datasync/ihp-datasync.cabal
@@ -146,8 +146,6 @@ test-suite ihp-datasync-hspec
                  , Test.DataSync.RLSIntegrationSpec
                  , Test.DataSync.DataSyncIntegrationSpec
     build-depends: hspec
-                 , resource-pool
-                 , postgresql-simple
 
 source-repository head
     type:     git


### PR DESCRIPTION
## Summary
- Remove stale `postgresql-simple` and `resource-pool` from ihp-datasync test suite `build-depends`
- The tests were already fully migrated to hasql (using `Hasql.Pool`, `Hasql.Session`, etc.) but the old dependencies were never cleaned up

## Test plan
- [x] `nix build .#ihp-datasync` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)