### PR TITLE
Fix IDE Data Editor FK dropdown showing auxiliary fields and flickering

### DIFF
--- a/ihp-ide/data/static/IDE/ihp-schemadesigner.js
+++ b/ihp-ide/data/static/IDE/ihp-schemadesigner.js
@@ -360,14 +360,20 @@ function initDataEditorForeignKeyAutocomplete() {
         var options = {
             ajax: {
                 url: element.dataset.selectUrl,
-                processResults: data => ({ results: data }),
+                processResults: data => ({
+                    results: data.map(row => {
+                        row._originalKeys = Object.keys(row);
+                        return row;
+                    })
+                }),
                 cache: true
             },
             templateResult: row => {
                 const result = document.createElement('div');
                 result.classList.add('record');
 
-                for (const key in row) {
+                const keys = row._originalKeys || Object.keys(row);
+                for (const key of keys) {
                     const keyValueContainer = document.createElement('span');
                     keyValueContainer.classList.add('key-value-container');
 

--- a/ihp-ide/data/static/IDE/schema-designer.css
+++ b/ihp-ide/data/static/IDE/schema-designer.css
@@ -321,6 +321,10 @@
     min-height: 800px;
 }
 
+.modal-body {
+    overflow: visible;
+}
+
 .select2-results__option span.key {
     opacity: 0.5;
     margin-right: 12px;


### PR DESCRIPTION
## Summary

- **Fix auxiliary fields in dropdown**: Select2 internally adds properties (`selected`, `disabled`, `text`, `_resultId`, `element`) to result objects. The `templateResult` callback used `for (const key in row)` which iterated over all properties including these Select2-internal ones. Fixed by saving original keys in `processResults` before Select2 decorates objects, then iterating only over those keys with `for...of`.
- **Fix dropdown flickering**: When the FK select is in the middle of the modal, Select2 couldn't decide whether to open above or below due to overflow clipping. Fixed by setting `overflow: visible` on `.modal-body` so Select2 can properly calculate available space.

Fixes #2456

## Test plan

- [ ] Open IDE Data editor, navigate to a table with foreign key columns
- [ ] Click "Add Row" and open a FK dropdown
- [ ] Verify only actual table columns are shown (no `selected`, `disabled`, `text`, `_resultId`, `element`)
- [ ] With the FK field near the middle of the modal, verify the dropdown opens cleanly without flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)