### PR TITLE
Fix contentDispositionAttachmentAndFileName to use RFC 5987 encoding

### DIFF
--- a/ihp/IHP/FileStorage/ControllerFunctions.hs
+++ b/ihp/IHP/FileStorage/ControllerFunctions.hs
@@ -44,6 +44,7 @@ import System.OsPath (encodeUtf)
 import qualified Network.Wreq as Wreq
 import Control.Lens hiding ((|>), set)
 import qualified Network.Mime as Mime
+import qualified Network.HTTP.Types.URI as URI
 
 -- | Uploads a file to a directory in the storage
 --
@@ -313,7 +314,9 @@ refreshTemporaryDownloadUrlFromFile record = do
             pure record
 
 contentDispositionAttachmentAndFileName :: Wai.FileInfo LByteString -> IO (Maybe Text)
-contentDispositionAttachmentAndFileName fileInfo = pure (Just ("attachment; filename=\"" <> cs (fileInfo.fileName) <> "\""))
+contentDispositionAttachmentAndFileName fileInfo =
+    let encodedFileName = cs (URI.urlEncode False (fileInfo.fileName))
+    in pure (Just ("attachment; filename*=UTF-8''" <> encodedFileName))
 
 -- | Saves an upload to the storage and sets the record attribute to the url.
 --

--- a/ihp/Test/Test/FileStorage/ControllerFunctionsSpec.hs
+++ b/ihp/Test/Test/FileStorage/ControllerFunctionsSpec.hs
@@ -45,6 +45,25 @@ tests = describe "IHP.FileStorage.ControllerFunctions" $ do
 
                 result.url `shouldBe` ("/Test.FileStorage.ControllerFunctionsSpec/4c55dac2-e411-45ac-aa10-b957b01221df")
 
+    describe "contentDispositionAttachmentAndFileName" $ do
+        let fileInfoWith name = FileInfo { fileName = name, fileContentType = "application/octet-stream", fileContent = "" }
+
+        it "produces RFC 5987 encoded header for a plain ASCII filename" $ do
+            result <- contentDispositionAttachmentAndFileName (fileInfoWith "report.pdf")
+            result `shouldBe` Just "attachment; filename*=UTF-8''report.pdf"
+
+        it "percent-encodes spaces in the filename" $ do
+            result <- contentDispositionAttachmentAndFileName (fileInfoWith "my report.pdf")
+            result `shouldBe` Just "attachment; filename*=UTF-8''my%20report.pdf"
+
+        it "percent-encodes special characters in the filename" $ do
+            result <- contentDispositionAttachmentAndFileName (fileInfoWith "file (final).pdf")
+            result `shouldBe` Just "attachment; filename*=UTF-8''file%20%28final%29.pdf"
+
+        it "percent-encodes non-ASCII characters in the filename" $ do
+            result <- contentDispositionAttachmentAndFileName (fileInfoWith (cs ("ファイル.pdf" :: Text)))
+            result `shouldBe` Just "attachment; filename*=UTF-8''%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB.pdf"
+
     describe "createTemporaryDownloadUrlFromPath" $ do
         it "returns baseUrl concatenated with objectPath when objectPath does not start with http:// or https://" $ do
             withFrameworkConfig \frameworkConfig -> do


### PR DESCRIPTION
- Replaces the raw filename="..." format with filename*=UTF-8''<percent-encoded> (RFC 5987) in contentDispositionAttachmentAndFileName, preventing SignatureDoesNotMatch errors from S3 when filenames contain spaces, special characters, or non-ASCII bytes.
- Adds hspec tests covering plain ASCII, spaces, special characters, and Unicode filenames.
