### PR TITLE
Add NamedDefaults for IsString (GHC 9.12+)

### DIFF
--- a/ihp/IHP/Prelude.hs
+++ b/ihp/IHP/Prelude.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK not-home, hide #-}
+#if __GLASGOW_HASKELL__ >= 912
+{-# LANGUAGE NamedDefaults #-}
+#endif
 module IHP.Prelude
 ( module CorePrelude
 , module Data.Text.IO
@@ -46,6 +50,9 @@ module IHP.Prelude
 , OsPath
 , textToOsPath
 , osPathToText
+#if __GLASGOW_HASKELL__ >= 912
+, default IsString
+#endif
 )
 where
 
@@ -143,3 +150,7 @@ osPathToText path = cs (unsafePerformIO (OsPath.decodeUtf path))
 instance IsString OsPath where
     fromString s = unsafePerformIO (OsPath.encodeUtf s)
     {-# NOINLINE fromString #-}
+
+#if __GLASGOW_HASKELL__ >= 912
+default IsString (Text, String)
+#endif


### PR DESCRIPTION
## Summary
- Export `default IsString (Text, String)` from `IHP.Prelude` so all importing modules automatically default ambiguous `IsString` constraints to `Text`, with `String` as fallback
- CPP-gated behind `#if __GLASGOW_HASKELL__ >= 912` — no-op on GHC 9.10, activates on GHC 9.12+
- Eliminates the need for ~1,357 `:: Text` annotations across the codebase once on GHC 9.12

## Test plan
- [x] Compiles on GHC 9.10.3 (CPP skips all NamedDefaults code)
- [x] All 388 tests pass
- [ ] Verify on GHC 9.12+ that defaults activate and `:: Text` annotations can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)