### PR TITLE
Fix Hoogle not loading in Safari

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -462,8 +462,12 @@ ihpFlake:
                 env.IHP_HOOGLE_PORT = if cfg.withHoogle then "8002" else "";
 
                 # Auto-start Hoogle search server when withHoogle is enabled
+                # Disable CSP security headers: Hoogle v5.0.18.4 sends `upgrade-insecure-requests`
+                # even over plain HTTP, which causes Safari to try loading CSS/JS over HTTPS and fail.
+                # Fixed upstream (github.com/ndmitchell/hoogle/issues/432) but not yet released.
+                # Since Hoogle only runs on localhost for development, these headers aren't needed.
                 processes.hoogle = lib.mkIf cfg.withHoogle {
-                    exec = "hoogle server --local -p 8002";
+                    exec = "hoogle server --local -p 8002 --no-security-headers";
                 };
 
                 scripts.deploy-to-nixos.exec = ''


### PR DESCRIPTION
## Summary

- Hoogle's CSP header includes `upgrade-insecure-requests` even over plain HTTP, which causes Safari to try loading CSS/JS over HTTPS on localhost — breaking the page entirely
- Chrome treats localhost as a secure context so it's unaffected
- Fixed upstream ([ndmitchell/hoogle#432](https://github.com/ndmitchell/hoogle/issues/432)) but not yet released
- Pass `--no-security-headers` since Hoogle only runs on localhost for development

## Test plan

- [ ] Restart `devenv up`
- [ ] Verify `curl -sI http://localhost:8002/ | grep -i security` returns nothing
- [ ] Open `http://localhost:8002/` in Safari — should render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)