### PR TITLE
Export uncheckedHsx and customHsx from preludes using Markup type

### DIFF
--- a/ihp/IHP/ControllerPrelude.hs
+++ b/ihp/IHP/ControllerPrelude.hs
@@ -85,7 +85,7 @@ import IHP.FileStorage.ControllerFunctions
 import IHP.FileStorage.Preprocessor.ImageMagick
 
 import IHP.Pagination.ControllerFunctions
-import IHP.HSX.MarkupQQ (hsx)
+import IHP.HSX.MarkupQQ (hsx, uncheckedHsx, customHsx)
 
 -- | Renders a view and stores it as modal HTML in the context for later rendering.
 --

--- a/ihp/IHP/ViewPrelude.hs
+++ b/ihp/IHP/ViewPrelude.hs
@@ -11,6 +11,8 @@ module IHP.ViewPrelude (
     module IHP.View.Form,
     module IHP.View.Types,
     hsx,
+    uncheckedHsx,
+    customHsx,
     toHtml,
     preEscapedToHtml,
     preEscapedTextValue,
@@ -41,7 +43,7 @@ module IHP.ViewPrelude (
 import IHP.Prelude
 import IHP.ViewSupport
 import IHP.View.Form
-import IHP.HSX.MarkupQQ (hsx)
+import IHP.HSX.MarkupQQ (hsx, uncheckedHsx, customHsx)
 import IHP.HSX.Markup (ToHtml(..), preEscapedToHtml, preEscapedTextValue, stringValue)
 import IHP.View.TimeAgo
 import IHP.ValidationSupport


### PR DESCRIPTION
## Summary
- When `hsx` was migrated from blaze (`IHP.HSX.QQ`) to the custom Markup type (`IHP.HSX.MarkupQQ`), `uncheckedHsx` and `customHsx` were not added to the prelude exports
- Users needing `uncheckedHsx` had to import it manually from `IHP.HSX.QQ`, which still produces the incompatible blaze `Html` type
- Now exports both `uncheckedHsx` and `customHsx` from `ViewPrelude` and `ControllerPrelude` via `IHP.HSX.MarkupQQ`

## Test plan
- [x] `ViewPrelude` and `ControllerPrelude` compile successfully with ghci

🤖 Generated with [Claude Code](https://claude.com/claude-code)