### PR TITLE
Split IHP.Test.Mocking to drop hspec from ihp library closure

### DIFF
--- a/Guide/testing.markdown
+++ b/Guide/testing.markdown
@@ -118,7 +118,7 @@ import Web.Controller.Posts ()
 import Web.FrontController ()
 import Network.Wai
 import IHP.ControllerPrelude
-import IHP.Hspec (withIHPApp)
+import IHP.Hspec (withIHPApp, responseStatusShouldBe, responseBodyShouldContain, responseBodyShouldNotContain)
 
 tests :: Spec
 tests = aroundAll (withIHPApp WebApplication config) do
@@ -163,6 +163,8 @@ tests = aroundAll (withIHPApp WebApplication config) do
                 body <- responseBody response
                 putStrLn (cs body)
 ```
+
+> **Note:** The `responseStatusShouldBe` / `responseBodyShouldContain` / `responseBodyShouldNotContain` assertion helpers are exported from `IHP.Hspec`. They used to live in `IHP.Test.Mocking` but were moved so that the core `ihp` library no longer depends on `hspec`. Existing test files that imported them from `IHP.Test.Mocking` need to switch the import to `IHP.Hspec`.
 
 ### Running Integration Tests
 

--- a/ihp-hspec/IHP/Hspec.hs
+++ b/ihp-hspec/IHP/Hspec.hs
@@ -1,4 +1,9 @@
-module IHP.Hspec (withIHPApp) where
+module IHP.Hspec
+    ( withIHPApp
+    , responseBodyShouldContain
+    , responseBodyShouldNotContain
+    , responseStatusShouldBe
+    ) where
 
 import IHP.Prelude
 import qualified Hasql.Connection as Hasql
@@ -23,8 +28,10 @@ import qualified IHP.ModelSupport as ModelSupport
 import IHP.Log.Types
 
 import qualified System.Process as Process
-import IHP.Test.Mocking (MockContext(..), runTestMiddlewares)
+import IHP.Test.Mocking (MockContext(..), runTestMiddlewares, responseBody)
 import qualified IHP.PGListener as PGListener
+import qualified Network.HTTP.Types as HTTP
+import Test.Hspec (shouldBe, shouldSatisfy, shouldNotSatisfy)
 
 withConnection :: ByteString -> (Hasql.Connection -> IO a) -> IO a
 withConnection databaseUrl action = do
@@ -107,3 +114,19 @@ injectDatabaseName databaseName databaseUrl =
         -- Remove database name from url so we can connect to the default database
         |> Text.replace "/app" ("/" <> databaseName)
         |> cs
+
+-- | Asserts that the response body contains the given text.
+responseBodyShouldContain :: Response -> Text -> IO ()
+responseBodyShouldContain response includedText = do
+    body :: Text <- cs <$> responseBody response
+    body `shouldSatisfy` (includedText `Text.isInfixOf`)
+
+-- | Asserts that the response body does not contain the given text.
+responseBodyShouldNotContain :: Response -> Text -> IO ()
+responseBodyShouldNotContain response includedText = do
+    body :: Text <- cs <$> responseBody response
+    body `shouldNotSatisfy` (includedText `Text.isInfixOf`)
+
+-- | Asserts that the response status is equal to the given status.
+responseStatusShouldBe :: Response -> HTTP.Status -> IO ()
+responseStatusShouldBe response status = responseStatus response `shouldBe` status

--- a/ihp-hspec/default.nix
+++ b/ihp-hspec/default.nix
@@ -1,13 +1,13 @@
-{ mkDerivation, base, hasql, ihp, ihp-ide, ihp-log, lib, process
-, text, uuid, vault, wai, wai-request-params
+{ mkDerivation, base, hasql, hspec, http-types, ihp, ihp-ide
+, ihp-log, lib, process, text, uuid, vault, wai, wai-request-params
 }:
 mkDerivation {
   pname = "ihp-hspec";
   version = "1.5.0";
   src = ./.;
   libraryHaskellDepends = [
-    base hasql ihp ihp-ide ihp-log process text uuid vault wai
-    wai-request-params
+    base hasql hspec http-types ihp ihp-ide ihp-log process text uuid
+    vault wai wai-request-params
   ];
   homepage = "https://ihp.digitallyinduced.com/";
   description = "Test helpers for IHP apps";

--- a/ihp-hspec/ihp-hspec.cabal
+++ b/ihp-hspec/ihp-hspec.cabal
@@ -36,6 +36,6 @@ library
         ImplicitParams
         RecordWildCards
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
-    build-depends: base >= 4.17.0 && < 4.22, ihp, ihp-log, wai, process, text, ihp-ide, vault, uuid, hasql, wai-request-params
+    build-depends: base >= 4.17.0 && < 4.22, ihp, ihp-log, wai, process, text, ihp-ide, vault, uuid, hasql, wai-request-params, hspec, http-types
     hs-source-dirs: .
     exposed-modules: IHP.Hspec

--- a/ihp/IHP/Test/Mocking.hs
+++ b/ihp/IHP/Test/Mocking.hs
@@ -22,8 +22,6 @@ import           IHP.ModelSupport                          (createModelContext, 
 import           IHP.Prelude
 import           IHP.Log.Types
 import           IHP.Job.Types
-import Test.Hspec
-import qualified Data.Text as Text
 import qualified Network.Wai as Wai
 import qualified IHP.LoginSupport.Helper.Controller as Session
 import qualified Network.Wai.Session.Maybe
@@ -237,22 +235,6 @@ responseBody res =
     content <- newIORef mempty
     f (\chunk -> modifyIORef' content (<> chunk)) (return ())
     toLazyByteString <$> readIORef content
-
--- | Asserts that the response body contains the given text.
-responseBodyShouldContain :: Response -> Text -> IO ()
-responseBodyShouldContain response includedText = do
-    body :: Text <- cs <$> responseBody response
-    body `shouldSatisfy` (includedText `Text.isInfixOf`)
-
--- | Asserts that the response body does not contain the given text.
-responseBodyShouldNotContain :: Response -> Text -> IO ()
-responseBodyShouldNotContain response includedText = do
-    body :: Text <- cs <$> responseBody response
-    body `shouldNotSatisfy` (includedText `Text.isInfixOf`)
-
--- | Asserts that the response status is equal to the given status.
-responseStatusShouldBe :: Response -> HTTP.Status -> IO ()
-responseStatusShouldBe response status = responseStatus response `shouldBe` status
 
 -- | Set's the current user for the application
 --

--- a/ihp/default.nix
+++ b/ihp/default.nix
@@ -35,7 +35,7 @@ mkDerivation {
     fast-logger filepath ghc-prim hashable haskell-src-exts
     haskell-src-meta hasql hasql-dynamic-statements hasql-implicits
     hasql-mapping hasql-pool hasql-postgresql-types hasql-transaction
-    hspec http-client http-client-tls http-media http-types ihp-context
+    http-client http-client-tls http-media http-types ihp-context
     ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
     ihp-pglistener inflections interpolate mime-types minio-hs
     mono-traversable mtl neat-interpolation network network-uri
@@ -83,7 +83,7 @@ mkDerivation {
     fast-logger filepath ghc-prim hashable haskell-src-exts
     haskell-src-meta hasql hasql-dynamic-statements hasql-implicits
     hasql-mapping hasql-pool hasql-postgresql-types hasql-transaction
-    hspec http-client http-client-tls http-media http-types ihp-context
+    http-client http-client-tls http-media http-types ihp-context
     ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
     ihp-pglistener inflections interpolate mime-types minio-hs
     mono-traversable mtl neat-interpolation network network-uri

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -105,7 +105,6 @@ common shared-properties
             , conduit-extra
             , wai-cors
             , random
-            , hspec
             , cereal
             , cereal-text
             , neat-interpolation
@@ -286,7 +285,9 @@ test-suite tests
     main-is: Test/Main.hs
     hs-source-dirs: Test
     ghc-options: -threaded
-    build-depends: ihp
+    build-depends:
+          ihp
+        , hspec
     other-modules:
         Test.ValidationSupport.ValidateFieldSpec
         Test.NameSupportSpec


### PR DESCRIPTION
## Summary

Follow-up to #2626. The earlier PR landed `lens`/`wreq` drops but had to revert the `IHP.Test.Mocking` move (commit `b271d646`) because it hit infinite recursion in `nix flake check`:

```
while evaluating derivation 'ihp-1.5.0'
... error: infinite recursion encountered
```

Root cause was a cabal2nix cyclic derivation: `ihp.test-suite` → `ihp-hspec` → `ihp` (cabal2nix merges library + test components into a single per-package nix derivation, so the test-suite's `ihp-hspec` dep gets hoisted into `ihp.drvPath`'s forced inputs, and `ihp-hspec.library` forces `ihp.drvPath`).

The real culprit turned out to be **three tiny assertion wrappers** at the bottom of `IHP.Test.Mocking` (`responseBodyShouldContain`, `responseBodyShouldNotContain`, `responseStatusShouldBe`) — they're the only code in the file that imports `Test.Hspec`. Everything else (`MockContext`, `runTestMiddlewares`, `withMockContext`, `callAction`, `responseBody`, etc.) depends only on `wai` / `wai-extra` / `cereal` / `http-types` / `ihp`, none of which need `hspec`.

## The split

- **`IHP.Test.Mocking` (in `ihp`)** keeps the middleware + mock-execution machinery. `import Test.Hspec` and the 3 wrappers are removed; the now-unused `import qualified Data.Text as Text` drops along with them. The module stays exposed so the 6 Mocking-using test files in `ihp`'s own test-suite (`MockingSpec`, `AutoRefreshSpec`, `RouterSupportSpec`, `Controller.NotFoundSpec`, `Controller.AccessDeniedSpec`, `ViewSupportSpec`) keep importing it directly from `ihp.library`. **No new cross-package dep, no cycle.**
- **`IHP.Hspec` (in `ihp-hspec`)** grows three new public functions: the same three assertion wrappers, importing `responseBody` from `IHP.Test.Mocking` (still in `ihp`). `ihp-hspec.cabal` gains `hspec` + `http-types` in its build-depends.
- **`ihp.cabal`** drops `hspec` from `shared-properties` and re-adds it explicitly under `test-suite tests` (ihp's own tests use `Test.Hspec` directly via `shouldBe` / `shouldSatisfy`, not via the three wrappers — verified by grep).

## Closure impact (measured on `aarch64-darwin`)

Walked `.#default.propagatedBuildInputs` — **6 packages leave `ihp`'s library closure**:

- `hspec`
- `hspec-core`
- `hspec-discover`
- `hspec-expectations`
- `quickcheck-io`
- `tf-random`

Self-size: **~38 MB** (on top of the ~81 MB already shipped in #2626 for `lens` + `wreq` + their unique subtrees). Total closure win since the series started: **~119 MB / 14 packages**.

## API impact

Minor breaking change for app authors: any test file that imports `responseStatusShouldBe` / `responseBodyShouldContain` / `responseBodyShouldNotContain` from `IHP.Test.Mocking` must switch the import to `IHP.Hspec`. The `Guide/testing.markdown` is updated to reflect this, and includes a release-note note pointing at the change.

`MockContext`, `callAction`, `withContext`, `withMockContext`, `withUser`, `responseBody`, and all other testing primitives stay in `IHP.Test.Mocking` — no change for existing users of those.

## Test plan

- [x] `echo ':l ihp/IHP/Test/Mocking.hs' | ghci` — clean
- [x] `echo ':l ihp-hspec/IHP/Hspec.hs' | ghci` — clean (116 modules)
- [x] All 6 ihp test files that import `IHP.Test.Mocking` type-check (119 modules)
- [x] `grep -rn 'Test\.Hspec\|shouldBe\|shouldSatisfy\|shouldNotSatisfy' ihp/IHP/` — zero hits
- [x] `nix build .#default --no-link -L` — **exit 0** (this is exactly what failed on `4c0bfd50` with infinite recursion)
- [x] `nix build .#ihp-hspec --no-link -L` — exit 0
- [x] Closure walk confirms all 6 hspec-subtree packages left `ihp.library`'s closure (`hspecStillPresent: []`, ihpClosureSize: 256)
- [ ] `nix flake check --impure` — CI
- [ ] Core-size benchmark — CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)