### PR TITLE
Fix autoRefresh WebSocket breakage from fallback status rewrite

### DIFF
--- a/ihp/IHP/ControllerSupport.hs
+++ b/ihp/IHP/ControllerSupport.hs
@@ -220,9 +220,14 @@ startWebSocketApp initialState onHTTP waiRequest waiRespond = do
     -- 'Wai.mapResponseStatus' is explicitly a no-op on 'ResponseRaw' (see
     -- the @mapResponseStatus _ r\@(ResponseRaw _ _) = r@ case in wai), so we
     -- have to pattern-match the raw constructor from 'Network.Wai.Internal'
-    -- and rebuild the fallback 'Response' with 'status101' ourselves. Warp
-    -- still runs the original raw handler — only the status that the
-    -- request logger observes changes.
+    -- and rebuild the fallback 'Response' ourselves. We use 'status200'
+    -- instead of the semantically correct 'status101' because Warp's
+    -- @hasBody@ check (@sc >= 200 && sc /= 204 && sc /= 304@) treats 1xx
+    -- as bodyless — causing it to send only the fallback headers and skip
+    -- the raw streaming handler entirely, which breaks the WebSocket
+    -- handshake. The on-the-wire status remains 101 (sent by the raw
+    -- handler); the rewritten fallback status only affects what
+    -- request-logger middlewares observe.
     waiRequest
         |> WebSockets.websocketsApp connectionOptions handleConnection
         |> \case
@@ -233,14 +238,16 @@ startWebSocketAppAndFailOnHTTP :: forall webSocketApp application. (?request :: 
 startWebSocketAppAndFailOnHTTP initialState = startWebSocketApp @webSocketApp @application initialState (?respond $ responseLBS HTTP.status400 [(hContentType, "text/plain")] "This endpoint is only available via a WebSocket")
 
 -- | Rewrite the 'ResponseRaw' fallback produced by 'Network.Wai.Handler.WebSockets.websocketsApp'
--- so the fallback 'Response' reports @101 Switching Protocols@ instead of the
--- hard-coded @status500@ from wai-websockets. See the comment in
--- 'startWebSocketApp' for the full rationale. This helper is only meaningful
--- for the responses produced by 'websocketsApp' — any other 'Response' is
--- returned unchanged.
+-- so the fallback 'Response' reports @200 OK@ instead of the hard-coded @status500@
+-- from wai-websockets. We cannot use @status101@ here because Warp's @hasBody@
+-- predicate returns @False@ for all 1xx statuses, causing Warp to skip the raw
+-- streaming handler and serve the fallback headers directly — which breaks the
+-- WebSocket handshake (see #2628). @status200@ is the closest non-alarming status
+-- that Warp's @hasBody@ accepts. See the comment in 'startWebSocketApp' for the
+-- full rationale.
 rewriteWebSocketFallbackStatus :: Response -> Response
 rewriteWebSocketFallbackStatus (WaiInternal.ResponseRaw handler fallback) =
-    WaiInternal.ResponseRaw handler (mapResponseStatus (const HTTP.status101) fallback)
+    WaiInternal.ResponseRaw handler (mapResponseStatus (const HTTP.status200) fallback)
 rewriteWebSocketFallbackStatus other = other
 
 

--- a/ihp/Test/Test/ControllerSupportSpec.hs
+++ b/ihp/Test/Test/ControllerSupportSpec.hs
@@ -20,7 +20,9 @@ import qualified Data.Aeson as Aeson
 import qualified Network.Wai as Wai
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString as BS
-import Network.HTTP.Types (status101, status400)
+import Network.HTTP.Types (status200, status400)
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.WebSockets as WebSockets
 
 -- | Minimal application fixture for 'startWebSocketApp' — just enough to
 -- satisfy the 'InitControllerContext' constraint without any real initialisation.
@@ -37,6 +39,16 @@ data TestWSApp = TestWSApp
 
 instance WS.WSApp TestWSApp where
     initialState = TestWSApp
+
+-- | WSApp that echoes received text data back to the client.
+-- Used to test that WebSocket connections actually work end-to-end.
+data EchoWSApp = EchoWSApp
+
+instance WS.WSApp EchoWSApp where
+    initialState = EchoWSApp
+    run = do
+        msg <- WS.receiveData @LBS.ByteString
+        WS.sendTextData msg
 
 tests = do
     describe "IHP.ControllerSupport" do
@@ -92,7 +104,9 @@ tests = do
             -- responseStatus res') and log 500 for every successful upgrade.
             -- 'startWebSocketApp' must rewrite the fallback status so the
             -- view-from-middleware agrees with the on-the-wire status.
-            it "presents successful WebSocket upgrades as status 101 to middleware" do
+            -- We use status200 (not status101) because Warp's hasBody
+            -- returns False for 1xx, which skips the raw handler (#2628).
+            it "rewrites WebSocket fallback status to non-500 for middleware" do
                 frameworkConfig <- FrameworkConfig.buildFrameworkConfig (FrameworkConfig.option Development)
                 let modelContext = notConnectedModelContext frameworkConfig.logger
                 let baseRequest = Wai.defaultRequest
@@ -113,7 +127,29 @@ tests = do
                         let ?application = TestApp
                         startWebSocketAppAndFailOnHTTP @TestWSApp @TestApp TestWSApp r respond
                 SResponse { simpleStatus } <- runSession (request baseRequest) app
-                simpleStatus `shouldBe` status101
+                simpleStatus `shouldBe` status200
+
+            -- Regression for digitallyinduced/ihp#2628: verify that the
+            -- fallback status rewrite does not break actual WebSocket
+            -- connections through Warp. A previous fix used status101 which
+            -- caused Warp to skip the raw handler entirely.
+            it "allows a real WebSocket connection through Warp" do
+                frameworkConfig <- FrameworkConfig.buildFrameworkConfig (FrameworkConfig.option Development)
+                let modelContext = notConnectedModelContext frameworkConfig.logger
+                let app r respond = do
+                        let ?request = r { Wai.vault =
+                                Vault.insert RequestVault.frameworkConfigVaultKey frameworkConfig
+                                $ Vault.insert RequestVault.modelContextVaultKey modelContext
+                                $ Wai.vault r
+                            }
+                        let ?respond = respond
+                        let ?application = TestApp
+                        startWebSocketAppAndFailOnHTTP @EchoWSApp @TestApp EchoWSApp r respond
+                Warp.testWithApplication (pure app) \port -> do
+                    WebSockets.runClient "127.0.0.1" port "/" \conn -> do
+                        WebSockets.sendTextData conn ("hello" :: Text)
+                        reply <- WebSockets.receiveData conn
+                        reply `shouldBe` ("hello" :: Text)
 
 bodyContains :: BS.ByteString -> LBS.ByteString -> Bool
 bodyContains needle haystack = BS.isInfixOf needle (LBS.toStrict haystack)


### PR DESCRIPTION
## Summary

- Fixes #2628: autoRefresh WebSocket connections fail immediately (0.0 kB, 45ms) on latest master
- Root cause: commit 1d36cf23 rewrote the `ResponseRaw` fallback status to `status101`, which triggers Warp's `hasBody` check (`sc >= 200 && sc /= 204 && sc /= 304`) to return `False` — causing Warp to skip the raw WebSocket handler and serve only the fallback headers
- Fix: use `status200` instead of `status101` for the fallback rewrite. This passes `hasBody` so Warp runs the raw handler, while still avoiding the alarming `500` in request logs
- Adds a regression test that makes a real WebSocket connection through `Warp.testWithApplication` (the previous test only used `Network.Wai.Test.runSession` which never invokes the raw handler)

## Test plan

- [x] `ControllerSupportSpec`: "rewrites WebSocket fallback status to non-500 for middleware" passes
- [x] `ControllerSupportSpec`: "allows a real WebSocket connection through Warp" passes (new test)
- [x] Full test suite: 466 examples, 0 failures
- [ ] Manual: load an IHP app with autoRefresh, verify WebSocket to `/AutoRefreshWSApp` stays open and auto-refreshes on DB changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)