### PR TITLE
Recover orphaned running jobs at worker startup

### DIFF
--- a/ihp/IHP/Job/Queue.hs
+++ b/ihp/IHP/Job/Queue.hs
@@ -14,6 +14,7 @@ module IHP.Job.Queue
 , jobDidSucceed
 , backoffDelay
 , recoverStaleJobs
+, recoverStaleJobsForTable
 , textToEnumJobStatusMap
 , textToEnumJobStatus
 , tryWriteTBQueue
@@ -36,6 +37,7 @@ import IHP.Job.Queue.Result
     , jobDidSucceed
     , backoffDelay
     , recoverStaleJobs
+    , recoverStaleJobsForTable
     )
 import IHP.Job.Queue.StatusInstances
     ( textToEnumJobStatusMap

--- a/ihp/IHP/Job/Queue/Result.hs
+++ b/ihp/IHP/Job/Queue/Result.hs
@@ -5,6 +5,7 @@ module IHP.Job.Queue.Result
 , jobDidSucceed
 , backoffDelay
 , recoverStaleJobs
+, recoverStaleJobsForTable
 ) where
 
 import IHP.Prelude
@@ -20,6 +21,7 @@ import qualified Hasql.Statement as Hasql
 import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Decoders as Decoders
 import Data.Functor.Contravariant (contramap)
+import Data.UUID (UUID)
 
 -- | Called when a job failed. Sets the job status to 'JobStatusFailed' or 'JobStatusRetry' (if more attempts are possible) and resets 'lockedBy'
 jobDidFail :: forall job context.
@@ -131,26 +133,56 @@ recoverStaleJobs :: forall job.
     ( Table job
     ) => HasqlPool.Pool -> NominalDiffTime -> IO ()
 recoverStaleJobs pool staleThreshold = do
-    let tableNameText = tableName @job
-    -- Tier 1: Recently stale jobs (threshold..24h) -> retry
+    _ <- recoverStaleJobsForTable pool (tableName @job) staleThreshold
+    pure ()
+
+-- | Like 'recoverStaleJobs' but takes the table name explicitly and reports
+-- which rows were recovered, returning @(count, previousWorkerUuids)@.
+--
+-- The @previousWorkerUuids@ list contains the @locked_by@ values that were
+-- attached to the recovered rows before they were reset, so callers can log
+-- "we recovered N rows previously held by worker X". Workers with a NULL
+-- @locked_by@ are filtered out of the list (but still counted).
+--
+-- Used both by the periodic recovery loop and by the boot-time sweep that
+-- runs once at worker startup.
+recoverStaleJobsForTable ::
+    HasqlPool.Pool -> Text -> NominalDiffTime -> IO (Int, [UUID])
+recoverStaleJobsForTable pool tableNameText staleThreshold = do
+    -- Tier 1: Recently stale jobs (threshold..24h) -> retry.
+    -- Capture the prior locked_by via a CTE so RETURNING can report it
+    -- (RETURNING on the UPDATE alone would observe the post-update NULL).
     let retrySql =
-            "UPDATE " <> tableNameText
-            <> " SET status = 'job_status_retry', locked_by = NULL, locked_at = NULL, run_at = NOW()"
+            "WITH stale AS ("
+            <> " SELECT id, locked_by AS prev_locked_by FROM \"" <> tableNameText <> "\""
             <> " WHERE status = 'job_status_running'"
             <> " AND locked_at < NOW() - interval '1 second' * $1"
             <> " AND locked_at > NOW() - interval '1 day'"
+            <> " FOR UPDATE"
+            <> " ) UPDATE \"" <> tableNameText <> "\" t"
+            <> " SET status = 'job_status_retry', locked_by = NULL, locked_at = NULL, run_at = NOW()"
+            <> " FROM stale WHERE t.id = stale.id"
+            <> " RETURNING stale.prev_locked_by"
     let retryEncoder = Encoders.param (Encoders.nonNullable (contramap (fromIntegral :: Int -> Int64) Encoders.int8))
-    let retryStatement = Hasql.unpreparable retrySql retryEncoder Decoders.noResult
+    let uuidRowsDecoder = Decoders.rowList (Decoders.column (Decoders.nullable Decoders.uuid))
+    let retryStatement = Hasql.unpreparable retrySql retryEncoder uuidRowsDecoder
 
     -- Tier 2: Ancient stale jobs (>24h) -> mark failed
     let failSql =
-            "UPDATE " <> tableNameText
-            <> " SET status = 'job_status_failed', locked_by = NULL, locked_at = NULL"
-            <> ", last_error = 'Stale job: worker likely crashed'"
+            "WITH stale AS ("
+            <> " SELECT id, locked_by AS prev_locked_by FROM \"" <> tableNameText <> "\""
             <> " WHERE status = 'job_status_running'"
             <> " AND locked_at < NOW() - interval '1 day'"
-    let failStatement = Hasql.unpreparable failSql Encoders.noParams Decoders.noResult
+            <> " FOR UPDATE"
+            <> " ) UPDATE \"" <> tableNameText <> "\" t"
+            <> " SET status = 'job_status_failed', locked_by = NULL, locked_at = NULL"
+            <> ", last_error = 'Stale job: worker likely crashed'"
+            <> " FROM stale WHERE t.id = stale.id"
+            <> " RETURNING stale.prev_locked_by"
+    let failStatement = Hasql.unpreparable failSql Encoders.noParams uuidRowsDecoder
 
     let thresholdSeconds = round staleThreshold :: Int
-    runPool pool (HasqlSession.statement thresholdSeconds retryStatement)
-    runPool pool (HasqlSession.statement () failStatement)
+    retryRows <- runPool pool (HasqlSession.statement thresholdSeconds retryStatement)
+    failRows <- runPool pool (HasqlSession.statement () failStatement)
+    let allRows = retryRows ++ failRows
+    pure (length allRows, catMaybes allRows)

--- a/ihp/IHP/Job/Queue/Result.hs
+++ b/ihp/IHP/Job/Queue/Result.hs
@@ -21,7 +21,6 @@ import qualified Hasql.Statement as Hasql
 import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Decoders as Decoders
 import Data.Functor.Contravariant (contramap)
-import Data.UUID (UUID)
 
 -- | Called when a job failed. Sets the job status to 'JobStatusFailed' or 'JobStatusRetry' (if more attempts are possible) and resets 'lockedBy'
 jobDidFail :: forall job context.

--- a/ihp/IHP/Job/Runner/WorkerLoop.hs
+++ b/ihp/IHP/Job/Runner/WorkerLoop.hs
@@ -17,6 +17,7 @@ import qualified IHP.Log as Log
 import IHP.Hasql.FromRow (FromRowHasql)
 import Control.Concurrent.STM (atomically, newTBQueue, readTBQueue, writeTBQueue, newTVarIO, readTVar, readTVarIO, writeTVar, modifyTVar', check)
 import IHP.Job.Queue (tryWriteTBQueue)
+import qualified Hasql.Pool as HasqlPool
 
 worker :: forall job.
     ( job ~ GetModelByTableName (GetTableName job)
@@ -51,6 +52,24 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
     let ?context = frameworkConfig
     let ?modelContext = modelContext
     let pool = modelContext.hasqlPool
+
+    -- Boot-time stale job sweep. If a previous worker process died abnormally
+    -- (RTS heap overflow panic, SIGKILL from the OOM killer, segfault, kernel
+    -- panic) the Haskell exception machinery never ran, so rows it had picked
+    -- up are still in 'job_status_running' with the dead worker's UUID in
+    -- 'locked_by'. The periodic recovery loop below will eventually reclaim
+    -- them, but only after 'staleJobTimeout' has elapsed - meaning the queue
+    -- can stay blocked for the full timeout on every restart.
+    --
+    -- We run the sweep here, before the dispatcher and PG listener are wired
+    -- up, so no concurrent worker could have just legitimately locked a row.
+    --
+    -- In Development we use a 0s threshold (single-worker model: any running
+    -- row is from the previous, now-dead, dev process). In Production we use
+    -- the configured threshold to avoid stomping on a peer worker's in-flight
+    -- job in a multi-worker deployment.
+    liftIO $ runBootStaleJobSweep @job pool isDevelopment
+
     action <- liftIO $ atomically $ newTBQueue (fromIntegral (maxConcurrency @job))
     -- Seed the queue with one initial JobAvailable so the dispatcher attempts a fetch on startup
     liftIO $ atomically $ writeTBQueue action JobAvailable
@@ -137,3 +156,30 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
         Nothing -> pure Nothing
 
     pure JobWorkerProcess { dispatcher, subscription, pollerReleaseKey, action, staleRecoveryReleaseKey, activeCount }
+
+-- | Recover any rows left in 'job_status_running' by a previous worker process
+-- that died abnormally. Called once per job type at worker startup.
+--
+-- Threshold: 0 in development (sweep everything; previous dev process is
+-- definitely dead), the configured 'staleJobTimeout' in production (avoid
+-- stomping on a peer worker's in-flight job in multi-worker deployments).
+--
+-- Logs a single line summarising the recovery so the developer immediately
+-- understands what happened. Skipped silently if 'staleJobTimeout' is
+-- 'Nothing' (recovery disabled by the user).
+runBootStaleJobSweep :: forall job context.
+    ( Job job
+    , Table job
+    , ?context :: context
+    , HasField "logger" context Log.Logger
+    ) => HasqlPool.Pool -> Bool -> IO ()
+runBootStaleJobSweep pool isDev = case staleJobTimeout @job of
+    Nothing -> pure ()
+    Just threshold -> do
+        let bootThreshold = if isDev then 0 else threshold
+        (count, prevWorkerUuids) <- Queue.recoverStaleJobsForTable pool (tableName @job) bootThreshold
+        when (count > 0) do
+            let workerSummary = case prevWorkerUuids of
+                    [] -> "<unknown worker>" :: Text
+                    uuids -> intercalate ", " (map tshow uuids)
+            Log.info ("Recovered " <> tshow count <> " stale running job(s) at startup from previous worker(s): " <> workerSummary)

--- a/ihp/Test/Test/JobQueueSpec.hs
+++ b/ihp/Test/Test/JobQueueSpec.hs
@@ -16,8 +16,6 @@ import qualified Control.Exception as Exception
 import System.Environment (lookupEnv)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
-import Data.UUID (UUID)
-import Data.List (sort)
 
 data TestContext = TestContext
     { logger :: Logger

--- a/ihp/Test/Test/JobQueueSpec.hs
+++ b/ihp/Test/Test/JobQueueSpec.hs
@@ -14,6 +14,10 @@ import Control.Concurrent.STM (atomically, newTBQueue)
 import qualified Control.Concurrent as Concurrent
 import qualified Control.Exception as Exception
 import System.Environment (lookupEnv)
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V4 as UUID
+import Data.UUID (UUID)
+import Data.List (sort)
 
 data TestContext = TestContext
     { logger :: Logger
@@ -48,6 +52,50 @@ tests = do
                 dropNotificationTriggers pool longTestTableName
                 didRecover <- waitUntil 6_000_000 (JobQueue.notificationTriggersHealthy pool longTestTableName)
                 didRecover `shouldBe` True
+
+    describe "IHP.Job.Queue.recoverStaleJobsForTable" do
+        it "resets a stuck running job and returns its previous worker uuid" do
+            withStaleRecoveryTable \pool -> do
+                workerUuid <- UUID.nextRandom
+                jobId <- UUID.nextRandom
+                insertRunningJob pool staleRecoveryTableName jobId workerUuid
+
+                (count, recoveredUuids) <- JobQueue.recoverStaleJobsForTable pool staleRecoveryTableName 0
+
+                count `shouldBe` 1
+                recoveredUuids `shouldBe` [workerUuid]
+
+                -- A second sweep should be a no-op since the row is no longer running
+                (count2, uuids2) <- JobQueue.recoverStaleJobsForTable pool staleRecoveryTableName 0
+                count2 `shouldBe` 0
+                uuids2 `shouldBe` []
+
+        it "returns previous worker uuids for multiple stale rows" do
+            withStaleRecoveryTable \pool -> do
+                workerA <- UUID.nextRandom
+                workerB <- UUID.nextRandom
+                jobA <- UUID.nextRandom
+                jobB <- UUID.nextRandom
+                insertRunningJob pool staleRecoveryTableName jobA workerA
+                insertRunningJob pool staleRecoveryTableName jobB workerB
+
+                (count, recoveredUuids) <- JobQueue.recoverStaleJobsForTable pool staleRecoveryTableName 0
+
+                count `shouldBe` 2
+                sort recoveredUuids `shouldBe` sort [workerA, workerB]
+
+        it "leaves rows alone when their locked_at is younger than the threshold" do
+            withStaleRecoveryTable \pool -> do
+                workerUuid <- UUID.nextRandom
+                jobId <- UUID.nextRandom
+                insertRunningJob pool staleRecoveryTableName jobId workerUuid
+
+                -- Threshold of 1 hour: the row we just inserted is much younger,
+                -- so nothing should be recovered.
+                (count, recoveredUuids) <- JobQueue.recoverStaleJobsForTable pool staleRecoveryTableName 3600
+
+                count `shouldBe` 0
+                recoveredUuids `shouldBe` []
 
 withJobWatcher :: Bool -> (HasqlPool.Pool -> IO ()) -> IO ()
 withJobWatcher enablePollerTriggerRepair =
@@ -87,6 +135,20 @@ withDB action = do
 testTableName :: Text
 testTableName = "job_queue_spec_jobs"
 
+staleRecoveryTableName :: Text
+staleRecoveryTableName = "stale_job_recovery_spec_jobs"
+
+withStaleRecoveryTable :: (HasqlPool.Pool -> IO ()) -> IO ()
+withStaleRecoveryTable action =
+    withDB \modelContext _ _ -> do
+        let pool = modelContext.hasqlPool
+        Exception.finally
+            (do
+                dropTestTable pool staleRecoveryTableName
+                createTestTable pool staleRecoveryTableName
+                action pool)
+            (dropTestTable pool staleRecoveryTableName)
+
 longTestTableName :: Text
 longTestTableName = "job_queue_spec_jobs_with_a_very_long_table_name_for_trigger_truncation_regression_1234567890"
 
@@ -106,9 +168,21 @@ createTestTable pool tableName = do
         <> " id UUID PRIMARY KEY,"
         <> " status TEXT DEFAULT 'job_status_not_started' NOT NULL,"
         <> " locked_by UUID DEFAULT NULL,"
+        <> " locked_at TIMESTAMP WITH TIME ZONE DEFAULT NULL,"
+        <> " last_error TEXT DEFAULT NULL,"
         <> " run_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,"
         <> " created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL"
         <> " );"
+
+insertRunningJob :: HasqlPool.Pool -> Text -> UUID -> UUID -> IO ()
+insertRunningJob pool tableName jobId workerUuid =
+    runScript pool $
+        "INSERT INTO \"" <> tableName <> "\""
+        <> " (id, status, locked_by, locked_at)"
+        <> " VALUES ('" <> UUID.toText jobId <> "',"
+        <> " 'job_status_running',"
+        <> " '" <> UUID.toText workerUuid <> "',"
+        <> " NOW());"
 
 dropTestTable :: HasqlPool.Pool -> Text -> IO ()
 dropTestTable pool tableName =


### PR DESCRIPTION
## Summary

When a worker process dies abnormally (RTS heap overflow panic, SIGKILL from the OOM killer, segfault, kernel panic) the Haskell exception machinery never runs, so rows it had picked up remain in `job_status_running` with the dead worker's UUID in `locked_by`. The existing periodic stale-job recovery loop only reclaims these rows after the configured `staleJobTimeout` (default 10 minutes) has elapsed, so a fast crash/restart loop in development can leave the queue blocked on every restart, and there's no signal to the developer about what happened.

This PR runs a stale-job sweep once at worker startup, before the dispatcher and PG listener are wired up, with environment-aware thresholds and a clear log line.

## Reproduction (the bug this fixes)

1. Set `GHCRTS=-M512M` in any IHP app
2. Write a job that allocates a few GB of intermediate `Map`s
3. `devenv up`, observe ghci panic with "heap overflow"
4. Inspect the job table: row stuck in `job_status_running`, no `last_error`, locked by the now-dead worker
5. Restart `devenv up` and the row stays stuck for the full 10-minute `staleJobTimeout` window

## Approach

- New helper `IHP.Job.Queue.recoverStaleJobsForTable :: Pool -> Text -> NominalDiffTime -> IO (Int, [UUID])`. Same two-tier recovery as the existing `recoverStaleJobs`, but uses a CTE so RETURNING captures the pre-update `locked_by` values (a plain UPDATE ... RETURNING would observe the post-update NULL). Returns `(count, previousWorkerUuids)` so callers can log what happened. `recoverStaleJobs` is now a thin wrapper that discards the report.
- New `runBootStaleJobSweep` in `IHP.Job.Runner.WorkerLoop`. Called once at the top of `jobWorkerFetchAndRunLoop`, before any STM/dispatcher/PG-listener setup, so no concurrent worker could have just legitimately locked a row.
- Threshold:
  - **Development** (`isDevelopment`): 0 seconds — sweep everything. The dev server is single-worker, so any running row is from the previous now-dead process.
  - **Production**: the configured `staleJobTimeout`. Avoids stomping on a peer worker's in-flight job in multi-worker deployments.
- Skipped silently when `staleJobTimeout @job` is `Nothing` (recovery disabled by the user).
- Recovery does **not** bump `attempts_count` — the job never got to run cleanly, so the user's full attempt budget is preserved. Same as the existing periodic sweep.
- Logs a single line `Recovered N stale running job(s) at startup from previous worker(s): X, Y, Z` so a developer iterating on a leaky job immediately sees what happened.

## Tests

`ihp/Test/Test/JobQueueSpec.hs` adds a new `IHP.Job.Queue.recoverStaleJobsForTable` describe with three cases:

1. Resets a stuck `job_status_running` row, returns its previous worker UUID, and a second sweep is a no-op.
2. Returns previous worker UUIDs for multiple stale rows from different workers.
3. Leaves rows alone when `locked_at` is younger than the threshold.

The existing `createTestTable` helper gained `locked_at` and `last_error` columns (additive, no impact on the existing trigger tests).

```
IHP.Job.Queue
  recreates missing triggers when poller repair is enabled [v]
  does not recreate missing triggers when poller repair is disabled [v]
  keeps polling after trigger repair errors and recovers once table exists again [v]
  recreates missing triggers for long table names when poller repair is enabled [v]
IHP.Job.Queue.recoverStaleJobsForTable
  resets a stuck running job and returns its previous worker uuid [v]
  returns previous worker uuids for multiple stale rows [v]
  leaves rows alone when their locked_at is younger than the threshold [v]

Finished in 7.85 seconds
7 examples, 0 failures
```

## Future work (out of scope)

- **Postgres session-bound advisory locks** tied to the worker connection. Postgres would release these automatically on connection drop, making the in-Haskell stale-job machinery redundant. More robust but requires a schema and protocol shift.
- **LISTEN/NOTIFY dead-man-switch**: workers heartbeat via `NOTIFY` and peers reset rows whose worker UUID hasn't beaten in N seconds.

The startup-sweep fix in this PR solves the developer-facing pain with no schema changes; the larger redesigns can come later if the team wants them.

## Test plan

- [x] `ihp/Test/Test/JobQueueSpec.hs` — 7/7 green against a local Postgres
- [x] `ihp/Test/Test/Main.hs` compiles cleanly (147 modules)
- [ ] Manual repro: run an IHP app with a leaky job, kill the worker with `kill -9`, restart, verify the orphaned row is recovered immediately and logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)