### PR TITLE
Switch from temporary to temporary-ospath

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -129,6 +129,9 @@ let
                 editedCabalFile = null;
             })));
 
+            # Fork of temporary using OsPath instead of FilePath
+            temporary-ospath = self.callHackageDirect { pkg = "temporary-ospath"; ver = "1.3"; sha256 = "0bb5pjiz83a2cj02g2kmnq2k3jyp7hiainy7iknyi9ncdgs7hrxk"; } {};
+
             # postgresql-types for proper binary encoders of Point, Polygon, Inet, Interval
             ptr-poker = self.callHackageDirect { pkg = "ptr-poker"; ver = "0.1.3"; sha256 = "0jl9df0kzsq5gd6fhfqc8my4wy7agg5q5jw4q92h4b7rkdf3hix7"; } {};
             # postgresql-simple-postgresql-types: bridge providing FromField/ToField instances

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -275,7 +275,7 @@ that is defined in flake-module.nix
                         ip
                         fast-logger
                         minio-hs
-                        temporary
+                        temporary-ospath
                         wai-cors
                         random
                         cereal-text

--- a/ihp-imagemagick/IHP/FileStorage/Preprocessor/ImageMagick.hs
+++ b/ihp-imagemagick/IHP/FileStorage/Preprocessor/ImageMagick.hs
@@ -13,7 +13,8 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Network.Wai.Parse as Wai
 import qualified Data.ByteString.Lazy as LBS
-import qualified System.IO.Temp as Temp
+import qualified System.IO.Temp.OsPath as Temp
+import qualified System.OsPath as OsPath
 import qualified System.Process as Process
 
 
@@ -52,7 +53,10 @@ import qualified System.Process as Process
 --
 applyImageMagick :: Text -> [String] -> Wai.FileInfo LBS.LazyByteString -> IO (Wai.FileInfo LBS.LazyByteString)
 applyImageMagick convertTo otherParams fileInfo = do
-    Temp.withTempDirectory "/tmp" "ihp-upload" $ \tempPath -> do
+    tmpDir <- OsPath.encodeUtf "/tmp"
+    template <- OsPath.encodeUtf "ihp-upload"
+    Temp.withTempDirectory tmpDir template $ \tempOsPath -> do
+        tempPath <- OsPath.decodeUtf tempOsPath
         let tempFilePath = tempPath <> "/image"
         let convertedFilePath = tempPath <> "/converted." <> Text.unpack convertTo
 

--- a/ihp-imagemagick/default.nix
+++ b/ihp-imagemagick/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, base, bytestring, lib, process, temporary, text
+{ mkDerivation, base, bytestring, filepath, lib, process, temporary-ospath, text
 , wai-extra
 }:
 mkDerivation {
@@ -6,7 +6,7 @@ mkDerivation {
   version = "1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring process temporary text wai-extra
+    base bytestring filepath process temporary-ospath text wai-extra
   ];
   description = "ImageMagick preprocessing for IHP file uploads";
   license = lib.licenses.mit;

--- a/ihp-imagemagick/ihp-imagemagick.cabal
+++ b/ihp-imagemagick/ihp-imagemagick.cabal
@@ -41,6 +41,7 @@ library
         , bytestring
         , wai-extra
         , process
-        , temporary
+        , temporary-ospath
+        , filepath >= 1.5
     hs-source-dirs: .
     exposed-modules: IHP.FileStorage.Preprocessor.ImageMagick

--- a/ihp-migrate/Test/SchemaMigrationSpec.hs
+++ b/ihp-migrate/Test/SchemaMigrationSpec.hs
@@ -9,7 +9,8 @@ import Prelude
 import IHP.SchemaMigration
 import qualified System.Directory as Directory
 import System.FilePath ((</>))
-import System.IO.Temp
+import System.IO.Temp.OsPath (withSystemTempDirectory)
+import System.OsPath (encodeUtf, decodeUtf)
 
 main :: IO ()
 main = hspec do
@@ -29,8 +30,10 @@ tests = do
 
 
 withTempApp :: IO a -> IO a
-withTempApp action =
-    withSystemTempDirectory "ihp-migrate-test" \tmp -> do
+withTempApp action = do
+    template <- encodeUtf "ihp-migrate-test"
+    withSystemTempDirectory template \tmpOsPath -> do
+        tmp <- decodeUtf tmpOsPath
         let appRoot      = tmp
         let migrationDir = appRoot </> "Application" </> "Migration"
 

--- a/ihp-migrate/default.nix
+++ b/ihp-migrate/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, base, directory, filepath, hasql, hasql-transaction
-, hspec, lib, string-conversions, temporary, text, with-utf8
+, hspec, lib, string-conversions, temporary-ospath, text, with-utf8
 }:
 mkDerivation {
   pname = "ihp-migrate";
@@ -16,7 +16,7 @@ mkDerivation {
     text with-utf8
   ];
   testHaskellDepends = [
-    base directory filepath hspec temporary with-utf8
+    base directory filepath hspec temporary-ospath with-utf8
   ];
   homepage = "https://ihp.digitallyinduced.com/";
   description = "Provides the IHP migrate binary";

--- a/ihp-migrate/ihp-migrate.cabal
+++ b/ihp-migrate/ihp-migrate.cabal
@@ -51,5 +51,5 @@ test-suite tests
     import: ihp-std
     type: exitcode-stdio-1.0
     main-is: SchemaMigrationSpec.hs
-    build-depends: base >= 4.17.0 && < 4.22, hspec, with-utf8, directory >= 1.3.8.0, ihp-migrate, filepath >= 1.5, temporary
+    build-depends: base >= 4.17.0 && < 4.22, hspec, with-utf8, directory >= 1.3.8.0, ihp-migrate, filepath >= 1.5, temporary-ospath
     hs-source-dirs: Test

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -17,7 +17,8 @@ import           System.Environment                (getEnvironment, lookupEnv)
 import           System.FilePath                   (takeDirectory)
 import           System.Process                    (CreateProcess (..), proc,
                                                     readCreateProcessWithExitCode)
-import           System.IO.Temp                    (withSystemTempDirectory)
+import           System.IO.Temp.OsPath              (withSystemTempDirectory)
+import           System.OsPath                     (encodeUtf, decodeUtf)
 import           Test.Hspec
 import qualified Prelude
 
@@ -448,8 +449,10 @@ ghciRunModule source =
     ghciRun source [] ["main"]
 
 ghciRun :: Text -> [Text] -> [Text] -> IO Text
-ghciRun source preLoadCommands postLoadCommands =
-    withSystemTempDirectory "typed-sql-ghci" \tempDir -> do
+ghciRun source preLoadCommands postLoadCommands = do
+    template <- encodeUtf "typed-sql-ghci"
+    withSystemTempDirectory template \tempOsDir -> do
+        tempDir <- decodeUtf tempOsDir
         packageRoot <- findIhpPackageRoot
         let repoRoot = takeDirectory packageRoot
         useRepoGhci <- doesFileExist (repoRoot </> ".ghci")

--- a/ihp-typed-sql/default.nix
+++ b/ihp-typed-sql/default.nix
@@ -2,7 +2,7 @@
 , filepath, haskell-src-meta, hasql, hasql-dynamic-statements
 , hasql-mapping, hasql-pool, hspec, ihp, ihp-log, lib
 , postgresql-libpq, postgresql-syntax, postgresql-types, process
-, scientific, string-conversions, template-haskell, temporary, text
+, scientific, string-conversions, template-haskell, temporary-ospath, text
 }:
 mkDerivation {
   pname = "ihp-typed-sql";
@@ -16,7 +16,7 @@ mkDerivation {
   ];
   testHaskellDepends = [
     base containers directory filepath hspec ihp ihp-log process
-    string-conversions temporary text
+    string-conversions temporary-ospath text
   ];
   homepage = "https://ihp.digitallyinduced.com/";
   description = "Compile-time typed SQL quasiquoter for IHP";

--- a/ihp-typed-sql/ihp-typed-sql.cabal
+++ b/ihp-typed-sql/ihp-typed-sql.cabal
@@ -91,7 +91,7 @@ test-suite tests
             , hspec
             , process
             , string-conversions
-            , temporary
+            , temporary-ospath
             , text
     other-modules:
         Test.TypedSqlSpec

--- a/ihp/default.nix
+++ b/ihp/default.nix
@@ -14,7 +14,7 @@
 , postgresql-simple-postgresql-types, postgresql-types, process
 , pwstore-fast, random, random-strings, regex-tdfa, resource-pool
 , resourcet, safe-exceptions, scientific, slugger, split, stm
-, string-conversions, tasty-bench, template-haskell, temporary
+, string-conversions, tasty-bench, template-haskell
 , text, time, transformers, typerep-map, unagi-chan, unix, unliftio
 , unordered-containers, uri-encode, uuid, vault, vector, wai
 , wai-app-static, wai-asset-path, wai-cors, wai-early-return
@@ -43,7 +43,7 @@ mkDerivation {
     postgresql-simple-postgresql-types postgresql-types process
     pwstore-fast random random-strings regex-tdfa resource-pool
     resourcet safe-exceptions scientific slugger split stm
-    string-conversions template-haskell temporary text time
+    string-conversions template-haskell text time
     transformers typerep-map unagi-chan unix unliftio
     unordered-containers uri-encode uuid vault vector wai
     wai-app-static wai-asset-path wai-cors wai-early-return wai-extra
@@ -67,7 +67,7 @@ mkDerivation {
     postgresql-simple-postgresql-types postgresql-types process
     pwstore-fast random random-strings regex-tdfa resource-pool
     resourcet safe-exceptions scientific slugger split stm
-    string-conversions template-haskell temporary text time
+    string-conversions template-haskell text time
     transformers typerep-map unagi-chan unix unliftio
     unordered-containers uri-encode uuid vault vector wai
     wai-app-static wai-asset-path wai-cors wai-early-return wai-extra
@@ -91,7 +91,7 @@ mkDerivation {
     postgresql-simple-postgresql-types postgresql-types process
     pwstore-fast random random-strings regex-tdfa resource-pool
     resourcet safe-exceptions scientific slugger split stm
-    string-conversions tasty-bench template-haskell temporary text time
+    string-conversions tasty-bench template-haskell text time
     transformers typerep-map unagi-chan unix unliftio
     unordered-containers uri-encode uuid vault vector wai
     wai-app-static wai-asset-path wai-cors wai-early-return wai-extra

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -103,7 +103,6 @@ common shared-properties
             , parser-combinators
             , fast-logger
             , minio-hs
-            , temporary
             , conduit-extra
             , wai-cors
             , lens


### PR DESCRIPTION
## Summary
- Replace `temporary` with `temporary-ospath` (v1.3) across ihp-imagemagick, ihp-migrate, and ihp-typed-sql
- Uses the modern `OsPath` type instead of `String`-based `FilePath` for temp file/directory APIs
- Remove unused `temporary` dependency from ihp core package
- Add `temporary-ospath` to nix overlay via `callHackageDirect`

## Test plan
- [ ] `nix flake check --impure` passes
- [ ] ihp-migrate tests pass (withSystemTempDirectory usage)
- [ ] ihp-typed-sql tests pass (ghci temp dir usage)
- [ ] ihp-imagemagick compiles (withTempDirectory usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)