### PR TITLE
Add IsScalar Integer instance so BIGSERIAL/BIGINT primary keys compile

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -1088,6 +1088,35 @@ tests = do
                         pure (let theRecord = Generated.ActualTypes.Bar id ticker date def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
                     |]
 
+            it "should generate a BIGSERIAL PRIMARY KEY row decoder (#2648)" do
+                -- Regression: BIGSERIAL primary keys produce Mapping.decoder for the id
+                -- column. Prior to fixing, generated code broke with
+                -- `No instance for Mapping.IsScalar Integer` because `PBigserial` maps to
+                -- `Integer` and IHP shipped no `IsScalar Integer` instance.
+                let bugStatements =
+                        [ StatementCreateTable CreateTable
+                            { name = "validities"
+                            , columns =
+                                [ (col "id" PBigserial) { notNull = True }
+                                , (col "validity" PPolygon) { notNull = True }
+                                ]
+                            , primaryKeyConstraint = PrimaryKeyConstraint ["id"]
+                            , constraints = []
+                            , unlogged = False
+                            , inherits = Nothing
+                            }
+                        ]
+                let [StatementCreateTable bugTable] = bugStatements
+                let ?schema = Schema bugStatements
+                let output = compileRowDecoderModule bugTable
+                getStatementBody output `shouldBe` [trimming|
+                    rowDecoder :: Decoders.Row Generated.ActualTypes.Validity
+                    rowDecoder = do
+                        id <- Decoders.column (Decoders.nonNullable Mapping.decoder)
+                        validity <- Decoders.column (Decoders.nonNullable Mapping.decoder)
+                        pure (let theRecord = Generated.ActualTypes.Validity id validity def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                    |]
+
             it "should generate correct Create statement module" do
                 let output = compileCreateStatement theTable
                 getStatementBody output `shouldBe` [trimming|

--- a/ihp/IHP/Hasql/FromRow.hs
+++ b/ihp/IHP/Hasql/FromRow.hs
@@ -20,6 +20,7 @@ module IHP.Hasql.FromRow
 
 import Prelude
 import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Mapping.IsScalar as Mapping
 import qualified Database.PostgreSQL.Simple.Types as PG
 import Data.Functor.Contravariant (contramap)
@@ -52,6 +53,16 @@ instance {-# OVERLAPPING #-} HasqlDecodeColumn Int where
 
 instance {-# OVERLAPPING #-} HasqlDecodeColumn (Maybe Int) where
     hasqlColumnDecoder = Decoders.column (Decoders.nullable (fromIntegral <$> Decoders.int4))
+
+-- | IHP's schema maps SQL @BIGINT@/@BIGSERIAL@ to Haskell 'Integer' (see @atomicType@
+-- in @SchemaCompiler@). @hasql-mapping@ ships no 'IsScalar Integer' instance, so
+-- @BIGSERIAL@ primary keys (and foreign keys referencing them) fail to typecheck
+-- in generated 'RowDecoder' modules with @No instance for Mapping.IsScalar Integer@.
+-- Provide one backed by the @int8@ codec, mirroring the 'DefaultParamEncoder Integer'
+-- instance in "IHP.Hasql.Encoders".
+instance Mapping.IsScalar Integer where
+    encoder = contramap fromInteger Encoders.int8
+    decoder = fromIntegral <$> Decoders.int8
 
 -- | 'IsScalar' instance for 'Id'' so that Id columns can use 'Mapping.encoder' and 'Mapping.decoder'
 -- directly in generated code, without manual wrapping/unwrapping.


### PR DESCRIPTION
## Summary

- Reported by Michael Fliegner: a schema with `id BIGSERIAL PRIMARY KEY NOT NULL` + a `polygon NOT NULL` column fails to build with `No instance for Mapping.IsScalar Integer` in the generated `Generated.Statements.RowDecoder<Model>` module.
- Root cause: `SchemaCompiler` maps `PBigserial`/`PBigInt` to Haskell `Integer`, and `hasql-mapping` does not ship an `IsScalar Integer` instance. Primary- and foreign-key columns emit bare `Mapping.decoder`, which routes through `IsScalar (Id' table) => IsScalar (PrimaryKey table)` and gets stuck on `Integer`. `polygon` is a red herring — that type works fine via `postgresql-types`' `IsScalar Polygon`.
- Fix: add an orphan `IsScalar Integer` in `ihp/IHP/Hasql/FromRow.hs` backed by the `int8` codec, mirroring the existing `DefaultParamEncoder Integer` in `IHP.Hasql.Encoders`. No generator changes; generated text stays the same. Adds a text-level regression test for `BIGSERIAL`+`polygon`.

Out of scope (separate bug): `SERIAL`/`INT` primary keys route through `hasql-mapping`'s `IsScalar Int`, which uses `int8` on the wire — so `SERIAL` (int4) PKs round-trip with the wrong wire type. Worth a follow-up.

## Test plan

- [x] `echo ':l ihp/IHP/Hasql/FromRow.hs' | ghci` — module compiles
- [x] `echo -e ':l ihp-ide/Test/Main.hs\nmain' | ghci` — 401/401 pass, including new `#2648` regression test
- [x] `echo -e ':l ihp/Test/Test/Main.hs\nmain' | ghci` — 484 pass (+23 pending, Postgres-dependent)
- [ ] End-to-end host-project repro with Michael's schema: regenerate, confirm `RowDecoderValidity.hs` compiles, and round-trip a `Validity` with `createRecord` + `fetch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)