### PR TITLE
Fix IDE prepared statement error in Data Controller

### DIFF
--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -191,7 +191,7 @@ instance Controller DataController where
 runSnippetQuery :: (?modelContext :: ModelContext) => Snippet -> Decoders.Result a -> IO a
 runSnippetQuery snippet decoder = do
     let pool = ?modelContext.hasqlPool
-    let statement = Snippet.toPreparedStatement snippet decoder
+    let statement = Snippet.toStatement snippet decoder
     let session = Session.statement () statement
     result <- HasqlPool.use pool session
     case result of
@@ -202,7 +202,7 @@ runSnippetQuery snippet decoder = do
 runSnippetExec :: (?modelContext :: ModelContext) => Snippet -> IO ()
 runSnippetExec snippet = do
     let pool = ?modelContext.hasqlPool
-    let statement = Snippet.toPreparedStatement snippet Decoders.noResult
+    let statement = Snippet.toStatement snippet Decoders.noResult
     let session = Session.statement () statement
     result <- HasqlPool.use pool session
     case result of


### PR DESCRIPTION
## Summary
- The IDE Data Controller used prepared (cached) SQL statements via `toPreparedStatement`, which assigns numbered handles (e.g. `"22"`) per PostgreSQL connection
- Schema changes from the Schema Designer invalidate these cached statements, causing `prepared statement "22" does not exist` errors when browsing/editing data
- Switched `runSnippetQuery` and `runSnippetExec` to use `toStatement` (unprepared) instead, which is appropriate since IDE queries are dynamic and don't benefit from prepared statement caching

## Test plan
- [ ] Open the IDE Schema Designer and modify a table (e.g. add/remove a column)
- [ ] Navigate to the Data tab and browse/edit rows in that table
- [ ] Verify no "prepared statement does not exist" errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)