### PR TITLE
Document MemoryHigh/MemoryMax for app and worker services

### DIFF
--- a/Guide/deployment.markdown
+++ b/Guide/deployment.markdown
@@ -1613,3 +1613,31 @@ systemctl status migrate
 journalctl -u app -n 50 --no-pager
 ```
 
+### Memory Limits and Restart Hardening
+
+By default `services.app` and `services.worker` are configured with `Restart = "always"` but do not set any memory bounds. This means that a memory leak in application code, or a runaway allocation inside a long-running job, can consume all available RAM before the Linux OOM killer intervenes. When that happens, the kernel may kill unrelated processes on the host — for example a colocated PostgreSQL when using `appWithPostgres` — instead of cleanly restarting just the offending unit.
+
+To bound the blast radius, set `MemoryHigh` and `MemoryMax` on the unit. Once the cgroup hits `MemoryMax`, systemd terminates only the processes inside that unit and immediately restarts it, because `Restart = "always"` is already the default:
+
+```nix
+systemd.services.app.serviceConfig = {
+    MemoryHigh = "1500M";
+    MemoryMax = "2G";
+    RestartSec = "5s";
+};
+
+systemd.services.worker.serviceConfig = {
+    MemoryHigh = "1500M";
+    MemoryMax = "2G";
+    RestartSec = "5s";
+};
+```
+
+- `MemoryMax` is a hard ceiling. Exceeding it triggers the cgroup OOM killer for that unit only; the `Restart = "always"` policy then brings the unit back up.
+- `MemoryHigh` is a soft ceiling. Exceeding it throttles the process and forces aggressive memory reclaim, which often surfaces leaks earlier and helps avoid hitting `MemoryMax` at all.
+- `RestartSec` prevents a tight restart loop if the unit crashes immediately on startup.
+
+Setting these on `services.worker` is especially valuable: job handlers that process unbounded event histories, call external APIs that return large responses, or build up large in-memory data structures are the most common source of memory growth in a long-lived Haskell process. Because the worker runs in its own systemd unit (and therefore its own cgroup), capping its memory there prevents a leaking background job from taking down the web tier.
+
+Choose values based on your instance size and what else runs on the host. Leave headroom for the kernel, for PostgreSQL if it is colocated, and for any other services. On a 2 GB instance running only `app` and `worker`, `MemoryHigh = "1500M"` / `MemoryMax = "2G"` is a reasonable starting point — tune after observing real usage with `systemd-cgtop` and `systemctl status app.service`.
+


### PR DESCRIPTION
## Summary

Add a "Memory Limits and Restart Hardening" subsection to the `systemd` Integration section of the deployment guide.

`services.app` and `services.worker` already set `Restart = "always"` and a watchdog, but no cgroup memory bounds. Without `MemoryMax`, a leaking unit can consume all host RAM before the kernel OOM killer intervenes, and the kill may land on unrelated processes (notably a colocated PostgreSQL under `appWithPostgres`) rather than the offending unit.

The new subsection shows how to set `MemoryHigh` / `MemoryMax` / `RestartSec` on both services so an OOM stays inside a single unit's cgroup and gets cleanly restarted by the existing `Restart = "always"` policy. Worker tuning is called out explicitly since long-running job handlers are the most common source of leaks in a long-lived Haskell process.

## Test plan

- [ ] Docs-only change — renders as expected in the Guide