### PR TITLE
Fix datetime-local timezone shift by replacing Flatpickr with native picker

### DIFF
--- a/ihp/data/static/helpers.js
+++ b/ihp/data/static/helpers.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', function () {
     initToggle();
     initTime();
     initDatePicker();
+    initDateTimeLocal();
     initFileUploadPreview();
 
     document.dispatchEvent(ihpLoadEvent);
@@ -34,6 +35,7 @@ document.addEventListener('turbolinks:load', function () {
     }, 1);
 
     initDatePicker();
+    initDateTimeLocal();
 
     document.dispatchEvent(ihpLoadEvent);
 });
@@ -397,19 +399,52 @@ function initDatePicker() {
         });
     });
 
-    document.querySelectorAll("input[type='datetime-local']").forEach(el => {
-        // Append Z so Flatpickr knows the server value is UTC
-        if (el.value && !el.value.endsWith('Z')) {
-            el.value = el.value + 'Z';
-        }
-        flatpickr(el, {
-            ...(el.dataset.enableTime ? {} : { enableTime: true }),
-            ...(el.dataset.time_24hr ? {} : { time_24hr: true }),
-            ...(el.dataset.dateFormat ? {} : { dateFormat: 'Z' }),
-            ...(el.dataset.altFormat ? {} : { altFormat: 'd.m.y, H:i' }),
-            ...(el.dataset.altInput ? {} : { altInput: true }),
+}
+
+// Converts server-rendered UTC values in datetime-local inputs to the user's
+// local timezone for display, and converts back to UTC on form submit.
+// This replaces Flatpickr for datetime-local inputs — the native browser
+// picker is used instead.
+function initDateTimeLocal() {
+    // Convert server-rendered UTC values to local time for display
+    document.querySelectorAll("input[type='datetime-local']").forEach(function(el) {
+        if (!el.value) return;
+        var utcDate = new Date(el.value + 'Z');
+        if (isNaN(utcDate.getTime())) return;
+        el.value = formatLocalDateTime(utcDate);
+    });
+
+    // On form submit, convert local values back to UTC before FormData reads them.
+    // Form-level listeners fire before IHP's document-level submit handler,
+    // so values are converted before submitForm() creates FormData.
+    document.querySelectorAll('form').forEach(function(form) {
+        if (form.dataset.datetimeLocalHandled) return;
+        form.dataset.datetimeLocalHandled = 'true';
+        form.addEventListener('submit', function() {
+            form.querySelectorAll("input[type='datetime-local']").forEach(function(el) {
+                if (!el.value) return;
+                var localDate = new Date(el.value);
+                if (isNaN(localDate.getTime())) return;
+                el.value = formatUTCDateTime(localDate);
+            });
         });
     });
+}
+
+function formatLocalDateTime(date) {
+    return date.getFullYear() + '-' +
+        String(date.getMonth() + 1).padStart(2, '0') + '-' +
+        String(date.getDate()).padStart(2, '0') + 'T' +
+        String(date.getHours()).padStart(2, '0') + ':' +
+        String(date.getMinutes()).padStart(2, '0');
+}
+
+function formatUTCDateTime(date) {
+    return date.getUTCFullYear() + '-' +
+        String(date.getUTCMonth() + 1).padStart(2, '0') + '-' +
+        String(date.getUTCDate()).padStart(2, '0') + 'T' +
+        String(date.getUTCHours()).padStart(2, '0') + ':' +
+        String(date.getUTCMinutes()).padStart(2, '0');
 }
 
 var locked = false;


### PR DESCRIPTION
## Summary

- Removes Flatpickr for `datetime-local` inputs, uses the native browser picker instead
- Adds JS (`initDateTimeLocal()`) to convert server-rendered UTC values to the user's local timezone on page load
- On form submit, converts local time back to UTC before `FormData` reads the values
- Flatpickr for `input[type='date']` fields is unchanged

**Root cause:** PR #2491 changed `dateTimeField` to render `UTCTime` as `YYYY-MM-DDTHH:MM` (no Z suffix) to match the HTML5 `datetime-local` spec. Flatpickr's `dateFormat: 'Z'` mode expects a Z-suffixed UTC string. Without it, Flatpickr interprets the UTC wall-clock time as local time, causing a timezone offset shift on every save. PR #2570 tried appending Z in JS, but the browser's `datetime-local` input sanitization interferes, causing a double offset.

**This fix:** Instead of fighting between the `datetime-local` spec and Flatpickr's UTC mode, we remove Flatpickr for these inputs entirely. The native picker handles display, and simple JS Date math handles the UTC↔local conversion:

| Step | Value | Explanation |
|------|-------|-------------|
| Server renders | `value="12:00"` | UTC wall-clock time |
| JS page load | `el.value = "14:00"` | Converted to local (UTC+2 example) |
| User sees | `14:00` in native picker | Correct local time |
| User saves (no change) | JS converts back to `12:00` | Local→UTC before form submit |
| Server receives | `12:00` | Unchanged ✓ |

Fixes #2565

## Test plan

- [ ] Open a record with a `UTCTime` datetime field in a non-UTC timezone — verify the native picker shows local time
- [ ] Save without changes — verify the stored time is unchanged
- [ ] Edit the time, save — verify the correct UTC value is stored
- [ ] Test with JS disabled — form still works (shows UTC times as graceful degradation)
- [ ] Verify `input[type='date']` fields still use Flatpickr

🤖 Generated with [Claude Code](https://claude.com/claude-code)