### PR TITLE
Simplify redundant pattern match in hasql session construction

### DIFF
--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -335,10 +335,7 @@ sqlStatementHasql pool input statement = do
     let ?context = ?modelContext
     let currentLogLevel = ?modelContext.logger.level
     let session = case (?modelContext.transactionRunner, ?modelContext.rowLevelSecurity) of
-            (Just _, _) ->
-                -- In transaction: RLS already configured at BEGIN time
-                Hasql.statement input statement
-            (_, Just RowLevelSecurityContext { rlsAuthenticatedRole, rlsUserId }) ->
+            (Nothing, Just RowLevelSecurityContext { rlsAuthenticatedRole, rlsUserId }) ->
                 Tx.transaction Tx.ReadCommitted Tx.Read $ do
                     Tx.statement (rlsAuthenticatedRole, rlsUserId) setRLSConfigStatement
                     Tx.statement input statement
@@ -393,9 +390,7 @@ sqlExecHasql pool snippet = do
     let currentLogLevel = ?modelContext.logger.level
     let statement = Snippet.toStatement snippet Decoders.noResult
     let session = case (?modelContext.transactionRunner, ?modelContext.rowLevelSecurity) of
-            (Just _, _) ->
-                Hasql.statement () statement
-            (_, Just RowLevelSecurityContext { rlsAuthenticatedRole, rlsUserId }) ->
+            (Nothing, Just RowLevelSecurityContext { rlsAuthenticatedRole, rlsUserId }) ->
                 Tx.transaction Tx.ReadCommitted Tx.Write $ do
                     Tx.statement (rlsAuthenticatedRole, rlsUserId) setRLSConfigStatement
                     Tx.statement () statement
@@ -437,9 +432,7 @@ sqlExecHasqlCount pool snippet = do
     let currentLogLevel = ?modelContext.logger.level
     let statement = Snippet.toStatement snippet Decoders.rowsAffected
     let session = case (?modelContext.transactionRunner, ?modelContext.rowLevelSecurity) of
-            (Just _, _) ->
-                Hasql.statement () statement
-            (_, Just RowLevelSecurityContext { rlsAuthenticatedRole, rlsUserId }) ->
+            (Nothing, Just RowLevelSecurityContext { rlsAuthenticatedRole, rlsUserId }) ->
                 Tx.transaction Tx.ReadCommitted Tx.Write $ do
                     Tx.statement (rlsAuthenticatedRole, rlsUserId) setRLSConfigStatement
                     Tx.statement () statement


### PR DESCRIPTION
## Summary
- The `(Just transactionRunner, _)` case in `sqlStatementHasql`, `sqlExecHasql`, and `sqlExecHasqlCount` was identical to the fallthrough `_` case — both just produce `Hasql.statement input statement`
- Simplified to only match on `(Nothing, Just rls)` for the RLS wrapping case, with everything else falling through to the plain statement

## Test plan
- [ ] Verify module compiles with `echo ':l ihp/IHP/ModelSupport.hs' | ghci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)