### PR TITLE
Fix devenv up Ctrl+C still leaving orphan processes

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -401,7 +401,7 @@ ihpFlake:
                 languages.haskell.stack.enable = false; # Stack is not used in IHP
 
                 scripts.start.exec = ''
-                    IHP_STATIC=${ihpFlake.inputs.self.packages.${system}.ihp-static} ${ghcCompiler.ihp-ide}/bin/RunDevServer
+                    exec env IHP_STATIC=${ihpFlake.inputs.self.packages.${system}.ihp-static} ${ghcCompiler.ihp-ide}/bin/RunDevServer
                 '';
 
                 processes.ihp.exec = "start";

--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1773582304,
-        "narHash": "sha256-C2xlNQLjzs65XqiPELQhKtOlZSU0RzJuCewbFhgRvTo=",
+        "lastModified": 1773912611,
+        "narHash": "sha256-myaDU1mM0/egmVZfZeTmz95mv5grqDDH+1T6nMMBCNc=",
         "owner": "digitallyinduced",
         "repo": "devenv",
-        "rev": "9168c83795bb67304684fe8a22f534508f8e1dad",
+        "rev": "6e5aa73d122f3b9d6c343c33d10b0223af467cea",
         "type": "github"
       },
       "original": {
@@ -1293,11 +1293,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773526578,
-        "narHash": "sha256-mF+K5ochHittBg7TOazOhFJv8CVW6r+Jlj6useF+XOw=",
+        "lastModified": 1773600612,
+        "narHash": "sha256-eY8JFns4OeEidye8VIW68LSoykbPO0bQujvQVLLK7Qg=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "462f8e29e40e8d8f709a5a91b967d084f91566de",
+        "rev": "ef483d53f25990bf0b4fd39f5414f885977ebd85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Rebase `digitallyinduced/devenv` fork onto upstream v2.0.5, picking up the signal forwarding fix ([cachix/devenv#2620](https://github.com/cachix/devenv/pull/2620)): wrapper scripts now forward TERM/INT to the child process group instead of only killing the bash wrapper
- Add `exec env` to the `start` script in `flake-module.nix` so RunDevServer replaces the bash wrapper process directly

**Root cause**: The devenv fork was 25 commits behind upstream v2.0.5. The upstream fix makes process wrapper scripts trap SIGTERM/SIGINT and forward them to the child process group via `kill -TERM -- -$pid`. Without this, RunDevServer and GHCi became orphaned on Ctrl+C, causing port conflicts (8003/8004 instead of 8000/8001) on restart.

## Test plan

- [ ] `devenv up` starts on 8000/8001
- [ ] Ctrl+C cleanly exits (no orphaned ghci/RunDevServer via `ps aux | grep ghci`)
- [ ] `lsof -i :8000` and `lsof -i :8001` show no listeners after exit
- [ ] `devenv up` again starts on 8000/8001 (not 8003/8004)

🤖 Generated with [Claude Code](https://claude.com/claude-code)