### PR TITLE
Fix missed auto refresh notifications during rerender

### DIFF
--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -124,7 +124,8 @@ autoRefresh runAction = do
                                     lastResponse <- Exception.evaluate (ByteString.toLazyByteString builder)
 
                                     event <- MVar.newEmptyMVar
-                                    let session = AutoRefreshSession { id, renderView, event, tables, lastResponse, lastPing }
+                                    notificationVersion <- newIORef 0
+                                    let session = AutoRefreshSession { id, renderView, event, tables, lastResponse, lastPing, notificationVersion }
                                     modifyIORef' autoRefreshServer (\s -> s { sessions = session:s.sessions } )
                                     async (gcSessions autoRefreshServer)
 
@@ -147,7 +148,7 @@ instance WSApp AutoRefreshWSApp where
         availableSessions <- getAvailableSessions autoRefreshServer
 
         when (sessionId `elem` availableSessions) do
-            AutoRefreshSession { renderView, event, lastResponse } <- getSessionById autoRefreshServer sessionId
+            AutoRefreshSession { renderView, event, lastResponse, notificationVersion } <- getSessionById autoRefreshServer sessionId
 
             let handleResponseException (ResponseException response) = case response of
                     Wai.ResponseBuilder status headers builder -> do
@@ -163,11 +164,12 @@ instance WSApp AutoRefreshWSApp where
 
             async $ forever do
                 MVar.takeMVar event
-                let currentRequest = ?request
-                -- Create a dummy respond function that does nothing, since actual response
-                -- is handled by the handleResponseException handler
-                let dummyRespond _ = error "AutoRefresh: respond should not be called directly"
-                ((renderView currentRequest dummyRespond) `catch` handleResponseException) `catch` handleOtherException
+                renderUntilCaughtUp notificationVersion do
+                    let currentRequest = ?request
+                    -- Create a dummy respond function that does nothing, since actual response
+                    -- is handled by the handleResponseException handler
+                    let dummyRespond _ = error "AutoRefresh: respond should not be called directly"
+                    ((renderView currentRequest dummyRespond) `catch` handleResponseException) `catch` handleOtherException
                 pure ()
 
             pure ()
@@ -216,8 +218,7 @@ registerNotificationTrigger touchedTablesVar autoRefreshServer = do
                 sessions <- (.sessions) <$> readIORef autoRefreshServer
                 sessions
                     |> filter (\session -> table `Set.member` session.tables)
-                    |> map (\session -> session.event)
-                    |> mapM (\event -> MVar.tryPutMVar event ())
+                    |> mapM markSessionDirty
                 pure ())
 
     -- Re-run trigger SQL for already-subscribed tables in dev mode
@@ -259,6 +260,25 @@ updateSession server sessionId updateFunction = do
     let updateSession' session = if session.id == sessionId then updateFunction session else session
     modifyIORef' server (\server -> server { sessions = map updateSession' server.sessions })
     pure ()
+
+-- | Marks a session as dirty and wakes its websocket worker.
+--
+-- The version counter keeps track of notifications even when the MVar is
+-- already full because a previous wakeup is still being processed.
+markSessionDirty :: AutoRefreshSession -> IO Bool
+markSessionDirty AutoRefreshSession { event, notificationVersion } = do
+    atomicModifyIORef' notificationVersion (\version -> let nextVersion = version + 1 in (nextVersion, ()))
+    MVar.tryPutMVar event ()
+
+-- | Re-runs the render action until no newer notification arrived during the
+-- previous render.
+renderUntilCaughtUp :: IORef Int -> IO () -> IO ()
+renderUntilCaughtUp notificationVersion renderAction = do
+    startVersion <- readIORef notificationVersion
+    renderAction
+    endVersion <- readIORef notificationVersion
+    when (endVersion > startVersion) do
+        renderUntilCaughtUp notificationVersion renderAction
 
 -- | Removes all expired sessions
 --

--- a/ihp/IHP/AutoRefresh/Types.hs
+++ b/ihp/IHP/AutoRefresh/Types.hs
@@ -24,6 +24,11 @@ data AutoRefreshSession = AutoRefreshSession
         , lastResponse :: !LByteString
         -- | Keep track of the last ping to this session to close it after too much time has passed without anything happening
         , lastPing :: !UTCTime
+        -- | Counts how many DB notifications have been seen for this session.
+        --
+        -- This allows the websocket worker to detect changes that happened while
+        -- a re-render was already in progress, even if the MVar wakeup was full.
+        , notificationVersion :: !(IORef Int)
         }
 
 data AutoRefreshServer = AutoRefreshServer

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -14,7 +14,7 @@ import IHP.ControllerPrelude hiding (get, request)
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived(..))
 import Network.HTTP.Types
-import IHP.AutoRefresh (globalAutoRefreshServerVar)
+import IHP.AutoRefresh (globalAutoRefreshServerVar, markSessionDirty, renderUntilCaughtUp)
 import IHP.AutoRefresh.Types
 import qualified Control.Concurrent.MVar as MVar
 import IHP.Controller.Response (ResponseException(..))
@@ -23,6 +23,7 @@ import qualified IHP.PGListener as PGListener
 import IHP.Log.Types (Logger(..), LogLevel(..))
 import IHP.Server (initMiddlewareStack)
 import IHP.Test.Mocking
+import qualified Data.UUID as UUID
 import qualified Network.Wai as Wai
 
 data WebApplication = WebApplication deriving (Eq, Show, Data)
@@ -158,3 +159,34 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                 case maybeServerRef of
                     Nothing -> pure ()
                     Just _ -> expectationFailure "Expected globalAutoRefreshServerVar to be Nothing"
+
+        describe "session state tracking" do
+            it "should keep notification versions even when the wakeup MVar is already full" $ withContext do
+                event <- MVar.newEmptyMVar
+                now <- getCurrentTime
+                notificationVersion <- newIORef 0
+                let session =
+                        AutoRefreshSession
+                            { id = UUID.nil
+                            , renderView = \_ _ -> pure ()
+                            , event
+                            , tables = mempty
+                            , lastResponse = ""
+                            , lastPing = now
+                            , notificationVersion
+                            }
+
+                markSessionDirty session `shouldReturn` True
+                markSessionDirty session `shouldReturn` False
+                readIORef notificationVersion `shouldReturn` 2
+
+            it "should rerender again when a second notification lands during an in-flight rerender" $ withContext do
+                notificationVersion <- newIORef 1
+                renderCount <- newIORef (0 :: Int)
+
+                renderUntilCaughtUp notificationVersion do
+                    currentRun <- atomicModifyIORef' renderCount (\count -> let nextCount = count + 1 in (nextCount, nextCount))
+                    when (currentRun == 1) do
+                        atomicModifyIORef' notificationVersion (\version -> let nextVersion = version + 1 in (nextVersion, ()))
+
+                readIORef renderCount `shouldReturn` 2


### PR DESCRIPTION
## Summary
- count notifications per auto-refresh session so changes that arrive while a rerender is already running are not lost
- rerun the render loop until it catches up with the latest notification version
- add focused regression tests for the full-MVar and in-flight-rerender cases

## Testing
- `direnv exec . bash -lc 'printf ":set args --match AutoRefresh\\n:l ihp/Test/Test/Main.hs\\nmain\\n" | ghci'`
