### PR TITLE
Replace callHackageDirect with pre-generated nix files to eliminate IFD

### DIFF
--- a/NixSupport/hackage/hasql-dynamic-statements.nix
+++ b/NixSupport/hackage/hasql-dynamic-statements.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, containers, hasql
+, hasql-implicits, hspec, hspec-discover, lib, rerebase
+, testcontainers-postgresql, text, text-builder
+}:
+mkDerivation {
+  pname = "hasql-dynamic-statements";
+  version = "0.5.1";
+  sha256 = "979644ad93b1f4f46e5c62a24ddf3debbe2acd61fa8e8b239cfdeef0d92d88cd";
+  libraryHaskellDepends = [
+    base bytestring containers hasql hasql-implicits text text-builder
+  ];
+  testHaskellDepends = [
+    hasql hspec rerebase testcontainers-postgresql
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/nikita-volkov/hasql-dynamic-statements";
+  description = "Hasql extension for dynamic construction of statements";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/hasql-implicits.nix
+++ b/NixSupport/hackage/hasql-implicits.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, aeson, base, bytestring, containers, hasql, iproute
+, lib, scientific, text, time, uuid, vector
+}:
+mkDerivation {
+  pname = "hasql-implicits";
+  version = "0.2.0.2";
+  sha256 = "266332a1881860ffd002a44d2903359c66bbcee3fe01ebfb1bfd30198b9de63e";
+  libraryHaskellDepends = [
+    aeson base bytestring containers hasql iproute scientific text time
+    uuid vector
+  ];
+  homepage = "https://github.com/nikita-volkov/hasql-implicits";
+  description = "Implicit definitions for Hasql, such as default codecs for standard types";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/hasql-mapping.nix
+++ b/NixSupport/hackage/hasql-mapping.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, aeson, base, bytestring, hasql, iproute, lib
+, scientific, text, time, uuid
+}:
+mkDerivation {
+  pname = "hasql-mapping";
+  version = "0.1";
+  sha256 = "12d50e628b7eba317a189166682bf93bf6c7751860662fab4e4731527ec9f7ca";
+  libraryHaskellDepends = [
+    aeson base bytestring hasql iproute scientific text time uuid
+  ];
+  homepage = "https://github.com/nikita-volkov/hasql-mapping";
+  description = "SDK for defining modular mappings to databases on top of Hasql";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/hasql-notifications.nix
+++ b/NixSupport/hackage/hasql-notifications.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, bytestring, hasql, hasql-pool, hspec
+, hspec-discover, lib, postgresql-libpq, QuickCheck, text
+}:
+mkDerivation {
+  pname = "hasql-notifications";
+  version = "0.2.5.0";
+  sha256 = "4bc7a81a5831d6a39e67baa1bab5d79a05e4444423a35ce93879971d00a46f7e";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring hasql hasql-pool postgresql-libpq text
+  ];
+  executableHaskellDepends = [ base hasql ];
+  testHaskellDepends = [ base bytestring hasql hspec QuickCheck ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/diogob/hasql-notifications";
+  description = "LISTEN/NOTIFY support for Hasql";
+  license = lib.licenses.bsd3;
+  mainProgram = "hasql-notifications";
+}

--- a/NixSupport/hackage/hasql-pool.nix
+++ b/NixSupport/hackage/hasql-pool.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, async, base, bytestring, hasql, hspec
+, hspec-discover, lib, postgresql-libpq, random, rerebase, stm
+, testcontainers-postgresql, text, text-builder, time, tuple, uuid
+}:
+mkDerivation {
+  pname = "hasql-pool";
+  version = "1.4.2";
+  sha256 = "ed83a674ae6ca875d5ed9f23e34f8a012b432d80fbcf625f5a345eb2bde73070";
+  libraryHaskellDepends = [
+    base bytestring hasql stm text time uuid
+  ];
+  testHaskellDepends = [
+    async hasql hspec postgresql-libpq random rerebase
+    testcontainers-postgresql text-builder tuple
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/nikita-volkov/hasql-pool";
+  description = "Pool of connections for Hasql";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/hasql-postgresql-types.nix
+++ b/NixSupport/hackage/hasql-postgresql-types.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, hasql, hasql-mapping, lib, postgresql-types
+, postgresql-types-algebra, ptr-peeker, ptr-poker, tagged
+, text-builder
+}:
+mkDerivation {
+  pname = "hasql-postgresql-types";
+  version = "0.2";
+  sha256 = "54d4c9bc063a030753d2aea7b2ff6c6a65cbdeafe50df3dfd1879f946915d083";
+  libraryHaskellDepends = [
+    base hasql hasql-mapping postgresql-types postgresql-types-algebra
+    ptr-peeker ptr-poker tagged text-builder
+  ];
+  homepage = "https://github.com/nikita-volkov/hasql-postgresql-types";
+  description = "Integration of \"hasql\" with \"postgresql-types\"";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/hasql-transaction.nix
+++ b/NixSupport/hackage/hasql-transaction.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, async, base, bytestring, bytestring-tree-builder
+, contravariant, hasql, lib, mtl, rerebase, text, transformers
+}:
+mkDerivation {
+  pname = "hasql-transaction";
+  version = "1.2.2";
+  sha256 = "bf902c7a983035e44b6936d6acab0c0ba7548106fb040ba8bb12b058b34eacda";
+  libraryHaskellDepends = [
+    base bytestring bytestring-tree-builder contravariant hasql mtl
+    text transformers
+  ];
+  testHaskellDepends = [ async hasql rerebase ];
+  homepage = "https://github.com/nikita-volkov/hasql-transaction";
+  description = "Composable abstraction over retryable transactions for Hasql";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/hasql.nix
+++ b/NixSupport/hackage/hasql.nix
@@ -1,0 +1,32 @@
+{ mkDerivation, aeson, attoparsec, base, bytestring
+, bytestring-strict-builder, contravariant, criterion, dlist
+, hashable, hspec, hspec-discover, iproute, lib, mtl
+, postgresql-binary, postgresql-connection-string, postgresql-libpq
+, profunctors, QuickCheck, quickcheck-instances, random, rerebase
+, scientific, testcontainers-postgresql, text, text-builder, time
+, transformers, unordered-containers, uuid, vector, witherable
+}:
+mkDerivation {
+  pname = "hasql";
+  version = "1.10.2.3";
+  sha256 = "ed8fc6d8e05cb9d05d22a63ad0acefac3795ab9ba517f14c574d9d4168f8afca";
+  libraryHaskellDepends = [
+    aeson attoparsec base bytestring bytestring-strict-builder
+    contravariant dlist hashable iproute mtl postgresql-binary
+    postgresql-connection-string postgresql-libpq profunctors
+    scientific text text-builder time transformers unordered-containers
+    uuid vector witherable
+  ];
+  testHaskellDepends = [
+    aeson attoparsec base bytestring contravariant dlist hashable hspec
+    iproute mtl postgresql-libpq profunctors QuickCheck
+    quickcheck-instances random rerebase scientific
+    testcontainers-postgresql text text-builder time transformers
+    unordered-containers uuid vector witherable
+  ];
+  testToolDepends = [ hspec-discover ];
+  benchmarkHaskellDepends = [ criterion rerebase ];
+  homepage = "https://github.com/nikita-volkov/hasql";
+  description = "Fast PostgreSQL driver with a flexible mapping API";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/ihp-zip.nix
+++ b/NixSupport/hackage/ihp-zip.nix
@@ -4,8 +4,8 @@ mkDerivation {
   version = "0.0.1";
   src = fetchgit {
     url = "https://github.com/digitallyinduced/ihp-zip";
-    sha256 = "0y0dj8ggi1jqzy74i0d6k9my8kdvfi516zfgnsl7znicwq9laald";
-    rev = "1c0d812d12d21269f83d6480a6ec7a8cdd054485";
+    sha256 = "116ly1ll3d9m702f7cwm5dbxpnyg4afjhg9yg3f0qi775db9vcgv";
+    rev = "62f632d23ee34b9783b82b53ab72e6ba5d716b76";
     fetchSubmodules = true;
   };
   libraryHaskellDepends = [ http-types ihp wai zip-archive ];

--- a/NixSupport/hackage/ihp-zip.nix
+++ b/NixSupport/hackage/ihp-zip.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, fetchgit, http-types, ihp, lib, wai, zip-archive }:
+mkDerivation {
+  pname = "ihp-zip";
+  version = "0.0.1";
+  src = fetchgit {
+    url = "https://github.com/digitallyinduced/ihp-zip";
+    sha256 = "0y0dj8ggi1jqzy74i0d6k9my8kdvfi516zfgnsl7znicwq9laald";
+    rev = "1c0d812d12d21269f83d6480a6ec7a8cdd054485";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [ http-types ihp wai zip-archive ];
+  description = "ihp-zip";
+  license = "unknown";
+}

--- a/NixSupport/hackage/postgresql-binary.nix
+++ b/NixSupport/hackage/postgresql-binary.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, aeson, base, binary-parser, bytestring
+, bytestring-strict-builder, containers, criterion, iproute, lib
+, mtl, postgresql-libpq, QuickCheck, quickcheck-instances, rerebase
+, scientific, tasty, tasty-hunit, tasty-quickcheck, text, time
+, transformers, unordered-containers, uuid, vector
+}:
+mkDerivation {
+  pname = "postgresql-binary";
+  version = "0.15.0.1";
+  sha256 = "7736e091b51820526a6417ab9932c083ffd31f0d3ec5baea1d5a07b65d85e34f";
+  libraryHaskellDepends = [
+    aeson base binary-parser bytestring bytestring-strict-builder
+    containers iproute mtl scientific text time transformers
+    unordered-containers uuid vector
+  ];
+  testHaskellDepends = [
+    aeson iproute postgresql-libpq QuickCheck quickcheck-instances
+    rerebase tasty tasty-hunit tasty-quickcheck
+  ];
+  benchmarkHaskellDepends = [ criterion rerebase ];
+  homepage = "https://github.com/nikita-volkov/postgresql-binary";
+  description = "Encoders and decoders for the PostgreSQL's binary format";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/postgresql-connection-string.nix
+++ b/NixSupport/hackage/postgresql-connection-string.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, charset, containers, hashable
+, hspec, lib, megaparsec, QuickCheck, quickcheck-classes, text
+, text-builder
+}:
+mkDerivation {
+  pname = "postgresql-connection-string";
+  version = "0.1.0.6";
+  sha256 = "2deb48d7f483b28d39f8d7d24d2ad70e69db5042dbd0351528e4f976acdab110";
+  libraryHaskellDepends = [
+    base bytestring charset containers hashable megaparsec QuickCheck
+    text text-builder
+  ];
+  testHaskellDepends = [
+    base containers hspec QuickCheck quickcheck-classes text
+  ];
+  homepage = "https://github.com/nikita-volkov/postgresql-connection-string";
+  description = "PostgreSQL connection string type, parser and builder";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/postgresql-simple-postgresql-types.nix
+++ b/NixSupport/hackage/postgresql-simple-postgresql-types.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, async, attoparsec, base, hspec, lib
+, postgresql-simple, postgresql-types, postgresql-types-algebra
+, QuickCheck, quickcheck-instances, stm, tagged
+, testcontainers-postgresql, text, text-builder
+}:
+mkDerivation {
+  pname = "postgresql-simple-postgresql-types";
+  version = "0.1.1";
+  sha256 = "25ed8f8ec444be55597bf4ed09bae149f854a607aeaa90c2b7cb191a74db481a";
+  libraryHaskellDepends = [
+    attoparsec base postgresql-simple postgresql-types
+    postgresql-types-algebra tagged text text-builder
+  ];
+  testHaskellDepends = [
+    async base hspec postgresql-simple postgresql-types
+    postgresql-types-algebra QuickCheck quickcheck-instances stm tagged
+    testcontainers-postgresql text
+  ];
+  homepage = "https://github.com/nikita-volkov/postgresql-simple-postgresql-types";
+  description = "Integration of \"postgresql-simple\" with \"postgresql-types\"";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/postgresql-types-algebra.nix
+++ b/NixSupport/hackage/postgresql-types-algebra.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, attoparsec, base, bytestring, lib, ptr-peeker
+, ptr-poker, tagged, text, text-builder
+}:
+mkDerivation {
+  pname = "postgresql-types-algebra";
+  version = "0.1";
+  sha256 = "6c40ca9d442f0b6c01f08b3d3e184c29674223b445edef4a3e672ec3ec193ae4";
+  libraryHaskellDepends = [
+    attoparsec base bytestring ptr-peeker ptr-poker tagged text
+    text-builder
+  ];
+  homepage = "https://github.com/nikita-volkov/postgresql-types-algebra";
+  description = "Type classes for PostgreSQL type mappings";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/postgresql-types.nix
+++ b/NixSupport/hackage/postgresql-types.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, aeson, async, attoparsec, base, bytestring
+, containers, hashable, hspec, hspec-discover, jsonifier, lib, mtl
+, postgresql-libpq, postgresql-types-algebra, ptr-peeker, ptr-poker
+, QuickCheck, quickcheck-classes, quickcheck-instances, scientific
+, stm, tagged, testcontainers-postgresql, text, text-builder, time
+, transformers, uuid, vector
+}:
+mkDerivation {
+  pname = "postgresql-types";
+  version = "0.1.2";
+  sha256 = "ce78e8a965016df3ea2af15fe53332a16a29b9e66f9d8c11f150f092bcea2dfd";
+  libraryHaskellDepends = [
+    aeson attoparsec base bytestring containers hashable jsonifier mtl
+    postgresql-types-algebra ptr-peeker ptr-poker QuickCheck scientific
+    tagged text text-builder time transformers uuid vector
+  ];
+  testHaskellDepends = [
+    aeson async attoparsec base bytestring containers hspec
+    postgresql-libpq postgresql-types-algebra ptr-peeker ptr-poker
+    QuickCheck quickcheck-classes quickcheck-instances scientific stm
+    tagged testcontainers-postgresql text text-builder time uuid vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  doHaddock = false;
+  homepage = "https://github.com/nikita-volkov/postgresql-types";
+  description = "Precise PostgreSQL types representation and driver-agnostic codecs";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/ptr-poker.nix
+++ b/NixSupport/hackage/ptr-poker.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, bytestring, criterion, hspec, hspec-discover
+, isomorphism-class, lib, numeric-limits, QuickCheck, rerebase
+, scientific, text
+}:
+mkDerivation {
+  pname = "ptr-poker";
+  version = "0.1.3";
+  sha256 = "0b41e14e6b6a195da6b2907cafe46905db3f9af13859e4753696ce682bc1ef29";
+  libraryHaskellDepends = [ base bytestring scientific text ];
+  testHaskellDepends = [
+    hspec isomorphism-class numeric-limits QuickCheck rerebase
+  ];
+  testToolDepends = [ hspec-discover ];
+  benchmarkHaskellDepends = [ criterion rerebase ];
+  homepage = "https://github.com/nikita-volkov/ptr-poker";
+  description = "Pointer poking action construction and composition toolkit";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/hackage/temporary-ospath.nix
+++ b/NixSupport/hackage/temporary-ospath.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, bytestring, directory, exceptions, file-io
+, filepath, lib, os-string, tasty, tasty-hunit, unix
+}:
+mkDerivation {
+  pname = "temporary-ospath";
+  version = "1.3";
+  sha256 = "74d0a7d57d9a0a3e775d8186544898f95122ccba017972c14cd3edc14dfb69f2";
+  libraryHaskellDepends = [
+    base bytestring directory exceptions file-io filepath os-string
+    unix
+  ];
+  testHaskellDepends = [
+    base directory file-io filepath os-string tasty tasty-hunit unix
+  ];
+  description = "Portable temporary file and directory support";
+  license = lib.licenses.bsd3;
+}

--- a/NixSupport/hackage/wai-session-clientsession-deferred.nix
+++ b/NixSupport/hackage/wai-session-clientsession-deferred.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, bytestring, cereal, clientsession, lib
+, transformers, wai-session-maybe
+}:
+mkDerivation {
+  pname = "wai-session-clientsession-deferred";
+  version = "1.0.0";
+  sha256 = "345c34a7e8b31fb255e3ec63c3a64ff8e7bf384f8ee0f73265a7e504c85e4717";
+  libraryHaskellDepends = [
+    base bytestring cereal clientsession transformers wai-session-maybe
+  ];
+  homepage = "https://github.com/digitallyinduced/wai-session-clientsession-deferred";
+  description = "Session store based on clientsession with deferred decryption";
+  license = "unknown";
+}

--- a/NixSupport/hackage/wai-session-maybe.nix
+++ b/NixSupport/hackage/wai-session-maybe.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, blaze-builder, bytestring, bytestring-builder
+, containers, cookie, entropy, http-types, lib, StateVar, time
+, transformers, vault, wai
+}:
+mkDerivation {
+  pname = "wai-session-maybe";
+  version = "1.0.0";
+  sha256 = "cb68f815b7d04e4e41a102344af3f0f6067297e2a711869f3554b79446d5682d";
+  libraryHaskellDepends = [
+    base blaze-builder bytestring bytestring-builder containers cookie
+    entropy http-types StateVar time transformers vault wai
+  ];
+  homepage = "https://github.com/digitallyinduced/wai-session-maybe";
+  description = "Flexible session middleware for WAI";
+  license = "unknown";
+}

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -63,11 +63,7 @@ let
             ihp-migrate = (localPackage "ihp-migrate").overrideAttrs (old: { mainProgram = "migrate"; });
             ihp-openai = localPackage "ihp-openai";
             ihp-ssc = localPackage "ihp-ssc";
-            ihp-zip = (hackagePackage "ihp-zip").overrideAttrs (old: {
-              postPatch = (old.postPatch or "") + ''
-                sed -i 's/(?context :: ControllerContext)/(?context :: ControllerContext, ?request :: Request, ?respond :: Respond)/' IHP/Zip/ControllerFunctions.hs
-              '';
-            });
+            ihp-zip = hackagePackage "ihp-zip";
             ihp-hsx = localPackage "ihp-hsx";
             ihp-graphql = localPackage "ihp-graphql";
             ihp-datasync-typescript = localPackage "ihp-datasync-typescript";

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -26,7 +26,9 @@ let
 
             # Pre-generated nix files for third-party Hackage packages, avoiding IFD.
             # To regenerate: run ./update-nix-from-cabal.sh after changing versions.
-            hackagePackage = name: fastBuild (self.callPackage "${flakeRoot}/NixSupport/hackage/${name}.nix" {});
+            # Note: unlike localPackage, these keep profiling enabled since downstream
+            # nixpkgs packages (e.g. jsonifier) may require profiling libraries.
+            hackagePackage = name: self.callPackage "${flakeRoot}/NixSupport/hackage/${name}.nix" {};
 
             # Use the nixpkgs version if available (i.e. published on Hackage and
             # picked up by the nixpkgs all-cabal-hashes snapshot), otherwise fall
@@ -63,7 +65,7 @@ let
             ihp-migrate = (localPackage "ihp-migrate").overrideAttrs (old: { mainProgram = "migrate"; });
             ihp-openai = localPackage "ihp-openai";
             ihp-ssc = localPackage "ihp-ssc";
-            ihp-zip = hackagePackage "ihp-zip";
+            ihp-zip = fastBuild (hackagePackage "ihp-zip");
             ihp-hsx = localPackage "ihp-hsx";
             ihp-graphql = localPackage "ihp-graphql";
             ihp-datasync-typescript = localPackage "ihp-datasync-typescript";

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -16,12 +16,17 @@ let
             # Uses pre-generated default.nix files to avoid IFD (Import From Derivation).
             # IFD causes nix to build cabal2nix during evaluation, making derivation
             # hashes platform-dependent and breaking caching across machines.
-            # To regenerate: run ./update-nix-from-cabal.sh after changing .cabal files.
+            # To regenerate: run ./update-nix-from-cabal.sh after changing .cabal files
+            # or upgrading third-party Hackage dependency versions.
             localPackage = name: fastBuild (
                 final.haskell.lib.overrideSrc
                     (super.callPackage "${flakeRoot}/${name}/default.nix" {})
                     { src = filteredSrc name; }
             );
+
+            # Pre-generated nix files for third-party Hackage packages, avoiding IFD.
+            # To regenerate: run ./update-nix-from-cabal.sh after changing versions.
+            hackagePackage = name: fastBuild (self.callPackage "${flakeRoot}/NixSupport/hackage/${name}.nix" {});
 
             # Use the nixpkgs version if available (i.e. published on Hackage and
             # picked up by the nixpkgs all-cabal-hashes snapshot), otherwise fall
@@ -58,11 +63,11 @@ let
             ihp-migrate = (localPackage "ihp-migrate").overrideAttrs (old: { mainProgram = "migrate"; });
             ihp-openai = localPackage "ihp-openai";
             ihp-ssc = localPackage "ihp-ssc";
-            ihp-zip = fastBuild ((super.callCabal2nix "ihp-zip" (final.fetchFromGitHub { owner = "digitallyinduced"; repo = "ihp-zip"; rev = "1c0d812d12d21269f83d6480a6ec7a8cdd054485"; sha256 = "0y0dj8ggi1jqzy74i0d6k9my8kdvfi516zfgnsl7znicwq9laald"; }) {}).overrideAttrs (old: {
+            ihp-zip = (hackagePackage "ihp-zip").overrideAttrs (old: {
               postPatch = (old.postPatch or "") + ''
                 sed -i 's/(?context :: ControllerContext)/(?context :: ControllerContext, ?request :: Request, ?respond :: Respond)/' IHP/Zip/ControllerFunctions.hs
               '';
-            }));
+            });
             ihp-hsx = localPackage "ihp-hsx";
             ihp-graphql = localPackage "ihp-graphql";
             ihp-datasync-typescript = localPackage "ihp-datasync-typescript";
@@ -82,16 +87,8 @@ let
             # session decryption and optional Set-Cookie (Maybe ByteString).
             # https://hackage.haskell.org/package/wai-session-maybe
             # https://hackage.haskell.org/package/wai-session-clientsession-deferred
-            wai-session-maybe = super.callHackageDirect {
-                pkg = "wai-session-maybe";
-                ver = "1.0.0";
-                sha256 = "sha256-DCdGNnwE9OC/E2ancM9tgxV1KNnAm/h0rJRd2hOa7ls=";
-            } {};
-            wai-session-clientsession-deferred = super.callHackageDirect {
-                pkg = "wai-session-clientsession-deferred";
-                ver = "1.0.0";
-                sha256 = "sha256-l/AQrZCJklAEYl6v8rtx00ohLkYgylFtxaihtszJkkc=";
-            } {};
+            wai-session-maybe = hackagePackage "wai-session-maybe";
+            wai-session-clientsession-deferred = hackagePackage "wai-session-clientsession-deferred";
 
             # Can be removed after v0.3.2 is on hackage
             # https://github.com/tippenein/countable-inflections/pull/6
@@ -106,17 +103,17 @@ let
             };
 
             # Hasql 1.10 ecosystem upgrade for postgresql-types binary encoding support.
-            # callHackageDirect used because these versions are newer than the nixpkgs all-cabal-hashes snapshot.
+            # Pre-generated nix files in NixSupport/hackage/ to avoid IFD.
             # dontCheck on postgresql/hasql packages: their tests require a running PostgreSQL server.
-            postgresql-binary = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "postgresql-binary"; ver = "0.15.0.1"; sha256 = "02cj87xbhpq4jn0ys3pdscblan69d5f1vcsgb5y2piw310x7d6xb"; } {});
-            postgresql-connection-string = self.callHackageDirect { pkg = "postgresql-connection-string"; ver = "0.1.0.6"; sha256 = "07iykhnjzryqqc1mccnmqf7lkg12rb4dq5azvrpfq6qaf6a6r0r1"; } {};
+            postgresql-binary = final.haskell.lib.dontCheck (hackagePackage "postgresql-binary");
+            postgresql-connection-string = hackagePackage "postgresql-connection-string";
 
-            hasql = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (self.callHackageDirect { pkg = "hasql"; ver = "1.10.2.3"; sha256 = "1j52ia75168n88rrraf4g20grdl3qak8r426rav87kjjjqx3717v"; } {}));
-            hasql-pool = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-pool"; ver = "1.4.2"; sha256 = "0gw8brk3kwb1s58s0npbmszh5byqv0frjyaql7mgkc317x67c049"; } {});
-            hasql-dynamic-statements = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-dynamic-statements"; ver = "0.5.1"; sha256 = "13c04wb1635361wrszn2kn4s5ygl7yzv8yn6bvpxgm2j7hr0v94q"; } {});
-            hasql-implicits = self.callHackageDirect { pkg = "hasql-implicits"; ver = "0.2.0.2"; sha256 = "0nyz96mgrc4i7x3q8wwv6zq8qpwam13f5y1rlbh102jp2ygb2mjy"; } {};
-            hasql-transaction = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-transaction"; ver = "1.2.2"; sha256 = "0y1clnyw76rszsdvz0fxj2az036bmw1whp6pqchyjamnbkmf37d3"; } {});
-            hasql-notifications = final.haskell.lib.dontCheck (self.callHackageDirect { pkg = "hasql-notifications"; ver = "0.2.5.0"; sha256 = "11jkrngiy175wc5hqx8pgagj4fdg42ry7afp4g4rr5hw8h43zg48"; } {});
+            hasql = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (hackagePackage "hasql"));
+            hasql-pool = final.haskell.lib.dontCheck (hackagePackage "hasql-pool");
+            hasql-dynamic-statements = final.haskell.lib.dontCheck (hackagePackage "hasql-dynamic-statements");
+            hasql-implicits = hackagePackage "hasql-implicits";
+            hasql-transaction = final.haskell.lib.dontCheck (hackagePackage "hasql-transaction");
+            hasql-notifications = final.haskell.lib.dontCheck (hackagePackage "hasql-notifications");
             # hasql-interpolate: upstream 1.0.1.0 requires hasql <1.10; use fork with hasql 1.10 support
             # https://github.com/awkward-squad/hasql-interpolate/pull/27
             # Uses overrideCabal instead of callCabal2nix to avoid IFD and Hackage cabal revision fetch failures
@@ -130,21 +127,21 @@ let
             })));
 
             # Fork of temporary using OsPath instead of FilePath
-            temporary-ospath = self.callHackageDirect { pkg = "temporary-ospath"; ver = "1.3"; sha256 = "0bb5pjiz83a2cj02g2kmnq2k3jyp7hiainy7iknyi9ncdgs7hrxk"; } {};
+            temporary-ospath = hackagePackage "temporary-ospath";
 
             # postgresql-types for proper binary encoders of Point, Polygon, Inet, Interval
-            ptr-poker = self.callHackageDirect { pkg = "ptr-poker"; ver = "0.1.3"; sha256 = "0jl9df0kzsq5gd6fhfqc8my4wy7agg5q5jw4q92h4b7rkdf3hix7"; } {};
+            ptr-poker = hackagePackage "ptr-poker";
             # postgresql-simple-postgresql-types: bridge providing FromField/ToField instances
             # for all postgresql-types types (Point, Polygon, Inet, Interval, etc.) in postgresql-simple
-            postgresql-simple-postgresql-types = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (self.callHackageDirect { pkg = "postgresql-simple-postgresql-types"; ver = "0.1.1"; sha256 = "09xqrcpp56jbfjqk9njw6l7aw13qi2838rwqg2xc483sjp0jxxzd"; } {}));
+            postgresql-simple-postgresql-types = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (hackagePackage "postgresql-simple-postgresql-types"));
             # ptr-peeker is marked broken in nixpkgs but is needed by postgresql-types
             # https://github.com/nikita-volkov/ptr-peeker/issues/10
             ptr-peeker = final.haskell.lib.dontCheck (final.haskell.lib.markUnbroken super.ptr-peeker);
-            postgresql-types-algebra = final.haskell.lib.doJailbreak (self.callHackageDirect { pkg = "postgresql-types-algebra"; ver = "0.1"; sha256 = "0ishl9dag7w73bclpaja4wj3s6jf8958jls2ffn1a6h3p9v40pfv"; } {});
+            postgresql-types-algebra = final.haskell.lib.doJailbreak (hackagePackage "postgresql-types-algebra");
             # dontCheck: tests require a running PostgreSQL server
-            postgresql-types = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (self.callHackageDirect { pkg = "postgresql-types"; ver = "0.1.2"; sha256 = "1plkc0pjhlbml5innkla44jad1jx8f876kw5ckz168jxvzrkb4jc"; } {}));
-            hasql-mapping = final.haskell.lib.doJailbreak (self.callHackageDirect { pkg = "hasql-mapping"; ver = "0.1"; sha256 = "1l6p7sbw6wwkk964bs3hljmja1kwy0b9gld24g71dcbjs24hchcf"; } {});
-            hasql-postgresql-types = final.haskell.lib.dontHaddock (final.haskell.lib.doJailbreak (self.callHackageDirect { pkg = "hasql-postgresql-types"; ver = "0.2"; sha256 = "0841s41izgjg4qfw6s74bwhixby3rwj167a2p8vbwp4xlf8wzaz6"; } {}));
+            postgresql-types = final.haskell.lib.dontCheck (final.haskell.lib.doJailbreak (hackagePackage "postgresql-types"));
+            hasql-mapping = final.haskell.lib.doJailbreak (hackagePackage "hasql-mapping");
+            hasql-postgresql-types = final.haskell.lib.dontHaddock (final.haskell.lib.doJailbreak (hackagePackage "hasql-postgresql-types"));
         };
 in
 final: prev: {

--- a/update-nix-from-cabal.sh
+++ b/update-nix-from-cabal.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# --- Local IHP packages ---
 for cabal_file in */*.cabal; do
   dir=$(dirname "$cabal_file")
   echo "Generating $dir/default.nix from $cabal_file"
@@ -19,3 +20,41 @@ for cabal_file in */*.cabal; do
   # but this keeps the generated file correct if used standalone.
   (cd "$dir" && cabal2nix .) > "./$dir/default.nix"
 done
+
+# --- Third-party Hackage packages ---
+# Pre-generated to avoid IFD (Import From Derivation).
+# Update versions here when upgrading dependencies.
+mkdir -p NixSupport/hackage
+
+hackage_packages=(
+  "wai-session-maybe 1.0.0"
+  "wai-session-clientsession-deferred 1.0.0"
+  "postgresql-binary 0.15.0.1"
+  "postgresql-connection-string 0.1.0.6"
+  "hasql 1.10.2.3"
+  "hasql-pool 1.4.2"
+  "hasql-dynamic-statements 0.5.1"
+  "hasql-implicits 0.2.0.2"
+  "hasql-transaction 1.2.2"
+  "hasql-notifications 0.2.5.0"
+  "temporary-ospath 1.3"
+  "ptr-poker 0.1.3"
+  "postgresql-simple-postgresql-types 0.1.1"
+  "postgresql-types-algebra 0.1"
+  "postgresql-types 0.1.2"
+  "hasql-mapping 0.1"
+  "hasql-postgresql-types 0.2"
+)
+
+for entry in "${hackage_packages[@]}"; do
+  name="${entry%% *}"
+  ver="${entry##* }"
+  echo "Generating NixSupport/hackage/${name}.nix from Hackage: ${name}-${ver}"
+  cabal2nix "cabal://${name}-${ver}" > "NixSupport/hackage/${name}.nix"
+done
+
+# ihp-zip: from GitHub fork
+echo "Generating NixSupport/hackage/ihp-zip.nix from GitHub"
+cabal2nix https://github.com/digitallyinduced/ihp-zip \
+  --revision 1c0d812d12d21269f83d6480a6ec7a8cdd054485 \
+  > NixSupport/hackage/ihp-zip.nix

--- a/update-nix-from-cabal.sh
+++ b/update-nix-from-cabal.sh
@@ -53,8 +53,8 @@ for entry in "${hackage_packages[@]}"; do
   cabal2nix "cabal://${name}-${ver}" > "NixSupport/hackage/${name}.nix"
 done
 
-# ihp-zip: from GitHub fork
+# ihp-zip: from GitHub
 echo "Generating NixSupport/hackage/ihp-zip.nix from GitHub"
 cabal2nix https://github.com/digitallyinduced/ihp-zip \
-  --revision 1c0d812d12d21269f83d6480a6ec7a8cdd054485 \
+  --revision 62f632d23ee34b9783b82b53ab72e6ba5d716b76 \
   > NixSupport/hackage/ihp-zip.nix


### PR DESCRIPTION
## Summary
- Replace all 18 `callHackageDirect`/`callCabal2nix` calls in `NixSupport/overlay.nix` with pre-generated nix files
- Add `NixSupport/hackage/` directory with `cabal2nix`-generated package definitions
- Extend `update-nix-from-cabal.sh` to regenerate these when dependency versions change

## Why
`callHackageDirect` internally calls `callCabal2nix`, which runs `cabal2nix` during Nix evaluation (IFD). This:
- Makes derivation hashes platform-dependent, breaking cross-machine binary cache hits
- Blocks parallel evaluation (18 sequential IFD barriers)
- Slows first-time builds for IHP users

IHP's own packages already avoid IFD via pre-generated `default.nix` files. This PR extends the same pattern to third-party Hackage dependencies.

## Test plan
- [ ] `nix flake show` completes without building `cabal2nix`
- [ ] `nix flake check --impure` passes
- [ ] `rg 'callHackageDirect|callCabal2nix' NixSupport/overlay.nix` returns only comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)