### PR TITLE
Fix missing Modal middleware in IDE ToolServer

### DIFF
--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -51,6 +51,7 @@ import qualified Data.Vault.Lazy as Vault
 import IHP.Controller.Response (responseHeadersVaultKey)
 import IHP.ControllerSupport (rlsContextVaultKey)
 import Wai.Request.Params.Middleware (requestBodyMiddleware)
+import IHP.Modal.Types (modalContainerVaultKey)
 
 runToolServer :: (?context :: Context) => ToolServerApplication -> _ -> IO ()
 runToolServer toolServerApplication liveReloadClients = do
@@ -114,6 +115,7 @@ withToolServerApplication toolServerApplication port liveReloadClients action = 
 
         let responseHeadersMiddleware = insertNewIORefVaultMiddleware responseHeadersVaultKey []
         let rlsContextMiddleware = insertNewIORefVaultMiddleware rlsContextVaultKey Nothing
+        let modalMiddleware = insertNewIORefVaultMiddleware modalContainerVaultKey Nothing
 
         let toolServerVaultMiddleware app req respond = do
                 availableApps <- AvailableApps <$> findApplications
@@ -133,6 +135,7 @@ withToolServerApplication toolServerApplication port liveReloadClients action = 
                     $ viewLayoutMiddleware
                     $ responseHeadersMiddleware
                     $ rlsContextMiddleware
+                    $ modalMiddleware
                     $ toolServerVaultMiddleware
                     $ modelContextMiddleware modelContext
                     $ frameworkConfigMiddleware frameworkConfig


### PR DESCRIPTION
## Summary
- The IDE ToolServer has its own middleware chain separate from the main app server
- It was missing the `modalMiddleware`, which initializes the `IORef (Maybe ModalContainer)` in the request vault
- This caused a runtime crash (`lookupModalVault: Could not find IORef`) when accessing the Schema Designer (e.g. `TablesAction`)

## Test plan
- [ ] Start an IHP project with `devenv up` and open the Schema Designer — it should load without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)