### PR TITLE
Pull ihp-zip from Hackage instead of GitHub

### DIFF
--- a/NixSupport/hackage/ihp-zip.nix
+++ b/NixSupport/hackage/ihp-zip.nix
@@ -1,14 +1,10 @@
-{ mkDerivation, fetchgit, http-types, ihp, lib, wai, zip-archive }:
+{ mkDerivation, base, http-types, ihp, lib, wai, zip-archive }:
 mkDerivation {
   pname = "ihp-zip";
-  version = "0.0.1";
-  src = fetchgit {
-    url = "https://github.com/digitallyinduced/ihp-zip";
-    sha256 = "116ly1ll3d9m702f7cwm5dbxpnyg4afjhg9yg3f0qi775db9vcgv";
-    rev = "62f632d23ee34b9783b82b53ab72e6ba5d716b76";
-    fetchSubmodules = true;
-  };
-  libraryHaskellDepends = [ http-types ihp wai zip-archive ];
-  description = "ihp-zip";
-  license = "unknown";
+  version = "0.1.0";
+  sha256 = "3ff75acfca08231d2ea365369a42b4b8f1abf05df64a980116eed193a778d860";
+  libraryHaskellDepends = [ base http-types ihp wai zip-archive ];
+  homepage = "https://ihp.digitallyinduced.com/";
+  description = "Support for making ZIP archives with IHP";
+  license = lib.licenses.mit;
 }

--- a/update-nix-from-cabal.sh
+++ b/update-nix-from-cabal.sh
@@ -44,6 +44,7 @@ hackage_packages=(
   "postgresql-types 0.1.2"
   "hasql-mapping 0.1"
   "hasql-postgresql-types 0.2"
+  "ihp-zip 0.1.0"
 )
 
 for entry in "${hackage_packages[@]}"; do
@@ -52,9 +53,3 @@ for entry in "${hackage_packages[@]}"; do
   echo "Generating NixSupport/hackage/${name}.nix from Hackage: ${name}-${ver}"
   cabal2nix "cabal://${name}-${ver}" > "NixSupport/hackage/${name}.nix"
 done
-
-# ihp-zip: from GitHub
-echo "Generating NixSupport/hackage/ihp-zip.nix from GitHub"
-cabal2nix https://github.com/digitallyinduced/ihp-zip \
-  --revision 62f632d23ee34b9783b82b53ab72e6ba5d716b76 \
-  > NixSupport/hackage/ihp-zip.nix


### PR DESCRIPTION
## Summary

- [`ihp-zip-0.1.0`](https://hackage.haskell.org/package/ihp-zip-0.1.0) is now on Hackage, so it no longer needs the special-case `cabal2nix --revision` block at the bottom of `update-nix-from-cabal.sh`.
- It joins the `hackage_packages` array alongside the other third-party deps, and `NixSupport/hackage/ihp-zip.nix` now fetches the Hackage tarball (with proper MIT license and `base` dep) instead of a pinned GitHub commit.

Upstream `ihp-zip.cabal` metadata was cleaned up in a companion commit in `digitallyinduced/ihp-zip` (`bdd8e70`, tag `v0.1.0`): real synopsis/description, MIT license, `homepage`/`bug-reports`/`category`, `base` dep, version bounds, `default-language: GHC2021`.

## Test plan

- [x] `cabal check` passes on the published tarball (zero errors/warnings)
- [x] `nix build` of `pkgs.ghc.ihp-zip` against the overlay succeeds from the Hackage source (sha256 `3ff75ac...78d860`) — produces `/nix/store/g7q9yc62nrws2k918p2b0z67amp1qzx4-ihp-zip-0.1.0`
- [ ] CI green (`nix flake check --impure`, GHC 9.10 / 9.12 / 9.14 `ihp-zip` builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)