### PR TITLE
Replace wai-session with dedicated forked packages

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -73,20 +73,24 @@ let
             ihp-hspec = hackageOrLocal "ihp-hspec";
             ihp-welcome = hackageOrLocal "ihp-welcome";
 
-            # Lazy session middleware: defer cookie decryption until first access,
-            # skip Set-Cookie when session is unmodified.
-            # PRs: https://github.com/singpolyma/wai-session/pull/17
-            #       https://github.com/singpolyma/wai-session-clientsession/pull/5
-            wai-session = final.haskell.lib.appendPatch super.wai-session
-                (builtins.fetchurl {
-                    url = "https://github.com/singpolyma/wai-session/commit/c0142c100975d7f4ba7516f5235d30a3e88e32a2.patch";
-                    sha256 = "0ymv7zwg4wdkdyz8wrfyjcprjq9iyik7iiaazsi1d6vhgm3fv6ls";
-                });
-            wai-session-clientsession = final.haskell.lib.appendPatch super.wai-session-clientsession
-                (builtins.fetchurl {
-                    url = "https://github.com/singpolyma/wai-session-clientsession/commit/8b383eac381b6a96ceaa7b3a282b0fe856452f78.patch";
-                    sha256 = "02127wd8y26aps34kmvxxvyyzg94p3i9f3drf7zwp8phdncb19pg";
-                });
+            # Forks of wai-session / wai-session-clientsession with deferred
+            # session decryption and optional Set-Cookie (Maybe ByteString).
+            # https://github.com/digitallyinduced/wai-session-maybe
+            # https://github.com/digitallyinduced/wai-session-clientsession-deferred
+            wai-session-maybe = super.callCabal2nix "wai-session-maybe"
+                (final.fetchFromGitHub {
+                    owner = "digitallyinduced";
+                    repo = "wai-session-maybe";
+                    rev = "v1.0.0";
+                    hash = "sha256-zXbWqp9L+JfD1RlW2Fvpb2XVhcL7hDHZCsl2wLMNKOQ=";
+                }) {};
+            wai-session-clientsession-deferred = super.callCabal2nix "wai-session-clientsession-deferred"
+                (final.fetchFromGitHub {
+                    owner = "digitallyinduced";
+                    repo = "wai-session-clientsession-deferred";
+                    rev = "v1.0.0";
+                    hash = "sha256-jrHXJGrlMdCv0JkD7+Sh55kkdQbbPCBIWhq+vatNi50=";
+                }) {};
 
             # Can be removed after v0.3.2 is on hackage
             # https://github.com/tippenein/countable-inflections/pull/6

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -162,6 +162,7 @@ that is defined in flake-module.nix
                     "ihp-job-dashboard" "ihp-imagemagick"
                     "ihp-hspec" "ihp-welcome" "ihp-zip"
                     "wai-asset-path" "wai-flash-messages" "wai-request-params"
+                    "wai-session-maybe" "wai-session-clientsession-deferred"
                 ];
             in lib.listToAttrs (map (name: {
                 name = "ghc912-${name}";
@@ -188,6 +189,7 @@ that is defined in flake-module.nix
                     "ihp-job-dashboard" "ihp-imagemagick"
                     "ihp-hspec" "ihp-welcome" "ihp-zip"
                     "wai-asset-path" "wai-flash-messages" "wai-request-params"
+                    "wai-session-maybe" "wai-session-clientsession-deferred"
                 ];
             in lib.listToAttrs (map (name: {
                 name = "ghc914-${name}";
@@ -240,8 +242,8 @@ that is defined in flake-module.nix
                         wai-util
                         aeson
                         uuid
-                        wai-session
-                        wai-session-clientsession
+                        wai-session-maybe
+                        wai-session-clientsession-deferred
                         clientsession
                         pwstore-fast
                         template-haskell

--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -8,10 +8,10 @@ import IHP.IDE.PortConfig
 import qualified IHP.ControllerSupport as ControllerSupport
 import IHP.ModelSupport
 import IHP.RouterSupport hiding (get)
-import Network.Wai.Session.ClientSession (clientsessionStore)
+import Network.Wai.Session.ClientSession.Deferred (clientsessionStore)
 import qualified Web.ClientSession as ClientSession
 import Network.Wai.Middleware.MethodOverridePost (methodOverridePost)
-import Network.Wai.Session (withSession)
+import Network.Wai.Session.Maybe (withSession)
 import qualified Network.WebSockets as Websocket
 import qualified Network.Wai.Handler.WebSockets as Websocket
 

--- a/ihp-ide/default.nix
+++ b/ihp-ide/default.nix
@@ -10,8 +10,9 @@
 , process, safe-exceptions, split, string-conversions, text, time
 , transformers, unagi-chan, unix, unliftio, uri-encode, uuid, vault
 , wai, wai-app-static, wai-asset-path, wai-extra
-, wai-request-params, wai-session, wai-session-clientsession
-, wai-util, wai-websockets, warp, websockets, with-utf8, wreq
+, wai-request-params, wai-session-clientsession-deferred
+, wai-session-maybe, wai-util, wai-websockets, warp, websockets
+, with-utf8, wreq
 }:
 mkDerivation {
   pname = "ihp-ide";
@@ -31,8 +32,9 @@ mkDerivation {
     mono-traversable neat-interpolation network network-uri process
     safe-exceptions split string-conversions text time transformers
     unagi-chan unix unliftio uri-encode uuid vault wai wai-app-static
-    wai-extra wai-request-params wai-session wai-session-clientsession
-    wai-util wai-websockets warp websockets with-utf8 wreq
+    wai-extra wai-request-params wai-session-clientsession-deferred
+    wai-session-maybe wai-util wai-websockets warp websockets with-utf8
+    wreq
   ];
   executableHaskellDepends = [
     aeson async attoparsec auto-update base base16-bytestring
@@ -45,8 +47,8 @@ mkDerivation {
     neat-interpolation network network-uri process safe-exceptions
     split string-conversions text time transformers unagi-chan unix
     unliftio uri-encode uuid vault wai wai-app-static wai-extra
-    wai-session wai-session-clientsession wai-util wai-websockets warp
-    websockets with-utf8 wreq
+    wai-session-clientsession-deferred wai-session-maybe wai-util
+    wai-websockets warp websockets with-utf8 wreq
   ];
   testHaskellDepends = [
     aeson async attoparsec auto-update base base16-bytestring
@@ -60,8 +62,8 @@ mkDerivation {
     process safe-exceptions split string-conversions text time
     transformers unagi-chan unix unliftio uri-encode uuid vault wai
     wai-app-static wai-asset-path wai-extra wai-request-params
-    wai-session wai-session-clientsession wai-util wai-websockets warp
-    websockets with-utf8 wreq
+    wai-session-clientsession-deferred wai-session-maybe wai-util
+    wai-websockets warp websockets with-utf8 wreq
   ];
   homepage = "https://ihp.digitallyinduced.com/";
   description = "Dev tools for IHP";

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -56,8 +56,8 @@ common shared-properties
             , network-uri
             , uri-encode
             , aeson
-            , wai-session
-            , wai-session-clientsession
+            , wai-session-maybe
+            , wai-session-clientsession-deferred
             , clientsession
             , vault
             , data-default

--- a/ihp/IHP/Controller/Session.hs
+++ b/ihp/IHP/Controller/Session.hs
@@ -40,7 +40,7 @@ import Network.Wai
 import qualified Data.Serialize as Serialize
 import Data.Serialize (Serialize)
 import Data.Serialize.Text ()
-import qualified Network.Wai.Session
+import qualified Network.Wai.Session.Maybe
 import System.IO.Unsafe (unsafePerformIO)
 
 -- | Types of possible errors as a result of
@@ -170,6 +170,6 @@ sessionVault = case lookupSessionVault ?request of
 lookupSessionVault :: Request -> Maybe (ByteString -> IO (Maybe ByteString), ByteString -> ByteString -> IO ())
 lookupSessionVault request = Vault.lookup sessionVaultKey request.vault
 
-sessionVaultKey :: Vault.Key (Network.Wai.Session.Session IO ByteString ByteString)
+sessionVaultKey :: Vault.Key (Network.Wai.Session.Maybe.Session IO ByteString ByteString)
 sessionVaultKey = unsafePerformIO Vault.newKey
 {-# NOINLINE sessionVaultKey #-}

--- a/ihp/IHP/Server.hs
+++ b/ihp/IHP/Server.hs
@@ -6,8 +6,8 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.Warp.Systemd as Systemd
 import Network.Wai
 import Network.Wai.Middleware.MethodOverridePost (methodOverridePost)
-import Network.Wai.Session (withSession)
-import Network.Wai.Session.ClientSession (clientsessionStore)
+import Network.Wai.Session.Maybe (withSession)
+import Network.Wai.Session.ClientSession.Deferred (clientsessionStore)
 import qualified Network.Wai.Middleware.HealthCheckEndpoint as HealthCheckEndpoint
 import qualified Web.ClientSession as ClientSession
 import IHP.Controller.Session (sessionVaultKey)

--- a/ihp/IHP/Test/Mocking.hs
+++ b/ihp/IHP/Test/Mocking.hs
@@ -26,7 +26,7 @@ import Test.Hspec
 import qualified Data.Text as Text
 import qualified Network.Wai as Wai
 import qualified IHP.LoginSupport.Helper.Controller as Session
-import qualified Network.Wai.Session
+import qualified Network.Wai.Session.Maybe
 import qualified Data.Serialize as Serialize
 import IHP.Controller.Session (sessionVaultKey)
 import IHP.Server (initMiddlewareStack)
@@ -278,7 +278,7 @@ withUser user callback =
     where
         newRequest = currentRequest { Wai.vault = newVault }
 
-        newSession :: Network.Wai.Session.Session IO ByteString ByteString
+        newSession :: Network.Wai.Session.Maybe.Session IO ByteString ByteString
         newSession = (lookupSession, insertSession)
 
         lookupSession key = if key == sessionKey

--- a/ihp/default.nix
+++ b/ihp/default.nix
@@ -14,13 +14,13 @@
 , postgresql-simple-postgresql-types, postgresql-types, process
 , pwstore-fast, random, random-strings, regex-tdfa, resource-pool
 , resourcet, safe-exceptions, scientific, slugger, split, stm
-, string-conversions, template-haskell, temporary, text, time
-, transformers, typerep-map, unagi-chan, unix, unliftio
+, string-conversions, tasty-bench, template-haskell, temporary
+, text, time, transformers, typerep-map, unagi-chan, unix, unliftio
 , unordered-containers, uri-encode, uuid, vault, vector, wai
 , wai-app-static, wai-asset-path, wai-cors, wai-extra
-, wai-flash-messages, wai-request-params, wai-session
-, wai-session-clientsession, wai-util, wai-websockets, warp
-, warp-systemd, websockets, with-utf8, wreq
+, wai-flash-messages, wai-request-params
+, wai-session-clientsession-deferred, wai-session-maybe, wai-util
+, wai-websockets, warp, warp-systemd, websockets, with-utf8, wreq
 }:
 mkDerivation {
   pname = "ihp";
@@ -47,8 +47,9 @@ mkDerivation {
     transformers typerep-map unagi-chan unix unliftio
     unordered-containers uri-encode uuid vault vector wai
     wai-app-static wai-asset-path wai-cors wai-extra wai-flash-messages
-    wai-request-params wai-session wai-session-clientsession wai-util
-    wai-websockets warp warp-systemd websockets with-utf8 wreq
+    wai-request-params wai-session-clientsession-deferred
+    wai-session-maybe wai-util wai-websockets warp warp-systemd
+    websockets with-utf8 wreq
   ];
   testHaskellDepends = [
     aeson async attoparsec base basic-prelude binary blaze-html
@@ -70,8 +71,33 @@ mkDerivation {
     transformers typerep-map unagi-chan unix unliftio
     unordered-containers uri-encode uuid vault vector wai
     wai-app-static wai-asset-path wai-cors wai-extra wai-flash-messages
-    wai-request-params wai-session wai-session-clientsession wai-util
-    wai-websockets warp warp-systemd websockets with-utf8 wreq
+    wai-request-params wai-session-clientsession-deferred
+    wai-session-maybe wai-util wai-websockets warp warp-systemd
+    websockets with-utf8 wreq
+  ];
+  benchmarkHaskellDepends = [
+    aeson async attoparsec base basic-prelude binary blaze-html
+    blaze-markup bytestring case-insensitive cereal cereal-text
+    classy-prelude clientsession conduit-extra containers contravariant
+    cookie countable-inflections data-default deepseq directory
+    fast-logger filepath ghc-prim hashable haskell-src-exts
+    haskell-src-meta hasql hasql-dynamic-statements hasql-implicits
+    hasql-mapping hasql-pool hasql-postgresql-types hasql-transaction
+    hspec http-client http-client-tls http-media http-types ihp-context
+    ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
+    ihp-pglistener inflections interpolate lens mime-types minio-hs
+    mono-traversable mtl neat-interpolation network network-uri
+    parser-combinators postgresql-simple
+    postgresql-simple-postgresql-types postgresql-types process
+    pwstore-fast random random-strings regex-tdfa resource-pool
+    resourcet safe-exceptions scientific slugger split stm
+    string-conversions tasty-bench template-haskell temporary text time
+    transformers typerep-map unagi-chan unix unliftio
+    unordered-containers uri-encode uuid vault vector wai
+    wai-app-static wai-asset-path wai-cors wai-extra wai-flash-messages
+    wai-request-params wai-session-clientsession-deferred
+    wai-session-maybe wai-util wai-websockets warp warp-systemd
+    websockets with-utf8 wreq
   ];
   homepage = "https://ihp.digitallyinduced.com/";
   description = "Haskell Web Framework";

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -59,8 +59,8 @@ common shared-properties
             , network-uri
             , uri-encode
             , aeson
-            , wai-session
-            , wai-session-clientsession
+            , wai-session-maybe
+            , wai-session-clientsession-deferred
             , clientsession
             , pwstore-fast
             , vault

--- a/wai-flash-messages/Network/Wai/Middleware/FlashMessages.hs
+++ b/wai-flash-messages/Network/Wai/Middleware/FlashMessages.hs
@@ -15,7 +15,7 @@ import Data.ByteString
 import qualified Data.Serialize as Serialize
 import Data.Serialize.Text ()
 import qualified Data.Vault.Lazy as Vault
-import qualified Network.Wai.Session as Session
+import qualified Network.Wai.Session.Maybe as Session
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 

--- a/wai-flash-messages/default.nix
+++ b/wai-flash-messages/default.nix
@@ -1,12 +1,12 @@
 { mkDerivation, base, bytestring, cereal, cereal-text, lib, text
-, vault, wai, wai-session
+, vault, wai, wai-session-maybe
 }:
 mkDerivation {
   pname = "wai-flash-messages";
   version = "1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring cereal cereal-text text vault wai wai-session
+    base bytestring cereal cereal-text text vault wai wai-session-maybe
   ];
   description = "Flash messages for wai apps";
   license = lib.licenses.mit;

--- a/wai-flash-messages/wai-flash-messages.cabal
+++ b/wai-flash-messages/wai-flash-messages.cabal
@@ -24,6 +24,6 @@ library
         BlockArguments
         OverloadedStrings
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
-    build-depends: base >= 4.17.0 && < 4.22, text, wai, vault, cereal, cereal-text, bytestring, wai-session
+    build-depends: base >= 4.17.0 && < 4.22, text, wai, vault, cereal, cereal-text, bytestring, wai-session-maybe
     hs-source-dirs: .
     exposed-modules: Network.Wai.Middleware.FlashMessages


### PR DESCRIPTION
## Summary

- Replaces `wai-session` (last release 2018) with [`wai-session-maybe`](https://github.com/digitallyinduced/wai-session-maybe) — module `Network.Wai.Session.Maybe`
- Replaces `wai-session-clientsession` (last release 2012) with [`wai-session-clientsession-deferred`](https://github.com/digitallyinduced/wai-session-clientsession-deferred) — module `Network.Wai.Session.ClientSession.Deferred`
- Removes the Nix overlay patches that were applying upstream PRs ([#17](https://github.com/singpolyma/wai-session/pull/17), [#5](https://github.com/singpolyma/wai-session-clientsession/pull/5))

The upstream packages are unmaintained and IHP's patches change the `SessionStore` type in a backwards-incompatible way (`IO ByteString` → `IO (Maybe ByteString)`). Publishing as separate packages with distinct module names avoids carrying Nix patches and allows coexistence with the original packages in dependency trees.

## Test plan

- [x] `ghci` type check passes (105 modules loaded)
- [x] IHP tests pass (470 examples, 0 failures)
- [x] ihp-ide tests pass (396 examples, 0 failures)
- [ ] CI (`nix flake check --impure`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)