### PR TITLE
Document GHCRTS heap cap to protect dev machines from runaway dev server

### DIFF
--- a/Guide/troubleshooting.markdown
+++ b/Guide/troubleshooting.markdown
@@ -229,7 +229,7 @@ A reasonable default is **roughly half of system RAM**: `-M8G` on a 16 GB box, `
 export GHCRTS="-M8G -hT -l"
 ```
 
-`-hT` writes a heap profile broken down by closure type, and `-l` writes an eventlog (`<process>.eventlog`) alongside it. The eventlog records what kind of values are growing over time — point Claude (or your favourite GHC profiling tool) at the file and ask what's leaking.
+`-hT` writes a heap profile broken down by closure type, and `-l` writes an eventlog (`<process>.eventlog`) alongside it. The eventlog records what kind of values are growing over time.
 
 ### OAuth/HTTPS in Docker fails: `certificate has unknown CA`
 

--- a/Guide/troubleshooting.markdown
+++ b/Guide/troubleshooting.markdown
@@ -223,12 +223,7 @@ A reasonable default is **roughly half of system RAM**: `-M8G` on a 16 GB box, `
 <<ghc: heap overflow>>
 ```
 
-…and exits. This is a clean death: the kernel never gets involved, your desktop and browser keep running, and you can scroll back to the panic in the dev-server log. Two things to be aware of afterwards:
-
-1. **Background jobs may be stranded in `running` state.** A job that was executing when the heap blew up will not transition to `failed`, because the worker never got a chance to write the row. Inspect the `jobs` table for rows with `status = 'running'` and an old `updated_at`, and either retry them through the jobs dashboard (see [the Jobs guide](https://ihp.digitallyinduced.com/Guide/jobs.html)) or update them by hand. If your project has a stale-job recovery script, run it.
-2. **Look at your code, not the cap.** A heap-overflow panic is a signal that something is leaking — a lazy thunk pile, a list you're building forever, an `IORef` that nothing prunes. The cap only protects the host machine; it does not fix the leak. Reach for `-M` first as a safety net, then go hunt the leak.
-
-**Investigating a real leak.** When you do go hunting, add heap profiling on top of the cap:
+…and exits. This is a clean death: the kernel never gets involved, your desktop and browser keep running, and you can scroll back to the panic in the dev-server log.
 
 ```bash
 export GHCRTS="-M8G -hT -l"

--- a/Guide/troubleshooting.markdown
+++ b/Guide/troubleshooting.markdown
@@ -195,6 +195,47 @@ export IHP_RELATION_SUPPORT=0
 
 See [Relationships: Disabling Relation Support for Faster Compilation](relationships.html#disabling-relation-support-for-faster-compilation) for details on what changes and what stops working.
 
+### `devenv up` eats all the RAM and OOM-kills the desktop
+
+**Problem:**
+
+When you run `devenv up`, the IHP dev server has no upper bound on how much memory it can consume. A memory leak in your code — accumulated thunks, retained job records, AutoRefresh sessions that never get released, an unbounded cache in a request handler — will grow the dev-server's resident set without bound until the kernel's OOM killer fires. Because the dev server is rarely the largest process at that moment, the OOM killer often takes down the desktop session, the browser, or another shell instead. You lose unrelated work and get no actionable signal.
+
+**Solution:**
+
+Cap the dev-server heap by exporting `GHCRTS` from your project's `.envrc`:
+
+```bash
+# Cap the dev-server heap so runaway memory growth dies cleanly
+# (HeapOverflow) instead of OOM-killing the whole desktop.
+export GHCRTS="-M8G"
+```
+
+`GHCRTS` is picked up automatically by IHP's dev server because it inherits the environment from `.envrc`.
+
+A reasonable default is **roughly half of system RAM**: `-M8G` on a 16 GB box, `-M4G` on an 8 GB box, `-M16G` on a 32 GB workstation. The cap should be generous, not tight — it exists to protect the desktop from a leak, not to shrink the dev-server footprint.
+
+**Setting the cap too low.** IHP runs the dev server with the non-moving garbage collector, which is great for latency but lets the heap grow freely between collection cycles. A tight cap will trip on legitimate workloads (large fixture loads, schema reload after a big migration, code generation passes). If `-M4G` keeps firing on a box with plenty of free RAM, raise the cap rather than fight the GC.
+
+**What happens when the cap is hit.** The dev server panics with:
+
+```
+<<ghc: heap overflow>>
+```
+
+…and exits. This is a clean death: the kernel never gets involved, your desktop and browser keep running, and you can scroll back to the panic in the dev-server log. Two things to be aware of afterwards:
+
+1. **Background jobs may be stranded in `running` state.** A job that was executing when the heap blew up will not transition to `failed`, because the worker never got a chance to write the row. Inspect the `jobs` table for rows with `status = 'running'` and an old `updated_at`, and either retry them through the jobs dashboard (see [the Jobs guide](https://ihp.digitallyinduced.com/Guide/jobs.html)) or update them by hand. If your project has a stale-job recovery script, run it.
+2. **Look at your code, not the cap.** A heap-overflow panic is a signal that something is leaking — a lazy thunk pile, a list you're building forever, an `IORef` that nothing prunes. The cap only protects the host machine; it does not fix the leak. Reach for `-M` first as a safety net, then go hunt the leak.
+
+**Investigating a real leak.** When you do go hunting, add heap profiling on top of the cap:
+
+```bash
+export GHCRTS="-M8G -hT -l"
+```
+
+`-hT` writes a heap profile broken down by closure type, and `-l` writes an eventlog (`<process>.eventlog`) alongside it. The eventlog records what kind of values are growing over time — point Claude (or your favourite GHC profiling tool) at the file and ask what's leaking.
+
 ### OAuth/HTTPS in Docker fails: `certificate has unknown CA`
 
 **Problem:**


### PR DESCRIPTION
## Summary

- The IHP dev server runs without an upper bound on heap size, so a memory leak in user code (jobs, AutoRefresh, request handlers, accumulated thunks) grows the resident set without bound.
- When the kernel's OOM killer fires, the dev server is rarely the largest process — so it often takes down the desktop session, the browser, or another shell instead. The developer loses unrelated work and gets no actionable signal.
- This adds a Troubleshooting entry walking through the `GHCRTS=-M…` workaround in `.envrc`, how to size the cap against the non-moving GC, what to check afterwards (stranded \`running\` jobs, the underlying leak), and how to enable heap profiling when investigating.

The change is documentation-only — no code changes, no behaviour change for existing users.

## Why opt-in docs rather than a default

The protection is near-zero-cost with a clean failure mode (`<<ghc: heap overflow>>` instead of an OOM kill), so it's worth surfacing. But the right value of `-M` varies a lot by developer machine and workload — `-M4G` on an 8 GB laptop would constantly trip on a 64 GB workstation running large fixture loads. Documentation puts the lever in the developer's hand without making policy.

## Future work (not in this PR)

- Add a commented-out \`GHCRTS\` line to the IHP project template's \`.envrc\` so new projects start with the option visible.
- Consider whether IHP's hardcoded ghci args in \`ihp-ide/exe/IHP/IDE/DevServer.hs\` should detect available system memory and set a sensible default \`-M\`.

## Test plan

- [ ] Render the Guide locally (\`devenv up\` from \`Guide/\`) and confirm the new section appears under Troubleshooting between "Slow Compilation of Generated Types" and "OAuth/HTTPS in Docker".
- [ ] Verify the \`<<ghc: heap overflow>>\` panic message matches what GHC actually prints when \`-M\` is hit.
- [ ] Sanity-check the cross-link to the Jobs guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)