### PR TITLE
Fix DataSubscription crash during WebSocket reconnect

### DIFF
--- a/ihp-datasync/data/DataSync/ihp-datasync.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.js
@@ -433,10 +433,6 @@ class DataSubscription {
     }
 
     subscribe(callback) {
-        if (this.isClosed) {
-            throw new Error('Trying to subscribe to a DataSubscription that is already closed');
-        }
-
         this.subscribers.push(callback);
 
         return () => {


### PR DESCRIPTION
## Summary
- Remove the `isClosed` guard in `DataSubscription.subscribe()` that throws "Trying to subscribe to a DataSubscription that is already closed"
- This is a race condition: when the WebSocket disconnects, `onDataSyncClosed()` sets `isClosed = true` but the subscription stays in `DataSubscriptionStore.queryMap`. If React re-renders during the disconnect→reconnect window, `subscribe()` throws and crashes the app.
- The check is unnecessary — subscribers get cached data and receive fresh data on reconnect via `updateSubscribers()`. If permanently closed, the subscription is already removed from `queryMap` via `onClose()`, so this code path is only reachable during the transient disconnect state.

## Test plan
- [ ] Start the app, open in browser, kill/restart the backend to simulate a WebSocket disconnect
- [ ] Navigate between pages during the disconnect — the app should show stale data briefly then update on reconnect, without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)