### PR TITLE
Enable Hoogle documentation for IHP packages

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -5,8 +5,8 @@ let
     ihpOverrides = final: self: super:
         let
             filter = inputs.nix-filter.lib;
-            # Disable profiling and haddock for faster local builds
-            fastBuild = pkg: final.haskell.lib.disableLibraryProfiling (final.haskell.lib.dontHaddock pkg);
+            # Disable profiling for faster local builds
+            fastBuild = pkg: final.haskell.lib.disableLibraryProfiling pkg;
 
             filteredSrc = name: filter {
                 root = "${toString flakeRoot}/${name}";


### PR DESCRIPTION
## Summary
- Remove `dontHaddock` from `fastBuild` in `NixSupport/overlay.nix` so IHP packages produce haddock output
- This allows `ghcWithHoogle` to index IHP types, making them searchable in the Hoogle server (port 8002) that IHP apps start by default

## Why this is safe
- IHP packages are binary-cached via cachix, so end users don't rebuild them locally
- The IHP dev shell loads packages from source via ghci, so haddock generation doesn't slow down IHP development

## Test plan
- [ ] `nix develop` in an IHP app, visit `http://localhost:8002`
- [ ] Search for an IHP type like `AutoRoute` or `HSX` — should now return results

🤖 Generated with [Claude Code](https://claude.com/claude-code)