### PR TITLE
Fix hasql-interpolate build failure with hasql 1.10

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -102,6 +102,12 @@ let
             hasql-implicits = self.callHackageDirect { pkg = "hasql-implicits"; ver = "0.2.0.2"; sha256 = "0nyz96mgrc4i7x3q8wwv6zq8qpwam13f5y1rlbh102jp2ygb2mjy"; } {};
             hasql-transaction = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-transaction"; ver = "1.2.2"; sha256 = "0y1clnyw76rszsdvz0fxj2az036bmw1whp6pqchyjamnbkmf37d3"; } {});
             hasql-notifications = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-notifications"; ver = "0.2.5.0"; sha256 = "11jkrngiy175wc5hqx8pgagj4fdg42ry7afp4g4rr5hw8h43zg48"; } {});
+            # hasql-interpolate: upstream 1.0.1.0 requires hasql <1.10; use fork with hasql 1.10 support
+            # https://github.com/awkward-squad/hasql-interpolate/pull/27
+            hasql-interpolate = final.haskell.lib.dontCheck (self.callCabal2nix "hasql-interpolate" (builtins.fetchTarball {
+                url = "https://github.com/ChrisPenner/hasql-interpolate/archive/bb4666fdb7e0fef9f67702cb198e45d0a1de0ab9.tar.gz";
+                sha256 = "1v3i4n4szxpir28a4vlhd2a0sl04fxkiw9wlyxcvd3vbrd9s2b8c";
+            }) {});
 
             # postgresql-types for proper binary encoders of Point, Polygon, Inet, Interval
             ptr-poker = self.callHackageDirect { pkg = "ptr-poker"; ver = "0.1.3"; sha256 = "0jl9df0kzsq5gd6fhfqc8my4wy7agg5q5jw4q92h4b7rkdf3hix7"; } {};


### PR DESCRIPTION
## Summary

- Pin `hasql-interpolate` to [ChrisPenner's fork](https://github.com/ChrisPenner/hasql-interpolate/tree/hasql-1.10) that supports hasql 1.10, fixing the bounds error for IHP apps that depend on this package
- The upstream release (1.0.1.0) requires `hasql >=1.8 && <1.10`, but IHP's overlay pins hasql 1.10.2.3
- A simple `doJailbreak` doesn't work because hasql 1.10 has API changes (ByteString→Text, Value coercion, composite→record)

Fixes #2417

## Test plan

- [ ] `nix develop --impure` succeeds for an IHP app that depends on `hasql-interpolate`
- [ ] Verify the forked hasql-interpolate builds against hasql 1.10.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)