### PR TITLE
Fix stale auto refresh response comparisons

### DIFF
--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -147,13 +147,14 @@ instance WSApp AutoRefreshWSApp where
         availableSessions <- getAvailableSessions autoRefreshServer
 
         when (sessionId `elem` availableSessions) do
-            AutoRefreshSession { renderView, event, lastResponse } <- getSessionById autoRefreshServer sessionId
+            AutoRefreshSession { renderView, event } <- getSessionById autoRefreshServer sessionId
 
             let handleResponseException (ResponseException response) = case response of
-                    Wai.ResponseBuilder status headers builder -> do
+                    Wai.ResponseBuilder _status _headers builder -> do
                         let html = ByteString.toLazyByteString builder
+                        responseChanged <- sessionResponseHasChanged autoRefreshServer sessionId html
 
-                        when (html /= lastResponse) do
+                        when responseChanged do
                             sendTextData html
                             updateSession autoRefreshServer sessionId (\session -> session { lastResponse = html })
                     _   -> error "Unimplemented WAI response type."
@@ -259,6 +260,17 @@ updateSession server sessionId updateFunction = do
     let updateSession' session = if session.id == sessionId then updateFunction session else session
     modifyIORef' server (\server -> server { sessions = map updateSession' server.sessions })
     pure ()
+
+-- | Returns 'True' when the rendered html differs from the session's latest
+-- known response.
+--
+-- This must read the current session state instead of comparing against a
+-- websocket-local snapshot, otherwise switching back to an earlier DOM state
+-- can be incorrectly suppressed as "unchanged".
+sessionResponseHasChanged :: IORef AutoRefreshServer -> UUID -> LByteString -> IO Bool
+sessionResponseHasChanged autoRefreshServer sessionId html = do
+    currentLastResponse <- (.lastResponse) <$> getSessionById autoRefreshServer sessionId
+    pure (html /= currentLastResponse)
 
 -- | Removes all expired sessions
 --

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -14,7 +14,7 @@ import IHP.ControllerPrelude hiding (get, request)
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived(..))
 import Network.HTTP.Types
-import IHP.AutoRefresh (globalAutoRefreshServerVar)
+import IHP.AutoRefresh (globalAutoRefreshServerVar, sessionResponseHasChanged, updateSession)
 import IHP.AutoRefresh.Types
 import qualified Control.Concurrent.MVar as MVar
 import IHP.Controller.Response (ResponseException(..))
@@ -23,6 +23,7 @@ import qualified IHP.PGListener as PGListener
 import IHP.Log.Types (Logger(..), LogLevel(..))
 import IHP.Server (initMiddlewareStack)
 import IHP.Test.Mocking
+import qualified Data.UUID as UUID
 import qualified Network.Wai as Wai
 
 data WebApplication = WebApplication deriving (Eq, Show, Data)
@@ -158,3 +159,30 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                 case maybeServerRef of
                     Nothing -> pure ()
                     Just _ -> expectationFailure "Expected globalAutoRefreshServerVar to be Nothing"
+
+        describe "session state tracking" do
+            it "should compare re-rendered html against the latest session response" $ withContext do
+                event <- MVar.newEmptyMVar
+                now <- getCurrentTime
+                let session =
+                        AutoRefreshSession
+                            { id = UUID.nil
+                            , renderView = \_ _ -> pure ()
+                            , event
+                            , tables = mempty
+                            , lastResponse = "resolved"
+                            , lastPing = now
+                            }
+                serverRef <-
+                    newIORef
+                        AutoRefreshServer
+                            { subscriptions = []
+                            , sessions = [session]
+                            , subscribedTables = mempty
+                            , pgListener = error "pgListener unused in session state test"
+                            }
+
+                updateSession serverRef UUID.nil (\currentSession -> currentSession { lastResponse = "unresolved" })
+
+                sessionResponseHasChanged serverRef UUID.nil "resolved" `shouldReturn` True
+                sessionResponseHasChanged serverRef UUID.nil "unresolved" `shouldReturn` False


### PR DESCRIPTION
## Summary
- compare websocket rerender output against the session's current `lastResponse` instead of the snapshot captured when the socket connected
- update the stored session response after sending the new HTML so later rerenders are compared against the latest DOM state
- add a focused regression test for the stale-snapshot case

That fix a bug appearing in specific transitions

Example:

Page opens in state A (unresolved thread).
Resolve changes it to B. B /= A, so refresh is sent.
Unresolve changes it back to A.
Old code compares new HTML A against the stale startup snapshot A, decides “unchanged”, and sends nothing.
The other tab stays stuck on B.