### PR TITLE
Remove ihp-ide from production build dependency chain

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -453,9 +453,9 @@ that is defined in flake-module.nix
                 pkgs.symlinkJoin {
                     name = "ihp-env-var-backwards-compat";
                     paths = [
-                        (hsDataDir pkgs.ghc.ihp-ide.data + "/lib/IHP")
-                        (hsDataDir pkgs.ghc.ihp-ide.data)
-                        (hsDataDir pkgs.ghc.ihp.data)
+                        ("${self}/ihp-ide/data/lib/IHP")
+                        ("${self}/ihp-ide/data")
+                        ("${self}/ihp/data")
                     ];
                     # The Makefile references $(IHP)/static/vendor/bootstrap.min.css etc.
                     # These vendor files (bootstrap, jquery, select2) are fetched via Nix


### PR DESCRIPTION
## Summary
- `ihp-env-var-backwards-compat` referenced `pkgs.ghc.ihp-ide.data` which transitively required building the entire `ihp-ide` Haskell package for production builds
- Changed to reference source tree directly (`${self}/ihp-ide/data` and `${self}/ihp/data`) since the data files are identical
- This removes `ihp-ide` from the production dependency chain and allows `ihp-env-var-backwards-compat` to be built in parallel with Haskell packages

## Test plan
- [ ] `nix build .#optimized-prod-server` succeeds in an IHP app
- [ ] `nix why-depends --derivation .#optimized-prod-server <ihp-ide-drv>` finds no path
- [ ] `nix develop` in an IHP app still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)