### PR TITLE
Fix IDE toolbar help popover not opening

### DIFF
--- a/ihp-ide/IHP/IDE/ToolServer/Layout.hs
+++ b/ihp-ide/IHP/IDE/ToolServer/Layout.hs
@@ -25,7 +25,7 @@ toolServerLayout inner = [hsx|
         <script src={assetPath "/vendor/morphdom-umd.min.js"}></script>
         <script src={assetPath "/vendor/jquery-4.0.0.min.js"}></script>
         <script src={assetPath "/vendor/timeago.js"}></script>
-        <script src={assetPath "/vendor/popper.min.js"}></script>
+        <script src={assetPath "/vendor/popper-2.11.6.min.js"}></script>
         <script src={assetPath "/vendor/bootstrap.min.js"}></script>
         
 
@@ -104,6 +104,7 @@ toolServerLayout inner = [hsx|
                 data-bs-placement="right"
                 data-bs-title="Questions, or need help with Haskell type errors?"
                 data-bs-trigger="focus"
+                tabindex="0"
                 id="nav-help"
             >
                 {helpIcon}


### PR DESCRIPTION
## Summary
- Fix `createPopper is not a function` error by switching from Popper v1 (`popper.min.js`) to the already-vendored Popper v2 (`popper-2.11.6.min.js`), which Bootstrap 5 requires
- Add `tabindex="0"` to the help `<a>` element, required by Bootstrap 5 for `data-bs-trigger="focus"` dismiss-on-next-click popovers to work cross-browser

## Test plan
- [ ] Run the IHP IDE dev server
- [ ] Click the question mark icon in the sidebar
- [ ] Verify the popover appears with the StackOverflow link and version info
- [ ] Click elsewhere to dismiss the popover
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)