### PR TITLE
Add app selector to Generate Controller preview

### DIFF
--- a/ihp-ide/IHP/IDE/CodeGen/View/NewController.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/View/NewController.hs
@@ -54,7 +54,7 @@ instance View NewControllerView where
                 <div class="generator-options">
                     <form method="POST" action={NewControllerAction}>
                         <input type="hidden" name="name" value={controllerName}/>
-                        <input type="hidden" name="applicationName" value={applicationName}/>
+                        {renderApplicationNameSelector}
                         <input
                             type="checkbox"
                             name="pagination"
@@ -66,12 +66,16 @@ instance View NewControllerView where
                     </form>
                 </div>
             |]
+            renderApplicationNameSelector = if length applications /= 1
+                then renderApplicationSelector
+                else [hsx|<input type="hidden" name="applicationName" value={applicationName}/>|]
             renderApplicationOptions = forM_ applications (\x -> [hsx|<option selected={x == applicationName}>{x}</option>|])
             renderApplicationSelector = [hsx|
                 <select
                     name="applicationName"
                     class="form-control select2-simple"
                     size="1"
+                    onchange="this.form.submit()"
                 >
                     {renderApplicationOptions}
                 </select>|]


### PR DESCRIPTION
## Summary

- When right-clicking a table in the schema designer and selecting "Generate Controller", the user can now choose which application (Web, Admin, etc.) to generate the controller for
- Previously the preview page hardcoded "Web" with no way to change it (#1479)
- The app selector dropdown appears in the generator-options area alongside the pagination checkbox, and auto-submits to regenerate the preview when changed

## Test plan

- [ ] In a multi-app IHP project, right-click a table in schema designer → "Generate Controller"
- [ ] Verify the application dropdown appears in the preview page
- [ ] Change the selected app and confirm the preview regenerates for that app
- [ ] Single-app projects should not show the dropdown (hidden input fallback)
- [ ] Existing "Generate Controller" flow from the code generators page still works

Fixes #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)