### PR TITLE
Fix WebSocket upgrades being logged as 500 instead of 101

### DIFF
--- a/ihp/IHP/ControllerSupport.hs
+++ b/ihp/IHP/ControllerSupport.hs
@@ -58,6 +58,7 @@ import Network.HTTP.Types.Header
 import qualified Data.Aeson as Aeson
 import qualified Network.Wai.Handler.WebSockets as WebSockets
 import qualified Network.WebSockets as WebSockets
+import qualified Network.Wai.Internal as WaiInternal
 import qualified IHP.WebSocket as WebSockets
 import qualified Data.TMap as TypeMap
 import IHP.RequestVault.ModelContext
@@ -206,27 +207,41 @@ startWebSocketApp initialState onHTTP waiRequest waiRespond = do
     -- wrapping a streaming handler plus a fallback 'Response'. Warp runs the
     -- raw handler and the client correctly receives HTTP 101 Switching
     -- Protocols — but request-logger middlewares (e.g. IHP's Apache access
-    -- log in Production) read 'responseStatus' on the fallback, and
-    -- wai-websockets hard-codes that fallback to 'status500' with a
-    -- "WebSockets are not supported by your WAI handler" body. The result
-    -- is that every successful WebSocket upgrade gets logged as
+    -- log in Production) compute the logged status from the fallback's
+    -- builder/stream form, and wai-websockets hard-codes that fallback to
+    -- 'status500' with a "WebSockets are not supported by your WAI handler"
+    -- body. The result is that every successful WebSocket upgrade gets
+    -- logged as
     --
     --     GET /DataSyncController HTTP/1.1 500 -
     --
-    -- even though nginx / the actual client sees 101. Rewrite the fallback
-    -- status to 101 via 'mapResponseStatus' so the logs match reality.
-    -- 'mapResponseStatus' descends into 'ResponseRaw' and rebuilds the inner
-    -- 'Response' with the new status, so Warp still runs the original raw
-    -- handler — only the middleware-visible status changes.
+    -- even though nginx / the actual client sees 101.
+    --
+    -- 'Wai.mapResponseStatus' is explicitly a no-op on 'ResponseRaw' (see
+    -- the @mapResponseStatus _ r\@(ResponseRaw _ _) = r@ case in wai), so we
+    -- have to pattern-match the raw constructor from 'Network.Wai.Internal'
+    -- and rebuild the fallback 'Response' with 'status101' ourselves. Warp
+    -- still runs the original raw handler — only the status that the
+    -- request logger observes changes.
     waiRequest
         |> WebSockets.websocketsApp connectionOptions handleConnection
         |> \case
-            Just response ->
-                waiRespond (mapResponseStatus (const HTTP.status101) response)
+            Just response -> waiRespond (rewriteWebSocketFallbackStatus response)
             Nothing -> onHTTP
 {-# INLINE startWebSocketAppAndFailOnHTTP #-}
 startWebSocketAppAndFailOnHTTP :: forall webSocketApp application. (?request :: Request, ?respond :: Respond, InitControllerContext application, ?application :: application, Typeable application, WebSockets.WSApp webSocketApp) => webSocketApp -> Application
 startWebSocketAppAndFailOnHTTP initialState = startWebSocketApp @webSocketApp @application initialState (?respond $ responseLBS HTTP.status400 [(hContentType, "text/plain")] "This endpoint is only available via a WebSocket")
+
+-- | Rewrite the 'ResponseRaw' fallback produced by 'Network.Wai.Handler.WebSockets.websocketsApp'
+-- so the fallback 'Response' reports @101 Switching Protocols@ instead of the
+-- hard-coded @status500@ from wai-websockets. See the comment in
+-- 'startWebSocketApp' for the full rationale. This helper is only meaningful
+-- for the responses produced by 'websocketsApp' — any other 'Response' is
+-- returned unchanged.
+rewriteWebSocketFallbackStatus :: Response -> Response
+rewriteWebSocketFallbackStatus (WaiInternal.ResponseRaw handler fallback) =
+    WaiInternal.ResponseRaw handler (mapResponseStatus (const HTTP.status101) fallback)
+rewriteWebSocketFallbackStatus other = other
 
 
 jumpToAction :: forall action. (Controller action, ?context :: Context.ControllerContext, ?modelContext :: ModelContext, ?respond :: Respond, ?request :: Request) => action -> IO ResponseReceived

--- a/ihp/IHP/ControllerSupport.hs
+++ b/ihp/IHP/ControllerSupport.hs
@@ -202,10 +202,27 @@ startWebSocketApp initialState onHTTP waiRequest waiRespond = do
 
     let connectionOptions = WebSockets.connectionOptions @webSocketApp
 
+    -- On a successful handshake 'websocketsApp' returns a 'ResponseRaw'
+    -- wrapping a streaming handler plus a fallback 'Response'. Warp runs the
+    -- raw handler and the client correctly receives HTTP 101 Switching
+    -- Protocols — but request-logger middlewares (e.g. IHP's Apache access
+    -- log in Production) read 'responseStatus' on the fallback, and
+    -- wai-websockets hard-codes that fallback to 'status500' with a
+    -- "WebSockets are not supported by your WAI handler" body. The result
+    -- is that every successful WebSocket upgrade gets logged as
+    --
+    --     GET /DataSyncController HTTP/1.1 500 -
+    --
+    -- even though nginx / the actual client sees 101. Rewrite the fallback
+    -- status to 101 via 'mapResponseStatus' so the logs match reality.
+    -- 'mapResponseStatus' descends into 'ResponseRaw' and rebuilds the inner
+    -- 'Response' with the new status, so Warp still runs the original raw
+    -- handler — only the middleware-visible status changes.
     waiRequest
         |> WebSockets.websocketsApp connectionOptions handleConnection
         |> \case
-            Just response -> waiRespond response
+            Just response ->
+                waiRespond (mapResponseStatus (const HTTP.status101) response)
             Nothing -> onHTTP
 {-# INLINE startWebSocketAppAndFailOnHTTP #-}
 startWebSocketAppAndFailOnHTTP :: forall webSocketApp application. (?request :: Request, ?respond :: Respond, InitControllerContext application, ?application :: application, Typeable application, WebSockets.WSApp webSocketApp) => webSocketApp -> Application

--- a/ihp/Test/Test/ControllerSupportSpec.hs
+++ b/ihp/Test/Test/ControllerSupportSpec.hs
@@ -5,11 +5,13 @@ module Test.ControllerSupportSpec where
 
 import IHP.Prelude
 import Test.Hspec
-import IHP.ControllerSupport (requestBodyJSON)
+import IHP.ControllerSupport (requestBodyJSON, InitControllerContext (..), startWebSocketAppAndFailOnHTTP)
 import IHP.Controller.Response (responseHeadersVaultKey)
 import IHP.Environment (Environment (..))
 import qualified IHP.FrameworkConfig as FrameworkConfig
+import IHP.ModelSupport (notConnectedModelContext)
 import qualified IHP.RequestVault as RequestVault
+import qualified IHP.WebSocket as WS
 import Wai.Request.Params.Middleware (RequestBody (..), requestBodyVaultKey)
 import Network.Wai.Middleware.EarlyReturn (earlyReturnMiddleware)
 import Network.Wai.Test (runSession, request, SResponse(..))
@@ -18,7 +20,23 @@ import qualified Data.Aeson as Aeson
 import qualified Network.Wai as Wai
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString as BS
-import Network.HTTP.Types (status400)
+import Network.HTTP.Types (status101, status400)
+
+-- | Minimal application fixture for 'startWebSocketApp' — just enough to
+-- satisfy the 'InitControllerContext' constraint without any real initialisation.
+data TestApp = TestApp
+    deriving (Eq, Show)
+
+instance InitControllerContext TestApp where
+    initContext = pure ()
+
+-- | Minimal 'WSApp' fixture for 'startWebSocketApp'. The run/onPing/onClose
+-- defaults from the class are sufficient — the regression test below never
+-- completes the handshake, so none of them actually fire.
+data TestWSApp = TestWSApp
+
+instance WS.WSApp TestWSApp where
+    initialState = TestWSApp
 
 tests = do
     describe "IHP.ControllerSupport" do
@@ -63,6 +81,39 @@ tests = do
                 simpleStatus `shouldBe` status400
                 simpleBody `shouldSatisfy` (not . bodyContains "not valid json")
                 simpleBody `shouldSatisfy` (not . bodyContains "raw request body was")
+
+        describe "startWebSocketApp" do
+            -- Regression for digitallyinduced/ihp#2625: 'wai-websockets'
+            -- builds a successful WebSocket upgrade as a 'ResponseRaw' whose
+            -- fallback 'Response' carries 'status500'. Warp runs the raw
+            -- streaming handler and the client correctly receives 101, but
+            -- request-logger middlewares read 'responseStatus' on the
+            -- fallback (because 'responseStatus (ResponseRaw _ res) =
+            -- responseStatus res') and log 500 for every successful upgrade.
+            -- 'startWebSocketApp' must rewrite the fallback status so the
+            -- view-from-middleware agrees with the on-the-wire status.
+            it "presents successful WebSocket upgrades as status 101 to middleware" do
+                frameworkConfig <- FrameworkConfig.buildFrameworkConfig (FrameworkConfig.option Development)
+                let modelContext = notConnectedModelContext frameworkConfig.logger
+                let baseRequest = Wai.defaultRequest
+                        { Wai.requestHeaders =
+                            [ ("Host", "localhost")
+                            , ("Upgrade", "websocket")
+                            , ("Connection", "Upgrade")
+                            , ("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+                            , ("Sec-WebSocket-Version", "13")
+                            ]
+                        , Wai.vault =
+                            Vault.insert RequestVault.frameworkConfigVaultKey frameworkConfig
+                            $ Vault.insert RequestVault.modelContextVaultKey modelContext Vault.empty
+                        }
+                let app r respond = do
+                        let ?request = r
+                        let ?respond = respond
+                        let ?application = TestApp
+                        startWebSocketAppAndFailOnHTTP @TestWSApp @TestApp TestWSApp r respond
+                SResponse { simpleStatus } <- runSession (request baseRequest) app
+                simpleStatus `shouldBe` status101
 
 bodyContains :: BS.ByteString -> LBS.ByteString -> Bool
 bodyContains needle haystack = BS.isInfixOf needle (LBS.toStrict haystack)


### PR DESCRIPTION
## Summary

`Network.Wai.Handler.WebSockets.websocketsApp` (from `wai-websockets`) builds a successful WebSocket handshake via `Wai.responseRaw` — a raw streaming handler plus a fallback `Response` for WAI handlers that can't process raw responses. Warp supports raw responses and sends `101 Switching Protocols` to the client as expected. But request-logger middlewares compute their status from the fallback, and [wai-websockets hard-codes that fallback](https://github.com/yesodweb/wai/blob/master/wai-websockets/Network/Wai/Handler/WebSockets.hs) to:

```haskell
backup = Wai.responseLBS status500 [...] "...WebSockets are not supported..."
```

Net effect: every successful WebSocket upgrade shows up in the Apache access log IHP uses in Production as

```
GET /DataSyncController HTTP/1.1 500 -
```

while the client and any upstream proxy (e.g. nginx) correctly see `101`.

## Proof

Verified on a live deploy by cross-referencing the two log sources for the same user, same time, same request:

**nginx access log** (upstream of IHP, sees the actual bytes on the wire):
```
92.208.148.81 - - [10/Apr/2026:00:42:57 +0200] "GET /DataSyncController HTTP/1.1" 101 281270 "-" "…Chrome/146…"
```

**IHP's Apache access log** (via the `requestLoggerMiddleware`):
```
Apr 10 00:41:57  92.208.148.81  "GET /DataSyncController HTTP/1.1" 500 -
```

Note the 60-second gap between the IHP log (request start) and nginx log (request end) — that's the full lifetime of a healthy WebSocket session. The WebSocket is working; the logs are lying.

This has been a recurring source of confusion when investigating AutoRefresh / DataSync connectivity. Multiple people (including me) chased it as a real bug before realising the upgrades were actually succeeding.

## Fix

Rewrite the fallback `Response` inside the `ResponseRaw` so its status is `101 Switching Protocols`, leaving the raw streaming handler untouched. Warp still performs the actual HTTP 101 upgrade on the wire; only the middleware-visible status changes.

### Gotcha: `Wai.mapResponseStatus` is a no-op on `ResponseRaw`

My first attempt reached for `Wai.mapResponseStatus (const status101)` — which _seems_ like the obvious tool — but it has no effect here. `wai@3.2.4` defines:

```haskell
mapResponseStatus _ r@(ResponseRaw _ _) = r
```

i.e. it is explicitly the identity on `ResponseRaw`. So the fallback stays at `status500` and the log still reads `500`. (The initial commit `20a1bf3` in this PR shipped the broken `mapResponseStatus` version; commit `1d36cf2` replaces it with the correct pattern-match approach below.)

The working fix pattern-matches `ResponseRaw` via `Network.Wai.Internal` and rebuilds the inner fallback with its status rewritten:

```haskell
rewriteWebSocketFallbackStatus :: Response -> Response
rewriteWebSocketFallbackStatus (WaiInternal.ResponseRaw handler fallback) =
    WaiInternal.ResponseRaw handler (mapResponseStatus (const HTTP.status101) fallback)
rewriteWebSocketFallbackStatus other = other
```

Applied to `mapResponseStatus`, the inner `fallback` is a `ResponseBuilder`, not a `ResponseRaw`, so `mapResponseStatus` _does_ descend into it as expected — it's only the outer `ResponseRaw` case that's a no-op.

## Regression test

`Test.ControllerSupportSpec` now has a `describe "startWebSocketApp"` block that runs a WebSocket upgrade request through `startWebSocketAppAndFailOnHTTP` via `Network.Wai.Test.runSession` and asserts that `SResponse.simpleStatus` is `status101`. `simpleStatus` is `Wai.responseStatus` on the captured `Response`, which for a `ResponseRaw` returns the fallback's status — exactly what the production request logger sees. No Warp, no real socket, no actual WebSocket handshake needed.

Negative-check verified locally: reverting `rewriteWebSocketFallbackStatus` back to plain `waiRespond response` causes the test to fail with `expected: 101 but got: 500`.

## Test plan

- [x] `cabal test ihp:tests` — 463 examples, 0 failures, 21 pending (hspec suite passes with the fix applied)
- [x] Local negative check: reverting the fix makes the new regression test fail as expected
- [ ] Hit a `webSocketApp @…`-mounted endpoint with a real browser WebSocket client → IHP access log should now show `101` matching what the client received
- [ ] Hit the same endpoint with a plain `curl /…` → still returns the existing `startWebSocketAppAndFailOnHTTP` 400 fallback (`onHTTP` path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)