### PR TITLE
Fix tooltip positioning in IDE Data tab

### DIFF
--- a/ihp-ide/data/static/IDE/ihp-schemadesigner.js
+++ b/ihp-ide/data/static/IDE/ihp-schemadesigner.js
@@ -187,10 +187,13 @@ function initCodeEditor() {
 }
 
 function initTooltip() {
+    // Remove any orphaned tooltip elements left over from Turbolinks/morphdom transitions
+    document.querySelectorAll('body > .tooltip').forEach(function (el) { el.remove(); });
+
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
         var existing = bootstrap.Tooltip.getInstance(el);
         if (existing) existing.dispose();
-        new bootstrap.Tooltip(el, { container: 'body' });
+        new bootstrap.Tooltip(el, { container: 'body', popperConfig: { strategy: 'fixed' } });
     });
 }
 
@@ -199,6 +202,14 @@ document.addEventListener('turbolinks:load', initCodeEditor);
 document.addEventListener('turbolinks:load', initQueryAce);
 document.addEventListener('turbolinks:load', initTooltip);
 document.addEventListener('turbolinks:load', initDataEditorForeignKeyAutocomplete);
+
+// Dispose all tooltips before Turbolinks replaces the page to prevent orphaned tooltip elements
+document.addEventListener('turbolinks:before-render', function () {
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+        var existing = bootstrap.Tooltip.getInstance(el);
+        if (existing) existing.dispose();
+    });
+});
 
 function initQueryAce() {
     var editorEl = document.getElementById('queryInput');


### PR DESCRIPTION
## Summary
- Fixes the mispositioned tooltip on the `+` button in the IDE's Data tab, where "Add TableName" was appearing at the top-right corner of the viewport instead of near the button
- Uses Popper.js `strategy: 'fixed'` so tooltips use `position: fixed` instead of `position: absolute`, avoiding incorrect offset calculations caused by the body's flex layout (`d-flex flex-row`)
- Cleans up orphaned tooltip DOM elements during Turbolinks/morphdom page transitions

## Test plan
- [ ] Open IDE Data tab, hover over the `+` button in the table header — tooltip should appear near the button, not at the top-right corner
- [ ] Navigate between Schema/Data tabs and verify tooltips still work correctly
- [ ] Verify Schema Designer tooltips (Add Column, Add Table) still position correctly

Fixes #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)