### PR TITLE
Set PGDATABASE=app to fix pg_isready database error

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -352,6 +352,7 @@ ihpFlake:
                 # Can be re-enabled once postgres is provided by devenv instead of IHP
                 env.IHP_DEVENV = "1";
                 env.DATABASE_URL = "postgres:///app?host=${config.devenv.shells.default.env.PGHOST}";
+                env.PGDATABASE = "app";
 
                 # Disabled for now
                 # As the devenv postgres uses a different location for the socket


### PR DESCRIPTION
## Summary
- Fixes digitallyinduced/ihp-boilerplate#56
- Sets `env.PGDATABASE = "app"` in the devenv shell config so that `pg_isready` and other pg* tools use the correct database name instead of defaulting to the OS username
- Consistent with `DATABASE_URL` already pointing to the `app` database

## Test plan
- [ ] Run `devenv up` and verify no `FATAL: database 'username' does not exist` in PostgreSQL logs
- [ ] Verify `pg_isready` returns success without the FATAL error
- [ ] Verify `psql` connects to the `app` database by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)