### PR TITLE
Suppress -Wambiguous-fields warnings in generated types

### DIFF
--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -94,7 +94,7 @@ actualTypesTableModule table =
         prelude = [trimming|
             -- This file is auto generated and will be overriden regulary. Please edit `Application/Schema.sql` to change the Types\n"
             {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, InstanceSigs, MultiParamTypeClasses, TypeFamilies, DataKinds, TypeOperators, UndecidableInstances, ConstraintKinds, StandaloneDeriving  #-}
-            {-# OPTIONS_GHC -Wno-unused-imports -Wno-dodgy-imports -Wno-unused-matches #-}
+            {-# OPTIONS_GHC -Wno-unused-imports -Wno-dodgy-imports -Wno-unused-matches -Wno-ambiguous-fields #-}
             module $moduleName where
             $defaultImports
             import Generated.Enums
@@ -129,7 +129,7 @@ tableModule options table =
         prelude = [trimming|
             -- This file is auto generated and will be overriden regulary. Please edit `Application/Schema.sql` to change the Types\n"
             {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, InstanceSigs, MultiParamTypeClasses, TypeFamilies, DataKinds, TypeOperators, UndecidableInstances, ConstraintKinds, StandaloneDeriving  #-}
-            {-# OPTIONS_GHC -Wno-unused-imports -Wno-dodgy-imports -Wno-unused-matches #-}
+            {-# OPTIONS_GHC -Wno-unused-imports -Wno-dodgy-imports -Wno-unused-matches -Wno-ambiguous-fields #-}
             module $moduleName where
             $defaultImports
             import Generated.ActualTypes


### PR DESCRIPTION
## Summary
- Add `-Wno-ambiguous-fields` to the `OPTIONS_GHC` pragma in generated per-table modules (`build/Generated/ActualTypes/<Table>.hs` and `build/Generated/<Table>.hs`)
- The `SetField`/`UpdateField` instances use record update syntax which triggers GHC-02256 warnings when `DuplicateRecordFields` is enabled
- IHP's own cabal packages already suppress this warning, but the generated code in user projects was missing it

Fixes #2486

## Test plan
- [x] All 368 existing tests pass
- [x] SchemaCompiler module compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)