### PR TITLE
Mark pathTo and renderFieldForUrl as NOINLINE to prevent Core bloat

### DIFF
--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -626,7 +626,6 @@ instance QueryParam a => QueryParam [a] where
     showQueryParam = List.intercalate "," . map showQueryParam
 
 instance {-# OVERLAPPABLE #-} (Show controller, AutoRoute controller) => HasPath controller where
-    {-# INLINABLE pathTo #-}
     pathTo !action = case customPathTo action of
         Just path -> path
         Nothing ->
@@ -658,6 +657,7 @@ instance {-# OVERLAPPABLE #-} (Show controller, AutoRoute controller) => HasPath
                 |> map (\(k, v) -> k <> "=" <> URI.encodeText v)
                 |> Text.intercalate "&"
                 |> (\q -> if Text.null q then q else Text.cons '?' q)
+    {-# NOINLINE pathTo #-}
 
 -- | Render a controller field value as 'Text' for URL query parameter inclusion.
 --
@@ -684,7 +684,7 @@ renderFieldForUrl val
         case gmapQ renderFieldForUrl val of
             [inner] -> inner
             _ -> ""
-{-# INLINABLE renderFieldForUrl #-}
+{-# NOINLINE renderFieldForUrl #-}
 
 -- | Parses the HTTP Method from the request and returns it.
 getMethod :: (?request :: Request, ?respond :: Respond) => Parser StdMethod


### PR DESCRIPTION
## Summary

- Changed `pathTo` from `INLINABLE` to `NOINLINE` in the default `HasPath` instance
- Changed `renderFieldForUrl` from `INLINABLE` to `NOINLINE`

`pathTo` uses `Data.Data` reflection which compiles to ~829 Core terms per controller type. With `INLINABLE`, GHC specialized the entire function body into every view and controller module — **200 copies** across the ihp-forum app. The view module `Web.View.Threads.Index` was 72% `pathTo` specializations by Core size.

`NOINLINE` keeps one copy in `IHP.RouterSupport`. The function call overhead is negligible since `pathTo` already does heavy runtime work internally (constructor reflection, string packing).

## Benchmark results (ihp-forum)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Core size | 15.6 MB | 12.7 MB | **-18.5%** |
| Compile allocations | 39.1 GB | 32.7 GB | **-16.4%** |
| Runtime mean | 6.48ms | 6.55ms | ~0% (noise) |

### Per-module Core size reductions

| Module | Before | After | Change |
|--------|--------|-------|--------|
| Web.View.Threads.Index | 349 KB | 98 KB | **-72%** |
| Web.View.Layout | 471 KB | 160 KB | **-66%** |
| Web.View.Threads.Show | 428 KB | 178 KB | **-58%** |
| Web.View.Comments.New | 319 KB | 149 KB | **-53%** |

## Test plan

- [x] All 43 RouterSupport tests pass
- [x] Runtime benchmark shows no regression
- [ ] CI benchmark workflow validates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)