### PR TITLE
Fix nix test derivations failing due to missing installPhase

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -328,6 +328,7 @@ ihpFlake:
                                 runghc $(make -f ${hsDataDir ghcCompiler.ihp-ide.data}/lib/IHP/Makefile.dist print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs
                                 touch $out
                             '';
+                            installPhase = "true";
                         };
                 } else {})
             // (if builtins.pathExists "${cfg.projectPath}/Test/Integration.hs"
@@ -365,6 +366,7 @@ ihpFlake:
                                 pg_ctl -D "$PGDATA" stop || true
                                 touch $out
                             '';
+                            installPhase = "true";
                         };
                 } else {});
 


### PR DESCRIPTION
## Summary
- Add `installPhase = "true"` to both `tests` and `integration-tests` derivations in `flake-module.nix`
- Without this, `stdenv`'s default `installPhase` runs `make install` which tries to `mkdir $out`, but `$out` already exists as a file from `touch $out` in `buildPhase`

## Test plan
- [x] `nix build .#tests` passes on an IHP project with `Test/Main.hs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)