### PR TITLE
Fix HasqlDecodeColumn Int using int8 instead of int4

### DIFF
--- a/ihp/IHP/Hasql/FromRow.hs
+++ b/ihp/IHP/Hasql/FromRow.hs
@@ -45,6 +45,14 @@ instance {-# OVERLAPPABLE #-} Mapping.IsScalar a => HasqlDecodeColumn a where
 instance {-# OVERLAPPING #-} Mapping.IsScalar a => HasqlDecodeColumn (Maybe a) where
     hasqlColumnDecoder = Decoders.column (Decoders.nullable Mapping.decoder)
 
+-- | IHP's schema maps SQL @INT@ (int4) to Haskell 'Int', but hasql-mapping's
+-- @IsScalar Int@ instance uses @int8@ (bigint). Override to match IHP conventions.
+instance {-# OVERLAPPING #-} HasqlDecodeColumn Int where
+    hasqlColumnDecoder = Decoders.column (Decoders.nonNullable (fromIntegral <$> Decoders.int4))
+
+instance {-# OVERLAPPING #-} HasqlDecodeColumn (Maybe Int) where
+    hasqlColumnDecoder = Decoders.column (Decoders.nullable (fromIntegral <$> Decoders.int4))
+
 -- | 'IsScalar' instance for 'Id'' so that Id columns can use 'Mapping.encoder' and 'Mapping.decoder'
 -- directly in generated code, without manual wrapping/unwrapping.
 instance Mapping.IsScalar (PrimaryKey table) => Mapping.IsScalar (Id' table) where

--- a/ihp/IHP/Pagination/ControllerFunctions.hs
+++ b/ihp/IHP/Pagination/ControllerFunctions.hs
@@ -19,7 +19,7 @@ import IHP.Pagination.Types ( Options(..), Pagination(..) )
 import IHP.QueryBuilder ( HasQueryBuilder, filterWhereILike, limit, offset )
 import IHP.Fetch (fetchCount)
 import IHP.ModelSupport (GetModelByTableName, sqlQueryHasql, Table)
-import IHP.Hasql.FromRow (FromRowHasql(..), HasqlDecodeColumn(..))
+import IHP.Hasql.FromRow (FromRowHasql(..))
 import IHP.Hasql.Encoders (ToSnippetParams(..), sqlToSnippet)
 import Network.Wai (Request)
 import qualified Hasql.Decoders as Decoders
@@ -216,7 +216,7 @@ paginatedSqlQueryWithOptions options sql placeholders = do
     let baseParams = toSnippetParams placeholders
 
     let countSnippet = sqlToSnippet ("SELECT count(subquery.*) FROM (" <> encodeUtf8 sql <> ") as subquery") baseParams
-    count :: Int <- sqlQueryHasql pool countSnippet (Decoders.singleRow hasqlColumnDecoder)
+    count :: Int <- sqlQueryHasql pool countSnippet (Decoders.singleRow (Decoders.column (Decoders.nonNullable (fromIntegral <$> Decoders.int8))))
 
     let pageSize = pageSize' options
         pagination = Pagination


### PR DESCRIPTION
IHP's schema maps SQL INT (int4) to Haskell Int, but the generic HasqlDecodeColumn instance delegated to hasql-mapping's IsScalar Int, which uses int8 (bigint). This caused UnexpectedColumnTypeStatementError when hand-written types used hasqlColumnDecoder with Int fields on INT columns.

The generated model decoders worked because they use explicit `fromIntegral <$> Decoders.int4`, but any custom FromRowHasql instance using the generic hasqlColumnDecoder would fail.

Add overlapping instances for Int and Maybe Int that use int4 with fromIntegral, matching IHP's schema conventions.