### PR TITLE
Add runDevScript for easy GHCi script execution

### DIFF
--- a/Guide/scripts.markdown
+++ b/Guide/scripts.markdown
@@ -68,96 +68,45 @@ In case you get a permission error, try to add the executable flag via `chmod +x
 
 ## Running a script from ghci
 
-You can also open a ghci prompt to test features in scripts interactively:
-
-```bash
-make ghci
-```
-
-Then you can load your script into the interpreter:
-```
-:l Application.Script.TestScript
-```
-
-and run the script from the IHP ghci command line:
+You can run scripts interactively from an already-running GHCi session using `runDevScript`. This uses the default IHP config (reading `DATABASE_URL` from the environment set by devenv):
 
 ```haskell
-IHP> runScript ihpDefaultConfig run
+-- Load and run a script file:
+ghci> import IHP.ScriptSupport
+ghci> :l Application/Script/HelloWorldToAllUsers.hs
+ghci> runDevScript run
 ```
 
-The `ihpDefaultConfig` is made available from the `Application.Script.Prelude` import but can be substituted
-with your own configuration data structure defined in `Config`.
+You can also run inline script code directly:
 
-The configuration type is `ConfigBuilder` which is an IHP internal data structure. It provides
-a number of configuration parameters stored as a record that tells IHP about your app's configuration:
-e.g. where to look for your database, or a place to store API keys.
+```haskell
+ghci> import IHP.ScriptSupport
+ghci> runDevScript do { users <- query @User |> fetch; forEach users \user -> putStrLn user.name }
+```
 
-This is particularly useful for adjusting
-logging levels or testing new APIs.
+### Using a custom config
 
-You can also define custom configurations in your Config.hs, e.g. for staging,
-local development, or simply use your production application configuration:
+If you need a custom configuration (e.g. for staging, custom logging, or API keys), use `runScript` with your own `ConfigBuilder` instead:
+
+```haskell
+ghci> :l Application.Script.TestScript
+ghci> runScript appConfig run
+```
+
+You can define custom configurations in your `Config.hs`:
 
 ```haskell
 -- Config.hs
-import qualified IHP.Log as Log
-import Config.hs
 import IHP.Log.Types
 
 appConfig :: ConfigBuilder
 appConfig = do
     option Development
-
-   -- option Production
-   -- option (AppHostname "ihpapp.io")
-   -- option (BaseUrl "https://ihpapp.io")
-
     option $ SES
-        {
-          accessKey = "myAccessKey"
+        { accessKey = "myAccessKey"
         , secretKey = "mySecretAccessKey"
-        , region = "eu-west-1" -- YOUR REGION
+        , region = "eu-west-1"
         }
-
-
-testConfig :: ConfigBuilder
-testConfig = do
-    option Development
-
-    logger <- liftIO $ newLogger def {
-        level = Debug,
-        formatter = withTimeAndLevelFormatter,
-        destination = File "Log/App.log" (SizeRotate (Bytes (4 * 1024 * 1024)) 4) defaultBufSize
-        }
-    option logger
-
-```
-
-Your app's configuration file `Config.hs` can then be imported in your Script:
-
-```haskell
--- Application/Script/TestScript
-#!/usr/bin/env run-script
-module Application.Script.TestScript where
-
-import Application.Script.Prelude
-
-import Config
-
-
-run :: (?modelContext :: ModelContext, ?context :: FrameworkConfig) => IO ()
-run = do
-    user <- query @User |> filterWhere(#name, "Php") |> fetch
-    user |> set #name "Ihp" |> updateRecord
-    pure ()
-
-```
-
-and then run the script from ghci:
-
-```haskell
-IHP> :l Application.Script.TestScript
-IHP> runScript appConfig run
 ```
 
 ## Building a script

--- a/ihp/IHP/ScriptSupport.hs
+++ b/ihp/IHP/ScriptSupport.hs
@@ -3,7 +3,7 @@ Module: IHP.ScriptSupport
 Description: Run scripts inside the framework context, but outside of the usual web request response lifecycle
 Copyright: (c) digitally induced GmbH, 2020
 -}
-module IHP.ScriptSupport (runScript, Script, module IHP.FrameworkConfig) where
+module IHP.ScriptSupport (runScript, runDevScript, Script, module IHP.FrameworkConfig) where
 
 import IHP.Prelude
 import IHP.FrameworkConfig
@@ -22,3 +22,22 @@ runScript configBuilder taskMain = withUtf8 do
             let ?context = frameworkConfig
             taskMain
 {-# INLINABLE runScript #-}
+
+-- | Run a script interactively from GHCi using the default IHP config.
+--
+-- This reads DATABASE_URL from the environment (set by devenv) and uses
+-- default settings for everything else. For custom config, use 'runScript' instead.
+--
+-- __Example:__ Run a script module from GHCi:
+--
+-- > import IHP.ScriptSupport
+-- > :l Application/Script/HelloWorld.hs
+-- > runDevScript run
+--
+-- __Example:__ Run inline script code:
+--
+-- > import IHP.ScriptSupport
+-- > runDevScript do { users <- query @User |> fetch; forEach users \user -> putStrLn user.name }
+--
+runDevScript :: Script -> IO ()
+runDevScript = runScript ihpDefaultConfig


### PR DESCRIPTION
## Summary
- Adds `runDevScript :: Script -> IO ()` to `IHP.ScriptSupport` — a one-argument wrapper around `runScript ihpDefaultConfig` for running scripts from an already-running GHCi session without needing to pass a config
- Rewrites the "Running a script from ghci" guide section to lead with `runDevScript` as the primary approach, keeping `runScript appConfig` as the custom-config alternative

## Test plan
- [x] `echo ':l ihp/IHP/ScriptSupport.hs' | ghci` compiles cleanly (Ok, 26 modules loaded)
- [ ] Verify `runDevScript run` works from GHCi in an IHP app with `devenv up` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)