### PR TITLE
Optimize DataSync updateRecord to not return full record

### DIFF
--- a/ihp-datasync/IHP/DataSync/ControllerImpl.hs
+++ b/ihp-datasync/IHP/DataSync/ControllerImpl.hs
@@ -347,15 +347,15 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
                 columnTypes <- columnTypeLookup table
 
                 let setSql = encodePatchToSetSql (renamer table) columnTypes patch
-                let updateResult = compileUpdate table setSql (Snippet.sql "id = " <> uuidParam id) (renamer table) columnTypes
-                let stmt = compiledQueryStatement updateResult
+                let updateSnippet = compileUpdateNoReturning table setSql (Snippet.sql "id = " <> uuidParam id)
+                let stmt = Snippet.toPreparedStatement updateSnippet (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.uuid)))
 
-                result :: [[Field]] <- sqlQueryWriteWithRLSAndTransactionId hasqlPool transactionId stmt
+                result :: [UUID] <- sqlQueryWriteWithRLSAndTransactionId hasqlPool transactionId stmt
 
                 case result of
-                    [record] ->
-                        sendJSON DidUpdateRecord { requestId, record }
-                    otherwise -> sendJSON DataSyncError { requestId, errorMessage = "Could not apply the update to the given record. Are you sure the record ID you passed is correct? If the record ID is correct, likely the row level security policy is not making the record visible to the UPDATE operation." }
+                    [_] ->
+                        sendJSON DidUpdateRecord { requestId }
+                    _ -> sendJSON DataSyncError { requestId, errorMessage = "Could not apply the update to the given record. Are you sure the record ID you passed is correct? If the record ID is correct, likely the row level security policy is not making the record visible to the UPDATE operation." }
 
                 pure ()
 
@@ -366,12 +366,12 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 let setSql = encodePatchToSetSql (renamer table) columnTypes patch
                 let inList = mconcat $ List.intersperse (Snippet.sql ", ") (map uuidParam ids)
-                let updateResult = compileUpdate table setSql (Snippet.sql "id IN (" <> inList <> Snippet.sql ")") (renamer table) columnTypes
-                let stmt = compiledQueryStatement updateResult
+                let updateSnippet = compileUpdateNoReturning table setSql (Snippet.sql "id IN (" <> inList <> Snippet.sql ")")
+                let stmt = Snippet.toPreparedStatement updateSnippet (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.uuid)))
 
-                records <- sqlQueryWriteWithRLSAndTransactionId hasqlPool transactionId stmt
+                _ :: [UUID] <- sqlQueryWriteWithRLSAndTransactionId hasqlPool transactionId stmt
 
-                sendJSON DidUpdateRecords { requestId, records }
+                sendJSON DidUpdateRecords { requestId }
 
                 pure ()
 

--- a/ihp-datasync/IHP/DataSync/DynamicQueryCompiler.hs
+++ b/ihp-datasync/IHP/DataSync/DynamicQueryCompiler.hs
@@ -172,6 +172,18 @@ compileUpdate table setSql whereSql renamer columnTypes =
     <> whereSql
     <> Snippet.sql (compileReturningClause renamer columnTypes)
 
+-- | Build an UPDATE statement that only returns @id@.
+--
+-- Used by DataSync where the client already has the record and doesn't need
+-- the full row back – only confirmation that the row was found and updated.
+compileUpdateNoReturning :: Text -> Snippet -> Snippet -> Snippet
+compileUpdateNoReturning table setSql whereSql =
+    Snippet.sql ("UPDATE " <> quoteIdentifier table <> " SET ")
+    <> setSql
+    <> Snippet.sql " WHERE "
+    <> whereSql
+    <> Snippet.sql " RETURNING id"
+
 -- | Compile a condition expression to a 'Snippet' with typed parameter encoding.
 compileConditionTyped :: ColumnTypeMap -> ConditionExpression -> Snippet
 compileConditionTyped _ (ColumnExpression column) = Snippet.sql (quoteIdentifier column)

--- a/ihp-datasync/IHP/DataSync/Types.hs
+++ b/ihp-datasync/IHP/DataSync/Types.hs
@@ -40,8 +40,8 @@ data DataSyncResponse
     | DidChangeCount { subscriptionId :: !UUID, count :: !Int }
     | DidCreateRecord { requestId :: !Int, record :: ![Field] } -- ^ Response to 'CreateRecordMessage'
     | DidCreateRecords { requestId :: !Int, records :: ![[Field]] } -- ^ Response to 'CreateRecordsMessage'
-    | DidUpdateRecord { requestId :: !Int, record :: ![Field] } -- ^ Response to 'UpdateRecordMessage'
-    | DidUpdateRecords { requestId :: !Int, records :: ![[Field]] } -- ^ Response to 'UpdateRecordsMessage'
+    | DidUpdateRecord { requestId :: !Int } -- ^ Response to 'UpdateRecordMessage'
+    | DidUpdateRecords { requestId :: !Int } -- ^ Response to 'UpdateRecordsMessage'
     | DidDeleteRecord { requestId :: !Int }
     | DidDeleteRecords { requestId :: !Int }
     | DidStartTransaction { requestId :: !Int, transactionId :: !UUID }

--- a/ihp-datasync/Test/DataSync/DataSyncIntegrationSpec.hs
+++ b/ihp-datasync/Test/DataSync/DataSyncIntegrationSpec.hs
@@ -359,9 +359,8 @@ tests = do
                                 [ ("body", String "Updated message") ] 3 Nothing)
                             response <- recv
                             case response of
-                                DidUpdateRecord { record, requestId } -> do
+                                DidUpdateRecord { requestId } -> do
                                     requestId `shouldBe` 3
-                                    findField "body" record `shouldBe` Just (String "Updated message")
                                 DataSyncError { errorMessage } ->
                                     expectationFailure (cs $ "Unexpected error: " <> errorMessage)
                                 _ -> expectationFailure "Expected DidUpdateRecord"

--- a/ihp-datasync/data/DataSync/ihp-datasync.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.js
@@ -539,7 +539,7 @@ export async function updateRecord(table, id, patch, options = {}) {
         await waitPendingChanges(table, patch);
         const response = await DataSyncController.getInstance().sendMessage(request);
 
-        return response.record;
+        return { id, ...patch };
     } catch (e) {
         undoUpdateRecordOptimistic();
         throw new Error(e.message);
@@ -563,7 +563,7 @@ export async function updateRecords(table, ids, patch, options = {}) {
     try {
         const response = await DataSyncController.getInstance().sendMessage(request);
 
-        return response.records;
+        return ids.map(id => ({ id, ...patch }));
     } catch (e) {
         throw new Error(e.message);
     }


### PR DESCRIPTION
## Summary

- Server no longer fetches/encodes the full record after UPDATE — only returns `id` to confirm the row was found and RLS allowed it
- Removes the `record`/`records` fields from `DidUpdateRecord`/`DidUpdateRecords` response types
- JS `updateRecord()` now returns `{ id, ...patch }` locally instead of the server response
- This is safe because the client already applies patches optimistically and receives server-side changes (triggers, defaults) via `DidUpdate` subscription notifications

## Test plan

- [x] All existing DataSync tests pass (73 examples, 0 failures)
- [ ] Verify with a DataSync app that updateRecord still works end-to-end
- [ ] Verify subscription `DidUpdate` notifications still deliver server-side trigger changes

**Breaking change:** Code that uses the return value of `updateRecord()` expecting the full server record will now only get `{ id, ...patch }`. Callers that need the full record should merge the patch into their local copy instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)