### PR TITLE
Fix DataSync append optimization double-apply bug

### DIFF
--- a/ihp-datasync/data/DataSync/ihp-datasync.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.js
@@ -279,6 +279,7 @@ class DataSubscription {
         this.newRecordBehaviour = (options && 'newRecordBehaviour' in options) ? options.newRecordBehaviour : this.detectNewRecordBehaviour();
         
         this.optimisticCreatedPendingRecordIds = [];
+        this.optimisticUpdatedPendingRecordIds = new Set();
     }
 
     detectNewRecordBehaviour() {
@@ -388,7 +389,7 @@ class DataSubscription {
         this.records = this.records.map(record => {
             if (record.id === id) {
                 const updated = Object.assign({}, record, changeSet);
-                if (appendSet) {
+                if (appendSet && !this.optimisticUpdatedPendingRecordIds.has(id)) {
                     for (const [key, value] of Object.entries(appendSet)) {
                         updated[key] = (typeof updated[key] === 'string' ? updated[key] : '') + value;
                     }
@@ -399,6 +400,7 @@ class DataSubscription {
             return record;
         });
 
+        this.optimisticUpdatedPendingRecordIds.delete(id);
         this.updateSubscribers();
     }
 
@@ -727,8 +729,11 @@ function updateRecordOptimistic(table, id, patch) {
 
             // Apply the patch optimistically
             dataSubscription.onUpdate(id, patch, null);
+            dataSubscription.optimisticUpdatedPendingRecordIds.add(id);
 
             rollbackOperations.push(() => {
+                dataSubscription.optimisticUpdatedPendingRecordIds.delete(id);
+
                 const records = dataSubscription.getRecords();
                 if (!records) {
                     return;

--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -1,0 +1,72 @@
+import { DataSubscription } from './ihp-datasync.js';
+
+function makeSubscription(records) {
+    const query = {
+        table: 'test',
+        conditionExpression: [],
+        orderByClause: [],
+        distinctOnColumn: null,
+        limit: null,
+        offset: null,
+    };
+    const sub = new DataSubscription(query);
+    sub.records = records;
+    sub.subscribers = [];
+    sub.updateSubscribers = function () {};
+    return sub;
+}
+
+describe('DataSubscription.onUpdate', () => {
+    test('applies appendSet normally', () => {
+        const sub = makeSubscription([{ id: '1', name: 'Foo' }]);
+
+        sub.onUpdate('1', null, { name: 'Bar' });
+
+        expect(sub.records[0].name).toBe('FooBar');
+    });
+
+    test('skips appendSet for optimistically updated records', () => {
+        const sub = makeSubscription([{ id: '1', name: 'Anrufbeantworter' }]);
+
+        // Simulate optimistic update
+        sub.onUpdate('1', { name: 'Anrufbeantworter123' }, null);
+        sub.optimisticUpdatedPendingRecordIds.add('1');
+
+        // Simulate DidUpdate arrival with appendSet
+        sub.onUpdate('1', null, { name: '123' });
+
+        expect(sub.records[0].name).toBe('Anrufbeantworter123');
+    });
+
+    test('applies appendSet for other records even with pending optimistic updates', () => {
+        const sub = makeSubscription([
+            { id: '1', name: 'Anrufbeantworter' },
+            { id: '2', name: 'Hello' },
+        ]);
+
+        // Optimistic update only on record 1
+        sub.onUpdate('1', { name: 'Anrufbeantworter123' }, null);
+        sub.optimisticUpdatedPendingRecordIds.add('1');
+
+        // appendSet for record 2 should apply normally
+        sub.onUpdate('2', null, { name: ' World' });
+
+        expect(sub.records[1].name).toBe('Hello World');
+    });
+
+    test('pending optimistic flag is cleared after processing', () => {
+        const sub = makeSubscription([{ id: '1', name: 'Anrufbeantworter' }]);
+
+        // Simulate optimistic update
+        sub.onUpdate('1', { name: 'Anrufbeantworter123' }, null);
+        sub.optimisticUpdatedPendingRecordIds.add('1');
+
+        // First DidUpdate: appendSet skipped
+        sub.onUpdate('1', null, { name: '123' });
+        expect(sub.records[0].name).toBe('Anrufbeantworter123');
+
+        // Subsequent append should work normally (flag cleared)
+        sub.onUpdate('1', null, { name: '456' });
+        expect(sub.records[0].name).toBe('Anrufbeantworter123456');
+    });
+});


### PR DESCRIPTION
## Summary

- When a user appends text to a DataSync field (e.g. "Foo" → "Foo123"), the server optimizes bandwidth by sending only the appended portion ("123") via `appendSet`. The sending client already has the correct value from its optimistic update, so applying the append again doubles the text ("Foo123123").
- Tracks optimistically updated record IDs in a `Set` on `DataSubscription` and skips `appendSet` for those records, mirroring the existing `optimisticCreatedPendingRecordIds` pattern.
- Adds Jest tests covering the bug scenario and edge cases (other records unaffected, flag cleared after processing).

## Test plan

- [x] Jest tests pass (135 total including 4 new)
- [x] Existing Haskell tests pass (389 examples, 0 failures)
- [ ] Manual test: open a DataSync-bound text input, append characters, verify no doubling
- [ ] Manual test: verify other browser tabs/windows see the correct updated value

🤖 Generated with [Claude Code](https://claude.com/claude-code)