### PR TITLE
Pin Postgres session timezone to UTC on every pooled connection

### DIFF
--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -93,6 +93,7 @@ createModelContext databaseUrl logger = do
     hasqlIdleTime :: Maybe Int <- envOrNothing "HASQL_IDLE_TIME"
     let hasqlPoolSettings =
             [ HasqlPoolConfig.staticConnectionSettings (HasqlSettings.connectionString (cs databaseUrl))
+            , HasqlPoolConfig.initSession (Hasql.script "SET SESSION timezone TO 'UTC'")
             ]
             <> maybe [HasqlPoolConfig.size 20] (\size -> [HasqlPoolConfig.size size]) hasqlPoolSize
             <> maybe [] (\idle -> [HasqlPoolConfig.idlenessTimeout (fromIntegral idle)]) hasqlIdleTime


### PR DESCRIPTION
## Summary
- Add `HasqlPoolConfig.initSession` that runs `SET SESSION timezone TO 'UTC'` on every freshly-acquired connection.
- IHP assumes UTC everywhere, but without an init session the timezone came from the server's `postgresql.conf` / role default / `PGTZ`, making `now()`, `current_timestamp`, and `date_trunc` non-deterministic across deployments.

## Why only timezone?
Inspired by [Rails' equivalent prelude](https://byroot.github.io/performance/2025/03/21/database-protocols.html). Of Rails' four SETs, only `timezone` is load-bearing for IHP:

- `client_encoding = UTF8` — hasql already sets this itself on connection acquisition.
- `client_min_messages = WARNING` — hasql already sets this itself.
- `standard_conforming_strings = on` — PostgreSQL default since 9.1.
- `intervalstyle = iso_8601` — Rails needs this because it parses intervals from the text protocol; hasql decodes them via the binary protocol into `DiffTime`, so the output style is irrelevant.

## Test plan
- [ ] `SHOW timezone` through the pool returns `UTC`.
- [ ] With `PGTZ=Europe/Berlin` (or `ALTER ROLE ... SET TIMEZONE = 'Europe/Berlin'`) on the server side, IHP queries still report `UTC` — proving the init session runs on every pooled connection.
- [ ] Existing test suites (`ihp-ide/Test/Main.hs`, `JobQueueSpec`, `FetchPipelinedSpec`, `Pagination/ControllerFunctionsSpec`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)