### PR TITLE
Remove postgresql-simple dependency from ihp-job-dashboard

### DIFF
--- a/ihp-job-dashboard/IHP/Job/Dashboard.hs
+++ b/ihp-job-dashboard/IHP/Job/Dashboard.hs
@@ -38,8 +38,6 @@ import Wai.Request.Params.Middleware (Respond)
 import Unsafe.Coerce
 import IHP.Job.Queue ()
 import IHP.Pagination.Types
-import qualified Database.PostgreSQL.Simple.FromField as PG
-import qualified Database.PostgreSQL.Simple.ToField as PG
 import Network.Wai (Request, requestMethod)
 import Network.HTTP.Types.Method (methodPost)
 
@@ -59,11 +57,8 @@ import qualified Hasql.DynamicStatements.Snippet as Snippet
 -- for your job type. Your custom implementations will then be used instead of the defaults.
 class ( job ~ GetModelByTableName (GetTableName job)
     , FilterPrimaryKey (GetTableName job)
-    , FromRow job
     , FromRowHasql job
     , Show (PrimaryKey (GetTableName job))
-    , PG.FromField (PrimaryKey (GetTableName job))
-    , PG.ToField (PrimaryKey (GetTableName job))
     , KnownSymbol (GetTableName job)
     , HasField "id" job (Id job)
     , HasField "status" job JobStatus

--- a/ihp-job-dashboard/default.nix
+++ b/ihp-job-dashboard/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, base, blaze-html, blaze-markup, hasql
 , hasql-dynamic-statements, hasql-implicits, hasql-pool, http-types
-, ihp, ihp-hsx, lib, mtl, postgresql-simple, text, wai
+, ihp, ihp-hsx, lib, mtl, text, wai
 , wai-request-params
 }:
 mkDerivation {
@@ -10,7 +10,7 @@ mkDerivation {
   libraryHaskellDepends = [
     base blaze-html blaze-markup hasql hasql-dynamic-statements
     hasql-implicits hasql-pool http-types ihp ihp-hsx mtl
-    postgresql-simple text wai wai-request-params
+    text wai wai-request-params
   ];
   homepage = "https://ihp.digitallyinduced.com/";
   description = "Dashboard for IHP job runners";

--- a/ihp-job-dashboard/ihp-job-dashboard.cabal
+++ b/ihp-job-dashboard/ihp-job-dashboard.cabal
@@ -24,7 +24,6 @@ library
             , blaze-markup
             , ihp
             , ihp-hsx
-            , postgresql-simple
             , http-types
             , wai-request-params
             , hasql-implicits


### PR DESCRIPTION
## Summary
- Remove unused `postgresql-simple` dependency from `ihp-job-dashboard`
- Remove `FromRow job`, `PG.FromField`, and `PG.ToField` constraints from `DisplayableJob` class — all database operations already use hasql (`FromRowHasql`, `DefaultParamEncoder`)
- Clean up corresponding imports, cabal `build-depends`, and `default.nix`

## Test plan
- [x] Module compiles with `ghci` (100 modules loaded)
- [x] IHP IDE tests pass (361 examples, 0 failures)
- [x] IHP core tests pass (422 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)