### PR TITLE
Remove multi-statement script workarounds (hasql 1.10.2.3 fix)

### DIFF
--- a/ihp-migrate/IHP/SchemaMigration.hs
+++ b/ihp-migrate/IHP/SchemaMigration.hs
@@ -56,22 +56,14 @@ migrate connection options = do
 -- | The sql statements contained in the migration file are executed. Then the revision is inserted into the @schema_migrations@ table.
 --
 -- All queries are executed inside a database transaction to make sure that it can be restored when something goes wrong.
---
--- We split the migration SQL into individual statements and execute each one
--- separately via 'Session.script'. This is necessary because hasql 1.10's
--- 'Session.script' uses @PQsendQuery@ + @singleResult@ internally, which only
--- handles a single result. Multi-statement SQL produces multiple results and
--- leaves unconsumed results on the connection, causing subsequent operations
--- to fail with "cannot enter pipeline mode, connection not idle".
 runMigration :: Connection.Connection -> Migration -> IO ()
 runMigration connection Migration { revision, migrationFile } = do
     migrationFilePath <- migrationPath Migration { revision, migrationFile }
     migrationSql <- Text.readFile (cs migrationFilePath)
 
-    let statements = splitStatements migrationSql
     runSession connection do
         Session.script "BEGIN"
-        forM_ statements Session.script
+        Session.script (cs migrationSql)
         Session.statement (fromIntegral revision :: Int64) insertRevisionStatement
         Session.script "COMMIT"
 
@@ -176,55 +168,3 @@ detectMigrationDir = do
     envValue <- lookupEnv "IHP_MIGRATION_DIR"
     pure (maybe "Application/Migration/" cs envValue)
 
--- | Split SQL text into individual statements by unquoted semicolons.
---
--- Respects single-quoted string literals (with @''@ escapes) and
--- @--@ line comments so that semicolons inside those are not treated
--- as statement separators.
-splitStatements :: Text -> [Text]
-splitStatements = filter (not . Text.null) . map Text.strip . splitOnUnquotedSemicolons
-  where
-    splitOnUnquotedSemicolons :: Text -> [Text]
-    splitOnUnquotedSemicolons sql = case nextSemicolon sql of
-        Nothing -> [sql]
-        Just (before, after) -> before : splitOnUnquotedSemicolons after
-
-    -- | Find the next unquoted semicolon. Returns the text before it
-    -- and the text after it, or Nothing if there is no unquoted semicolon.
-    nextSemicolon :: Text -> Maybe (Text, Text)
-    nextSemicolon = go ""
-      where
-        go acc sql
-            | Text.null sql = Nothing
-            | otherwise =
-                -- Skip ahead to the next interesting character
-                let (chunk, rest) = Text.break (\c -> c == ';' || c == '\'' || c == '-') sql
-                    acc' = acc <> chunk
-                in case Text.uncons rest of
-                    Nothing -> Nothing
-                    Just (';', rest') -> Just (acc', rest')
-                    Just ('\'', rest') ->
-                        let (str, after) = spanString rest'
-                        in go (acc' <> "'" <> str <> "'") after
-                    Just ('-', rest') -> case Text.uncons rest' of
-                        Just ('-', rest'') ->
-                            let (comment, after) = Text.break (== '\n') rest''
-                            in go (acc' <> "--" <> comment) after
-                        _ -> go (acc' <> "-") rest'
-                    _ -> Nothing -- unreachable
-
-    -- | Consume a single-quoted string body (after the opening quote).
-    -- Returns the string contents (without quotes) and the remaining text
-    -- after the closing quote.
-    spanString :: Text -> (Text, Text)
-    spanString sql =
-        let (chunk, rest) = Text.break (== '\'') sql
-        in case Text.uncons rest of
-            Nothing -> (chunk, "") -- unterminated string
-            Just ('\'', rest') -> case Text.uncons rest' of
-                Just ('\'', rest'') ->
-                    -- Escaped quote ''
-                    let (more, after) = spanString rest''
-                    in (chunk <> "''" <> more, after)
-                _ -> (chunk, rest') -- end of string
-            _ -> (chunk, rest) -- unreachable

--- a/ihp-migrate/Test/SchemaMigrationSpec.hs
+++ b/ihp-migrate/Test/SchemaMigrationSpec.hs
@@ -27,35 +27,6 @@ tests = do
                             , Migration { revision = 1605721940, migrationFile = "1605721940-create-users.sql" }
                             ]
 
-        describe "splitStatements" do
-            it "should split simple statements" do
-                splitStatements "CREATE TABLE a (id INT); CREATE TABLE b (id INT);"
-                    `shouldBe` ["CREATE TABLE a (id INT)", "CREATE TABLE b (id INT)"]
-
-            it "should handle statements without trailing semicolon" do
-                splitStatements "CREATE TABLE a (id INT); CREATE TABLE b (id INT)"
-                    `shouldBe` ["CREATE TABLE a (id INT)", "CREATE TABLE b (id INT)"]
-
-            it "should ignore semicolons inside single-quoted strings" do
-                splitStatements "INSERT INTO t (v) VALUES ('hello; world'); SELECT 1"
-                    `shouldBe` ["INSERT INTO t (v) VALUES ('hello; world')", "SELECT 1"]
-
-            it "should handle escaped quotes in strings" do
-                splitStatements "INSERT INTO t (v) VALUES ('it''s a test'); SELECT 1"
-                    `shouldBe` ["INSERT INTO t (v) VALUES ('it''s a test')", "SELECT 1"]
-
-            it "should ignore semicolons in line comments" do
-                splitStatements "SELECT 1; -- this; is a comment\nSELECT 2"
-                    `shouldBe` ["SELECT 1", "-- this; is a comment\nSELECT 2"]
-
-            it "should handle empty input" do
-                splitStatements "" `shouldBe` []
-
-            it "should filter blank statements from extra semicolons" do
-                splitStatements "SELECT 1;; SELECT 2;" `shouldBe` ["SELECT 1", "SELECT 2"]
-
-            it "should handle a single statement" do
-                splitStatements "CREATE TABLE users (id INT)" `shouldBe` ["CREATE TABLE users (id INT)"]
 
 withTempApp :: IO a -> IO a
 withTempApp action =


### PR DESCRIPTION
## Summary
- Hasql 1.10.2.3 (commit e15b750) fixes `Session.script` to properly consume all results from multi-statement SQL, so the workarounds that split SQL into individual statements are no longer needed
- Removes `splitStatements` SQL parser from `SchemaMigration` and passes full migration SQL directly to `Session.script`
- Collapses `notificationTriggerStatements` (AutoRefresh) and `createNotificationTriggerStatements` (Job/Queue) from `[Text]` lists into single multi-statement `Text` scripts
- Net deletion of ~95 lines of workaround code

## Test plan
- [ ] Verify migrations still run correctly with multi-statement SQL files
- [ ] Verify AutoRefresh notification triggers are created properly
- [ ] Verify job queue notification triggers are created properly
- [ ] Run `nix flake check --impure` once pre-existing build issues are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)