### PR TITLE
Generate DefaultParamEncoder for enum array columns

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -48,6 +48,8 @@ tests = do
                         defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum (Just "public") "mood" inputValue)
                     instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe Mood) where
                         defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum (Just "public") "mood" inputValue)
+                    instance Hasql.Implicits.Encoders.DefaultParamEncoder [Mood] where
+                        defaultParam = Hasql.Encoders.nonNullable $ Hasql.Encoders.foldableArray $ Hasql.Encoders.nonNullable (Hasql.Encoders.enum (Just "public") "mood" inputValue)
                 |]
             it "should deal with enums that have no values" do
                 -- https://github.com/digitallyinduced/ihp/issues/1026

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -602,6 +602,8 @@ compileEnumDataDefinitions enum@(CreateEnumType { name, values }) =
         <> "    defaultParam = Hasql.Encoders.nonNullable (Hasql.Encoders.enum (Just \"public\") " <> tshow (Text.toLower name) <> " inputValue)\n"
         <> "instance Hasql.Implicits.Encoders.DefaultParamEncoder (Maybe " <> modelName <> ") where\n"
         <> "    defaultParam = Hasql.Encoders.nullable (Hasql.Encoders.enum (Just \"public\") " <> tshow (Text.toLower name) <> " inputValue)\n"
+        <> "instance Hasql.Implicits.Encoders.DefaultParamEncoder [" <> modelName <> "] where\n"
+        <> "    defaultParam = Hasql.Encoders.nonNullable $ Hasql.Encoders.foldableArray $ Hasql.Encoders.nonNullable (Hasql.Encoders.enum (Just \"public\") " <> tshow (Text.toLower name) <> " inputValue)\n"
     where
         modelName = tableNameToModelName name
         valueConstructors = map enumValueToConstructorName values


### PR DESCRIPTION
## Summary
- Enum types used in PostgreSQL array columns (e.g. `firing_type[]`) need a `DefaultParamEncoder [EnumType]` instance for hasql encoding
- The schema compiler already generates instances for `EnumType` and `Maybe EnumType` but was missing the list variant, causing compilation errors for any table with an enum array column
- Follows the same pattern as the hand-written `[JobStatus]` instance in `IHP.Job.Queue`

## Test plan
- [ ] Updated `SchemaCompilerSpec` test to include the new `[Mood]` instance in expected output
- [ ] Verify projects with enum array columns (e.g. `firing_type firing_type[]`) compile without `DefaultParamEncoder` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)