### PR TITLE
Update nixpkgs and enable withHoogle by default

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -74,7 +74,7 @@ ihpFlake:
                         and auto-starts a Hoogle server on port 8002.
                     '';
                     type = lib.types.bool;
-                    default = false;
+                    default = true;
                 };
 
                 dontCheckPackages = lib.mkOption {

--- a/flake.lock
+++ b/flake.lock
@@ -1341,11 +1341,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1768621446,
-        "narHash": "sha256-6YwHV1cjv6arXdF/PQc365h1j+Qje3Pydk501Rm4Q+4=",
+        "lastModified": 1773222311,
+        "narHash": "sha256-BHoB/XpbqoZkVYZCfXJXfkR+GXFqwb/4zbWnOr2cRcU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72ac591e737060deab2b86d6952babd1f896d7c5",
+        "rev": "0590cd39f728e129122770c029970378a79d076a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Update nixpkgs from 2026-01-17 to 2026-03-11
- Set `withHoogle = true` by default

Testing whether updated nixpkgs resolves the OOM issue with hoogle database generation that caused CI to fail in #2512. If CI passes, this means Hoogle will be enabled out-of-the-box for all IHP projects.

## Test plan

- [ ] CI `nix-flake-check` passes (hoogle database builds without OOM)
- [ ] nix-ci.com checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)