### PR TITLE
Fix sqlExecDiscardResult to use noResult decoder

### DIFF
--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -300,8 +300,9 @@ sqlExec theQuery theParameters = do
 -- > sqlExecDiscardResult "CREATE TABLE users ()" ()
 sqlExecDiscardResult :: (?modelContext :: ModelContext, ToSnippetParams q) => Query -> q -> IO ()
 sqlExecDiscardResult theQuery theParameters = do
-    _ <- sqlExec theQuery theParameters
-    pure ()
+    let pool = ?modelContext.hasqlPool
+    let snippet = sqlToSnippet (fromQuery theQuery) (toSnippetParams theParameters)
+    sqlExecHasql pool snippet
 {-# INLINABLE sqlExecDiscardResult #-}
 
 


### PR DESCRIPTION
## Summary
- `sqlExecDiscardResult` was delegating to `sqlExec` which uses `sqlExecHasqlCount` (`Decoders.rowsAffected`). This fails for SQL commands that don't return a row count in their command tag (e.g. `SET CONSTRAINTS ... DEFERRED`), causing `UnexpectedResultStatementError "Empty bytes"`.
- Now delegates to `sqlExecHasql` which uses `Decoders.noResult` instead.

## Test plan
- [x] Compiles cleanly with `ghc --make -fno-code`
- [ ] Verify `sqlExecDiscardResult "SET CONSTRAINTS ... DEFERRED" ()` no longer throws `HasqlSessionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)