### PR TITLE
[codex] Avoid eval-time IFD for IHP data paths

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -7,15 +7,7 @@ that is defined in flake-module.nix
 {
     perSystem = { config, system, nix-filter, pkgs, lib, ... }:
     let
-                    hsDataDir = package:
-                            let
-                                ghcName   = package.passthru.compiler.haskellCompilerName;         # e.g. "ghc-9.10.1"
-                                shareRoot = "${package.data}/share/${ghcName}";
-                                # Pick the first (typically only) platform-specific directory, filtering out "doc"
-                                dirs = builtins.filter (d: d != "doc") (builtins.attrNames (builtins.readDir shareRoot));
-                                sys = lib.head dirs;
-                            in
-                                "${shareRoot}/${sys}/${package.name}";
+                    ihpLib = config.packages.ihp-env-var-backwards-compat;
 
                     # Wrap a package's check phase with a temporary PostgreSQL server
                     withTestPostgres = pkg: pkg.overrideAttrs (old: {
@@ -111,7 +103,7 @@ that is defined in flake-module.nix
                         pkgs.postgresql
                     ];
                     buildPhase = ''
-                        export IHP_LIB=${hsDataDir pkgs.ghc.ihp-ide.data}
+                        export IHP_LIB=${ihpLib}
 
                         # Start temporary PostgreSQL
                         export PGDATA="$TMPDIR/pgdata"
@@ -357,7 +349,7 @@ that is defined in flake-module.nix
                     pkgs.symlinkJoin {
                         name = "ihp-static";
                         paths = [
-                            (hsDataDir pkgs.ghc.ihp.data + "/static")
+                            ("${self}/ihp/data/static")
                             (pkgs.linkFarm "ihp-vendor-js" [
                                 # jQuery — current version
                                 { name = "vendor/jquery-4.0.0.min.js"; path = jquery "4.0.0.min.js" "1amdfbjdqncpv9x00n8f8xg43nvaapwfiq6kypx8nzyrkbm4d99r"; }

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -168,17 +168,9 @@ ihpFlake:
             cfg = config.ihp;
             ihp = ihpFlake.inputs.self;
             ghcCompiler = pkgs.ghc;
+            ihpLib = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
             # Auto-detect whether a build-time PostgreSQL is needed (e.g. ihp-typed-sql)
             buildWithPostgres = builtins.any (p: (p.pname or "") == "ihp-typed-sql") (cfg.haskellPackages ghcCompiler);
-            hsDataDir = package:
-                    let
-                        ghcName   = package.passthru.compiler.haskellCompilerName;         # e.g. "ghc-9.10.1"
-                        shareRoot = "${package.data}/share/${ghcName}";
-                        # Pick the first (typically only) platform-specific directory, filtering out "doc"
-                        dirs = builtins.filter (d: d != "doc") (builtins.attrNames (builtins.readDir shareRoot));
-                        sys = lib.head dirs;
-                    in
-                        "${shareRoot}/${sys}/${package.name}";
         in lib.mkIf cfg.enable {
             _module.args.pkgs = lib.mkDefault (import inputs.nixpkgs { inherit system; overlays = config.devenv.shells.default.overlays; config = { }; });
 
@@ -200,7 +192,7 @@ ihpFlake:
                     relationSupport = cfg.relationSupport;
                     appName = cfg.appName;
                     filter = ihpFlake.inputs.nix-filter.lib;
-                    ihp-env-var-backwards-compat = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
+                    ihp-env-var-backwards-compat = ihpLib;
                     ihp-static = ihpFlake.inputs.self.packages.${system}.ihp-static;
                     static = self'.packages.static;
                     inherit buildWithPostgres;
@@ -221,7 +213,7 @@ ihpFlake:
                     relationSupport = cfg.relationSupport;
                     appName = cfg.appName;
                     filter = ihpFlake.inputs.nix-filter.lib;
-                    ihp-env-var-backwards-compat = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
+                    ihp-env-var-backwards-compat = ihpLib;
                     ihp-static = ihpFlake.inputs.self.packages.${system}.ihp-static;
                     static = self'.packages.static;
                     inherit buildWithPostgres;
@@ -302,8 +294,8 @@ ihpFlake:
                         # See https://github.com/svanderburg/node2nix/issues/217#issuecomment-751311272
                         export HOME=/tmp
 
-                        export IHP_LIB=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
-                        export IHP=${ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat}
+                        export IHP_LIB=${ihpLib}
+                        export IHP=${ihpLib}
 
                         make -j static/prod.css static/prod.js
                         runHook postBuild
@@ -331,10 +323,10 @@ ihpFlake:
                             nativeBuildInputs = with pkgs; [ (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler])) ];
                             buildPhase = ''
                                 # shellcheck disable=SC2046
-                                make -f ${hsDataDir ghcCompiler.ihp-ide.data}/lib/IHP/Makefile.dist build/Generated/Types.hs
+                                make -f ${ihpLib}/lib/IHP/Makefile.dist build/Generated/Types.hs
 
                                 # shellcheck disable=SC2046
-                                runghc $(make -f ${hsDataDir ghcCompiler.ihp-ide.data}/lib/IHP/Makefile.dist print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs
+                                runghc $(make -f ${ihpLib}/lib/IHP/Makefile.dist print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs
                                 touch $out
                             '';
                             installPhase = "true";
@@ -351,7 +343,7 @@ ihpFlake:
                                 postgresql
                             ];
                             buildPhase = ''
-                                export IHP_LIB=${hsDataDir ghcCompiler.ihp-ide.data}
+                                export IHP_LIB=${ihpLib}
 
                                 # Start temporary PostgreSQL
                                 export PGDATA="$TMPDIR/pgdata"


### PR DESCRIPTION
## Summary
- avoid eval-time IFD when resolving IHP data paths in the app-facing flake module
- stop probing derivation-backed cabal data directories with `builtins.readDir`
- route test and static path consumers through `ihp-env-var-backwards-compat` instead

## Root Cause
`hsDataDir` used `builtins.readDir` on derivation-backed `package.data` paths. That forces Nix to realize those outputs during evaluation, which turns flake evaluation for test/static derivations into eval-time IFD.

## Impact
Evaluation no longer needs to realize `ihp-ide.data` just to construct the test and static derivations, which avoids unexpected build work during evaluation and cross-target deploys.

## Validation
- `nix eval --json .#checks.aarch64-darwin --apply builtins.attrNames`
- `nix eval --raw .#checks.aarch64-darwin.integration-test.drvPath`
- `nix eval --raw .#checks.aarch64-darwin.ihp-static.drvPath`
- `nix eval --raw .#checks.aarch64-darwin.boilerplate-unoptimized-prod-server.drvPath`
- `rg -n "builtins\\.readDir|hsDataDir" flake-module.nix devenv-module.nix`

Closes #2611