### PR TITLE
Drop cereal legacy session-UUID format from parseSessionUUID

### DIFF
--- a/ihp/IHP/LoginSupport/Middleware.hs
+++ b/ihp/IHP/LoginSupport/Middleware.hs
@@ -31,7 +31,6 @@ import IHP.Hasql.FromRow (FromRowHasql)
 import qualified Network.Wai as Wai
 import qualified Data.Vault.Lazy as Vault
 import qualified Data.UUID as UUID
-import qualified Data.ByteString as BS
 
 -- | Middleware that reads a userId from the session and stores it in
 -- 'currentUserIdVaultKey'. No database query is performed.
@@ -72,22 +71,11 @@ userIdMiddlewareFor sessionKeyName idKey app req respond = do
     app req' respond
 {-# INLINE userIdMiddlewareFor #-}
 
--- | Parse UUID from session bytes. Handles both:
---
---   - New format: raw 36-byte UUID ASCII (e.g. \"550e8400-e29b-41d4-a716-446655440000\")
---   - Old format: 8-byte cereal length prefix + 36-byte UUID ASCII (44 bytes total)
---
--- The old format comes from sessions written with @Serialize (Id' table)@ which
--- prepends an 8-byte big-endian length prefix via cereal. We support both formats
--- so existing sessions continue to work without logging users out on upgrade.
---
--- TODO: Remove old format support after 2026-05-01. At that point all
--- session cookies using the cereal encoding will have expired.
+-- | Parse UUID from session bytes. Expects the raw 36-byte UUID ASCII format
+-- written by 'IHP.LoginSupport.Helper.Controller.login'
+-- (e.g. \"550e8400-e29b-41d4-a716-446655440000\").
 parseSessionUUID :: ByteString -> Maybe UUID
-parseSessionUUID bs
-    | Just uuid <- UUID.fromASCIIBytes bs = Just uuid
-    | BS.length bs == 44 = UUID.fromASCIIBytes (BS.drop 8 bs)
-    | otherwise = Nothing
+parseSessionUUID = UUID.fromASCIIBytes
 {-# INLINE parseSessionUUID #-}
 
 -- | Middleware that reads the userId from 'currentUserIdVaultKey', fetches

--- a/ihp/Test/Test/LoginSupport/AuthVaultSpec.hs
+++ b/ihp/Test/Test/LoginSupport/AuthVaultSpec.hs
@@ -7,7 +7,6 @@ module Test.LoginSupport.AuthVaultSpec where
 import IHP.Prelude
 import Test.Hspec
 
-import qualified Data.ByteString as BS
 import qualified Data.UUID as UUID
 import qualified Network.Wai as Wai
 import Network.Wai.Test (defaultRequest, runSession, request)
@@ -85,27 +84,15 @@ tests = do
                 runSession (request defaultRequest >> pure ()) app
 
     describe "parseSessionUUID" do
-        it "parses a raw 36-byte UUID (new format)" do
+        it "parses a raw 36-byte UUID" do
             let uuid = "550e8400-e29b-41d4-a716-446655440000"
             parseSessionUUID uuid `shouldBe` UUID.fromASCIIBytes uuid
-
-        it "parses a cereal-encoded 44-byte UUID (old format, backward compat)" do
-            -- Old format: 8-byte cereal length prefix + 36-byte UUID ASCII
-            let uuid = "550e8400-e29b-41d4-a716-446655440000"
-            let cerealPrefix = BS.pack [0, 0, 0, 0, 0, 0, 0, 36] -- 8-byte big-endian length = 36
-            let oldFormat = cerealPrefix <> uuid
-            BS.length oldFormat `shouldBe` 44
-            parseSessionUUID oldFormat `shouldBe` UUID.fromASCIIBytes uuid
 
         it "returns Nothing for empty bytes" do
             parseSessionUUID "" `shouldBe` Nothing
 
         it "returns Nothing for invalid bytes" do
             parseSessionUUID "not-a-uuid" `shouldBe` Nothing
-
-        it "returns Nothing for random 44 bytes that don't contain a UUID" do
-            let garbage = BS.replicate 44 0x41  -- 44 'A' bytes
-            parseSessionUUID garbage `shouldBe` Nothing
 
     describe "userIdMiddleware" do
         it "populates currentUserIdVaultKey from session" do
@@ -127,18 +114,6 @@ tests = do
             let app = composed $ \req respond -> do
                     let ?request = req
                     (Controller.currentUserOrNothing :: Maybe CurrentUserRecord) `shouldBe` Nothing
-                    respond $ Wai.responseLBS status200 [] ""
-            runSession (request defaultRequest >> pure ()) app
-
-        it "handles cereal-encoded session values (backward compat)" do
-            let uuid = "550e8400-e29b-41d4-a716-446655440000"
-            let cerealPrefix = BS.pack [0, 0, 0, 0, 0, 0, 0, 36]
-            let oldBytes = cerealPrefix <> UUID.toASCIIBytes uuid
-            let sessionMiddleware = mockSessionMiddleware "login.user" oldBytes
-            let composed = sessionMiddleware . userIdMiddleware "login.user"
-            let app = composed $ \req respond -> do
-                    let ?request = req
-                    Controller.currentUserIdOrNothing `shouldBe` Just (Id uuid)
                     respond $ Wai.responseLBS status200 [] ""
             runSession (request defaultRequest >> pure ()) app
 


### PR DESCRIPTION
## Summary

- `parseSessionUUID` collapses to `UUID.fromASCIIBytes`. The 44-byte cereal branch (8-byte length prefix + 36-byte ASCII) was a backward-compat shim for sessions written before `login` switched to raw UUID ASCII bytes — those cookies have long since expired. The in-source TODO already planned this for 2026-05-01.
- `IHP.Test.Mocking.withUser` switches from `Serialize.encode user.id` to `UUID.toASCIIBytes (unpackId user.id)` so it matches what `login` writes (and what `parseSessionUUID` now accepts).
- Drops the corresponding "old format" cases in `AuthVaultSpec`.

`Serialize (Id' table)` in `IHP.Controller.Session` stays — it's a public instance used by `setSession`/`getSession` for generic session values, unrelated to the login session reader.

## Test plan

- [x] `ghci` typechecks `IHP.LoginSupport.Middleware` and `IHP.Test.Mocking` clean
- [x] `ghci :l ihp/Test/Test/Main.hs; main` → `482 examples, 0 failures, 23 pending` (pending are Postgres-dependent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)