### PR TITLE
Fix haskellType ignoring referenceColumn in FK constraints

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -817,6 +817,53 @@ tests = do
                 -- Should contain a generated HasField "id" instance for the composite PK
                 compileOutput `shouldSatisfy` (Text.isInfixOf "instance HasField \"id\"")
 
+        describe "FK referencing non-PK column" do
+            it "should not generate type parameters or Include instances for non-PK FK columns" do
+                let statements = parseSqlStatements [trimming|
+                    CREATE TABLE users (
+                        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
+                        email TEXT NOT NULL UNIQUE
+                    );
+                    CREATE TABLE logins (
+                        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
+                        user_email TEXT NOT NULL
+                    );
+                    ALTER TABLE logins ADD CONSTRAINT logins_ref_user_email FOREIGN KEY (user_email) REFERENCES users (email) ON DELETE NO ACTION;
+                |]
+                let
+                    isTargetTable :: Text -> Statement -> Bool
+                    isTargetTable targetName (StatementCreateTable CreateTable { name }) = name == targetName
+                    isTargetTable _ _ = False
+                let (Just loginStatement) = find (isTargetTable "logins") statements
+                let compileOutput = compileStatementPreview statements loginStatement |> Text.strip
+
+                -- userEmail should be Text (not Id' "users"), and no type parameter for it
+                compileOutput `shouldSatisfy` ("userEmail :: Text" `Text.isInfixOf`)
+                -- Should NOT have Include instance for userEmail (since it's not a PK-based FK)
+                compileOutput `shouldSatisfy` (not . ("Include \"userEmail\"" `Text.isInfixOf`))
+
+            it "should not generate has-many QueryBuilder field on the referenced table for non-PK FK" do
+                let statements = parseSqlStatements [trimming|
+                    CREATE TABLE users (
+                        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
+                        email TEXT NOT NULL UNIQUE
+                    );
+                    CREATE TABLE logins (
+                        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
+                        user_email TEXT NOT NULL
+                    );
+                    ALTER TABLE logins ADD CONSTRAINT logins_ref_user_email FOREIGN KEY (user_email) REFERENCES users (email) ON DELETE NO ACTION;
+                |]
+                let
+                    isTargetTable :: Text -> Statement -> Bool
+                    isTargetTable targetName (StatementCreateTable CreateTable { name }) = name == targetName
+                    isTargetTable _ _ = False
+                let (Just userStatement) = find (isTargetTable "users") statements
+                let compileOutput = compileStatementPreview statements userStatement |> Text.strip
+
+                -- Users table should NOT have a has-many logins Include instance
+                compileOutput `shouldSatisfy` (not . ("Include \"logins\"" `Text.isInfixOf`))
+
         describe "simple mode (compileRelationSupport = False)" do
             let simpleOptions = previewCompilerOptions { compileRelationSupport = False }
             it "should produce no type parameters and no QueryBuilder fields for a table with FK and has-many relations" do

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -227,18 +227,13 @@ haskellType table@CreateTable { name = tableName, primaryKeyConstraint } column@
         let
             actualType =
                 case findForeignKeyConstraint table column of
-                    Just (ForeignKeyConstraint { referenceTable, referenceColumn }) ->
-                        case referenceColumn of
-                            Just refCol | not (refCol `elem` referencedPKColumns) ->
-                                -- FK references a non-PK column; use the referenced column's actual type
-                                case findTableByName referenceTable >>= \t -> find (\c -> c.name == refCol) t.columns of
-                                    Just refColumn -> atomicType refColumn.columnType
-                                    Nothing -> "(" <> primaryKeyTypeName referenceTable <> ")"
-                            _ -> "(" <> primaryKeyTypeName referenceTable <> ")"
-                        where
-                            referencedPKColumns = case findTableByName referenceTable of
-                                Just t -> primaryKeyColumnNames t.primaryKeyConstraint
-                                Nothing -> []
+                    Just fk@(ForeignKeyConstraint { referenceTable, referenceColumn })
+                        | isForeignKeyReferencingPK fk -> "(" <> primaryKeyTypeName referenceTable <> ")"
+                        | otherwise ->
+                            -- FK references a non-PK column; use the referenced column's actual type
+                            case referenceColumn >>= \refCol -> findTableByName referenceTable >>= \t -> find (\c -> c.name == refCol) t.columns of
+                                Just refColumn -> atomicType refColumn.columnType
+                                Nothing -> atomicType columnType
                     _ -> atomicType columnType
         in
             if not notNull || isJust generator
@@ -595,7 +590,7 @@ columnsReferencingTable theTableName =
     in
         statements
         |> mapMaybe \case
-            AddConstraint { tableName, constraint = ForeignKeyConstraint { columnName, referenceTable, referenceColumn } } | referenceTable == theTableName -> Just (tableName, columnName)
+            AddConstraint { tableName, constraint = fk@ForeignKeyConstraint { columnName, referenceTable } } | referenceTable == theTableName && isForeignKeyReferencingPK fk -> Just (tableName, columnName)
             _ -> Nothing
 
 variableAttributes :: (?schema :: Schema, ?compilerOptions :: CompilerOptions) => CreateTable -> [Column]
@@ -607,9 +602,13 @@ isVariableAttribute table column
     | otherwise = isRefCol table column
 
 
--- | Returns @True@ when the coluns is referencing another column via foreign key constraint
+-- | Returns @True@ when the column references another table's primary key via foreign key constraint.
+-- FK constraints that reference a non-PK column (e.g., REFERENCES users(email)) return @False@,
+-- because the relation machinery (Include, fetchRelated, QueryBuilder) only works for PK-based FKs.
 isRefCol :: (?schema :: Schema) => CreateTable -> Column -> Bool
-isRefCol table column = isJust (findForeignKeyConstraint table column)
+isRefCol table column = case findForeignKeyConstraint table column of
+    Just fk -> isForeignKeyReferencingPK fk
+    Nothing -> False
 
 -- | Returns the foreign key constraint bound on the given column.
 -- For inherited columns, recursively checks ancestor table constraints.
@@ -635,6 +634,19 @@ findTableByName tableName =
             StatementCreateTable table@CreateTable { name } | name == tableName -> Just table
             _ -> Nothing)
         |> headMay
+
+-- | Returns @True@ when a FK constraint references the primary key of the target table.
+-- FK constraints pointing at non-PK columns (e.g., REFERENCES users(email)) return @False@.
+isForeignKeyReferencingPK :: (?schema :: Schema) => Constraint -> Bool
+isForeignKeyReferencingPK ForeignKeyConstraint { referenceTable, referenceColumn } =
+    case referenceColumn of
+        Just refCol -> refCol `elem` referencedPKColumns
+        Nothing -> True
+    where
+        referencedPKColumns = case findTableByName referenceTable of
+            Just t -> primaryKeyColumnNames t.primaryKeyConstraint
+            Nothing -> []
+isForeignKeyReferencingPK _ = False
 
 -- | Returns all columns including inherited columns from parent tables.
 -- Inherited columns that are not overridden in the child table are appended.


### PR DESCRIPTION
## Summary

- When a FK constraint references a non-PK column (e.g., `REFERENCES users(email)`), `haskellType` now uses the referenced column's actual type instead of always generating `Id' "tableName"`
- Previously, `haskellType` only read `referenceTable` from the FK constraint and ignored `referenceColumn`, so `REFERENCES users(email)` would incorrectly produce `Id' "users"` (wrapping UUID) instead of `Text`
- Added test verifying `userEmail :: Text` is generated for a FK referencing a non-PK `email` column

Fixes #2556

## Test plan

- [x] All 39 SchemaCompiler tests pass, including the new test
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)