### PR TITLE
Fix autoRefresh meta tag missing after putContext removal

### DIFF
--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -54,7 +54,7 @@ autoRefresh :: (
     , ?context :: ControllerContext
     , ?request :: Request
     , ?respond :: Respond
-    ) => ((?modelContext :: ModelContext, ?respond :: Respond) => IO ResponseReceived) -> IO ResponseReceived
+    ) => ((?modelContext :: ModelContext, ?respond :: Respond, ?request :: Request) => IO ResponseReceived) -> IO ResponseReceived
 autoRefresh runAction = do
     -- When PGListener is not available, degrade gracefully to a
     -- plain action without auto-refresh.

--- a/ihp/IHP/AutoRefresh/View.hs
+++ b/ihp/IHP/AutoRefresh/View.hs
@@ -7,10 +7,10 @@ import IHP.HSX.Markup (Html)
 import IHP.Controller.Context
 import IHP.AutoRefresh (autoRefreshStateVaultKey)
 import qualified Data.Vault.Lazy as Vault
-import Network.Wai (vault)
+import Network.Wai (Request, vault)
 
-autoRefreshMeta :: (?context :: ControllerContext) => Html
+autoRefreshMeta :: (?context :: ControllerContext, ?request :: Request) => Html
 autoRefreshMeta =
-    case Vault.lookup autoRefreshStateVaultKey ?context.request.vault of
+    case Vault.lookup autoRefreshStateVaultKey ?request.vault of
         Just (AutoRefreshEnabled { sessionId }) -> [hsx|<meta property="ihp-auto-refresh-id" content={tshow sessionId}/>|]
         _ -> mempty

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -15,7 +15,10 @@ import Network.Wai
 import Network.HTTP.Types
 import IHP.AutoRefresh (globalAutoRefreshServerVar, sessionResponseHasChanged, updateSession)
 import IHP.AutoRefresh.Types
+import IHP.AutoRefresh.View (autoRefreshMeta)
 import qualified Control.Concurrent.MVar as MVar
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified IHP.PGListener as PGListener
 import IHP.Log.Types (Logger(..), LogLevel(..))
 import IHP.Server (initMiddlewareStack)
@@ -28,12 +31,17 @@ data WebApplication = WebApplication deriving (Eq, Show, Data)
 
 data TestController
     = ShowItemAction
+    | ShowItemHtmlAction
   deriving (Eq, Show, Data)
 
 instance Controller TestController where
     action ShowItemAction = autoRefresh do
         let marketId = param @Text "marketId"
         renderPlain (cs marketId)
+    action ShowItemHtmlAction = autoRefresh do
+        let marketId = param @Text "marketId"
+        let meta = autoRefreshMeta
+        respondHtml [hsx|<html><head>{meta}</head><body>{marketId}</body></html>|]
 
 instance AutoRoute TestController
 
@@ -92,6 +100,17 @@ testLogger = Logger
 tests :: Spec
 tests = beforeAll (mockContextNoDatabase WebApplication config) do
     describe "AutoRefresh" do
+        describe "autoRefreshMeta" do
+            it "renders the ihp-auto-refresh-id meta tag on the initial response" $ withContext do
+                MVar.modifyMVar_ globalAutoRefreshServerVar (\_ -> pure Nothing)
+
+                PGListener.withPGListener "" testLogger \pgListener -> do
+                    response <- callActionWithQueryParams pgListener ShowItemHtmlAction [("marketId", "abc-123")]
+                    let bodyBs = LBS.toStrict (simpleBody response)
+                    BS.isInfixOf "ihp-auto-refresh-id" bodyBs `shouldBe` True
+
+                    MVar.modifyMVar_ globalAutoRefreshServerVar (\_ -> pure Nothing)
+
         describe "renderView" do
             it "should preserve query parameters when re-rendering with a websocket request" $ withContext do
                 -- Clean up any leftover global state from previous tests


### PR DESCRIPTION
## Summary

- `autoRefreshMeta` now reads `?request.vault` instead of `?context.request.vault` — the latter goes through a TMap lookup that PR #2632 inadvertently made stale, so the meta tag silently dropped out of the rendered HTML.
- Added `?request :: Request` to `autoRefresh`'s `runAction` constraint so that the `let ?request = newRequest` rebinding actually propagates into the user's do-block.
- Added a regression test. The existing AutoRefreshSpec used `renderPlain`, which skips the layout / `autoRefreshMeta` path entirely — that's how this slipped past CI.

Closes #2628.

## Root cause

PR #2631 (`status101 → status200`) fixed the WebSocket upgrade, but PR #2632 (`Replace putContext/fromContext with dedicated request vault keys`, merged 3 minutes later) removed the line in `autoRefresh` that kept the ControllerContext TMap's Request entry in sync with the augmented `newRequest`:

```haskell
modifyIORef' customFieldsRef (TypeMap.insert @Network.Wai.Request newRequest)
```

The PR description claimed this was safe because "the request vault already carries autoRefreshState directly" — true for code reading `?request.vault`, but `autoRefreshMeta` reads `?context.request.vault`, which hits the `HasField "request" ControllerContext` instance that does `TypeMap.lookup @Request`. Without the update, the TMap held the pristine WAI request (inserted by `newControllerContext`), so the lookup missed `autoRefreshStateVaultKey` and the function emitted `mempty`. No meta tag → client-side `ihp-auto-refresh.js:6-9` returns early → no WebSocket → "no browser error, no auto refresh".

## Test plan

- [x] New `autoRefreshMeta` test fails before the fix, passes after.
- [x] Full `ihp` test suite (485 examples) passes.
- [ ] Watch CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)