### PR TITLE
Fix HSX wildcard pattern not implemented

### DIFF
--- a/ihp-hsx/Test/IHP/HSX/QQSpec.hs
+++ b/ihp-hsx/Test/IHP/HSX/QQSpec.hs
@@ -47,6 +47,9 @@ tests = do
             let placeData = PlaceId "Punches Cross"
             [hsx|<h1>{(\(PlaceId x) -> x)(placeData)}</h1>|] `shouldBeSameHtml` "<h1>Punches Cross</h1>"
 
+        it "should support wildcard patterns in lambdas" do
+            [hsx|<h1>{(\(_, x) -> x) ("a" :: Text, "b" :: Text)}</h1>|] `shouldBeSameHtml` "<h1>b</h1>"
+
         it "should support infix notation for standard constructors e.g. (:):" do
             [hsx| <h1>{show $ (:) 1  [2,3,42]}</h1> |] `shouldBeSameHtml` "<h1>[1,2,3,42]</h1>"
 

--- a/ihp-hsx/parser/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/parser/IHP/HSX/HsExpToTH.hs
@@ -97,7 +97,7 @@ toPat (ParPat xP _ lP _) = (toPat . unLoc) lP
 toPat (ConPat pat_con_ext ((unLoc -> name)) pat_args) = TH.ConP (toName name) (map toType []) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))
 toPat (ViewPat pat_con pat_args pat_con_ext) = error "TH.ViewPattern not implemented"
 toPat (SumPat _ _ _ _) = error "TH.SumPat not implemented"
-toPat (WildPat _ ) = error "TH.WildPat not implemented"
+toPat (WildPat _) = TH.WildP
 toPat (NPat _ _ _ _ ) = error "TH.NPat not implemented"
 toPat p = todo "toPat" p
 


### PR DESCRIPTION
## Summary
- Maps GHC's `WildPat` to `TH.WildP` in `HsExpToTH.hs`, fixing the `TH.WildPat not implemented` compile error when using wildcard patterns (`_`) in lambdas inside HSX expressions
- Adds a test case verifying wildcard patterns work in HSX lambdas

Fixes #1852

## Test plan
- [x] `cabal test ihp-hsx-tests` — all 106 tests pass including the new wildcard pattern test

🤖 Generated with [Claude Code](https://claude.com/claude-code)