### PR TITLE
Fix documentation sidebar width bug

### DIFF
--- a/Guide/layout.html
+++ b/Guide/layout.html
@@ -24,7 +24,7 @@
             </button>
         </nav>
 
-        <div class="text-end nav-column navbar-collapse">
+        <div class="text-end nav-column">
             <div class="nav-logo">
                 <img src="images/ihp-logo-readme.svg" style="width:13ch;" />
             </div>
@@ -284,6 +284,7 @@
                 display: block;
                 width: 25%;
                 max-width: 25%;
+                flex-shrink: 0;
                 padding-right: 4rem;
             }
 


### PR DESCRIPTION
## Summary
- Remove Bootstrap's `navbar-collapse` class from the sidebar div, which was setting `flex-basis: 100%` and `flex-grow: 1`, causing the sidebar to expand far beyond its intended 25% width
- Add `flex-shrink: 0` to `.nav-column` to prevent the sidebar from shrinking below 25% on smaller screens

Fixes #2463

## Test plan
- [ ] Open Guide/index.html in browser at various widths (768px, 1024px, 1440px, 1920px) — sidebar should be 25%
- [ ] Resize to <768px — hamburger menu toggle should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)