### PR TITLE
Disallow SELECT * in typedSql by default

### DIFF
--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -60,12 +60,28 @@ forEach rows \(itemId, name, views) -> do
 
 Primary key columns are automatically typed as `Id' "table_name"` rather than raw `UUID`.
 
-## Selecting All Columns (`table.*`)
+## Selecting All Columns
 
-Use `table.*` to select all columns from a table, which returns the model type directly:
+### Why `SELECT *` is disallowed by default
+
+`SELECT *` and `SELECT table.*` are not allowed in `typedSql` by default. At compile time, `*` is expanded to whatever columns exist in the development database and a decoder is built for those exact columns. If the production database has a different schema (e.g., a migration added or removed a column), the query will return different columns than the decoder expects, causing a runtime error.
+
+Instead, list columns explicitly:
 
 ```haskell
 items <- sqlQueryTyped [typedSql|
+    SELECT id, name, views FROM items ORDER BY name
+|]
+```
+
+The compile error message will suggest the exact column names to use.
+
+### Opting in with `typedSqlStar`
+
+If you understand the risk and want to use `table.*` anyway (e.g., during rapid prototyping), use the `typedSqlStar` quasiquoter:
+
+```haskell
+items <- sqlQueryTyped [typedSqlStar|
     SELECT items.* FROM items ORDER BY name
 |]
 
@@ -77,7 +93,7 @@ This requires a `FromRowHasql` instance on the model type. IHP's generated types
 Table aliases work too:
 
 ```haskell
-items <- sqlQueryTyped [typedSql|
+items <- sqlQueryTyped [typedSqlStar|
     SELECT i.* FROM items i
     JOIN authors a ON a.id = i.author_id
     ORDER BY i.name

--- a/ihp-typed-sql/IHP/TypedSql.hs
+++ b/ihp-typed-sql/IHP/TypedSql.hs
@@ -1,5 +1,6 @@
 module IHP.TypedSql
     ( typedSql
+    , typedSqlStar
     , TypedQuery (..)
     , sqlQueryTyped
     , sqlExecTyped
@@ -10,7 +11,7 @@ import qualified Hasql.DynamicStatements.Snippet as Snippet
 import           IHP.ModelSupport                (sqlQueryHasql)
 import           IHP.Prelude
 
-import           IHP.TypedSql.Quoter                 (typedSql)
+import           IHP.TypedSql.Quoter                 (typedSql, typedSqlStar)
 import           IHP.TypedSql.Types                  (TypedQuery (..))
 
 -- | Run a typed SELECT query and return all result rows.

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -7,6 +7,7 @@ module IHP.TypedSql.ParamHints
     , extractJoinNullableTablesFromAst
     , extractNonNullableComputedColumnsFromAst
     , resolveParamHintTypes
+    , detectStarSelects
     ) where
 
 import           Data.Foldable                (foldMap, toList)
@@ -661,3 +662,54 @@ stripMaybeType :: TH.Type -> TH.Type
 stripMaybeType (TH.AppT (TH.ConT maybeName) inner)
     | maybeName == ''Maybe = inner
 stripMaybeType other = other
+
+----------------------------------------------------------------------
+-- Star select detection
+----------------------------------------------------------------------
+
+-- | Detect SELECT * and SELECT table.* in the target list of a query.
+-- Returns a list of descriptive strings (e.g. ["*", "items.*"]) for use in error messages.
+-- Does NOT flag COUNT(*) (function argument) or (expr).* (composite expansion).
+detectStarSelects :: Ast.PreparableStmt -> [String]
+detectStarSelects = \case
+    Ast.SelectPreparableStmt selectStmt -> starFromSelectStmt selectStmt
+    _ -> []
+
+starFromSelectStmt :: Ast.SelectStmt -> [String]
+starFromSelectStmt (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
+    starFromSelectClause selectClause
+starFromSelectStmt (Right _) = []
+
+starFromSelectClause :: Ast.SelectClause -> [String]
+starFromSelectClause (Left simpleSelect) = starFromSimpleSelect simpleSelect
+starFromSelectClause (Right _) = []
+
+starFromSimpleSelect :: Ast.SimpleSelect -> [String]
+starFromSimpleSelect = \case
+    Ast.NormalSimpleSelect maybeTargeting _into _from _where _group _having _window ->
+        case maybeTargeting of
+            Just (Ast.NormalTargeting targets) -> concatMap starFromTargetEl (toList targets)
+            Just (Ast.DistinctTargeting _ targets) -> concatMap starFromTargetEl (toList targets)
+            _ -> []
+    Ast.BinSimpleSelect _op left _distinct right ->
+        starFromSelectClause left <> starFromSelectClause right
+    _ -> []
+
+starFromTargetEl :: Ast.TargetEl -> [String]
+starFromTargetEl = \case
+    Ast.AsteriskTargetEl -> ["*"]
+    Ast.ExprTargetEl expr -> starFromExpr expr
+    Ast.ImplicitlyAliasedExprTargetEl expr _ -> starFromExpr expr
+    Ast.AliasedExprTargetEl expr _ -> starFromExpr expr
+
+-- | Detect table.* pattern: a simple column reference (identifier) followed by AllIndirectionEl.
+-- Does NOT flag (expr).* like (ROW(...))::type.* which is composite expansion.
+starFromExpr :: Ast.AExpr -> [String]
+starFromExpr = \case
+    Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref ident (Just indirection)))
+        | any isAllIndirection (toList indirection) ->
+            [Text.unpack (identToText ident) <> ".*"]
+    _ -> []
+  where
+    isAllIndirection Ast.AllIndirectionEl = True
+    isAllIndirection _ = False

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -678,11 +678,17 @@ detectStarSelects = \case
 starFromSelectStmt :: Ast.SelectStmt -> [String]
 starFromSelectStmt (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
     starFromSelectClause selectClause
-starFromSelectStmt (Right _) = []
+starFromSelectStmt (Right parens) = starFromSelectWithParens parens
+
+starFromSelectWithParens :: Ast.SelectWithParens -> [String]
+starFromSelectWithParens (Ast.NoParensSelectWithParens (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
+    starFromSelectClause selectClause
+starFromSelectWithParens (Ast.WithParensSelectWithParens inner) =
+    starFromSelectWithParens inner
 
 starFromSelectClause :: Ast.SelectClause -> [String]
 starFromSelectClause (Left simpleSelect) = starFromSimpleSelect simpleSelect
-starFromSelectClause (Right _) = []
+starFromSelectClause (Right parens) = starFromSelectWithParens parens
 
 starFromSimpleSelect :: Ast.SimpleSelect -> [String]
 starFromSimpleSelect = \case

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -5,9 +5,11 @@
 
 module IHP.TypedSql.Quoter
     ( typedSql
+    , typedSqlStar
     ) where
 
 import           Data.Coerce                    (coerce)
+import qualified Data.List                      as List
 import qualified Data.Map.Strict                as Map
 import qualified Data.Set                       as Set
 import qualified Data.String.Conversions        as CS
@@ -22,7 +24,7 @@ import           IHP.TypedSql.Metadata          (DescribeColumn (..), DescribeRe
                                                  describeStatement)
 import           IHP.TypedSql.ParamHints        (extractParamHintsFromAst, extractJoinNullableTablesFromAst,
                                                  extractNonNullableComputedColumnsFromAst,
-                                                 parseSql, resolveParamHintTypes)
+                                                 parseSql, resolveParamHintTypes, detectStarSelects)
 import           IHP.TypedSql.Placeholders      (PlaceholderPlan (..), parseExpr,
                                                  planPlaceholders)
 import           IHP.TypedSql.RowType           (SqlRow (..), sanitizeColumnName, deduplicateNames, sqlRowType)
@@ -30,20 +32,33 @@ import           IHP.TypedSql.TypeMapping       (hsTypeForColumns, hsTypesForCol
 import           IHP.TypedSql.Types             (TypedQuery (..))
 
 -- | QuasiQuoter entry point for typed SQL.
--- High-level: produces a TH expression that builds a TypedQuery at compile time.
+-- Disallows SELECT * and SELECT table.* by default to prevent production errors
+-- when the schema changes. Use 'typedSqlStar' to opt in to star selects.
 typedSql :: TH.QuasiQuoter
 typedSql =
     TH.QuasiQuoter
-        { TH.quoteExp = typedSqlExp
+        { TH.quoteExp = typedSqlExp False
         , TH.quotePat = \_ -> fail "typedSql: not supported in patterns"
         , TH.quoteType = \_ -> fail "typedSql: not supported in types"
         , TH.quoteDec = \_ -> fail "typedSql: not supported at top-level"
         }
 
+-- | Like 'typedSql' but allows SELECT * and SELECT table.* patterns.
+-- Use this when you understand that star selects can break at runtime if the
+-- schema changes between compilation and deployment.
+typedSqlStar :: TH.QuasiQuoter
+typedSqlStar =
+    TH.QuasiQuoter
+        { TH.quoteExp = typedSqlExp True
+        , TH.quotePat = \_ -> fail "typedSqlStar: not supported in patterns"
+        , TH.quoteType = \_ -> fail "typedSqlStar: not supported in types"
+        , TH.quoteDec = \_ -> fail "typedSqlStar: not supported at top-level"
+        }
+
 -- | Build the TH expression for a typed SQL quasiquote.
 -- This is the heart of typedSql: parse placeholders, describe SQL, and assemble a TypedQuery.
-typedSqlExp :: String -> TH.ExpQ
-typedSqlExp rawSql = do
+typedSqlExp :: Bool -> String -> TH.ExpQ
+typedSqlExp allowStar rawSql = do
     let PlaceholderPlan { ppDescribeSql, ppRuntimeSql, ppExprs } = planPlaceholders rawSql
     parsedExprs <- mapM parseExpr ppExprs
 
@@ -58,6 +73,20 @@ typedSqlExp rawSql = do
     let parsedAst = parseSql ppDescribeSql
     when (isNothing parsedAst) do
         TH.reportWarning "typedSql: could not parse SQL for type refinement; parameter hints and LEFT/RIGHT JOIN nullability detection are disabled for this query."
+
+    unless allowStar do
+        case parsedAst of
+            Just ast -> do
+                let stars = detectStarSelects ast
+                unless (null stars) do
+                    let columnNames = map (CS.cs . dcName) drColumns
+                    let suggestion = List.intercalate ", " columnNames
+                    fail ("typedSql: SELECT " <> List.intercalate ", " stars
+                        <> " is not allowed because it can break at runtime when the schema changes. "
+                        <> "List columns explicitly:\n  SELECT " <> suggestion <> " FROM ...\n"
+                        <> "Or use [typedSqlStar| ... |] if you understand the risk.")
+            Nothing -> pure ()
+
     let paramHints = maybe Map.empty extractParamHintsFromAst parsedAst
     paramHintTypes <- resolveParamHintTypes drTables drTypes paramHints
 

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -10,7 +10,8 @@ import           IHP.ModelSupport                  (createModelContext,
                                                     sqlExecDiscardResult)
 import           IHP.Prelude
 import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullableTables,
-                                                    extractNonNullableComputedColumnsFromAst)
+                                                    extractNonNullableComputedColumnsFromAst,
+                                                    detectStarSelects)
 import           System.Directory                  (doesFileExist,
                                                     getCurrentDirectory)
 import           System.Environment                (getEnvironment, lookupEnv)
@@ -61,6 +62,16 @@ tests = do
             (mkTestModule "TypedQuery Text"
                 "[typedSql| SELECT ROW(name, views)::typed_sql_test_pair FROM typed_sql_test_items LIMIT 1 |]")
             ["composite columns must be expanded"]
+
+        compileFailTest "fails when using SELECT * (bare asterisk)"
+            (mkTestModule "TypedQuery Text"
+                "[typedSql| SELECT * FROM typed_sql_test_items LIMIT 1 |]")
+            ["is not allowed"]
+
+        compileFailTest "fails when using SELECT table.*"
+            (mkTestModule "TypedQuery Text"
+                "[typedSql| SELECT typed_sql_test_items.* FROM typed_sql_test_items LIMIT 1 |]")
+            ["is not allowed"]
 
         compileFailTest "fails when SQL references an unknown column"
             (mkTestModule "TypedQuery Text"
@@ -373,6 +384,30 @@ tests = do
             let Just ast = parseSql "SELECT NULL::text"
             extractNonNullableComputedColumnsFromAst ast `shouldBe` Set.empty
 
+        it "detectStarSelects detects bare SELECT *" do
+            let Just ast = parseSql "SELECT * FROM items"
+            detectStarSelects ast `shouldBe` ["*"]
+
+        it "detectStarSelects detects SELECT table.*" do
+            let Just ast = parseSql "SELECT items.* FROM items"
+            detectStarSelects ast `shouldBe` ["items.*"]
+
+        it "detectStarSelects detects SELECT alias.*" do
+            let Just ast = parseSql "SELECT i.* FROM items i"
+            detectStarSelects ast `shouldBe` ["i.*"]
+
+        it "detectStarSelects does not flag COUNT(*)" do
+            let Just ast = parseSql "SELECT COUNT(*) FROM items"
+            detectStarSelects ast `shouldBe` []
+
+        it "detectStarSelects does not flag explicit columns" do
+            let Just ast = parseSql "SELECT id, name FROM items"
+            detectStarSelects ast `shouldBe` []
+
+        it "detectStarSelects does not flag composite expansion" do
+            let Just ast = parseSql "SELECT (ROW(name, views)::my_type).* FROM items"
+            detectStarSelects ast `shouldBe` []
+
 -- Test helpers ---------------------------------------------------------------
 
 requirePostgresTestHook :: IO ()
@@ -682,7 +717,7 @@ compilePassModule = Text.unlines
     , "import GHC.Records (HasField)"
     , "import IHP.ModelSupport (Id'(..), PrimaryKey)"
     , "import IHP.Hasql.FromRow (FromRowHasql (..))"
-    , "import IHP.TypedSql (TypedQuery, typedSql)"
+    , "import IHP.TypedSql (TypedQuery, typedSql, typedSqlStar)"
     , "import IHP.TypedSql.RowType (SqlRow)"
     , "import qualified Hasql.Decoders as HasqlDecoders"
     , ""
@@ -712,10 +747,10 @@ compilePassModule = Text.unlines
     , "qName = [typedSql| SELECT name FROM typed_sql_test_items LIMIT 1 |]"
     , ""
     , "qAllFields :: TypedQuery TypedSqlTestItem"
-    , "qAllFields = [typedSql| SELECT typed_sql_test_items.* FROM typed_sql_test_items LIMIT 1 |]"
+    , "qAllFields = [typedSqlStar| SELECT typed_sql_test_items.* FROM typed_sql_test_items LIMIT 1 |]"
     , ""
     , "qAllFieldsAlias :: TypedQuery TypedSqlTestItem"
-    , "qAllFieldsAlias = [typedSql| SELECT i.* FROM typed_sql_test_items i JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , "qAllFieldsAlias = [typedSqlStar| SELECT i.* FROM typed_sql_test_items i JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     , ""
     , "qPrimaryKey :: TypedQuery (Id' \"typed_sql_test_items\")"
     , "qPrimaryKey = [typedSql| SELECT id FROM typed_sql_test_items LIMIT 1 |]"
@@ -838,7 +873,7 @@ runtimeModule = Text.unlines
     , "import IHP.Log.Types"
     , "import IHP.ModelSupport (Id'(..), ModelContext, PrimaryKey, createModelContext, releaseModelContext)"
     , "import IHP.Hasql.FromRow (FromRowHasql (..))"
-    , "import IHP.TypedSql (sqlExecTyped, sqlQueryTyped, typedSql)"
+    , "import IHP.TypedSql (sqlExecTyped, sqlQueryTyped, typedSql, typedSqlStar)"
     , "import qualified Hasql.Decoders as HasqlDecoders"
     , "import System.Environment (lookupEnv)"
     , ""
@@ -905,7 +940,7 @@ runtimeModule = Text.unlines
     , "        when ((namesViaTypedSql :: [Text]) /= [\"First\", \"Second\"]) do"
     , "            error (\"unexpected names from typedSql second query: \" <> show namesViaTypedSql)"
     , ""
-    , "        allItems <- sqlQueryTyped [typedSql|"
+    , "        allItems <- sqlQueryTyped [typedSqlStar|"
     , "            SELECT typed_sql_test_items.*"
     , "            FROM typed_sql_test_items"
     , "            ORDER BY name"

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -408,6 +408,10 @@ tests = do
             let Just ast = parseSql "SELECT (ROW(name, views)::my_type).* FROM items"
             detectStarSelects ast `shouldBe` []
 
+        it "detectStarSelects detects star in parenthesized SELECT" do
+            let Just ast = parseSql "(SELECT * FROM items)"
+            detectStarSelects ast `shouldBe` ["*"]
+
 -- Test helpers ---------------------------------------------------------------
 
 requirePostgresTestHook :: IO ()


### PR DESCRIPTION
## Summary

- `SELECT *` and `SELECT table.*` in `[typedSql| ... |]` now produce a compile-time error by default, because `*` is expanded at compile time and can cause runtime decoder failures if the production schema differs
- The error message suggests the exact column names to use instead
- A new `[typedSqlStar| ... |]` quasiquoter is provided as an explicit opt-in for users who understand the risk
- Added 8 new tests (6 unit tests for `detectStarSelects`, 2 compile-fail tests)

## Test plan

- [x] All 90 existing tests pass (0 failures)
- [x] New `detectStarSelects` unit tests verify detection of `SELECT *`, `SELECT table.*`, `SELECT alias.*`
- [x] Correctly ignores `COUNT(*)`, explicit column lists, and composite expansion `(expr).*`
- [x] Compile-fail tests verify that `[typedSql| SELECT * ... |]` and `[typedSql| SELECT table.* ... |]` produce errors
- [x] Existing `table.*` tests updated to use `typedSqlStar` and still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)