### PR TITLE
Clean up outdated flake-module.nix comments and broken shutdown config

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -414,9 +414,6 @@ ihpFlake:
                 env.DATABASE_URL = "postgres:///app?host=${config.devenv.shells.default.env.PGHOST}";
                 env.PGDATABASE = "app";
 
-                # Disabled for now
-                # As the devenv postgres uses a different location for the socket
-                # this would break lots of known commands such as `make db`
                 services.postgres.enable = true;
                 services.postgres.settings = {
                     logging_collector = true;
@@ -447,10 +444,6 @@ ihpFlake:
                     }
                 ];
 
-                # Explicit shutdown command to work around devenv-tasks v2 not
-                # propagating signals to child processes (#2481)
-                processes.postgres.process-compose.shutdown.command = "pg_ctl stop -D \"$PGDATA\" -m fast";
-                processes.postgres.process-compose.shutdown.timeout_seconds = 15;
 
                 # Used in the Makefile https://github.com/digitallyinduced/ihp-boilerplate/blob/master/Makefile
                 env.IHP = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;


### PR DESCRIPTION
## Summary
- Remove outdated comments about postgres socket location and disabled state
- Remove the explicit `pg_ctl` shutdown command and timeout that was failing

## Test plan
- [ ] Verify `devenv up` starts postgres correctly without the shutdown config

🤖 Generated with [Claude Code](https://claude.com/claude-code)