### PR TITLE
Fix make target in staticFilesCompiledByMake

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -275,7 +275,7 @@ ihpFlake:
                         export IHP_LIB=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
                         export IHP=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
 
-                        make -j static/app.css static/app.js
+                        make -j static/prod.css static/prod.js
                         runHook postBuild
                     '';
                     installPhase = ''


### PR DESCRIPTION
## Summary
- The `staticFilesCompiledByMake` derivation in `flake-module.nix` referenced `static/app.css` and `static/app.js`, but `Makefile.dist` only defines targets for `static/prod.css` and `static/prod.js`
- This caused nix builds to fail with `No rule to make target 'static/app.css'`
- Fixed by changing the make invocation to use the correct `prod.css`/`prod.js` target names

## Test plan
- [ ] Verify `nix build` succeeds for an IHP app that uses the default Makefile bundling

🤖 Generated with [Claude Code](https://claude.com/claude-code)