### PR TITLE
Start temporary PostgreSQL during nix build for typedSql

### DIFF
--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -24,7 +24,7 @@ import IHP.TypedSql (typedSql, sqlQueryTyped, sqlExecTyped)
 
 The `QuasiQuotes` extension is required but already enabled by default in IHP projects.
 
-**Important**: Your development database must be running during compilation, because `typedSql` uses `DATABASE_URL` to connect and describe queries at compile time.
+**Important**: Your development database must be running during compilation, because `typedSql` uses `DATABASE_URL` to connect and describe queries at compile time. For `nix build`, this is handled automatically — see [Production Builds](#production-builds) below.
 
 ## Basic Queries
 
@@ -354,6 +354,10 @@ Key differences:
 **When to use `sqlQuery`**: Simple queries where you already have `FromRow` instances, or when you can't have the database running during compilation.
 
 **When to use `typedSql`**: Complex queries, queries with many columns, or any time you want compile-time safety. Especially useful when the query shape changes frequently during development.
+
+### Production Builds
+
+When you run `nix build`, IHP automatically detects that `ihp-typed-sql` is in your dependencies and starts a temporary PostgreSQL instance during compilation. Your `Application/Schema.sql` is loaded into this temporary database so that `typedSql` can infer types at compile time — no extra configuration needed.
 
 ### Migrating from `sqlQuery` to `typedSql`
 

--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -16,6 +16,9 @@
 , ihp-env-var-backwards-compat
 , ihp-static
 , static
+, buildWithPostgres ? false  # Start a temporary PostgreSQL during build (e.g. for typedSql TH)
+, appSchemaSql ? null       # Path to Application/Schema.sql (required when buildWithPostgres = true)
+, ihpSchemaSql ? null       # Path to IHPSchema.sql (required when buildWithPostgres = true)
 }:
 
 let
@@ -323,7 +326,30 @@ CABAL_EOF
         disallowedReferences = [ ihp ];
     };
 
-    appLibPackage = pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
+    # Override that starts a temporary PostgreSQL during build for compile-time DB access (e.g. typedSql)
+    withBuildTimePostgres = pkg: pkgs.haskell.lib.overrideCabal pkg (old: {
+        libraryToolDepends = (old.libraryToolDepends or []) ++ [ pkgs.postgresql ];
+        preBuild = (old.preBuild or "") + ''
+            # Start temporary PostgreSQL for compile-time type inference
+            export PGDATA="$TMPDIR/pgdata"
+            export PGHOST="$TMPDIR/pghost"
+            mkdir -p "$PGHOST"
+            initdb -D "$PGDATA" --no-locale --encoding=UTF8
+            echo "unix_socket_directories = '$PGHOST'" >> "$PGDATA/postgresql.conf"
+            echo "listen_addresses = '''" >> "$PGDATA/postgresql.conf"
+            pg_ctl -D "$PGDATA" -l "$TMPDIR/pg.log" start
+
+            createdb -h "$PGHOST" app
+            psql -h "$PGHOST" app < ${ihpSchemaSql}
+            psql -h "$PGHOST" app < ${appSchemaSql}
+            export DATABASE_URL="postgresql:///app?host=$PGHOST"
+        '';
+        postBuild = (old.postBuild or "") + ''
+            pg_ctl -D "$PGDATA" stop || true
+        '';
+    });
+
+    appLibPackageBase = pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
         ghc.callPackage ({ mkDerivation, base }: mkDerivation {
             pname = "${appName}-lib";
             version = "0.1.0";
@@ -332,6 +358,11 @@ CABAL_EOF
             license = pkgs.lib.licenses.free;
         }) {}
     ));
+
+    appLibPackage =
+        if buildWithPostgres
+        then withBuildTimePostgres appLibPackageBase
+        else appLibPackageBase;
 
     allHaskellPackagesWithAppLib = ghc.ghcWithPackages (p: [ appLibPackage ]);
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -158,6 +158,7 @@ ihpFlake:
                         If your app doesn't use the Makefile to bundle the CSS, you can disable this for faster builds.
                     '';
                 };
+
             };
         }
     );
@@ -167,6 +168,8 @@ ihpFlake:
             cfg = config.ihp;
             ihp = ihpFlake.inputs.self;
             ghcCompiler = pkgs.ghc;
+            # Auto-detect whether a build-time PostgreSQL is needed (e.g. ihp-typed-sql)
+            buildWithPostgres = builtins.any (p: (p.pname or "") == "ihp-typed-sql") (cfg.haskellPackages ghcCompiler);
             hsDataDir = package:
                     let
                         ghcName   = package.passthru.compiler.haskellCompilerName;         # e.g. "ghc-9.10.1"
@@ -200,6 +203,9 @@ ihpFlake:
                     ihp-env-var-backwards-compat = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
                     ihp-static = ihpFlake.inputs.self.packages.${system}.ihp-static;
                     static = self'.packages.static;
+                    inherit buildWithPostgres;
+                    appSchemaSql = "${self'.packages.schema}/Schema.sql";
+                    ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";
                 };
 
                 unoptimized-prod-server = import "${ihp}/NixSupport/default.nix" {
@@ -218,6 +224,9 @@ ihpFlake:
                     ihp-env-var-backwards-compat = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
                     ihp-static = ihpFlake.inputs.self.packages.${system}.ihp-static;
                     static = self'.packages.static;
+                    inherit buildWithPostgres;
+                    appSchemaSql = "${self'.packages.schema}/Schema.sql";
+                    ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";
                 };
 
                 static =


### PR DESCRIPTION
## Summary
- Auto-detects `ihp-typed-sql` in haskell dependencies and starts a temporary PostgreSQL during the app library build phase
- Loads `IHPSchema.sql` and `Application/Schema.sql` into the temp DB so `typedSql` TH splices can infer types at compile time
- Uses a `withBuildTimePostgres` override to keep the base `appLibPackage` derivation clean

## Test plan
- [x] Tested with a fresh IHP app in `/tmp/test-typedsql` using `[typedSql|SELECT name FROM users|]`
- [x] `nix build` succeeds — build log shows `initdb`, schema loading, and successful compilation
- [x] Apps without `ihp-typed-sql` are unaffected (override not applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)