### PR TITLE
Add Docker migration-before-start pattern to deployment docs

### DIFF
--- a/Guide/deployment.markdown
+++ b/Guide/deployment.markdown
@@ -868,7 +868,9 @@ $ docker run \
 
 ### Running Migrations Automatically in Docker
 
-Instead of using the default `unoptimized-docker-image` or `optimized-docker-image` flake outputs, you can define a custom Docker image in your `flake.nix` that runs database migrations before starting the server. This is useful when you want a single container that handles both migrations and the web server:
+Instead of using the default `unoptimized-docker-image` or `optimized-docker-image` flake outputs, you can define a custom Docker image in your `flake.nix` that runs database migrations before starting the server. This is useful when you want a single container that handles both migrations and the web server.
+
+**Note:** This pattern is designed for single-replica deployments. If you run multiple replicas, migrations may race against each other. In that case, run migrations as a separate one-shot container or init container before starting the app replicas.
 
 ```nix
 packages = {
@@ -878,8 +880,6 @@ packages = {
     config = {
       Env = [
         "IHP_MIGRATION_DIR=${./Application/Migration}/"
-        "DATABASE_URL"
-        "IHP_BASEURL"
         "IHP_REQUEST_LOGGER_IP_ADDR_SOURCE=FromHeader"
         "IHP_ENV=Production"
       ];
@@ -894,6 +894,8 @@ packages = {
   };
 };
 ```
+
+Pass `DATABASE_URL`, `IHP_BASEURL`, and other environment variables at runtime via `docker run -e` or your orchestrator's env configuration.
 
 Build and load this image with:
 


### PR DESCRIPTION
## Summary
- Documents how to create a custom Docker image that runs database migrations automatically before starting the web server
- Uses `pkgs.dockerTools.buildImage` with a `pkgs.writeShellScript` wrapper that calls `migrate` then `exec RunProdServer`
- Added as a new subsection under "Deploying with Docker", after the Worker Docker Image section

## Test plan
- [ ] Verify the nix code example is correct by reviewing against a working IHP app's flake.nix
- [ ] Check the Guide renders correctly with `devenv up` from the Guide directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)