### PR TITLE
Allow apps to override nixpkgs config in flake-module

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -165,7 +165,7 @@ ihpFlake:
                     in
                         "${shareRoot}/${sys}/${package.name}";
         in lib.mkIf cfg.enable {
-            _module.args.pkgs = import inputs.nixpkgs { inherit system; overlays = config.devenv.shells.default.overlays; config = { }; };
+            _module.args.pkgs = lib.mkDefault (import inputs.nixpkgs { inherit system; overlays = config.devenv.shells.default.overlays; config = { }; });
 
             # release build package
             packages = {


### PR DESCRIPTION
## Summary
- Use `lib.mkDefault` for `_module.args.pkgs` in `flake-module.nix` so IHP apps can override the nixpkgs import with custom config (e.g. `allowBroken = true`, `allowUnfree = true`)
- Previously this was a plain assignment (priority 100) which conflicted with any user override, causing `The option 'perSystem..._module.args.pkgs' is defined multiple times` errors
- With `mkDefault` (priority 1000), IHP's default still wins over flake-parts' `mkOptionDefault` (priority 1500), but yields to a user's plain assignment (priority 100)

Users can now override pkgs in their app flake:
```nix
perSystem = { system, config, ... }: {
  _module.args.pkgs = import inputs.nixpkgs {
    inherit system;
    config.allowBroken = true;
    overlays = config.devenv.shells.default.overlays;
  };
};
```

Fixes #2116

## Test plan
- [ ] Verify existing IHP apps build without changes (mkDefault preserves current behavior)
- [ ] Verify an app can override `_module.args.pkgs` with custom nixpkgs config without conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)