### PR TITLE
Add isEmpty helper for Html/MarkupM

### DIFF
--- a/ihp-hsx/Test/IHP/HSX/MarkupSpec.hs
+++ b/ihp-hsx/Test/IHP/HSX/MarkupSpec.hs
@@ -1,0 +1,31 @@
+{-|
+Module: IHP.HSX.MarkupSpec
+Copyright: (c) digitally induced GmbH, 2024
+-}
+module IHP.HSX.MarkupSpec where
+
+import Test.Hspec
+import Prelude
+import IHP.HSX.Markup
+
+tests :: SpecWith ()
+tests = do
+    describe "IHP.HSX.Markup" do
+        describe "isEmpty" do
+            it "should return True for mempty" do
+                isEmpty (mempty :: Html) `shouldBe` True
+
+            it "should return True for empty string literal" do
+                isEmpty ("" :: Html) `shouldBe` True
+
+            it "should return False for non-empty markup" do
+                isEmpty (escapeHtml "hello") `shouldBe` False
+
+            it "should return False for raw bytestring content" do
+                isEmpty (rawByteString "<div></div>") `shouldBe` False
+
+            it "should return True for concatenation of empty values" do
+                isEmpty (mempty <> mempty :: Html) `shouldBe` True
+
+            it "should return False for concatenation with non-empty value" do
+                isEmpty (mempty <> escapeHtml "x") `shouldBe` False

--- a/ihp-hsx/Test/Main.hs
+++ b/ihp-hsx/Test/Main.hs
@@ -5,8 +5,10 @@ import Prelude
 import Test.Hspec
 import qualified IHP.HSX.QQSpec
 import qualified IHP.HSX.ParserSpec
+import qualified IHP.HSX.MarkupSpec
 
 main :: IO ()
 main = hspec do
     IHP.HSX.QQSpec.tests
     IHP.HSX.ParserSpec.tests
+    IHP.HSX.MarkupSpec.tests

--- a/ihp-hsx/direct/IHP/HSX/Markup.hs
+++ b/ihp-hsx/direct/IHP/HSX/Markup.hs
@@ -21,6 +21,7 @@ module IHP.HSX.Markup
 , ApplyAttribute (..)
 , AttributeValue (..)
 , spreadAttributes
+, isEmpty
 -- * Blaze compatibility
 , preEscapedToHtml
 , preEscapedTextValue
@@ -264,6 +265,15 @@ instance {-# OVERLAPPABLE #-} AttributeValue a => ApplyAttribute a where
 spreadAttributes :: ApplyAttribute value => [(Text, value)] -> Markup
 spreadAttributes = foldMap (\(name, value) -> applyAttribute name (" " <> name <> "=\"") value)
 {-# INLINE spreadAttributes #-}
+
+-- | Check whether a markup value is empty (produces no output).
+--
+-- Since 'Builder' is opaque, this renders the markup and checks
+-- whether the result is a zero-length 'ByteString'.  For empty markup
+-- the builder produces nothing, so this is effectively free.
+isEmpty :: MarkupM a -> Bool
+isEmpty (Markup b) = LBS.null (Builder.toLazyByteString b)
+{-# INLINE isEmpty #-}
 
 -- | Blaze compatibility: emit pre-escaped HTML (no escaping applied).
 -- Use for trusted HTML content only. Accepts Text, String, ByteString, etc.

--- a/ihp-hsx/ihp-hsx.cabal
+++ b/ihp-hsx/ihp-hsx.cabal
@@ -154,6 +154,7 @@ test-suite ihp-hsx-tests
     other-modules:
         IHP.HSX.ParserSpec
         IHP.HSX.QQSpec
+        IHP.HSX.MarkupSpec
         IHP.HSX.CustomHsxCases
     default-language:    GHC2021
     build-depends:

--- a/ihp/IHP/HaskellSupport.hs
+++ b/ihp/IHP/HaskellSupport.hs
@@ -61,6 +61,7 @@ import qualified Data.Text as Text
 import qualified Data.Map as Map
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.Aeson.Key as Aeson
+import qualified IHP.HSX.Markup as Markup
 
 import IHP.Record ((|>), get, set, setJust, setMaybe, modify, modifyJust, SetField(..), UpdateField(..), incrementField, decrementField, CopyFields(..))
 
@@ -93,7 +94,11 @@ instance IsEmpty UUID.UUID where
     {-# INLINE isEmpty #-}
 
 instance IsEmpty (Map a b) where
-    isEmpty = Map.null    
+    isEmpty = Map.null
+    {-# INLINE isEmpty #-}
+
+instance IsEmpty (Markup.MarkupM a) where
+    isEmpty = Markup.isEmpty
     {-# INLINE isEmpty #-}
 
 ifOrEmpty :: (Monoid a) => Bool -> a -> a


### PR DESCRIPTION
## Summary
- Adds `isEmpty :: MarkupM a -> Bool` to `IHP.HSX.Markup` — renders the builder and checks if the result is zero-length
- Adds `IsEmpty (MarkupM a)` instance in `IHP.HaskellSupport` so IHP app code can use the existing `IsEmpty` class with `Html` values
- Adds 6 test cases in a new `MarkupSpec` module

Closes #2618

## Test plan
- [x] `MarkupSpec` tests pass (mempty, empty string, non-empty, raw bytestring, concatenation cases)
- [ ] `nix flake check --impure` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)