### PR TITLE
Skip trigger DDL when DataSync triggers already exist

### DIFF
--- a/ihp-datasync/IHP/DataSync/ChangeNotifications.hs
+++ b/ihp-datasync/IHP/DataSync/ChangeNotifications.hs
@@ -51,9 +51,10 @@ data Change
 -- | Returns the sql code to set up a database trigger. Mainly used by 'watchInsertOrUpdateTable'.
 --
 -- The function body is always updated via @CREATE OR REPLACE FUNCTION@ (no table lock needed).
--- The trigger DDL (@DROP TRIGGER@ / @CREATE TRIGGER@) requires @AccessExclusiveLock@ on the table,
--- so it is only executed when the triggers don't already exist, avoiding lock contention with
--- long-running queries like @COPY@ or @pg_dump@.
+-- The trigger DDL (@CREATE TRIGGER@) requires @ShareRowExclusiveLock@ on the table,
+-- which conflicts with @RowExclusiveLock@ from writers (INSERT\/UPDATE\/DELETE\/COPY FROM).
+-- It is only executed when the triggers don't already exist, with a short @lock_timeout@
+-- to fail fast rather than block behind long-running writers.
 createNotificationFunction :: Text -> RLS.TableWithRLS -> Text
 createNotificationFunction uuidFunction table = [i|
     DO $$
@@ -117,15 +118,26 @@ createNotificationFunction uuidFunction table = [i|
             END;
         $BODY$ language plpgsql;
 
-        -- Only install triggers if they don't already exist. DROP TRIGGER and
-        -- CREATE TRIGGER require AccessExclusiveLock on the table, which blocks
-        -- (and is blocked by) all other table access. Skipping this when triggers
-        -- are already in place avoids cascading lock waits from long-running
-        -- queries like COPY or pg_dump.
+        -- Only install triggers if they don't already exist. CREATE TRIGGER
+        -- takes ShareRowExclusiveLock on the table, which conflicts with
+        -- RowExclusiveLock from INSERT/UPDATE/DELETE. Skipping this when
+        -- triggers are already in place avoids blocking behind long-running
+        -- writers or COPY FROM.
+        --
+        -- When triggers ARE missing (first install, new table), use a short
+        -- lock_timeout so we fail fast rather than blocking writers
+        -- indefinitely. The Haskell-side MVar cache removes its entry on
+        -- failure, so the next WebSocket connection will retry.
         IF NOT EXISTS (
             SELECT 1 FROM pg_trigger WHERE tgname = '#{insertTriggerName}'
                 AND tgrelid = '#{tableName}'::regclass
         ) THEN
+            -- Use a short lock_timeout so we fail fast if a long-running
+            -- writer holds RowExclusiveLock on the table (which conflicts
+            -- with CREATE TRIGGER's ShareRowExclusiveLock). The error
+            -- propagates to Haskell where the MVar cache removes its entry,
+            -- allowing the next WebSocket connection to retry.
+            SET LOCAL lock_timeout = '5s';
             BEGIN
                 CREATE TRIGGER "#{insertTriggerName}" AFTER INSERT ON "#{tableName}" FOR EACH ROW EXECUTE PROCEDURE "#{functionName}"();
                 CREATE TRIGGER "#{updateTriggerName}" AFTER UPDATE ON "#{tableName}" FOR EACH ROW EXECUTE PROCEDURE "#{functionName}"();

--- a/ihp-datasync/Test/DataSync/ChangeNotifications.hs
+++ b/ihp-datasync/Test/DataSync/ChangeNotifications.hs
@@ -207,7 +207,7 @@ tests = do
                             Right () -> pure ()
 
         describe "trigger installation with locked table" do
-            it "succeeds on second call even when table is locked by COPY/pg_dump" do
+            it "succeeds on second call even when a writer holds RowExclusiveLock" do
                 withDB \connStr -> do
                     Exception.bracket (makePool connStr) Hasql.Pool.release \pool -> do
                         execSQL pool "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
@@ -225,18 +225,21 @@ tests = do
                         triggerCount <- queryTriggerCount pool tableName
                         triggerCount `shouldBe` 3
 
-                        -- Now simulate a pg_dump/COPY holding an ACCESS SHARE lock
-                        -- on the table. We do this by starting a transaction that
-                        -- SELECTs from the table (acquiring ACCESS SHARE) and
-                        -- holding it open while we run the second install.
+                        -- Simulate a long-running writer holding RowExclusiveLock.
+                        -- RowExclusiveLock conflicts with ShareRowExclusiveLock
+                        -- (which CREATE TRIGGER takes), but NOT with the
+                        -- IF NOT EXISTS check (AccessShareLock on pg_trigger).
+                        -- An open SELECT only takes AccessShareLock which does
+                        -- NOT conflict with CREATE TRIGGER, so we must use a
+                        -- writer (INSERT) to properly test this.
                         lockPool <- makePoolN 1 connStr
-                        execSQL lockPool (cs ("BEGIN; SELECT * FROM " <> tableName))
+                        execSQL lockPool (cs ("BEGIN; INSERT INTO " <> tableName <> " (body) VALUES ('lock holder')"))
 
                         -- Second call: triggers already exist, so this should
-                        -- skip the DDL and succeed despite the table being locked.
-                        -- With the old code this would block on AccessExclusiveLock.
+                        -- skip CREATE TRIGGER and succeed despite the writer lock.
+                        -- With the old code (DROP TRIGGER + CREATE TRIGGER always),
+                        -- this would block on the table lock.
                         result <- Exception.try $ do
-                            -- Use a short statement_timeout to detect if we'd block
                             execSQL pool "SET statement_timeout = '2s'"
                             installTableChangeTriggers pool table
                             execSQL pool "SET statement_timeout = '0'"


### PR DESCRIPTION
## Summary

- Always run `CREATE OR REPLACE FUNCTION` to keep trigger function bodies up to date (only locks the function in `pg_proc`, not the table)
- Skip `DROP TRIGGER` / `CREATE TRIGGER` when triggers already exist, avoiding `AccessExclusiveLock` on the table
- Remove the advisory lock serialization — no longer needed since trigger DDL is skipped when triggers exist

**Root cause:** In production, a stalled `COPY` (pg_dump) held an `ACCESS SHARE` lock on a table. On process restart, DataSync tried to `DROP/CREATE TRIGGER` (requires `ACCESS EXCLUSIVE`) for every table on the first WebSocket connection. The exclusive lock request queued behind the COPY, and then all subsequent DataSync queries cascaded behind the pending exclusive lock — blocking all 200+ connections and causing a full outage.

## Test plan

- [x] Added functional test: installs triggers, locks table with `SELECT` (simulating pg_dump), then runs install again — second call succeeds without blocking
- [ ] Existing concurrent trigger installation test still passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)