### PR TITLE
Fix crash when Application/Migration/ directory doesn't exist

### DIFF
--- a/ihp-migrate/IHP/SchemaMigration.hs
+++ b/ihp-migrate/IHP/SchemaMigration.hs
@@ -138,14 +138,18 @@ findAllMigrations :: IO [Migration]
 findAllMigrations = do
     migrationDir <- detectMigrationDir
     migrationDirOsPath <- encodeUtf (cs migrationDir)
-    directoryFiles <- Directory.listDirectory migrationDirOsPath
-    fileNames <- mapM decodeUtf directoryFiles
-    let textNames = map (cs :: FilePath -> Text) fileNames
-    textNames
-        & filter (\path -> ".sql" `Text.isSuffixOf` path)
-        & mapMaybe pathToMigration
-        & sortBy (comparing revision)
-        & pure
+    exists <- Directory.doesDirectoryExist migrationDirOsPath
+    if exists
+        then do
+            directoryFiles <- Directory.listDirectory migrationDirOsPath
+            fileNames <- mapM decodeUtf directoryFiles
+            let textNames = map (cs :: FilePath -> Text) fileNames
+            textNames
+                & filter (\path -> ".sql" `Text.isSuffixOf` path)
+                & mapMaybe pathToMigration
+                & sortBy (comparing revision)
+                & pure
+        else pure []
 
 -- | Given a path such as Application/Migrate/00-initial-migration.sql it returns a Migration
 --


### PR DESCRIPTION
## Summary
- `findAllMigrations` crashed with an IO exception when `Application/Migration/` didn't exist
- Now checks with `doesDirectoryExist` first and returns an empty list if the directory is missing

## Test plan
- [x] Verified module compiles with ghci
- [ ] Run an IHP app without an `Application/Migration/` directory and confirm no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)