### PR TITLE
Fix `devenv up` Ctrl-C not stopping postgres

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -379,6 +379,11 @@ ihpFlake:
                     }
                 ];
 
+                # Explicit shutdown command to work around devenv-tasks v2 not
+                # propagating signals to child processes (#2481)
+                processes.postgres.process-compose.shutdown.command = "pg_ctl stop -D \"$PGDATA\" -m fast";
+                processes.postgres.process-compose.shutdown.timeout_seconds = 15;
+
                 # Used in the Makefile https://github.com/digitallyinduced/ihp-boilerplate/blob/master/Makefile
                 env.IHP = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
 


### PR DESCRIPTION
## Summary

- Adds explicit `shutdown.command` (`pg_ctl stop`) to the postgres process in `flake-module.nix`
- Works around devenv-tasks v2 not propagating SIGINT to child processes in separate process groups
- Prevents `postmaster.pid` lock file conflicts when restarting after Ctrl-C

## Details

The devenv v1→v2 upgrade introduced `process-wrap` which isolates child processes in separate process groups. When process-compose sends SIGINT on Ctrl-C, it reaches `devenv-tasks` but doesn't propagate to postgres. The explicit `pg_ctl stop -D "$PGDATA" -m fast` shutdown command bypasses this broken signal chain entirely.

Fixes #2481

## Test plan

- [ ] Run `devenv up` in an IHP app — confirm postgres starts
- [ ] Press Ctrl-C — confirm postgres stops (`ps aux | grep postgres` shows nothing)
- [ ] Run `devenv up` again — should start cleanly without `postmaster.pid` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)