### PR TITLE
Add missing vendor files to ihp-env-var-backwards-compat

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -456,6 +456,14 @@ that is defined in flake-module.nix
                         (hsDataDir pkgs.ghc.ihp-ide.data)
                         (hsDataDir pkgs.ghc.ihp.data)
                     ];
+                    # The Makefile references $(IHP)/static/vendor/bootstrap.min.css etc.
+                    # These vendor files (bootstrap, jquery, select2) are fetched via Nix
+                    # in ihp-static, not in the ihp cabal data-files.
+                    postBuild = ''
+                        for f in ${config.packages.ihp-static}/vendor/*; do
+                            ln -sf "$f" "$out/static/vendor/$(basename "$f")" 2>/dev/null || true
+                        done
+                    '';
                 };
         };
     };


### PR DESCRIPTION
## Summary
- The boilerplate Makefile references `$(IHP)/static/vendor/bootstrap.min.css`, `jquery-3.6.0.slim.min.js`, etc., but these vendor files are fetched via `pkgs.fetchurl` in the `ihp-static` package — they're not part of the `ihp` cabal `data-files`
- This was masked because the old make target (`static/app.css`) didn't match any Makefile rule, so `make` said "Nothing to be done" and succeeded. After #2418 corrected the target to `static/prod.css`, make actually executes the rules and fails on the missing dependencies
- Fix: add a `postBuild` hook to `ihp-env-var-backwards-compat` that symlinks vendor files from `ihp-static` into `static/vendor/`

## Test plan
- [x] Verified locally that `nix build .#packages.aarch64-darwin.ihp-env-var-backwards-compat` now includes `static/vendor/bootstrap.min.css`, all jQuery versions, select2, etc.
- [ ] CI `boilerplate-staticFilesCompiledByMake` check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)