### PR TITLE
Remove dead postgresql-simple instances from Job Queue

### DIFF
--- a/ihp-job-dashboard/IHP/Job/Dashboard.hs
+++ b/ihp-job-dashboard/IHP/Job/Dashboard.hs
@@ -36,7 +36,6 @@ import IHP.ModelSupport
 import IHP.ControllerPrelude
 import Wai.Request.Params.Middleware (Respond)
 import Unsafe.Coerce
-import IHP.Job.Queue ()
 import IHP.Pagination.Types
 import Network.Wai (Request, requestMethod)
 import Network.HTTP.Types.Method (methodPost)

--- a/ihp/IHP/Job/Queue.hs
+++ b/ihp/IHP/Job/Queue.hs
@@ -8,8 +8,6 @@ module IHP.Job.Queue where
 
 import IHP.Prelude
 import IHP.Job.Types
-import qualified Database.PostgreSQL.Simple.FromField as PG
-import qualified Database.PostgreSQL.Simple.ToField as PG
 import qualified Control.Concurrent.Async as Async
 import qualified Control.Concurrent as Concurrent
 import qualified Control.Exception.Safe as Exception
@@ -313,33 +311,9 @@ recoverStaleJobs staleThreshold = do
     withoutQueryLogging (sqlExecHasql pool retrySnippet)
     withoutQueryLogging (sqlExecHasql pool failSnippet)
 
--- | Mapping for @JOB_STATUS@:
---
--- > CREATE TYPE JOB_STATUS AS ENUM ('job_status_not_started', 'job_status_running', 'job_status_failed', 'job_status_succeeded', 'job_status_retry');
-instance PG.FromField JobStatus where
-    fromField field (Just "job_status_not_started") = pure JobStatusNotStarted
-    fromField field (Just "job_status_running") = pure JobStatusRunning
-    fromField field (Just "job_status_failed") = pure JobStatusFailed
-    fromField field (Just "job_status_timed_out") = pure JobStatusTimedOut
-    fromField field (Just "job_status_succeeded") = pure JobStatusSucceeded
-    fromField field (Just "job_status_retry") = pure JobStatusRetry
-    fromField field (Just value) = PG.returnError PG.ConversionFailed field ("Unexpected value for enum value. Got: " <> cs value)
-    fromField field Nothing = PG.returnError PG.UnexpectedNull field "Unexpected null for enum value"
-
 -- The default state is @not started@
 instance Default JobStatus where
     def = JobStatusNotStarted
-
--- | Mapping for @JOB_STATUS@:
---
--- > CREATE TYPE JOB_STATUS AS ENUM ('job_status_not_started', 'job_status_running', 'job_status_failed', 'job_status_succeeded', 'job_status_retry');
-instance PG.ToField JobStatus where
-    toField JobStatusNotStarted = PG.toField ("job_status_not_started" :: Text)
-    toField JobStatusRunning = PG.toField ("job_status_running" :: Text)
-    toField JobStatusFailed = PG.toField ("job_status_failed" :: Text)
-    toField JobStatusTimedOut = PG.toField ("job_status_timed_out" :: Text)
-    toField JobStatusSucceeded = PG.toField ("job_status_succeeded" :: Text)
-    toField JobStatusRetry = PG.toField ("job_status_retry" :: Text)
 
 instance InputValue JobStatus where
     inputValue JobStatusNotStarted = "job_status_not_started" :: Text

--- a/ihp/IHP/PGSimpleCompat.hs
+++ b/ihp/IHP/PGSimpleCompat.hs
@@ -4,9 +4,6 @@
 -- | Consolidates all postgresql-simple FromField\/ToField\/FromRow orphan instances
 -- for IHP model types. This module exists so that eventually these instances (plus
 -- @ihp-postgresql-simple-extra@) can be extracted into a separate legacy package.
---
--- Note: JobStatus FromField\/ToField instances remain in "IHP.Job.Queue" to
--- avoid a circular dependency through @IHP.Job.Types -> IHP.Prelude -> IHP.ModelSupport@.
 module IHP.PGSimpleCompat () where
 
 import Prelude


### PR DESCRIPTION
## Summary
- Remove `PG.FromField JobStatus` and `PG.ToField JobStatus` instances from `IHP.Job.Queue` — all encoding/decoding now uses hasql (`DefaultParamEncoder` for encoding, `textToEnumJobStatus` for decoding)
- Remove the `Database.PostgreSQL.Simple.FromField`/`ToField` imports from `IHP.Job.Queue`
- Remove `IHP.Job.Queue ()` orphan-instance import from `ihp-job-dashboard`
- Update stale comment in `IHP.PGSimpleCompat`

Stacked on #2388.

## Test plan
- [x] `IHP.Job.Queue`, `IHP.Job.Runner`, and `IHP.Job.Dashboard` all compile via ghci
- [x] Full test suite passes (361 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)