### PR TITLE
Add integration test support with automatic temp PostgreSQL

### DIFF
--- a/Guide/testing.markdown
+++ b/Guide/testing.markdown
@@ -1,6 +1,9 @@
 # Testing
 
-This section provides some guidelines for testing your IHP applications. It is highly recommended to write a test for your Controller and Views to assert the logic, and reach better code quality.
+This section provides some guidelines for testing your IHP applications. IHP supports two kinds of tests:
+
+- **Unit tests** (`Test/Main.hs`) — Pure tests and tests that don't need a database.
+- **Integration tests** (`Test/Integration.hs`) — Tests that use `withIHPApp` and need a running PostgreSQL database.
 
 ```toc
 
@@ -16,16 +19,68 @@ The following setup and tests can be viewed in the [Blog example](https://github
             cabal-install
             # ...
             p.ihp
-            
+
             hspec
             ihp-hspec
         ];
 ```
 2. Rebuild environment with `devenv up`
-3. Create a new `Test/Main.hs` module. Here you will import all your test specs.
+
+## Unit Tests
+
+Unit tests live in `Test/Main.hs` and don't require a database. Use these for testing pure logic, view rendering, or anything that doesn't need `withIHPApp`.
+
+### Setting Up Unit Tests
+
+Create a `Test/Main.hs` module:
 
 ```haskell
-# Test/Main.hs
+-- Test/Main.hs
+
+module Main where
+
+import Test.Hspec
+import IHP.Prelude
+
+import Test.MySpec
+
+main :: IO ()
+main = hspec do
+    Test.MySpec.tests
+```
+
+### Running Unit Tests
+
+**Interactively with ghci:**
+
+```
+ghci
+:l Test/Main
+main
+```
+
+**With runghc** (useful for CI, while `devenv up` is running in another tab):
+
+```
+runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs
+```
+
+**Via nix** (runs automatically as part of `nix flake check`):
+
+```
+nix flake check
+```
+
+## Integration Tests
+
+Integration tests live in `Test/Integration.hs` and use `withIHPApp`, which needs a PostgreSQL database with your app's schema loaded.
+
+### Setting Up Integration Tests
+
+Create a `Test/Integration.hs` module:
+
+```haskell
+-- Test/Integration.hs
 
 module Main where
 
@@ -38,9 +93,11 @@ main :: IO ()
 main = hspec do
     Test.Controller.PostsSpec.tests
 ```
-4. Add a new spec file for your controller.
+
+Add a spec file for your controller:
+
 ```haskell
-# Test/Controller/PostsSpec.hs
+-- Test/Controller/PostsSpec.hs
 module Test.Controller.PostsSpec where
 
 import Network.HTTP.Types.Status
@@ -107,44 +164,34 @@ tests = aroundAll (withIHPApp WebApplication config) do
                 body <- responseBody response
                 putStrLn (cs body)
 ```
-5. Execute the tests:
+
+### Running Integration Tests
+
+**Interactively with ghci** (requires `devenv up` running in another tab to provide PostgreSQL):
+
 ```
-nix-shell
 ghci
-:l Test/Main
+:l Test/Integration
 main
 ```
 
-Please note that when entering `ghci` it might give a warning:
+**With runghc** (requires `devenv up` running in another tab):
 
 ```
-ghci
-GHCi, version 8.10.3: https://www.haskell.org/ghc/  :? for help
-*** WARNING: . is writable by someone else, IGNORING!
-Suggested fix: execute 'chmod go-w .'
+runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Integration.hs
 ```
 
-In this case, follow the suggested fix, exist ghci (`:q`) and execute `chmod go-w .`. Then you can resume the process. When ghci loads correctly it should show
+**Via nix** (runs automatically as part of `nix flake check` — a temporary PostgreSQL is started automatically, no `devenv up` needed):
 
 ```
-GHCi, version 8.10.3: https://www.haskell.org/ghc/  :? for help
-package flags have changed, resetting and loading new packages...
-Loaded GHCi configuration from /home/amitaibu/Sites/Haskell/ihp/blog/.ghci
+nix flake check
 ```
 
-Another way of executing the tests, that we'll use on [CI](https://github.com/digitallyinduced/ihp-boilerplate/blob/master/.github/workflows/test.yml), is to use the `runghc` command, while running `devenv up` on another tab:
+To run a particular set of tests, use `--match`:
 
 ```
-runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs
+runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Integration.hs --match "Posts"
 ```
-
-To run a particular set of tests, use `--match`.
-
-```
-runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs --match "Posts"
-```
-
-This command will execute all tests which are described under describe "Posts controller functionality".
 
 ## Setting the Current User During Testing
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -308,6 +308,43 @@ ihpFlake:
                                 touch $out
                             '';
                         };
+                } else {})
+            // (if builtins.pathExists "${cfg.projectPath}/Test/Integration.hs"
+                then {
+                    "integration-tests" = pkgs.stdenv.mkDerivation {
+                            name = "${config.ihp.appName}-integration-tests";
+                            src = builtins.path { path = config.ihp.projectPath; name = "source"; };
+                            nativeBuildInputs = with pkgs; [
+                                (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler]))
+                                gnumake
+                                postgresql
+                            ];
+                            buildPhase = ''
+                                export IHP_LIB=${hsDataDir ghcCompiler.ihp-ide.data}
+
+                                # Start temporary PostgreSQL
+                                export PGDATA="$TMPDIR/pgdata"
+                                export PGHOST="$TMPDIR/pghost"
+                                mkdir -p "$PGHOST"
+                                initdb -D "$PGDATA" --no-locale --encoding=UTF8
+                                echo "unix_socket_directories = '$PGHOST'" >> "$PGDATA/postgresql.conf"
+                                echo "listen_addresses = '''" >> "$PGDATA/postgresql.conf"
+                                pg_ctl -D "$PGDATA" -l "$TMPDIR/pg.log" start
+
+                                createdb -h "$PGHOST" app
+                                export DATABASE_URL="postgresql:///app?host=$PGHOST"
+
+                                # Generate types and run integration tests
+                                make -f $IHP_LIB/lib/IHP/Makefile.dist build/Generated/Types.hs
+
+                                # shellcheck disable=SC2046
+                                runghc $(make -f $IHP_LIB/lib/IHP/Makefile.dist print-ghc-extensions) -i. -ibuild -iConfig Test/Integration.hs
+
+                                # Cleanup
+                                pg_ctl -D "$PGDATA" stop || true
+                                touch $out
+                            '';
+                        };
                 } else {});
 
             devenv.shells.default = lib.mkIf cfg.enable {


### PR DESCRIPTION
## Summary
- Adds an `integration-tests` package to `flake-module.nix` that automatically starts a temporary PostgreSQL, creates an `app` database, and runs `Test/Integration.hs` when present — fixing #1620
- Restructures the testing guide to clearly separate unit tests (`Test/Main.hs`, no DB) from integration tests (`Test/Integration.hs`, needs PostgreSQL)
- Updates outdated `nix-shell` references to `devenv up` / `nix develop`

## Test plan
- [ ] `nix flake show` on IHP repo — verify no syntax errors
- [ ] `nix flake check --impure` on IHP repo — verify existing tests still pass
- [ ] Test on ihp-boilerplate with a `Test/Integration.hs` using `withIHPApp` — verify `nix flake check` starts postgres and runs integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)