### PR TITLE
Default Apache request log %u to the current user's UUID

### DIFF
--- a/ihp/IHP/FrameworkConfig.hs
+++ b/ihp/IHP/FrameworkConfig.hs
@@ -41,8 +41,11 @@ import IHP.Log (makeRequestLogger, defaultRequestLogger)
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Middleware.Cors as Cors
 import qualified Network.Wai.Parse as WaiParse
+import Network.Wai (Request)
 import qualified Control.Exception as Exception
 import IHP.EnvVar
+import IHP.LoginSupport.Types (currentUserIdVaultKey, lookupAuthVault)
+import qualified Data.UUID as UUID
 
 import qualified Prelude
 import qualified GHC.Stack as Stack
@@ -103,7 +106,11 @@ ihpDefaultConfig = do
                                     reqLogger <- (logger |> defaultRequestLogger)
                                     pure (RequestLoggerMiddleware reqLogger)
                 Production  ->  do
-                                    reqLogger <- (logger |> makeRequestLogger def { RequestLogger.outputFormat = RequestLogger.Apache requestLoggerIpAddrSource })
+                                    let apacheSettings = RequestLogger.defaultApacheSettings
+                                            |> RequestLogger.setApacheIPAddrSource requestLoggerIpAddrSource
+                                            |> RequestLogger.setApacheUserGetter defaultApacheUserGetter
+                                    let settings = def { RequestLogger.outputFormat = RequestLogger.ApacheWithSettings apacheSettings }
+                                    reqLogger <- (logger |> makeRequestLogger settings)
                                     pure (RequestLoggerMiddleware reqLogger)
 
 
@@ -293,3 +300,12 @@ configIO :: (MonadIO monad, HasCallStack) => IO result -> monad result
 configIO action = liftIO (action `catch` wrapWithCallStack)
     where
         wrapWithCallStack exception = throwIO (ExceptionWithCallStack Stack.callStack exception)
+
+-- | Default 'setApacheUserGetter' for the production request logger.
+--
+-- Emits the logged-in user's UUID as the Apache @%u@ field, so request logs
+-- attribute traffic to a user id. Returns 'Nothing' for anonymous requests,
+-- which wai-extra renders as @-@.
+defaultApacheUserGetter :: Request -> Maybe ByteString
+defaultApacheUserGetter request =
+    UUID.toASCIIBytes <$> lookupAuthVault currentUserIdVaultKey request


### PR DESCRIPTION
## Summary

- Production's Apache request log has always shown `-` in the `%u` user
  field because `wai-extra`'s `setApacheUserGetter` was never wired up.
- This PR installs a default getter that reads `currentUserIdVaultKey`
  out of the request vault and renders the user's UUID via
  `Data.UUID.toASCIIBytes`.
- Anonymous requests still fall through to `Nothing`, which wai-extra
  renders as `-`. Dev mode is untouched since its `Detailed` output
  format doesn't surface `%u`.

The auth middleware populates the vault before `requestLoggerMiddleware`
wraps the handler (see `initMiddlewareStack` in `ihp/IHP/Server.hs`), so
by the time the logger reads the request the UUID is there.

Apps that want a different identifier (email, tenant id, …) can still
override `RequestLoggerMiddleware` in their own `Config/Config.hs`.

## Test plan

- [x] `echo ':l ihp/IHP/FrameworkConfig.hs' | ghci` — typechecks
- [x] `echo -e ':l ihp-ide/Test/Main.hs\nmain' | ghci` — 401 / 401 pass
- [ ] Manual: run an IHP app with `IHP_ENV=Production`, hit a route while
      logged out (`%u` = `-`), log in and hit the same route (`%u` =
      user's UUID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)