### PR TITLE
Fix RowDecoder generating nullable decoder for PRIMARY KEY columns

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -941,6 +941,33 @@ tests = do
                         pure (let theRecord = Generated.ActualTypes.Post id title body def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
                     |]
 
+            it "should generate nonNullable decoder for PRIMARY KEY column even without explicit NOT NULL (#2531)" do
+                let bugStatements =
+                        [ StatementCreateTable CreateTable
+                            { name = "bars"
+                            , columns =
+                                [ (col "id" PUUID) { defaultValue = Just (CallExpression "uuid_generate_v4" []) }
+                                , (col "ticker" PText) { notNull = True }
+                                , (col "date" PDate) { notNull = True }
+                                ]
+                            , primaryKeyConstraint = PrimaryKeyConstraint ["id"]
+                            , constraints = []
+                            , unlogged = False
+                            , inherits = Nothing
+                            }
+                        ]
+                let [StatementCreateTable bugTable] = bugStatements
+                let ?schema = Schema bugStatements
+                let output = compileRowDecoderModule bugTable
+                getStatementBody output `shouldBe` [trimming|
+                    rowDecoder :: Decoders.Row Generated.ActualTypes.Bar
+                    rowDecoder = do
+                        id <- Decoders.column (Decoders.nonNullable Mapping.decoder)
+                        ticker <- Decoders.column (Decoders.nonNullable Decoders.text)
+                        date <- Decoders.column (Decoders.nonNullable Decoders.date)
+                        pure (let theRecord = Generated.ActualTypes.Bar id ticker date def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                    |]
+
             it "should generate correct Create statement module" do
                 let output = compileCreateStatement theTable
                 getStatementBody output `shouldBe` [trimming|

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -881,13 +881,14 @@ hasqlColumnDecoder :: (?schema :: Schema) => CreateTable -> Column -> Text
 hasqlColumnDecoder table column@Column { name, columnType, notNull, generator } =
     "Decoders.column (" <> nullability <> " " <> decoder <> ")"
     where
-        -- Match the logic in haskellType: if not notNull OR has a generator, treat as nullable
-        isNullable = not notNull || isJust generator
-        nullability = if isNullable then "Decoders.nullable" else "Decoders.nonNullable"
-
         -- Id columns (primary keys and foreign keys) use Mapping.decoder which
         -- goes through the IsScalar instance for Id'
         isPrimaryKey = [name] == primaryKeyColumnNames table.primaryKeyConstraint
+
+        -- Match the logic in haskellType: primary keys are always nonNullable (even without
+        -- explicit NOT NULL), otherwise nullable if not notNull or has a generator
+        isNullable = not isPrimaryKey && (not notNull || isJust generator)
+        nullability = if isNullable then "Decoders.nullable" else "Decoders.nonNullable"
         isForeignKey = isJust (findForeignKeyConstraint table column)
         needsIdWrapper = isPrimaryKey || isForeignKey
 


### PR DESCRIPTION
## Summary

- Fixes `hasqlColumnDecoder` generating `Decoders.nullable` instead of `Decoders.nonNullable` for PRIMARY KEY columns that lack an explicit `NOT NULL` constraint (e.g. `id UUID DEFAULT uuid_generate_v4() PRIMARY KEY`)
- The Haskell type (`haskellType`) already correctly generates `Id' "table"` (non-Maybe) for primary keys, but the decoder didn't match, causing a type error
- Adds a regression test for the fix

Fixes #2531

## Test plan

- [x] Failing test added that reproduces the bug
- [x] All 38 SchemaCompiler tests pass after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)