### PR TITLE
Use prepared statements for Snippet-based queries

### DIFF
--- a/ihp-ide/IHP/IDE/Data/Controller.hs
+++ b/ihp-ide/IHP/IDE/Data/Controller.hs
@@ -191,7 +191,7 @@ instance Controller DataController where
 runSnippetQuery :: (?modelContext :: ModelContext) => Snippet -> Decoders.Result a -> IO a
 runSnippetQuery snippet decoder = do
     let pool = ?modelContext.hasqlPool
-    let statement = Snippet.toStatement snippet decoder
+    let statement = Snippet.toPreparedStatement snippet decoder
     let session = Session.statement () statement
     result <- HasqlPool.use pool session
     case result of
@@ -202,7 +202,7 @@ runSnippetQuery snippet decoder = do
 runSnippetExec :: (?modelContext :: ModelContext) => Snippet -> IO ()
 runSnippetExec snippet = do
     let pool = ?modelContext.hasqlPool
-    let statement = Snippet.toStatement snippet Decoders.noResult
+    let statement = Snippet.toPreparedStatement snippet Decoders.noResult
     let session = Session.statement () statement
     result <- HasqlPool.use pool session
     case result of

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -371,7 +371,7 @@ sqlStatementHasql pool input statement = do
 --
 sqlQueryHasql :: (?modelContext :: ModelContext) => HasqlPool.Pool -> Snippet.Snippet -> Decoders.Result a -> IO a
 sqlQueryHasql pool snippet decoder =
-    sqlStatementHasql pool () (Snippet.toStatement snippet decoder)
+    sqlStatementHasql pool () (Snippet.toPreparedStatement snippet decoder)
 {-# INLINABLE sqlQueryHasql #-}
 
 -- | Like 'sqlStatementHasql' but for write operations (DELETE, UPDATE, INSERT without results).
@@ -420,7 +420,7 @@ sqlExecStatement pool input statement = do
 -- When RLS is enabled, the statement is wrapped in a transaction that first sets the
 -- role and user id via 'setRLSConfigStatement'.
 sqlExecHasql :: (?modelContext :: ModelContext) => HasqlPool.Pool -> Snippet.Snippet -> IO ()
-sqlExecHasql pool snippet = sqlExecStatement pool () (Snippet.toStatement snippet Decoders.noResult)
+sqlExecHasql pool snippet = sqlExecStatement pool () (Snippet.toPreparedStatement snippet Decoders.noResult)
 {-# INLINABLE sqlExecHasql #-}
 
 -- | Like 'sqlExecHasql' but returns the number of affected rows
@@ -431,7 +431,7 @@ sqlExecHasqlCount :: (?modelContext :: ModelContext) => HasqlPool.Pool -> Snippe
 sqlExecHasqlCount pool snippet = do
     let ?context = ?modelContext
     let currentLogLevel = ?modelContext.logger.level
-    let statement = Snippet.toStatement snippet Decoders.rowsAffected
+    let statement = Snippet.toPreparedStatement snippet Decoders.rowsAffected
     let session = case (?modelContext.transactionRunner, ?modelContext.rowLevelSecurity) of
             (Nothing, Just RowLevelSecurityContext { rlsAuthenticatedRole, rlsUserId }) ->
                 Tx.transaction Tx.ReadCommitted Tx.Write $ do


### PR DESCRIPTION
## Summary

- Replace `Snippet.toStatement` → `Snippet.toPreparedStatement` at all 5 call sites (`sqlQueryHasql`, `sqlExecHasql`, `sqlExecHasqlCount`, `runSnippetQuery`, `runSnippetExec`)
- This enables PostgreSQL prepared statement plan caching for all Snippet-based queries (`deleteRecord`, `sqlQuery`, `sqlExec`, pagination, IDE data browser), matching the behavior already used by the QueryBuilder/`buildStatement` path
- The `toPreparedStatement` function was already patched into `hasql-dynamic-statements` in the nix overlay but wasn't being used yet

## Test plan

- [x] `ihp/IHP/ModelSupport.hs` compiles
- [x] `ihp-ide/IHP/IDE/Data/Controller.hs` compiles
- [x] IHP core tests pass (468 examples, 0 failures)
- [x] IHP IDE tests pass (368 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)