### PR TITLE
Docs: explain that side-effect actions need forms, not links

### DIFF
--- a/Guide/form.markdown
+++ b/Guide/form.markdown
@@ -1032,6 +1032,47 @@ This way no special behavior will be attached to your forms.
 
 To dig deeper into the JavaScript, [take a look at the source in helpers.js](https://github.com/digitallyinduced/ihp/blob/master/lib/IHP/static/helpers.js#L115).
 
+## Actions with Side Effects
+
+Any action that creates, updates, or deletes data is a **side effect**. According to the HTTP specification, GET requests should be safe and free of side effects — only POST, PUT, PATCH, and DELETE requests should modify data.
+
+In practice this means: **don't use a plain `<a>` link to trigger a side-effect action.** Links make GET requests, but actions like toggling a status, approving a record, or deleting an entry need a form that submits via POST (or DELETE).
+
+### Example: "Mark as Done" Button
+
+Suppose you have a `UpdateTodoAction` that marks a todo as done. The correct way to trigger it is with a form:
+
+```haskell
+<form method="POST" action={UpdateTodoAction todo.id}>
+    <button type="submit" class="btn btn-primary">Mark as Done</button>
+</form>
+```
+
+This sends a POST request to `UpdateTodoAction`, which is what the router expects for update actions.
+
+### Example: Delete with a Form
+
+Delete actions expect a DELETE HTTP method. Since browsers only support GET and POST in plain HTML forms, IHP uses a hidden `_method` field to override the method (see [Method Override Middleware](routing.html#method-override-middleware)):
+
+```haskell
+<form method="POST" action={DeleteTodoAction todo.id}>
+    <input type="hidden" name="_method" value="DELETE"/>
+    <button type="submit" class="btn btn-danger">Delete</button>
+</form>
+```
+
+### The `js-delete` Shortcut
+
+IHP's generated index views use a convenient shorthand for delete links:
+
+```haskell
+<a href={DeleteTodoAction todo.id} class="js-delete">Delete</a>
+```
+
+The `js-delete` CSS class tells IHP's JavaScript helpers to intercept the click and submit a proper DELETE request via a dynamically created form — so the link never actually makes a GET request. This is purely a convenience shortcut; writing an explicit form as shown above is the more transparent approach and works even without JavaScript.
+
+**Common mistake:** Seeing `js-delete` links in generated code, new users sometimes assume that any `<a>` link can trigger side-effect actions. It cannot — `js-delete` is a special case handled by JavaScript. For all other side-effect actions, use a form with the appropriate method.
+
 ## Working within the Bootstrap CSS framework
 
 While the default forms layout is vertical with one field per line, it is easy to change. Bootstrap's excellent [forms documentation](https://getbootstrap.com/docs/5.3/forms/overview/) shows how.

--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -333,7 +333,18 @@ instance HasPath RegistrationsController where
 
 ## Method Override Middleware
 
-HTML forms don't support special HTTP methods like `DELETE`. To work around this issue, IHP has [a middleware](https://hackage.haskell.org/package/wai-extra-3.0.1/docs/Network-Wai-Middleware-MethodOverridePost.html) which transforms e.g. a `POST` request with a form field `_method` set to `DELETE` to a `DELETE` request.
+HTML forms only support GET and POST methods, but IHP's router expects DELETE requests for delete actions (and PUT/PATCH for updates). To bridge this gap, IHP includes [a middleware](https://hackage.haskell.org/package/wai-extra-3.0.1/docs/Network-Wai-Middleware-MethodOverridePost.html) that transforms a POST request with a hidden form field `_method` into the corresponding HTTP method.
+
+For example, this form sends a DELETE request:
+
+```haskell
+<form method="POST" action={DeleteWidgetAction widget.id}>
+    <input type="hidden" name="_method" value="DELETE"/>
+    <button type="submit">Delete</button>
+</form>
+```
+
+This is important because actions with side effects (creating, updating, deleting data) should never use GET requests. Plain `<a>` links make GET requests, so they are not suitable for side-effect actions. See the [Actions with Side Effects](form.html#actions-with-side-effects) section in the Forms guide for a full explanation and examples.
 
 ## Custom 403 and 404 pages
 

--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -265,7 +265,34 @@ timeAgo post.createdAt -- "1 minute ago"
 dateTime post.createdAt -- "10.6.2019, 15:58"
 ```
 
-### Customizing Delete Confirmation
+### Delete Buttons
+
+Delete actions require a DELETE HTTP method, but browsers can only send GET and POST from plain HTML. There are two ways to handle this in IHP.
+
+#### Explicit Form Approach
+
+The most transparent way is to use a form with a hidden `_method` field. IHP's [Method Override Middleware](routing.html#method-override-middleware) converts this POST into a DELETE request:
+
+```haskell
+<form method="POST" action={DeleteToolAction tool.id}>
+    <input type="hidden" name="_method" value="DELETE"/>
+    <button type="submit" class="btn btn-danger">Delete Tool</button>
+</form>
+```
+
+This works without JavaScript and makes the HTTP method explicit.
+
+#### `js-delete` Shorthand
+
+IHP's generated code uses a shorthand: adding the `js-delete` CSS class to a link. IHP's JavaScript helpers intercept the click and submit a proper DELETE request via a dynamically created form:
+
+```haskell
+<a href={DeleteToolAction tool.id} class="js-delete">Delete Tool</a>
+```
+
+This is convenient but requires JavaScript. Note that `js-delete` is a special case — you cannot use plain links for other side-effect actions. See the [Actions with Side Effects](form.html#actions-with-side-effects) section in the Forms guide for details.
+
+#### Customizing Delete Confirmation
 
 By default, a message `Are you sure you want to delete this?` is shown as a simple confirmation alert with yes/no choices. The message text can be customized:
 


### PR DESCRIPTION
## Summary

Closes #974.

- Added "Actions with Side Effects" section to `Guide/form.markdown` explaining that GET requests must not modify data, with concrete examples (POST form for "Mark as Done", DELETE form with `_method` override, and clarification that `js-delete` is a JS convenience shortcut)
- Expanded the delete docs in `Guide/view.markdown` (renamed to "Delete Buttons") to show the explicit form approach first, then `js-delete` as shorthand
- Fleshed out the "Method Override Middleware" section in `Guide/routing.markdown` with a concrete example and cross-link

## Test plan

- [ ] Read through the three modified guide sections and verify markdown renders correctly
- [ ] Verify cross-links between sections resolve (`form.html#actions-with-side-effects`, `routing.html#method-override-middleware`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)