### PR TITLE
Mark actionPrefixText as NOINLINE to reduce code bloat

### DIFF
--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -503,7 +503,7 @@ actionPrefixText
 
         getPrefix :: Text -> Text
         getPrefix t = fst (Text.breakOn "." t)
-{-# INLINE actionPrefixText #-}
+{-# NOINLINE actionPrefixText #-}
 
 -- | Strips the "Action" suffix from action names
 --


### PR DESCRIPTION
## Summary

- Changed `actionPrefixText` from `INLINE` to `NOINLINE` in `IHP/RouterSupport.hs`
- `actionPrefixText` depends only on `Typeable controller` — it computes a URL prefix from the module name. With `INLINE`, GHC duplicated the entire function body (434 Core terms) at every `pathTo` call site across all views and controllers. With `NOINLINE`, each call site is a ~3-term CAF reference. The result is still computed once per program lifetime and cached, so there is zero runtime performance cost.

## Measurements

Compiled [ihp-forum](https://github.com/digitallyinduced/ihp-forum) with `-O1 -ddump-simpl` before and after:

| Module | Before | After | Change |
|--------|--------|-------|--------|
| **Total Core** | 19.2MB | 15.6MB | **-19%** |
| Web/View/Layout | 890KB | 471KB | **-47%** |
| Web/View/Threads/Index | 669KB | 349KB | **-48%** |
| Web/View/Threads/Show | 749KB | 429KB | **-43%** |
| Web/View/Comments/New | 535KB | 319KB | **-40%** |
| Web/Controller/Comments | 1.3MB | 1.2MB | -8% |
| Web/Controller/Users | 1.2MB | 1.0MB | -17% |

## Test plan

- [x] All 388 IHP tests pass
- [x] Verified `actionPrefixText` calls are still lifted to top-level CAFs (computed once, cached)
- [x] Verified zero runtime performance cost — same lazy evaluation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)