### PR TITLE
Switch default GHC to 9.12

### DIFF
--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -544,23 +544,7 @@ We highly recommend only using nixpkgs versions which are provided by IHP becaus
 
 ### Switching GHC Versions
 
-IHP ships with GHC 9.10 by default. This is the recommended version and all IHP packages are binary-cached for it.
-
-GHC 9.12 is available as an experimental opt-in. To switch, add an overlay in your project's `flake.nix` that remaps `ghc` to `ghc912`:
-
-```nix
-devenv.shells.default = {
-    overlays = lib.mkAfter [
-        (final: prev: { ghc = prev.ghc912; })
-    ];
-};
-```
-
-This works because IHP's overlay provides both `pkgs.ghc` (GHC 9.10) and `pkgs.ghc912` (GHC 9.12) with all IHP packages. The extra overlay swaps the default. After adding the overlay, run `direnv reload` to rebuild the development environment.
-
-**Note:** GHC 9.12 is not yet binary-cached. Everything will build from source, which takes significantly longer on the first build. We recommend setting up your own [cachix binary cache](https://cachix.org/) if you use GHC 9.12 regularly.
-
-To switch back to GHC 9.10, remove the overlay and run `direnv reload`.
+IHP ships with GHC 9.12 by default.
 
 ### Binary Cache
 

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -155,13 +155,8 @@ let
         };
 in
 final: prev: {
-    # Default: GHC 9.10 (binary-cached via nixpkgs haskellPackages)
-    ghc = final.haskellPackages.override {
-        overrides = ihpOverrides final;
-    };
-
-    # Experimental: GHC 9.12 (not yet binary-cached; builds from source)
-    ghc912 = final.haskell.packages.ghc912.override {
+    # Default: GHC 9.12
+    ghc = final.haskell.packages.ghc912.override {
         overrides = final.lib.composeManyExtensions [
             (ihpOverrides final)
             (self: super: {

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -150,31 +150,6 @@ that is defined in flake-module.nix
                 };
             }
 
-            # GHC 9.12 compatibility checks (build and test all IHP packages)
-            // (let
-                ghc912 = pkgs.ghc912;
-                ihpPackageNames = [
-                    "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
-                    "ihp-postgres-parser" "ihp-context" "ihp-pagehead"
-                    "ihp-log" "ihp-modal" "ihp-mail"
-                    "ihp-migrate" "ihp-openai" "ihp-ssc" "ihp-graphql"
-                    "ihp-datasync-typescript" "ihp-sitemap"
-                    "ihp-job-dashboard" "ihp-imagemagick"
-                    "ihp-hspec" "ihp-welcome" "ihp-zip"
-                    "wai-asset-path" "wai-flash-messages" "wai-request-params"
-                ];
-            in lib.listToAttrs (map (name: {
-                name = "ghc912-${name}";
-                value = ghc912.${name};
-            }) ihpPackageNames))
-
-            # GHC 9.12 packages that need a running PostgreSQL for their tests
-            // {
-                ghc912-ihp = withTestPostgres pkgs.ghc912.ihp;
-                ghc912-ihp-datasync = withTestPostgres pkgs.ghc912.ihp-datasync;
-                ghc912-ihp-typed-sql = withTestPostgres pkgs.ghc912.ihp-typed-sql;
-                ghc912-ihp-pglistener = withTestPostgres pkgs.ghc912.ihp-pglistener;
-            }
         ;
 
         devenv.shells.default = {


### PR DESCRIPTION
## Summary
- Promotes GHC 9.12 from experimental to the default compiler version
- Removes separate `ghc912-*` CI checks (now redundant since the default checks use GHC 9.12)
- Updates the Guide to reflect the new default

## Test plan
- [ ] CI builds all IHP packages with GHC 9.12
- [ ] HSX benchmark results look reasonable
- [ ] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)