### PR TITLE
Fix composite primary key support (#992)

### DIFF
--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -459,7 +459,7 @@ compileTypeAlias table@(CreateTable { name, columns }) =
         hasManyDefaults
             | ?compilerOptions.compileRelationSupport =
                 columnsReferencingTable name
-                |> map (\(tableName, columnName) -> "(QueryBuilder.QueryBuilder \"" <> tableName <> "\")")
+                |> map (\(tableName, columnName, _) -> "(QueryBuilder.QueryBuilder \"" <> tableName <> "\")")
                 |> unwords
             | otherwise = ""
 
@@ -529,10 +529,10 @@ columnsWithBitIndices allColumns subset =
     let subsetNames = setFromList (map (.name) subset) :: Set Text
     in [(col, idx) | (col, idx) <- zip allColumns [0..], col.name `member` subsetNames]
 
-compileQueryBuilderFields :: [(Text, Text)] -> [(Text, Text)]
+compileQueryBuilderFields :: [(Text, Text, Maybe Text)] -> [(Text, Text)]
 compileQueryBuilderFields columns = map compileQueryBuilderField columns
     where
-        compileQueryBuilderField (refTableName, refColumnName) =
+        compileQueryBuilderField (refTableName, refColumnName, _refColumn) =
             let
                 -- Given a relationship like the following:
                 --
@@ -551,7 +551,7 @@ compileQueryBuilderFields columns = map compileQueryBuilderField columns
                 -- being added to the data structure.
                 hasDuplicateQueryBuilder =
                     columns
-                    |> map fst
+                    |> map (\(t, _, _) -> t)
                     |> map columnNameToFieldName
                     |> filter (columnNameToFieldName refTableName ==)
                     |> length
@@ -583,14 +583,14 @@ compileQueryBuilderFields columns = map compileQueryBuilderField columns
 --
 -- >>> columnsReferencingTable "companies"
 -- [ ("users", "company_id") ]
-columnsReferencingTable :: (?schema :: Schema) => Text -> [(Text, Text)]
+columnsReferencingTable :: (?schema :: Schema) => Text -> [(Text, Text, Maybe Text)]
 columnsReferencingTable theTableName =
     let
         (Schema statements) = ?schema
     in
         statements
         |> mapMaybe \case
-            AddConstraint { tableName, constraint = fk@ForeignKeyConstraint { columnName, referenceTable } } | referenceTable == theTableName && isForeignKeyReferencingPK fk -> Just (tableName, columnName)
+            AddConstraint { tableName, constraint = fk@ForeignKeyConstraint { columnName, referenceTable, referenceColumn } } | referenceTable == theTableName && isForeignKeyReferencingPK fk -> Just (tableName, columnName, referenceColumn)
             _ -> Nothing
 
 variableAttributes :: (?schema :: Schema, ?compilerOptions :: CompilerOptions) => CreateTable -> [Column]
@@ -871,16 +871,22 @@ compileFromRowHasqlInstance table@(CreateTable { name, columns }) =
     hasqlRowDecoder = #{rowDecoderModule}.rowDecoder
 |]
 
-compileFromRowQueryBuilder :: (?schema :: Schema) => CreateTable -> (Text, Text) -> Text
-compileFromRowQueryBuilder table (refTableName, refFieldName) = "(QueryBuilder.filterWhere (#" <> columnNameToFieldName refFieldName <> ", " <> primaryKeyField <> ") (QueryBuilder.query @" <> tableNameToModelName refTableName <> "))"
+compileFromRowQueryBuilder :: (?schema :: Schema) => CreateTable -> (Text, Text, Maybe Text) -> Text
+compileFromRowQueryBuilder table (refTableName, refFieldName, maybeRefColumn) = "(QueryBuilder.filterWhere (#" <> columnNameToFieldName refFieldName <> ", " <> primaryKeyField <> ") (QueryBuilder.query @" <> tableNameToModelName refTableName <> "))"
     where
         primaryKeyField :: Text
         primaryKeyField = if refColumn.notNull then actualPrimaryKeyField else "Just " <> actualPrimaryKeyField
         actualPrimaryKeyField :: Text
-        actualPrimaryKeyField = case primaryKeyColumns table of
-                [] -> error $ "Impossible happened in compileFromRowHasqlInstance. No primary keys found for table " <> cs table.name <> ". At least one primary key is required."
-                [pk] -> columnNameToFieldName pk.name
-                pks -> error $ "No support yet for composite foreign keys. Tables cannot have foreign keys to table '" <> cs table.name <> "' which has more than one column as its primary key."
+        actualPrimaryKeyField = case maybeRefColumn of
+                -- When the FK constraint specifies the referenced column, use it directly.
+                -- This handles composite PK tables where a FK references a specific column
+                -- (which must have a standalone UNIQUE constraint).
+                Just refCol -> columnNameToFieldName refCol
+                -- Otherwise fall back to the single primary key column
+                Nothing -> case primaryKeyColumns table of
+                    [] -> error $ "Impossible happened in compileFromRowHasqlInstance. No primary keys found for table " <> cs table.name <> ". At least one primary key is required."
+                    [pk] -> columnNameToFieldName pk.name
+                    pks -> error $ "No support yet for composite foreign keys. Tables cannot have foreign keys to table '" <> cs table.name <> "' which has more than one column as its primary key."
 
         (Just refTable) = let (Schema statements) = ?schema in
                 statements
@@ -1069,7 +1075,7 @@ compileInclude table@(CreateTable { name }) = (belongsToIncludes <> hasManyInclu
         columns = allColumnsIncludingInherited table
         belongsToIncludes = map compileBelongsTo (filter (isRefCol table) columns)
         hasManyIncludes = columnsReferencingTable name
-                |> (\refs -> zip (map fst refs) (map fst (compileQueryBuilderFields refs)))
+                |> (\refs -> zip (map (\(t, _, _) -> t) refs) (map fst (compileQueryBuilderFields refs)))
                 |> map compileHasMany
         typeArgs = dataTypeArguments table
         modelName = tableNameToModelName name

--- a/ihp/IHP/Fetch.hs
+++ b/ihp/IHP/Fetch.hs
@@ -33,8 +33,7 @@ import IHP.Hasql.FromRow (FromRowHasql(..), HasqlDecodeColumn(..))
 import IHP.QueryBuilder.HasqlCompiler (buildStatement)
 import qualified Hasql.Decoders as Decoders
 import Hasql.Implicits.Encoders (DefaultParamEncoder)
-import qualified Hasql.Statement as Hasql
-import IHP.Fetch.Statement (fetchByIdOneOrNothingStatement, fetchByIdListStatement, buildQueryListStatement, buildQueryMaybeStatement, buildCountStatement, buildExistsStatement)
+import IHP.Fetch.Statement (buildQueryListStatement, buildQueryMaybeStatement, buildCountStatement, buildExistsStatement)
 
 class Fetchable fetchable model | fetchable -> model where
     type FetchResult fetchable model
@@ -148,23 +147,14 @@ fetchExists !queryBuilder = do
     let pool = ?modelContext.hasqlPool
     sqlStatementHasql pool () (buildExistsStatement queryBuilder)
 
-genericFetchId :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder (Id' table)) => Id' table -> IO [model]
-genericFetchId !id = do
-    trackTableRead (tableName @model)
-    sqlStatementHasql ?modelContext.hasqlPool id fetchByIdListStatement
+genericFetchId :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Id' table -> IO [model]
+genericFetchId !id = query @model |> filterWhereId id |> fetch
 
-genericfetchIdOneOrNothing :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder (Id' table)) => Id' table -> IO (Maybe model)
-genericfetchIdOneOrNothing !id = do
-    trackTableRead (tableName @model)
-    sqlStatementHasql ?modelContext.hasqlPool id fetchByIdOneOrNothingStatement
+genericfetchIdOneOrNothing :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Id' table -> IO (Maybe model)
+genericfetchIdOneOrNothing !id = query @model |> filterWhereId id |> fetchOneOrNothing
 
-genericFetchIdOne :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder (Id' table)) => Id' table -> IO model
-genericFetchIdOne !id = do
-    trackTableRead (tableName @model)
-    result <- sqlStatementHasql ?modelContext.hasqlPool id fetchByIdOneOrNothingStatement
-    case result of
-        Just model -> pure model
-        Nothing -> throwIO RecordNotFoundException { queryAndParams = cs (Hasql.toSql (fetchByIdOneOrNothingStatement @table @model)) }
+genericFetchIdOne :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Id' table -> IO model
+genericFetchIdOne !id = query @model |> filterWhereId id |> fetchOne
 
 genericFetchIds :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder [PrimaryKey (GetTableName model)]) => [Id model] -> IO [model]
 genericFetchIds !ids = query @model |> filterWhereIdIn ids |> fetch
@@ -183,13 +173,13 @@ findMaybeBy !field !value !queryBuilder = queryBuilder |> filterWhere (field, va
 findManyBy !field !value !queryBuilder = queryBuilder |> filterWhere (field, value) |> fetch
 -- Step.findOneByWorkflowId id    ==    queryBuilder |> findBy #templateId id
 
-instance (model ~ GetModelById (Id' table), GetTableName model ~ table, FilterPrimaryKey table, DefaultParamEncoder (Id' table)) => Fetchable (Id' table) model where
+instance (model ~ GetModelById (Id' table), GetTableName model ~ table, FilterPrimaryKey table) => Fetchable (Id' table) model where
     type FetchResult (Id' table) model = model
     fetch = genericFetchIdOne
     fetchOneOrNothing = genericfetchIdOneOrNothing
     fetchOne = genericFetchIdOne
 
-instance (model ~ GetModelById (Id' table), GetTableName model ~ table, FilterPrimaryKey table, DefaultParamEncoder (Id' table)) => Fetchable (Maybe (Id' table)) model where
+instance (model ~ GetModelById (Id' table), GetTableName model ~ table, FilterPrimaryKey table) => Fetchable (Maybe (Id' table)) model where
     type FetchResult (Maybe (Id' table)) model = [model]
     fetch (Just a) = genericFetchId a
     fetch Nothing = pure []

--- a/ihp/IHP/Fetch/Statement.hs
+++ b/ihp/IHP/Fetch/Statement.hs
@@ -8,50 +8,22 @@ Internal module containing hasql 'Statement' definitions shared by
 'IHP.Fetch' and 'IHP.FetchPipelined'.
 -}
 module IHP.Fetch.Statement
-( fetchByIdOneOrNothingStatement
-, fetchByIdListStatement
-, buildQueryListStatement
+( buildQueryListStatement
 , buildQueryMaybeStatement
 , buildCountStatement
 , buildExistsStatement
 ) where
 
 import Prelude
-import IHP.ModelSupport (Table(..), primaryKeyConditionColumnSelector, GetModelByTableName)
-import IHP.ModelSupport.Types (Id'(..), GetTableName)
+import IHP.ModelSupport (Table(..), GetModelByTableName)
 import IHP.Hasql.FromRow (FromRowHasql(..))
 import qualified Hasql.Statement as Hasql
 import qualified Hasql.Decoders as Decoders
-import qualified Hasql.Encoders as Encoders
-import Hasql.Implicits.Encoders (DefaultParamEncoder(..))
-import qualified Data.Text as Text
 import IHP.QueryBuilder.Types (HasQueryBuilder(..), SQLQuery(..))
 import IHP.QueryBuilder.Compiler (buildQuery)
 import IHP.QueryBuilder.HasqlCompiler (buildStatement, buildWrappedStatement)
 import GHC.TypeLits (KnownSymbol)
 import Data.Int (Int64)
-
--- | Prepared statement for fetching a single record by primary key.
---
--- > SELECT table.col1, table.col2, ... FROM table WHERE table.id = $1 LIMIT 1
-fetchByIdOneOrNothingStatement :: forall table model. (Table model, GetTableName model ~ table, FromRowHasql model, DefaultParamEncoder (Id' table)) => Hasql.Statement (Id' table) (Maybe model)
-fetchByIdOneOrNothingStatement = Hasql.preparable sql (Encoders.param defaultParam) (Decoders.rowMaybe (hasqlRowDecoder @model))
-  where
-    sql = "SELECT " <> qualifiedColumns <> " FROM " <> tn <> " WHERE " <> pkCol <> " = $1 LIMIT 1"
-    tn = tableName @model
-    pkCol = primaryKeyConditionColumnSelector @model
-    qualifiedColumns = Text.intercalate ", " (map (\c -> tn <> "." <> c) (columnNames @model))
-
--- | Prepared statement for fetching records by primary key (returns list).
---
--- > SELECT table.col1, table.col2, ... FROM table WHERE table.id = $1
-fetchByIdListStatement :: forall table model. (Table model, GetTableName model ~ table, FromRowHasql model, DefaultParamEncoder (Id' table)) => Hasql.Statement (Id' table) [model]
-fetchByIdListStatement = Hasql.preparable sql (Encoders.param defaultParam) (Decoders.rowList (hasqlRowDecoder @model))
-  where
-    sql = "SELECT " <> qualifiedColumns <> " FROM " <> tn <> " WHERE " <> pkCol <> " = $1"
-    tn = tableName @model
-    pkCol = primaryKeyConditionColumnSelector @model
-    qualifiedColumns = Text.intercalate ", " (map (\c -> tn <> "." <> c) (columnNames @model))
 
 -- | Build a statement that fetches all rows matching a query builder.
 buildQueryListStatement :: forall model table queryBuilderProvider joinRegister.

--- a/ihp/IHP/Hasql/Encoders.hs
+++ b/ihp/IHP/Hasql/Encoders.hs
@@ -33,7 +33,6 @@ import Data.Functor.Contravariant (contramap)
 import Data.Functor.Contravariant.Divisible (divide)
 import Data.Vector (Vector)
 import IHP.ModelSupport.Types (Id'(..), PrimaryKey)
-import Data.UUID (UUID)
 import Database.PostgreSQL.Simple.Types (Binary(..))
 import qualified Hasql.Mapping.IsScalar as Mapping
 import Hasql.PostgresqlTypes ()
@@ -85,31 +84,57 @@ instance Mapping.IsScalar (PrimaryKey table) => DefaultParamEncoder (Maybe (Id' 
 instance Mapping.IsScalar (PrimaryKey table) => DefaultParamEncoder [Maybe (Id' table)] where
     defaultParam = Encoders.nonNullable $ Encoders.foldableArray $ Encoders.nullable (contramap (\(Id pk) -> pk) Mapping.encoder)
 
--- | Encode '(UUID, UUID)' as PostgreSQL composite/record type
--- Used for composite primary keys with two UUID columns
-instance DefaultParamEncoder (UUID, UUID) where
-    defaultParam = Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" uuidPairComposite
-
--- | Encode '[(UUID, UUID)]' as PostgreSQL array of composite types
--- Used by filterWhereIdIn for tables with composite primary keys of two UUIDs
-instance DefaultParamEncoder [(UUID, UUID)] where
-    defaultParam = Encoders.nonNullable $ Encoders.foldableArray $ Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" uuidPairComposite
-
 -- | Encode '(Id' a, Id' b)' as PostgreSQL composite/record type
--- Used for composite primary keys with two Id columns (where both resolve to UUID)
-instance (PrimaryKey a ~ UUID, PrimaryKey b ~ UUID) => DefaultParamEncoder (Id' a, Id' b) where
+-- Used for composite primary keys with two Id columns of any scalar PK type
+instance (Mapping.IsScalar (PrimaryKey a), Mapping.IsScalar (PrimaryKey b)) => DefaultParamEncoder (Id' a, Id' b) where
     defaultParam = Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" $
-        contramap (\(Id a, Id b) -> (a, b)) uuidPairComposite
+        divide (\(Id a, Id b) -> (a, b))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
 
 -- | Encode '[(Id' a, Id' b)]' as PostgreSQL array of composite types
--- Used by filterWhereIdIn for tables with composite primary keys of two Id columns
-instance (PrimaryKey a ~ UUID, PrimaryKey b ~ UUID) => DefaultParamEncoder [(Id' a, Id' b)] where
+-- Used by filterWhereIdIn for tables with two-column composite primary keys
+instance (Mapping.IsScalar (PrimaryKey a), Mapping.IsScalar (PrimaryKey b)) => DefaultParamEncoder [(Id' a, Id' b)] where
     defaultParam = Encoders.nonNullable $ Encoders.foldableArray $ Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" $
-        contramap (\(Id a, Id b) -> (a, b)) uuidPairComposite
+        divide (\(Id a, Id b) -> (a, b))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
 
--- | Helper: composite encoder for a pair of UUIDs
-uuidPairComposite :: Encoders.Composite (UUID, UUID)
-uuidPairComposite = divide id (Encoders.field (Encoders.nonNullable Encoders.uuid)) (Encoders.field (Encoders.nonNullable Encoders.uuid))
+-- | Encode '(Id' a, Id' b, Id' c)' as PostgreSQL composite/record type
+-- Used for composite primary keys with three Id columns of any scalar PK type
+instance (Mapping.IsScalar (PrimaryKey a), Mapping.IsScalar (PrimaryKey b), Mapping.IsScalar (PrimaryKey c)) => DefaultParamEncoder (Id' a, Id' b, Id' c) where
+    defaultParam = Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" $
+        divide (\(Id a, Id b, Id c) -> (a, (b, c)))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
+            (divide id (Encoders.field (Encoders.nonNullable Mapping.encoder)) (Encoders.field (Encoders.nonNullable Mapping.encoder)))
+
+-- | Encode '[(Id' a, Id' b, Id' c)]' as PostgreSQL array of composite types
+-- Used by filterWhereIdIn for tables with three-column composite primary keys
+instance (Mapping.IsScalar (PrimaryKey a), Mapping.IsScalar (PrimaryKey b), Mapping.IsScalar (PrimaryKey c)) => DefaultParamEncoder [(Id' a, Id' b, Id' c)] where
+    defaultParam = Encoders.nonNullable $ Encoders.foldableArray $ Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" $
+        divide (\(Id a, Id b, Id c) -> (a, (b, c)))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
+            (divide id (Encoders.field (Encoders.nonNullable Mapping.encoder)) (Encoders.field (Encoders.nonNullable Mapping.encoder)))
+
+-- | Encode '(Id' a, Id' b, Id' c, Id' d)' as PostgreSQL composite/record type
+-- Used for composite primary keys with four Id columns of any scalar PK type
+instance (Mapping.IsScalar (PrimaryKey a), Mapping.IsScalar (PrimaryKey b), Mapping.IsScalar (PrimaryKey c), Mapping.IsScalar (PrimaryKey d)) => DefaultParamEncoder (Id' a, Id' b, Id' c, Id' d) where
+    defaultParam = Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" $
+        divide (\(Id a, Id b, Id c, Id d) -> (a, (b, c, d)))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
+            (divide (\(b, c, d) -> (b, (c, d)))
+                (Encoders.field (Encoders.nonNullable Mapping.encoder))
+                (divide id (Encoders.field (Encoders.nonNullable Mapping.encoder)) (Encoders.field (Encoders.nonNullable Mapping.encoder))))
+
+-- | Encode '[(Id' a, Id' b, Id' c, Id' d)]' as PostgreSQL array of composite types
+-- Used by filterWhereIdIn for tables with four-column composite primary keys
+instance (Mapping.IsScalar (PrimaryKey a), Mapping.IsScalar (PrimaryKey b), Mapping.IsScalar (PrimaryKey c), Mapping.IsScalar (PrimaryKey d)) => DefaultParamEncoder [(Id' a, Id' b, Id' c, Id' d)] where
+    defaultParam = Encoders.nonNullable $ Encoders.foldableArray $ Encoders.nonNullable $ Encoders.composite (Nothing :: Maybe Text) "" $
+        divide (\(Id a, Id b, Id c, Id d) -> (a, (b, c, d)))
+            (Encoders.field (Encoders.nonNullable Mapping.encoder))
+            (divide (\(b, c, d) -> (b, (c, d)))
+                (Encoders.field (Encoders.nonNullable Mapping.encoder))
+                (divide id (Encoders.field (Encoders.nonNullable Mapping.encoder)) (Encoders.field (Encoders.nonNullable Mapping.encoder))))
 
 -- | Encode 'Binary ByteString' as PostgreSQL bytea
 -- IHP wraps bytea columns in Binary, so we need to unwrap before encoding

--- a/ihp/Test/Test/ModelFixtures.hs
+++ b/ihp/Test/Test/ModelFixtures.hs
@@ -7,6 +7,7 @@ module Test.ModelFixtures where
 
 import IHP.Prelude
 import IHP.ModelSupport
+import IHP.QueryBuilder (FilterPrimaryKey(..), filterWhere)
 import IHP.Hasql.FromRow (FromRowHasql(..), HasqlDecodeColumn(..))
 import IHP.Job.Types (JobStatus(..))
 import IHP.Job.Queue ()
@@ -91,6 +92,15 @@ type instance PrimaryKey "composite_taggings" = (Id' "posts", Id' "tags")
 instance Table CompositeTagging where
     columnNames = ["post_id", "tag_id"]
     primaryKeyColumnNames = ["post_id", "tag_id"]
+
+instance FromRowHasql CompositeTagging where
+    hasqlRowDecoder = CompositeTagging
+        <$> hasqlColumnDecoder
+        <*> hasqlColumnDecoder
+
+instance FilterPrimaryKey "composite_taggings" where
+    filterWhereId (Id (Id postId, Id tagId)) builder =
+        builder |> filterWhere (#postId, postId) |> filterWhere (#tagId, tagId)
 
 data User = User
     { id :: UUID

--- a/ihp/Test/Test/QueryBuilderSpec.hs
+++ b/ihp/Test/Test/QueryBuilderSpec.hs
@@ -218,6 +218,15 @@ tests = do
 
                         (toSQL theQuery) `shouldBe` "SELECT composite_taggings.post_id, composite_taggings.tag_id FROM composite_taggings WHERE (composite_taggings.post_id, composite_taggings.tag_id) = ANY ($1)"
 
+        describe "filterWhereId" do
+            describe "with composite keys" do
+                it "should decompose into per-column WHERE conditions" do
+                    let theId :: Id CompositeTagging = Id (Id "b80e37a8-41d4-4731-b050-a716879ef1d1", Id "629b7ee0-3675-4b02-ba3e-cdbd7b513553")
+                    let theQuery = query @CompositeTagging
+                            |> filterWhereId theId
+
+                    (toSQL theQuery) `shouldBe` "SELECT composite_taggings.post_id, composite_taggings.tag_id FROM composite_taggings WHERE (composite_taggings.post_id = $1) AND (composite_taggings.tag_id = $2)"
+
         describe "filterWhereCaseInsensitive" do
             it "should produce a SQL with a WHERE LOWER() condition" do
                 let theQuery = query @Post


### PR DESCRIPTION
## Summary

- **Rewrite `genericFetchId*` to use `filterWhereId`** — replaces `fetchByIdOneOrNothingStatement` (which requires encoding the composite Id as a single parameter via `DefaultParamEncoder`) with `filterWhereId` (which decomposes into per-column `filterWhere` calls). This makes `fetch`/`fetchOne`/`fetchOneOrNothing` work for tables with composite primary keys of any arity.
- **Add 3-tuple and 4-tuple Hasql composite encoders** — extends the existing 2-column pattern to support `filterWhereIdIn` for 3+ column composite PKs.
- **Fix `compileFromRowQueryBuilder` for composite-PK tables** — uses the FK constraint's `referenceColumn` when available instead of requiring a single PK column, handling the case where a FK references a specific column of a composite-PK table.

Closes #992

## Test plan

- [x] All 389 IDE tests pass
- [x] All 469 core IHP tests pass (23 pending due to no PostgreSQL)
- [x] All three modified files type-check cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)