### PR TITLE
Re-add ConvertibleStrings Text/String Html instances

### DIFF
--- a/ihp-hsx/Test/IHP/HSX/MarkupSpec.hs
+++ b/ihp-hsx/Test/IHP/HSX/MarkupSpec.hs
@@ -6,6 +6,8 @@ module IHP.HSX.MarkupSpec where
 
 import Test.Hspec
 import Prelude
+import Data.Text (Text)
+import Data.String.Conversions (cs)
 import IHP.HSX.Markup
 
 tests :: SpecWith ()
@@ -29,3 +31,17 @@ tests = do
 
             it "should return False for concatenation with non-empty value" do
                 isEmpty (mempty <> escapeHtml "x") `shouldBe` False
+
+        describe "ConvertibleStrings" do
+            it "converts Text to Html via cs" do
+                renderMarkupText (cs ("hello" :: Text) :: Html) `shouldBe` "hello"
+
+            it "HTML-escapes Text when converted via cs" do
+                renderMarkupText (cs ("<script>alert(1)</script>" :: Text) :: Html)
+                    `shouldBe` "&lt;script&gt;alert(1)&lt;/script&gt;"
+
+            it "converts String to Html via cs" do
+                renderMarkupText (cs ("hello" :: String) :: Html) `shouldBe` "hello"
+
+            it "HTML-escapes String when converted via cs" do
+                renderMarkupText (cs ("a & b" :: String) :: Html) `shouldBe` "a &amp; b"

--- a/ihp-hsx/direct/IHP/HSX/Markup.hs
+++ b/ihp-hsx/direct/IHP/HSX/Markup.hs
@@ -293,8 +293,6 @@ stringValue = escapeHtml . Text.pack
 {-# INLINE stringValue #-}
 
 -- | Convert 'Text' into HTML-escaped 'Markup' via @cs@.
--- Mirrors Blaze's @instance ConvertibleStrings Text Html@ that was lost
--- when the HSX backend moved from Blaze to the direct ByteString builder.
 instance ConvertibleStrings Text Markup where
     {-# INLINE convertString #-}
     convertString = escapeHtml

--- a/ihp-hsx/direct/IHP/HSX/Markup.hs
+++ b/ihp-hsx/direct/IHP/HSX/Markup.hs
@@ -40,7 +40,7 @@ import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Builder.Extra as Extra
 import qualified Data.ByteString.Builder.Prim as BP
-import Data.String.Conversions (ConvertibleStrings, cs)
+import Data.String.Conversions (ConvertibleStrings (convertString), cs)
 import Data.String (IsString(..))
 import Data.Word (Word8)
 import Unsafe.Coerce (unsafeCoerce)
@@ -291,3 +291,15 @@ preEscapedTextValue = Markup . TE.encodeUtf8Builder
 stringValue :: String -> Markup
 stringValue = escapeHtml . Text.pack
 {-# INLINE stringValue #-}
+
+-- | Convert 'Text' into HTML-escaped 'Markup' via @cs@.
+-- Mirrors Blaze's @instance ConvertibleStrings Text Html@ that was lost
+-- when the HSX backend moved from Blaze to the direct ByteString builder.
+instance ConvertibleStrings Text Markup where
+    {-# INLINE convertString #-}
+    convertString = escapeHtml
+
+-- | Convert 'String' into HTML-escaped 'Markup' via @cs@.
+instance ConvertibleStrings String Markup where
+    {-# INLINE convertString #-}
+    convertString = escapeHtml . Text.pack


### PR DESCRIPTION
## Summary

- When HSX moved from Blaze to the direct `ByteString Builder` backend (e5c6fbd1), `Html` became a type alias for `IHP.HSX.Markup.Markup` instead of `Text.Blaze.Html5.Html`. The old Blaze `ConvertibleStrings` instances in `ihp-hsx/blaze/IHP/HSX/ConvertibleStrings.hs` still exist, but they target the now-unused Blaze `Html5.Html` type, so `cs (someText :: Text) :: Html` no longer resolves.
- Re-adds `instance ConvertibleStrings Text Markup` and `instance ConvertibleStrings String Markup` on the direct backend, mirroring Blaze's semantics (HTML-escape then output).
- Adds tests covering both happy-path conversion and HTML escaping of special characters (`<`, `>`, `&`).

## Note on `blaze/IHP/HSX/ConvertibleStrings.hs`

That file still has instances, but they target `Text.Blaze.Html5.Html` / `AttributeValue` — the old Blaze types, which are no longer what a user's `Html` resolves to. It's still transitively imported via `IHP.HSX.ToHtml` (which also uses the old `Html5.Html`) and a handful of `()` imports in `ihp/IHP/View/Form/*.hs` and `ihp/IHP/View/TimeAgo.hs`, but none of those files reference `Text.Blaze` directly anymore. So it's effectively stale — but removing it is a bigger refactor than this fix, and is left out of scope.

## Test plan

- [x] `ihp-hsx` test suite passes (116 examples, 0 failures) including the 4 new `ConvertibleStrings` cases
- [x] `IHP.HSX.Markup` type-checks standalone via `ghci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)