### PR TITLE
Rename FrameworkConfig.authMiddleware field to authenticationMiddleware

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -70,6 +70,8 @@ The `initAuthentication` function has been deprecated in favor of a WAI middlewa
 
 **Deprecated functions:** `initAuthentication` still works but is deprecated. `currentRoleOrNothing`, `currentRole`, `currentRoleId`, `ensureIsRole` have been removed. Use the type-specific variants instead: `currentUserOrNothing`/`currentAdminOrNothing`, `currentUser`/`currentAdmin`, `currentUserId`/`currentAdminId`, `ensureIsUser`/`ensureIsAdmin`.
 
+**`FrameworkConfig` field rename:** the `authMiddleware` record field on `FrameworkConfig` has been renamed to `authenticationMiddleware` to avoid an ambiguity with the `authMiddleware` function from `IHP.LoginSupport.Middleware`. Typical apps only set this via `option $ AuthMiddleware (authMiddleware @User)` in `Config.hs` and need no changes. Only code that reads the field directly (e.g. `frameworkConfig.authMiddleware`) needs to update to `frameworkConfig.authenticationMiddleware`.
+
 ## Join Support Removed from QueryBuilder
 
 The query builder's join functions (`innerJoin`, `innerJoinThirdTable`, `labelResults`) and all `*JoinedTable` filter/order functions have been removed. Use `typedSql` instead, which provides full SQL expressiveness with compile-time type safety.

--- a/ihp/IHP/FrameworkConfig.hs
+++ b/ihp/IHP/FrameworkConfig.hs
@@ -188,7 +188,7 @@ buildFrameworkConfig appConfig = do
             (IdeBaseUrl ideBaseUrl) <- findOption @IdeBaseUrl
             (RLSAuthenticatedRole rlsAuthenticatedRole) <- findOption @RLSAuthenticatedRole
             customMiddleware <- findOption @CustomMiddleware
-            authMiddleware <- findOption @AuthMiddleware
+            authenticationMiddleware <- findOption @AuthMiddleware
             initializers <- fromMaybe [] <$> findOptionOrNothing @[Initializer]
 
             appConfig <- State.get

--- a/ihp/IHP/FrameworkConfig/Types.hs
+++ b/ihp/IHP/FrameworkConfig/Types.hs
@@ -104,7 +104,7 @@ newtype CustomMiddleware = CustomMiddleware Middleware
 -- >
 -- > config :: ConfigBuilder
 -- > config = do
--- >     option $ AuthMiddleware authMiddleware
+-- >     option $ AuthMiddleware (authMiddleware @User)
 --
 newtype AuthMiddleware = AuthMiddleware Middleware
 
@@ -172,7 +172,7 @@ data FrameworkConfig = FrameworkConfig
 
     -- | Authentication middleware that populates the request vault with the
     -- current user/admin. Runs after session and model context middlewares.
-    , authMiddleware :: !AuthMiddleware
+    , authenticationMiddleware :: !AuthMiddleware
     , initializers :: ![Initializer]
     }
 

--- a/ihp/IHP/Server.hs
+++ b/ihp/IHP/Server.hs
@@ -155,7 +155,7 @@ initMiddlewareStack frameworkConfig modelContext maybePgListener = do
 
     let corsMiddleware = initCorsMiddleware frameworkConfig
     let CustomMiddleware customMiddleware = frameworkConfig.customMiddleware
-    let AuthMiddleware authMw = frameworkConfig.authMiddleware
+    let AuthMiddleware authMw = frameworkConfig.authenticationMiddleware
     let pgListenerMw = maybe id pgListenerMiddleware maybePgListener
 
     let responseHeadersMiddleware = insertNewIORefVaultMiddleware responseHeadersVaultKey []


### PR DESCRIPTION
## Summary

- Renames the `FrameworkConfig` record field `authMiddleware` → `authenticationMiddleware` so it stops colliding with the `authMiddleware` function exported from `IHP.LoginSupport.Middleware`.
- Fixes the "Ambiguous occurrence 'authMiddleware'" error users hit when following the [authentication guide](Guide/authentication.markdown) example:
  ```haskell
  import IHP.LoginSupport.Middleware
  config = do
      option \$ AuthMiddleware (authMiddleware @User)
  ```
- Adds an UPGRADE.md note. Typical apps that only set the option via `option \$ AuthMiddleware (...)` need no changes; only code that reads the field directly (e.g. `frameworkConfig.authMiddleware`) needs to update to `frameworkConfig.authenticationMiddleware`.

The field had a single internal reader (`ihp/IHP/Server.hs`) and a single writer (record-wildcards in `buildFrameworkConfig`), both updated here.

Reported by Alvydas Vitkauskas on Slack.

## Test plan

- [x] `ghci :l ihp/IHP/Server.hs` — all 105 modules load clean
- [x] `Test/LoginSupport/AuthVaultSpec.hs` — 18/18 pass (user auth, admin auth, composition, `parseSessionUUID`, id-middlewares)
- [x] `ihp-ide/Test/Main.hs` — 400/400 pass
- [x] Reproduced the original ambiguity error against master, confirmed gone on this branch