### PR TITLE
Add -Werror=missing-fields to all framework packages

### DIFF
--- a/ihp-context/ihp-context.cabal
+++ b/ihp-context/ihp-context.cabal
@@ -32,7 +32,7 @@ common shared-properties
         , ImplicitParams
         , BlockArguments
         , LambdaCase
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-datasync-typescript/ihp-datasync-typescript.cabal
+++ b/ihp-datasync-typescript/ihp-datasync-typescript.cabal
@@ -36,7 +36,7 @@ common shared-properties
         , LambdaCase
         , TemplateHaskell
         , OverloadedRecordDot
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-datasync/ihp-datasync.cabal
+++ b/ihp-datasync/ihp-datasync.cabal
@@ -91,7 +91,7 @@ common shared-properties
             +RTS -A256m -n4m -H512m -qg -N -RTS
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -Wmissed-specialisations
             -Wall-missed-specialisations
@@ -106,7 +106,7 @@ common shared-properties
             +RTS -A256m -n4m -H512m -qg -N -RTS
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -Wmissed-specialisations
             -Wall-missed-specialisations

--- a/ihp-graphql/ihp-graphql.cabal
+++ b/ihp-graphql/ihp-graphql.cabal
@@ -47,7 +47,7 @@ common shared-properties
         , LambdaCase
         , TemplateHaskell
         , OverloadedRecordDot
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-hspec/ihp-hspec.cabal
+++ b/ihp-hspec/ihp-hspec.cabal
@@ -27,7 +27,7 @@ library
         OverloadedStrings
         ImplicitParams
         RecordWildCards
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
     build-depends: base >= 4.17.0 && < 4.22, ihp, ihp-log, wai, process, text, ihp-ide, vault, uuid, hasql, wai-request-params
     hs-source-dirs: .
     exposed-modules: IHP.Hspec

--- a/ihp-hsx/ihp-hsx.cabal
+++ b/ihp-hsx/ihp-hsx.cabal
@@ -60,7 +60,7 @@ common common-flags
         -Wredundant-constraints
         -Wunused-imports
         -Wunused-foralls
-        -Wmissing-fields
+        -Werror=missing-fields
         -Winaccessible-code
         -Wmissed-specialisations
         -Wall-missed-specialisations

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -120,7 +120,7 @@ common shared-properties
 
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -Wmissed-specialisations
             -Wall-missed-specialisations
@@ -135,7 +135,7 @@ common shared-properties
 
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -Wmissed-specialisations
             -Wall-missed-specialisations

--- a/ihp-imagemagick/ihp-imagemagick.cabal
+++ b/ihp-imagemagick/ihp-imagemagick.cabal
@@ -30,7 +30,7 @@ common ihp-std
         BlockArguments
         OverloadedStrings
         ImplicitParams
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: ihp-std

--- a/ihp-job-dashboard/ihp-job-dashboard.cabal
+++ b/ihp-job-dashboard/ihp-job-dashboard.cabal
@@ -15,7 +15,7 @@ build-type:          Simple
 
 library
     default-language: GHC2021
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
     build-depends:
             base >= 4.17.0 && < 4.22
             , wai

--- a/ihp-log/ihp-log.cabal
+++ b/ihp-log/ihp-log.cabal
@@ -32,7 +32,7 @@ common shared-properties
         , OverloadedRecordDot
         , DuplicateRecordFields
         , LambdaCase
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-mail/ihp-mail.cabal
+++ b/ihp-mail/ihp-mail.cabal
@@ -41,7 +41,7 @@ common shared-properties
         , TemplateHaskell
         , OverloadedRecordDot
         , DeepSubsumption
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-migrate/ihp-migrate.cabal
+++ b/ihp-migrate/ihp-migrate.cabal
@@ -24,7 +24,7 @@ common ihp-std
         BlockArguments
         OverloadedStrings
         ImplicitParams
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: ihp-std

--- a/ihp-modal/ihp-modal.cabal
+++ b/ihp-modal/ihp-modal.cabal
@@ -30,7 +30,7 @@ common shared-properties
         , RecordWildCards
         , QuasiQuotes
         , OverloadedRecordDot
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-openai/ihp-openai.cabal
+++ b/ihp-openai/ihp-openai.cabal
@@ -49,7 +49,7 @@ library
         -Wredundant-constraints
         -Wunused-imports
         -Wunused-foralls
-        -Wmissing-fields
+        -Werror=missing-fields
         -Winaccessible-code
         -Wmissed-specialisations
         -fexpose-all-unfoldings

--- a/ihp-pagehead/ihp-pagehead.cabal
+++ b/ihp-pagehead/ihp-pagehead.cabal
@@ -31,7 +31,7 @@ common shared-properties
         , LambdaCase
         , QuasiQuotes
         , OverloadedRecordDot
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-pglistener/ihp-pglistener.cabal
+++ b/ihp-pglistener/ihp-pglistener.cabal
@@ -40,7 +40,7 @@ common shared-properties
         , DuplicateRecordFields
         , BlockArguments
         , LambdaCase
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-postgres-parser/ihp-postgres-parser.cabal
+++ b/ihp-postgres-parser/ihp-postgres-parser.cabal
@@ -42,7 +42,7 @@ common shared-properties
         ghc-options:
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -Wno-ambiguous-fields
             -Werror=incomplete-patterns
@@ -54,7 +54,7 @@ common shared-properties
 
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -fspecialise-aggressively
             -Wno-ambiguous-fields

--- a/ihp-postgresql-simple-extra/ihp-postgresql-simple-extra.cabal
+++ b/ihp-postgresql-simple-extra/ihp-postgresql-simple-extra.cabal
@@ -49,7 +49,7 @@ common shared-properties
         , LambdaCase
         , TemplateHaskell
         , OverloadedRecordDot
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/ihp-schema-compiler/ihp-schema-compiler.cabal
+++ b/ihp-schema-compiler/ihp-schema-compiler.cabal
@@ -56,7 +56,7 @@ common shared-properties
         ghc-options:
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -Wno-ambiguous-fields
             -Werror=incomplete-patterns
@@ -68,7 +68,7 @@ common shared-properties
 
             -Wunused-imports
             -Wunused-foralls
-            -Wmissing-fields
+            -Werror=missing-fields
             -Winaccessible-code
             -fspecialise-aggressively
             -Wno-ambiguous-fields

--- a/ihp-sitemap/ihp-sitemap.cabal
+++ b/ihp-sitemap/ihp-sitemap.cabal
@@ -30,7 +30,7 @@ common ihp-std
         BlockArguments
         OverloadedStrings
         ImplicitParams
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: ihp-std

--- a/ihp-ssc/ihp-ssc.cabal
+++ b/ihp-ssc/ihp-ssc.cabal
@@ -32,7 +32,7 @@ library
         , TemplateHaskell
         , OverloadedRecordDot
         , DeepSubsumption
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
     hs-source-dirs: .
     build-depends: ihp, ihp-log, aeson, megaparsec, bytestring, wai, websockets, ihp-hsx, base, string-conversions, basic-prelude, text, blaze-html, attoparsec, wai-request-params
     exposed-modules:

--- a/ihp-welcome/ihp-welcome.cabal
+++ b/ihp-welcome/ihp-welcome.cabal
@@ -32,7 +32,7 @@ common ihp-std
         ImplicitParams
         DataKinds
         UndecidableInstances
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: ihp-std

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -158,7 +158,7 @@ common shared-properties
         , TemplateHaskell
         , OverloadedRecordDot
         , DeepSubsumption
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
 
 library
     import: shared-properties

--- a/wai-asset-path/wai-asset-path.cabal
+++ b/wai-asset-path/wai-asset-path.cabal
@@ -22,7 +22,7 @@ library
         DisambiguateRecordFields
         BlockArguments
         OverloadedStrings
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
     build-depends: base >= 4.17.0 && < 4.22, text, wai, vault
     hs-source-dirs: .
     exposed-modules: Network.Wai.Middleware.AssetPath

--- a/wai-flash-messages/wai-flash-messages.cabal
+++ b/wai-flash-messages/wai-flash-messages.cabal
@@ -22,7 +22,7 @@ library
         DisambiguateRecordFields
         BlockArguments
         OverloadedStrings
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
     build-depends: base >= 4.17.0 && < 4.22, text, wai, vault, cereal, cereal-text, bytestring, wai-session
     hs-source-dirs: .
     exposed-modules: Network.Wai.Middleware.FlashMessages

--- a/wai-request-params/wai-request-params.cabal
+++ b/wai-request-params/wai-request-params.cabal
@@ -15,7 +15,7 @@ build-type:          Simple
 
 library
     default-language: GHC2021
-    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
     hs-source-dirs: .
     exposed-modules:
           Wai.Request.Params


### PR DESCRIPTION
## Summary
- Promotes `-Wmissing-fields` to `-Werror=missing-fields` across all 26 IHP framework cabal files
- Catches uninitialized record fields at compile time rather than producing runtime errors
- Packages that already had `-Wmissing-fields` (ihp-ide, ihp-datasync, ihp-schema-compiler, ihp-postgres-parser, ihp-hsx, ihp-openai) are upgraded from warning to error
- Remaining packages get `-Werror=missing-fields` added alongside existing `-Werror=incomplete-patterns -Werror=unused-imports`
- Only affects framework packages, not IHP apps

## Test plan
- [x] All 361 ihp-ide tests pass
- [x] Codebase compiles cleanly with no missing-fields violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)