### PR TITLE
Fix DataSync concurrent trigger installation error

### DIFF
--- a/ihp-datasync/IHP/DataSync/ChangeNotifications.hs
+++ b/ihp-datasync/IHP/DataSync/ChangeNotifications.hs
@@ -62,7 +62,7 @@ createNotificationFunction uuidFunction table = [i|
         -- Serialize concurrent trigger installation for the same table across
         -- multiple server processes. Without this, concurrent CREATE OR REPLACE
         -- FUNCTION calls cause "tuple concurrently updated" errors (XX000).
-        PERFORM pg_advisory_xact_lock(hashtext('ihp_datasync_install_' || '#{tableName}'));
+        PERFORM pg_advisory_xact_lock(hashtext('#{functionName}'));
 
         -- Always update the function body. CREATE OR REPLACE FUNCTION only locks
         -- the function in pg_proc, not the table, so this is safe to run


### PR DESCRIPTION
## Summary
- Adds `pg_advisory_xact_lock` to serialize DataSync trigger installation SQL across multiple server processes
- Fixes `tuple concurrently updated` (XX000) errors when multiple WebSocket connections (or multiple server processes) concurrently run `CREATE OR REPLACE FUNCTION` on the same `pg_proc` catalog row
- The existing Haskell-side MVar lock only serializes within a single process — this fix handles multi-process deployments

## Test plan
- [ ] Deploy with multiple IHP server processes hitting the same database
- [ ] Open multiple browser tabs simultaneously to trigger concurrent DataSync subscriptions
- [ ] Verify no `tuple concurrently updated` errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)