### PR TITLE
Add GHC 9.14 compatibility checks to flake check

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -178,16 +178,19 @@ final: prev: {
     };
 
     # Experimental: GHC 9.14 (bleeding edge, expected to fail)
-    # Only defined when nixpkgs includes the ghc914 package set
-} // prev.lib.optionalAttrs (prev.haskell.packages ? ghc914) {
-    ghc914 = final.haskell.packages.ghc914.override {
-        overrides = final.lib.composeManyExtensions [
-            (ihpOverrides final)
-            (self: super: {
-                say = final.haskell.lib.dontCheck super.say;
-                text-icu = final.haskell.lib.dontCheck super.text-icu;
-                cryptonite = final.haskell.lib.dontCheck super.cryptonite;
-            })
-        ];
-    };
+    # Only defined when nixpkgs includes the ghc914 package set.
+    # Attribute always exists but throws if ghc914 is unavailable in nixpkgs.
+    ghc914 =
+        if prev.haskell.packages ? ghc914
+        then final.haskell.packages.ghc914.override {
+            overrides = final.lib.composeManyExtensions [
+                (ihpOverrides final)
+                (self: super: {
+                    say = final.haskell.lib.dontCheck super.say;
+                    text-icu = final.haskell.lib.dontCheck super.text-icu;
+                    cryptonite = final.haskell.lib.dontCheck super.cryptonite;
+                })
+            ];
+        }
+        else throw "ghc914 is not available in this nixpkgs";
 }

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -177,7 +177,7 @@ that is defined in flake-module.nix
             }
 
             # GHC 9.14 compatibility checks (only when nixpkgs includes ghc914)
-            // (lib.optionalAttrs (pkgs ? ghc914) (let
+            // (lib.optionalAttrs (pkgs.haskell.packages ? ghc914) (let
                 ghc914 = pkgs.ghc914;
                 ihpPackageNames = [
                     "ihp-ide" "ihp-hsx" "ihp-schema-compiler"


### PR DESCRIPTION
## Summary
- Adds `ghc914` package set to the Nix overlay alongside `ghc` (9.10) and `ghc912`
- Wires all 25 IHP packages as `ghc914-*` checks in `nix flake check`
- **Experimental / expected to fail** — this is for early exploration of GHC 9.14 compatibility, not intended to be merged as-is

## Test plan
- [ ] `nix flake check --impure` — see which `ghc914-*` checks pass/fail
- [ ] Catalog build failures to track what needs fixing for GHC 9.14 support

🤖 Generated with [Claude Code](https://claude.com/claude-code)