### PR TITLE
Fix CI: convert template path to Nix path type

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
                 overlays.default = import ./NixSupport/overlay.nix { inherit inputs self; };
                 flakeModules.default = flake-parts-lib.importApply ./flake-module.nix { inherit inputs; };
                 templates.default = {
-                    path = inputs.ihp-boilerplate;
+                    path = /. + builtins.unsafeDiscardStringContext (toString inputs.ihp-boilerplate);
                     description = "Template for an IHP project";
                     welcomeText = ''
                         TODO this is shown when running nix init, could contain instruction to get started


### PR DESCRIPTION
## Summary

- Newer Determinate Nix (installed by `DeterminateSystems/nix-installer-action@main`) validates templates with `builtins.isPath`, which rejects flake input store path strings
- Convert `inputs.ihp-boilerplate` to a true Nix path type using `/. + builtins.unsafeDiscardStringContext(...)` so the template passes validation
- Fixes the "Binary Build" CI failure since March 5

## Test plan

- [x] `nix eval --impure --expr 'builtins.isPath ...'` returns `true`
- [x] `nix flake check --no-build` passes template validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)