### PR TITLE
Remove duplicate GHC2021 from app-lib default-extensions

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -260,7 +260,6 @@ CABAL_HEADER
 
             cat >> ${appName}-lib.cabal <<'CABAL_EOF'
     default-extensions:
-        GHC2021
         OverloadedStrings
         NoImplicitPrelude
         ImplicitParams


### PR DESCRIPTION
## Summary
- Remove `GHC2021` from `default-extensions` in the auto-generated `app-lib.cabal` — it's already set as `default-language`. Cabal 3.12+ treats this as a serious warning and aborts the configure phase, breaking `nix build .#unoptimized-prod-server`.

## Test plan
- [ ] `nix build .#unoptimized-prod-server` succeeds on an IHP app project

🤖 Generated with [Claude Code](https://claude.com/claude-code)