### PR TITLE
Fix UUID type mismatch in foreign key hover card query

### DIFF
--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -167,7 +167,7 @@ instance Controller DataController where
 
     action ShowForeignKeyHoverCardAction { tableName, id, columnName } = do
         hovercardData <- do
-            let fetchIdSnippet = Snippet.sql "SELECT " <> quoteIdentifier columnName <> Snippet.sql "::text FROM " <> quoteIdentifier tableName <> Snippet.sql " WHERE id = " <> Snippet.param id
+            let fetchIdSnippet = Snippet.sql "SELECT " <> quoteIdentifier columnName <> Snippet.sql "::text FROM " <> quoteIdentifier tableName <> Snippet.sql " WHERE id = " <> Snippet.param id <> Snippet.sql "::uuid"
             foreignIdResult <- runSnippetQuery fetchIdSnippet (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
 
             case foreignIdResult of


### PR DESCRIPTION
## Summary
- The `ShowForeignKeyHoverCardAction` query passed the `id` parameter as text but compared it against a UUID column without a cast, causing `operator does not exist: uuid = text`
- Added `::uuid` cast to the parameter, matching the pattern already used in the second query in the same action

## Test plan
- [ ] Open the Data tab in the IHP IDE, hover over a foreign key cell to trigger the hover card — should display the referenced record without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)