### PR TITLE
Use upstream Tsvector FromField/ToField instances

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -134,8 +134,8 @@ let
             # postgresql-simple-postgresql-types: bridge providing FromField/ToField instances
             # for all postgresql-types types (Point, Polygon, Inet, Interval, etc.) in postgresql-simple
             postgresql-simple-postgresql-types = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (self.callCabal2nix "postgresql-simple-postgresql-types" (builtins.fetchTarball {
-                url = "https://github.com/nikita-volkov/postgresql-simple-postgresql-types/archive/1aebd39.tar.gz";
-                sha256 = "1saz10qyhp5ag13kq5x3rl12nc9mv6xiycik941rcpqcdkcirny4";
+                url = "https://github.com/mpscholten/postgresql-simple-postgresql-types/archive/cd614d3.tar.gz";
+                sha256 = "02400hhy50i0p60v4f9bxjdkcilf6chw815g43c48hpvvdbik32j";
             }) {}));
             # ptr-peeker is marked broken in nixpkgs but is needed by postgresql-types
             ptr-peeker = final.haskell.lib.dontCheck (final.haskell.lib.markUnbroken super.ptr-peeker);

--- a/ihp-postgresql-simple-extra/IHP/Postgres/TSVector.hs
+++ b/ihp-postgresql-simple-extra/IHP/Postgres/TSVector.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-|
 Module: IHP.Postgres.TSVector
-Description: Adds support for the Postgres tsvector type
+Description: Re-exports the Postgres tsvector type and provides a backwards-compatible alias
 Copyright: (c) digitally induced GmbH, 2021
 -}
 module IHP.Postgres.TSVector
@@ -9,74 +8,7 @@ module IHP.Postgres.TSVector
 , module PostgresqlTypes.Tsvector
 ) where
 
-import BasicPrelude
-import IHP.Postgres.TypeInfo
-import Database.PostgreSQL.Simple.ToField
-import Database.PostgreSQL.Simple.FromField
-import Database.PostgreSQL.Simple.TypeInfo.Macro
-import qualified Data.Text.Encoding as TextEncoding
-import Data.Attoparsec.ByteString.Char8 as Attoparsec hiding (Parser(..))
-import Data.Attoparsec.Internal.Types (Parser)
-import Data.ByteString.Builder (byteString)
 import PostgresqlTypes.Tsvector
 
 -- | Type alias for backwards compatibility
 type TSVector = Tsvector
-
-instance FromField Tsvector where
-    fromField f v =
-        if typeOid f /= $(inlineTypoid tsvector)
-        then returnError Incompatible f ""
-        else case v of
-               Nothing -> returnError UnexpectedNull f ""
-               Just bs ->
-                   case parseOnly parseTsvectorBS bs of
-                     Left  err -> returnError ConversionFailed f err
-                     Right val -> pure val
-
--- | Parse tsvector text representation from ByteString
--- Format: 'word1':1A,2B 'word2':3C
-parseTsvectorBS :: Parser ByteString Tsvector
-parseTsvectorBS = do
-    lexemes <- parseLexeme `sepBy` skipSpace1
-    case refineFromLexemeList lexemes of
-        Just tv -> pure tv
-        Nothing -> fail "invalid tsvector lexeme"
-    where
-        skipSpace1 = skipWhile (== ' ')
-        parseLexeme = do
-            skipSpace
-            char '\''
-            token <- Attoparsec.takeWhile (/= '\'')
-            char '\''
-            char ':'
-            positions <- parsePosition `sepBy1` char ','
-            pure (TextEncoding.decodeUtf8 token, positions)
-        parsePosition = do
-            pos <- Attoparsec.decimal
-            weight <- option DWeight $ choice
-                [ char 'A' >> pure AWeight
-                , char 'B' >> pure BWeight
-                , char 'C' >> pure CWeight
-                , char 'D' >> pure DWeight
-                ]
-            pure (pos, weight)
-
-instance ToField Tsvector where
-    toField tv = Many $ intersperse (Plain " ") $ map serializeLexeme (toLexemeList tv)
-        where
-            serializeLexeme (token, positions) = Many
-                [ Plain $ byteString "'"
-                , Plain $ byteString $ TextEncoding.encodeUtf8 token
-                , Plain $ byteString "'"
-                , Plain $ byteString ":"
-                , Many $ intersperse (Plain $ byteString ",") (map serializePosition positions)
-                ]
-            serializePosition (pos, weight) = Many
-                [ toField (fromIntegral pos :: Int)
-                , Plain $ byteString $ case weight of
-                    AWeight -> "A"
-                    BWeight -> "B"
-                    CWeight -> "C"
-                    DWeight -> ""
-                ]


### PR DESCRIPTION
## Summary
- Updates `postgresql-simple-postgresql-types` pin to include `FromField`/`ToField` instances for `Tsvector` (via `ViaIsScalar`)
- Removes hand-written orphan instances from `ihp-postgresql-simple-extra/IHP/Postgres/TSVector.hs` — the module now only re-exports the type and provides the `TSVector` alias
- Upstream PR: https://github.com/nikita-volkov/postgresql-simple-postgresql-types/pull/2

## Test plan
- [ ] Verify `nix flake check --impure` passes
- [ ] Verify IHP apps using `TSVector` still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)