### PR TITLE
Remove fetchSQLQuery and hide SQLQuery from public API

### DIFF
--- a/ihp/IHP/Fetch.hs
+++ b/ihp/IHP/Fetch.hs
@@ -21,7 +21,6 @@ module IHP.Fetch
 , genericFetchIdsOne
 , fetchCount
 , fetchExists
-, fetchSQLQuery
 , fetchLatest
 , fetchLatestBy
 )
@@ -237,13 +236,6 @@ instance (model ~ GetModelById (Id' table), GetModelByTableName table ~ model, G
     fetchOneOrNothing = genericfetchIdsOneOrNothing
     {-# INLINE fetchOne #-}
     fetchOne = genericFetchIdsOne
-
-fetchSQLQuery :: (FromRowHasql model, ?modelContext :: ModelContext) => SQLQuery -> IO [model]
-fetchSQLQuery theQuery = do
-    trackTableRead theQuery.selectFrom
-    let pool = ?modelContext.hasqlPool
-    let snippet = buildSnippet theQuery
-    sqlQueryHasql pool snippet (Decoders.rowList hasqlRowDecoder)
 
 -- | Returns the latest record or Nothing
 --

--- a/ihp/IHP/QueryBuilder.hs
+++ b/ihp/IHP/QueryBuilder.hs
@@ -15,7 +15,6 @@ module IHP.QueryBuilder
   query
   -- * Core Types
 , QueryBuilder (..)
-, SQLQuery (..)
 , Condition (..)
 , Join (..)
 , OrderByClause (..)


### PR DESCRIPTION
## Summary
- Remove unused `fetchSQLQuery` function from `IHP.Fetch`
- Stop re-exporting `SQLQuery(..)` from `IHP.QueryBuilder` (it remains available from `IHP.QueryBuilder.Types` for internal use)

## Context
`fetchSQLQuery` was introduced in 2021 (PR #843) as an escape hatch for SSC to execute pre-built `SQLQuery` values. The intended pattern — storing a mutable `SQLQuery` as component state — is better served by storing query parameters as plain data and rebuilding the query with `QueryBuilder` combinators at fetch time.

`SQLQuery(..)` is only needed internally by the query compilation pipeline (`Compiler.hs`, `HasqlCompiler.hs`, `Fetch.hs`), so it doesn't need to be in the public `IHP.QueryBuilder` export list.

## Test plan
- [x] `ghci` loads `IHP.Fetch`, `IHP.QueryBuilder`, and `IHP.QueryBuilder.HasqlCompiler` without errors
- [x] All 361 IDE tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)