### PR TITLE
Force Set-Cookie flush for deferred clientsession store

### DIFF
--- a/ihp/IHP/Controller/Session.hs
+++ b/ihp/IHP/Controller/Session.hs
@@ -26,6 +26,7 @@ module IHP.Controller.Session
   , getSessionAndClear
   , sessionVaultKey
   , lookupSessionVault
+  , forceSessionCookie
   ) where
 
 import Prelude
@@ -169,6 +170,24 @@ sessionVault = case lookupSessionVault ?request of
 
 lookupSessionVault :: Request -> Maybe (ByteString -> IO (Maybe ByteString), ByteString -> ByteString -> IO ())
 lookupSessionVault request = Vault.lookup sessionVaultKey request.vault
+
+-- | Force the deferred clientsession store to emit a @Set-Cookie@ on this
+-- response, even if the action did not otherwise read or write the session.
+--
+-- @wai-session-clientsession-deferred@ only writes the session cookie when
+-- the session vault has been touched during the request. Actions that just
+-- render a view without doing any IO can therefore omit @Set-Cookie@,
+-- causing OAuth flows (e.g. Azure SSO) to lose their session and bounce the
+-- user back through reauthentication. Calling 'forceSessionCookie' marks
+-- the session as dirty via a namespaced sentinel key (@__ihp_flush@) so the
+-- deferred store flushes the cookie unconditionally.
+--
+-- This is a no-op if the session middleware is not installed.
+forceSessionCookie :: (?request :: Request) => IO ()
+forceSessionCookie = case lookupSessionVault ?request of
+    Just (_, insert) -> insert "__ihp_flush" ""
+    Nothing -> pure ()
+{-# INLINABLE forceSessionCookie #-}
 
 sessionVaultKey :: Vault.Key (Network.Wai.Session.Maybe.Session IO ByteString ByteString)
 sessionVaultKey = unsafePerformIO Vault.newKey

--- a/ihp/IHP/ControllerSupport.hs
+++ b/ihp/IHP/ControllerSupport.hs
@@ -33,6 +33,7 @@ module IHP.ControllerSupport
 ) where
 
 import Prelude
+import qualified IHP.Controller.Session as Session
 import Data.IORef (IORef, modifyIORef', readIORef)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
@@ -89,6 +90,10 @@ runAction :: forall controller. (Controller controller, ?context :: Context.Cont
 runAction controller = do
     let ?theAction = controller
     let ?request = ?context.request
+
+    -- Force the deferred clientsession store to flush Set-Cookie even when
+    -- the action does no IO. See 'Session.forceSessionCookie' for details.
+    Session.forceSessionCookie
 
     -- Exceptions are now caught by the error handler middleware
     authenticatedModelContext <- prepareRLSIfNeeded ?modelContext


### PR DESCRIPTION
Ran into this issue which was a bit tricky to debug setting up an OAUTH callback loop for authenticating again a client user identity pool.

wai-session-clientsession-deferred only emits Set-Cookie when the session vault is touched during a request. Actions that just render a view without any IO never mark the session dirty, which breaks Azure SSO and similar OAuth flows: the user lands on a no-IO view, no Set-Cookie is sent, and the next navigation bounces back through reauthentication.

Add Session.forceSessionCookie which marks the session dirty via a namespaced __ihp_flush sentinel key, and call it once from runAction so every controller response carries the cookie regardless of what the action does.