### PR TITLE
Fix job worker reliability: retry on error, reduce poll interval

### DIFF
--- a/ihp/IHP/Job/Runner.hs
+++ b/ihp/IHP/Job/Runner.hs
@@ -171,6 +171,7 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
                 Left exception -> do
                     Log.error ("Job worker: Failed to fetch next job: " <> tshow exception)
                     Concurrent.threadDelay 1000000  -- 1s backoff to avoid tight error loops
+                    runJobLoop -- retry after transient error
                 Right (Just job) -> do
                     Log.info ("Starting job: " <> tshow job)
 


### PR DESCRIPTION
## Summary
- **Retry on transient errors**: After the job worker redesign (#2327), `runJobLoop` silently exits when `fetchNextJob` throws (pool exhaustion, connection timeout). Since the NOTIFY signal was already consumed from the TBQueue, nothing triggers a new worker — the job waits for the poller. Now it retries with 1s backoff (async exceptions still rethrown for clean shutdown).
- **Reduce poll interval 60s → 10s**: The poller is the safety net when pg_notify is missed. 60s is too long as a fallback. 10s is one lightweight COUNT query per job type — negligible overhead.
- **Add notification logging**: Debug log when pg_notify is received, warn when a notification is dropped due to a full queue.

Fixes amitaibu/ihp-sensors#18

## Test plan
- [ ] Create a job and verify it's picked up within seconds
- [ ] Verify graceful shutdown still works (CTRL+C waits for jobs, second CTRL+C force-kills)
- [ ] With `DEBUG=1`, verify "Received pg_notify" appears when a job is created
- [ ] Verify normal job processing is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)