### PR TITLE
Fix hasql-interpolate Hackage cabal revision fetch failure

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -119,10 +119,15 @@ let
             hasql-notifications = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-notifications"; ver = "0.2.5.0"; sha256 = "11jkrngiy175wc5hqx8pgagj4fdg42ry7afp4g4rr5hw8h43zg48"; } {});
             # hasql-interpolate: upstream 1.0.1.0 requires hasql <1.10; use fork with hasql 1.10 support
             # https://github.com/awkward-squad/hasql-interpolate/pull/27
-            hasql-interpolate = final.haskell.lib.dontCheck (self.callCabal2nix "hasql-interpolate" (builtins.fetchTarball {
-                url = "https://github.com/ChrisPenner/hasql-interpolate/archive/bb4666fdb7e0fef9f67702cb198e45d0a1de0ab9.tar.gz";
-                sha256 = "1v3i4n4szxpir28a4vlhd2a0sl04fxkiw9wlyxcvd3vbrd9s2b8c";
-            }) {});
+            # Uses overrideCabal instead of callCabal2nix to avoid IFD and Hackage cabal revision fetch failures
+            hasql-interpolate = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (final.haskell.lib.overrideCabal super.hasql-interpolate (old: {
+                src = builtins.fetchTarball {
+                    url = "https://github.com/ChrisPenner/hasql-interpolate/archive/bb4666fdb7e0fef9f67702cb198e45d0a1de0ab9.tar.gz";
+                    sha256 = "1v3i4n4szxpir28a4vlhd2a0sl04fxkiw9wlyxcvd3vbrd9s2b8c";
+                };
+                revision = null;
+                editedCabalFile = null;
+            })));
 
             # postgresql-types for proper binary encoders of Point, Polygon, Inet, Interval
             ptr-poker = self.callHackageDirect { pkg = "ptr-poker"; ver = "0.1.3"; sha256 = "0jl9df0kzsq5gd6fhfqc8my4wy7agg5q5jw4q92h4b7rkdf3hix7"; } {};


### PR DESCRIPTION
  ## Summary

  - Fixes hash mismatch error when downstream apps run `nix develop` with `hasql-interpolate` as a dependency
  - Replaces `callCabal2nix` with `overrideCabal` to avoid IFD and stale Hackage cabal revision hashes
  - Related: #2419, #2417

  ## Problem

  PR #2419 added `hasql-interpolate` to the overlay using `callCabal2nix`, which uses **IFD (Import From Derivation)** — a Nix mechanism where a
  derivation is built *during evaluation* (not during the build phase) so its output can be imported as a Nix expression. In this case,
  `callCabal2nix` builds `cabal2nix` at eval time to convert the `.cabal` file into a Nix derivation.

  This approach still triggered a fetch of the Hackage cabal file revision (`hasql-interpolate-1.0.1.0-r3.cabal`), which fails with a hash mismatch
  when nixpkgs' `all-cabal-hashes` snapshot becomes stale relative to Hackage.

  ## Fix

  Switch to `overrideCabal super.hasql-interpolate` which:
  1. Reuses the existing nixpkgs derivation structure (no IFD needed)
  2. Replaces `src` with ChrisPenner's hasql-1.10-compatible fork
  3. Sets `revision = null` and `editedCabalFile = null` to prevent the Hackage cabal revision fetch entirely
  4. Adds `doJailbreak` to relax the `hasql <1.10` version bound

  ## Test plan

  - [ ] `nix develop --impure` succeeds in a downstream app with `hasql-interpolate` in `haskellPackages`
  - [ ] `import Hasql.Interpolate` works in application code
