### PR TITLE
Fix IDE Add Row failing for columns with now() default

### DIFF
--- a/ihp-ide/IHP/IDE/Data/View/Layout.hs
+++ b/ihp-ide/IHP/IDE/Data/View/Layout.hs
@@ -67,20 +67,16 @@ isBoolField fieldName tableCols = case (find (\c -> c.columnName == (cs fieldNam
     Nothing -> False
 
 isSqlFunction :: Text -> Bool
-isSqlFunction text = text `elem`
+isSqlFunction text = Text.toLower text `elem`
     [ "uuidv7()"
     , "uuidv4()"
     , "uuid_generate_v4()"
-    , "NOW()"
-    , "NULL"]
+    , "now()"
+    , "null"
+    , "default"]
 
 isSqlFunction_ :: ByteString -> Bool
-isSqlFunction_ text = text `elem`
-    [ "uuidv7()"
-    , "uuidv4()"
-    , "uuid_generate_v4()"
-    , "NOW()"
-    , "NULL"]
+isSqlFunction_ text = isSqlFunction (cs text)
 
 fillField col value isBoolField = "fillField('" <> col.columnName <> "', '" <> value <> "'," <> isBoolField <> ");"
 


### PR DESCRIPTION
## Summary
- `isSqlFunction` matched `"NOW()"` (uppercase) but PostgreSQL returns `"now()"` (lowercase) as `column_default`, so the "Parse as SQL" checkbox wasn't pre-checked when adding a row in the IDE
- This caused `now()` to be sent as a text bind parameter instead of raw SQL, producing: `column "created_at" is of type timestamp with time zone but expression is of type text`
- Fix makes `isSqlFunction` case-insensitive via `Text.toLower`, adds `"default"` to the recognized list, and deduplicates `isSqlFunction_`

## Test plan
- [ ] Open IDE, navigate to a table with a `created_at TIMESTAMP WITH TIME ZONE DEFAULT now()` column
- [ ] Click "Add Row" — verify the `created_at` field shows `now()` with "Parse as SQL" checkbox pre-checked
- [ ] Submit the form — verify the row is created successfully without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)