### PR TITLE
Use prepared statements for hasql queries

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -98,7 +98,22 @@ let
 
             hasql = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (self.callHackageDirect { pkg = "hasql"; ver = "1.10.2.3"; sha256 = "1j52ia75168n88rrraf4g20grdl3qak8r426rav87kjjjqx3717v"; } {}));
             hasql-pool = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-pool"; ver = "1.4.1"; sha256 = "08my6djljjgpkxgk4xc3z314ad0rf6g4yvv470rmm12nbzj2g66a"; } {});
-            hasql-dynamic-statements = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-dynamic-statements"; ver = "0.5.0.1"; sha256 = "1vdydp8n0zq3mwkzids64b86d9q2l11yc8df4brhmwx06qmvq3sc"; } {});
+            # Patched to add toPreparedStatement: like toStatement but creates a preparable
+            # (cached) statement instead of an unpreparable one. This allows IHP queries to
+            # benefit from PostgreSQL's prepared statement plan caching.
+            hasql-dynamic-statements = final.haskell.lib.dontCheck (final.haskell.lib.overrideCabal (self.callHackageDirect { pkg = "hasql-dynamic-statements"; ver = "0.5.0.1"; sha256 = "1vdydp8n0zq3mwkzids64b86d9q2l11yc8df4brhmwx06qmvq3sc"; } {}) (old: {
+                postPatch = (old.postPatch or "") + ''
+                    substituteInPlace src/library/Hasql/DynamicStatements/Snippet.hs \
+                        --replace-warn "toStatement," \
+                                       "toStatement, toPreparedStatement,"
+                    cat >> src/library/Hasql/DynamicStatements/Snippet.hs << 'PREPARED_STATEMENT'
+
+            toPreparedStatement :: Snippet -> Decoders.Result result -> Statement.Statement () result
+            toPreparedStatement (Snippet sql _ encoder) decoder =
+              Statement.preparable (TextBuilder.toText (sql 1)) encoder decoder
+            PREPARED_STATEMENT
+                '';
+            }));
             hasql-implicits = self.callHackageDirect { pkg = "hasql-implicits"; ver = "0.2.0.2"; sha256 = "0nyz96mgrc4i7x3q8wwv6zq8qpwam13f5y1rlbh102jp2ygb2mjy"; } {};
             hasql-transaction = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-transaction"; ver = "1.2.2"; sha256 = "0y1clnyw76rszsdvz0fxj2az036bmw1whp6pqchyjamnbkmf37d3"; } {});
             hasql-notifications = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-notifications"; ver = "0.2.5.0"; sha256 = "11jkrngiy175wc5hqx8pgagj4fdg42ry7afp4g4rr5hw8h43zg48"; } {});

--- a/ihp-datasync/IHP/DataSync/RowLevelSecurity.hs
+++ b/ihp-datasync/IHP/DataSync/RowLevelSecurity.hs
@@ -81,7 +81,7 @@ sqlQueryWithRLSSession ::
 sqlQueryWithRLSSession snippet decoder =
     Tx.transaction Tx.ReadCommitted Tx.Read $ do
         Tx.statement (Role.authenticatedRole, encodedUserId) setRLSConfigStatement
-        Tx.statement () (Snippet.toStatement snippet decoder)
+        Tx.statement () (Snippet.toPreparedStatement snippet decoder)
     where
         encodedUserId = case (.id) <$> currentUserOrNothing of
             Just userId -> tshow userId
@@ -102,7 +102,7 @@ sqlQueryWriteWithRLSSession ::
 sqlQueryWriteWithRLSSession snippet decoder =
     Tx.transaction Tx.ReadCommitted Tx.Write $ do
         Tx.statement (Role.authenticatedRole, encodedUserId) setRLSConfigStatement
-        Tx.statement () (Snippet.toStatement snippet decoder)
+        Tx.statement () (Snippet.toPreparedStatement snippet decoder)
     where
         encodedUserId = case (.id) <$> currentUserOrNothing of
             Just userId -> tshow userId
@@ -119,7 +119,7 @@ sqlExecWithRLSSession ::
 sqlExecWithRLSSession snippet =
     Tx.transaction Tx.ReadCommitted Tx.Write $ do
         Tx.statement (Role.authenticatedRole, encodedUserId) setRLSConfigStatement
-        Tx.statement () (Snippet.toStatement snippet Decoders.noResult)
+        Tx.statement () (Snippet.toPreparedStatement snippet Decoders.noResult)
     where
         encodedUserId = case (.id) <$> currentUserOrNothing of
             Just userId -> tshow userId
@@ -136,7 +136,7 @@ sqlQueryScalarWithRLSSession ::
 sqlQueryScalarWithRLSSession snippet decoder =
     Tx.transaction Tx.ReadCommitted Tx.Read $ do
         Tx.statement (Role.authenticatedRole, encodedUserId) setRLSConfigStatement
-        Tx.statement () (Snippet.toStatement snippet decoder)
+        Tx.statement () (Snippet.toPreparedStatement snippet decoder)
     where
         encodedUserId = case (.id) <$> currentUserOrNothing of
             Just userId -> tshow userId

--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -54,14 +54,14 @@ instance Controller DataController where
             let pool = ?modelContext.hasqlPool
             Just <$> if isQuery queryText then do
                     let snippet = wrapDynamicQuery (Snippet.sql (cs queryText))
-                    let statement = Snippet.toStatement snippet dynamicFieldDecoder
+                    let statement = Snippet.toPreparedStatement snippet dynamicFieldDecoder
                     let session = Session.statement () statement
                     result <- HasqlPool.use pool session
                     case result of
                         Right rows -> pure (Right (SelectQueryResult rows))
                         Left err -> pure (Left (usageErrorToConsoleError err))
                 else do
-                    let statement = Snippet.toStatement (Snippet.sql (cs queryText)) Decoders.rowsAffected
+                    let statement = Snippet.toPreparedStatement (Snippet.sql (cs queryText)) Decoders.rowsAffected
                     let session = Session.statement () statement
                     result <- HasqlPool.use pool session
                     case result of
@@ -190,7 +190,7 @@ instance Controller DataController where
 runSnippetQuery :: (?modelContext :: ModelContext) => Snippet -> Decoders.Result a -> IO a
 runSnippetQuery snippet decoder = do
     let pool = ?modelContext.hasqlPool
-    let statement = Snippet.toStatement snippet decoder
+    let statement = Snippet.toPreparedStatement snippet decoder
     let session = Session.statement () statement
     result <- HasqlPool.use pool session
     case result of
@@ -201,7 +201,7 @@ runSnippetQuery snippet decoder = do
 runSnippetExec :: (?modelContext :: ModelContext) => Snippet -> IO ()
 runSnippetExec snippet = do
     let pool = ?modelContext.hasqlPool
-    let statement = Snippet.toStatement snippet Decoders.noResult
+    let statement = Snippet.toPreparedStatement snippet Decoders.noResult
     let session = Session.statement () statement
     result <- HasqlPool.use pool session
     case result of

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -336,7 +336,7 @@ sqlQueryHasql :: (?modelContext :: ModelContext) => HasqlPool.Pool -> Snippet.Sn
 sqlQueryHasql pool snippet decoder = do
     let ?context = ?modelContext
     let currentLogLevel = ?modelContext.logger.level
-    let statement = Snippet.toStatement snippet decoder
+    let statement = Snippet.toPreparedStatement snippet decoder
     let session = case (?modelContext.transactionRunner, ?modelContext.rowLevelSecurity) of
             (Just _, _) ->
                 -- In transaction: RLS already configured at BEGIN time
@@ -381,7 +381,7 @@ sqlExecHasql :: (?modelContext :: ModelContext) => HasqlPool.Pool -> Snippet.Sni
 sqlExecHasql pool snippet = do
     let ?context = ?modelContext
     let currentLogLevel = ?modelContext.logger.level
-    let statement = Snippet.toStatement snippet Decoders.noResult
+    let statement = Snippet.toPreparedStatement snippet Decoders.noResult
     let session = case (?modelContext.transactionRunner, ?modelContext.rowLevelSecurity) of
             (Just _, _) ->
                 Hasql.statement () statement
@@ -425,7 +425,7 @@ sqlExecHasqlCount :: (?modelContext :: ModelContext) => HasqlPool.Pool -> Snippe
 sqlExecHasqlCount pool snippet = do
     let ?context = ?modelContext
     let currentLogLevel = ?modelContext.logger.level
-    let statement = Snippet.toStatement snippet Decoders.rowsAffected
+    let statement = Snippet.toPreparedStatement snippet Decoders.rowsAffected
     let session = case (?modelContext.transactionRunner, ?modelContext.rowLevelSecurity) of
             (Just _, _) ->
                 Hasql.statement () statement


### PR DESCRIPTION
## Summary
- `Snippet.toStatement` from hasql-dynamic-statements always creates **unprepared** statements (`Statement.unpreparable`), so every query through IHP's hasql path pays the full parse/plan cost on every execution
- Patches hasql-dynamic-statements to add `toPreparedStatement` (uses `Statement.preparable`) and switches all 11 production call sites to use it
- Enables PostgreSQL to cache query plans for repeated queries with the same SQL shape but different parameters

Upstream issue: https://github.com/nikita-volkov/hasql-dynamic-statements/issues/9

## Test plan
- [x] All 361 existing tests pass
- [x] ghci type-checks ModelSupport.hs (13 modules) and IDE Data Controller (107 modules)
- [ ] Manual testing with a real IHP app to verify queries execute correctly with prepared statements
- [ ] Verify `make db` still works (isCachedPlanError retry logic now actually serves its purpose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)