### PR TITLE
Add devHaskellPackages option for dev-only dependencies

### DIFF
--- a/Guide/database-migrations.markdown
+++ b/Guide/database-migrations.markdown
@@ -54,7 +54,6 @@ To test your migrations locally, first add `ihp-migrate` to your `flake.nix` if 
                          # Haskell dependencies go here
                          p.ihp
 +                        p.ihp-migrate
-                         cabal-install
 ```
 then you can run this tool locally like:
 

--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -1012,7 +1012,6 @@ We start by adding the `jwt` package to the `flake.nix` file.
 haskellPackages = p: with p; [
     # Haskell dependencies go here
     p.ihp
-    cabal-install
     base
     # ...
     jwt # <-- ADD THIS LINE

--- a/Guide/mail.markdown
+++ b/Guide/mail.markdown
@@ -18,7 +18,6 @@ Add `ihp-mail` to your `flake.nix` file:
 haskellPackages = p: with p; [
     # Haskell dependencies go here
     p.ihp
-    cabal-install
     base
     wai
     # Add this:

--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -40,11 +40,9 @@ Let's say we want to use [mmark](https://hackage.haskell.org/package/mmark) for 
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                     ];
                 };
             };
@@ -81,11 +79,9 @@ In the list following `haskellPackages` we can see a few haskell dependencies al
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                         mmark
                     ];
                 };
@@ -98,6 +94,36 @@ In the list following `haskellPackages` we can see a few haskell dependencies al
 Stop the development server by hitting CTRL + C. Your terminal should now automatically start rebuilding the development environment. This is triggered by `direnv` detecting that the `flake.nix` has changed.
 
 Run `devenv up` again to start the development server, and `mmark` should now be used as expected.
+
+## Dev-Only Haskell Packages
+
+Some Haskell packages are only needed during development (e.g. `cabal-install`, `hlint`, `stylish-haskell`) and should not be included in production builds. IHP provides a `devHaskellPackages` option for this purpose.
+
+By default, `devHaskellPackages` includes `cabal-install` and `hlint`. These are available in your development shell (ghci, devenv) but are **not** included when building production binaries via `nix build`.
+
+To add additional dev-only packages, set `devHaskellPackages` in your `flake.nix`:
+
+```nix
+perSystem = { pkgs, ... }: {
+    ihp = {
+        enable = true;
+        projectPath = ./.;
+        haskellPackages = p: with p; [
+            p.ihp
+            base
+            wai
+            text
+        ];
+        devHaskellPackages = p: with p; [
+            cabal-install
+            hlint
+            stylish-haskell
+        ];
+    };
+};
+```
+
+Packages in `haskellPackages` are included in both development and production. Packages in `devHaskellPackages` are only available during development. If you don't set `devHaskellPackages`, it defaults to `cabal-install` and `hlint`.
 
 
 ## Using a Native Dependency
@@ -135,11 +161,9 @@ All dependencies of our project are listed in `flake.nix` at the root of the pro
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                     ];
                 };
             };
@@ -178,11 +202,9 @@ We now just have to add `imagemagick` to `packages`:
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                     ];
                 };
             };
@@ -229,11 +251,9 @@ Let's say we want to use [the google-oauth2 package from hackage](https://hackag
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                         google-oauth2
                     ];
                 };
@@ -406,11 +426,9 @@ To jailbreak the package open `flake.nix` and append `"google-oauth2"` to the `d
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                     ];
                     doJailbreakPackages = [ "google-oauth2" ];
                 };
@@ -504,11 +522,9 @@ Open `flake.nix` and append the package name to the `dontCheckPackages` list:
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                     ];
                     dontCheckPackages = [ "my-failing-package" ]; # <------- ADD YOUR PACKAGE HERE
                 };

--- a/Guide/recipes.markdown
+++ b/Guide/recipes.markdown
@@ -275,11 +275,9 @@ To make an HTTP request, you need [`Wreq`](https://hackage.haskell.org/package/w
 ```bash
 ...
 haskellDeps = p: with p; [
-    cabal-install
     base
     wai
     text
-    hlint
     p.ihp
     wreq <-- Add this
 ];

--- a/Guide/testing.markdown
+++ b/Guide/testing.markdown
@@ -16,7 +16,6 @@ The following setup and tests can be viewed in the [Blog example](https://github
 1. Add `hspec` and `ihp-hspec` in `flake.nix`
 ```nix
         haskellPackages = p: with p; [
-            cabal-install
             # ...
             p.ihp
 
@@ -246,11 +245,9 @@ perSystem = { pkgs, ... }: {
         haskellPackages = p: with p; [
             # Haskell dependencies go here
             p.ihp
-            cabal-install
             base
             wai
             text
-            hlint
             hspec
         ];
     };

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -615,11 +615,9 @@ To install this package, open the `flake.nix` file and append `mmark` to the `ha
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
                         p.ihp
-                        cabal-install
                         base
                         wai
                         text
-                        hlint
                         mmark # <--------- OUR NEW PACKAGE ADDED HERE
                     ];
                 };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -40,16 +40,27 @@ ihpFlake:
                 haskellPackages = lib.mkOption {
                     description = ''
                         Function returning a list of Haskell packages to be installed in the IHP environment.
+                        These packages are included in both the development shell and production builds.
+                        The set of Haskell packages is passed to the function.
+                    '';
+                    default = p: [
+                        p.base
+                        p.wai
+                        p.text
+                        p.ihp
+                        p.hasql # Required for generated Types.hs (FromRowHasql instances)
+                    ];
+                };
+
+                devHaskellPackages = lib.mkOption {
+                    description = ''
+                        Function returning a list of Haskell packages that are only available in the
+                        development shell (ghci, etc.) but NOT included in production builds.
                         The set of Haskell packages is passed to the function.
                     '';
                     default = p: [
                         p.cabal-install
-                        p.base
-                        p.wai
-                        p.text
                         p.hlint
-                        p.ihp
-                        p.hasql # Required for generated Types.hs (FromRowHasql instances)
                     ];
                 };
 
@@ -299,7 +310,7 @@ ihpFlake:
                     tests = pkgs.stdenv.mkDerivation {
                             name = "${config.ihp.appName}-tests";
                             src = builtins.path { path = config.ihp.projectPath; name = "source"; };
-                            nativeBuildInputs = with pkgs; [ (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler])) ];
+                            nativeBuildInputs = with pkgs; [ (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler])) ];
                             buildPhase = ''
                                 # shellcheck disable=SC2046
                                 make -f ${hsDataDir ghcCompiler.ihp-ide.data}/lib/IHP/Makefile.dist build/Generated/Types.hs
@@ -316,7 +327,7 @@ ihpFlake:
                             name = "${config.ihp.appName}-integration-tests";
                             src = builtins.path { path = config.ihp.projectPath; name = "source"; };
                             nativeBuildInputs = with pkgs; [
-                                (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler]))
+                                (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler]))
                                 gnumake
                                 postgresql
                             ];
@@ -376,7 +387,7 @@ ihpFlake:
                 languages.haskell.enable = true;
                 languages.haskell.package = (if cfg.withHoogle
                                              then ghcCompiler.ghc.withHoogle
-                                             else ghcCompiler.ghc.withPackages) cfg.haskellPackages;
+                                             else ghcCompiler.ghc.withPackages) (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p);
 
                 languages.haskell.stack.enable = false; # Stack is not used in IHP
 


### PR DESCRIPTION
## Summary
- Adds a new `devHaskellPackages` flake option for Haskell packages that should only exist in the dev shell, not in production builds
- Moves `cabal-install` and `hlint` from `haskellPackages` default to `devHaskellPackages` default, preventing them from ending up as `libraryHaskellDepends` in prod builds (which can cause version conflicts, e.g. `stylish-haskell` pulling in Cabal 3.12 while everything else needs 3.16)
- Dev shell and test builds merge both lists; production builds (`optimized-prod-server`, `unoptimized-prod-server`) only use `haskellPackages`
- Updates all Guide examples to remove `cabal-install`/`hlint` from `haskellPackages` snippets and adds a new "Dev-Only Haskell Packages" documentation section

## Backward compatibility
- Apps with explicit `haskellPackages` including `cabal-install`: still works, those stay in prod. Users can optionally move them to `devHaskellPackages`
- Apps using the default `haskellPackages`: `cabal-install`/`hlint` move to dev-only automatically. No breakage since nobody imports these in app code

## Test plan
- [ ] `nix flake show` in a test IHP app parses correctly
- [ ] Dev shell has `cabal-install` and `hlint` on PATH
- [ ] `nix build .#unoptimized-prod-server` does NOT include `cabal-install`/`hlint` in the `-lib` package's dependencies
- [ ] Adding `stylish-haskell` to `devHaskellPackages` makes it available in dev shell but not prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)