### PR TITLE
Deprecate sqlQuery/sqlExec, add unsafe* variants

### DIFF
--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -305,80 +305,126 @@ do
 
 The IHP query builder is designed to be able to easily express many basic sql queries. When your application is growing you will typically hit a point where a complex SQL query cannot be easily expressed with the IHP query builder. In that case it's recommended to use handwritten SQL to access your data.
 
-> **Tip:** For compile-time type-checked SQL queries, see the [Typed SQL Guide](typed-sql.html). Typed SQL automatically infers Haskell types from your SQL at compile time, eliminating the need for manual `FromRow` instances.
+> **Recommended:** Use the `[typedSql| ... |]` quasi quoter from [`IHP.TypedSql`](typed-sql.html). It connects to your development database at compile time and infers Haskell types for parameters and results — so mistakes surface as compile errors instead of runtime crashes. `sqlQuery`, `sqlQuerySingleRow`, `sqlQueryScalar`, `sqlQueryScalarOrNothing`, `sqlExec`, and `sqlExecDiscardResult` are **deprecated**; use `typedSql` with `sqlQueryTyped` / `sqlExecTyped`, or fall back to the `unsafeSql*` variants when a truly raw query is required.
 
-Use the function [`sqlQuery`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:sqlQuery) to run a raw SQL query:
+### Typed queries (preferred)
+
+Use [`typedSql`](https://ihp.digitallyinduced.com/api-docs/IHP-TypedSql.html#v:typedSql) with [`sqlQueryTyped`](https://ihp.digitallyinduced.com/api-docs/IHP-TypedSql.html#v:sqlQueryTyped) for any query you can write as a literal. Parameters are interpolated via `${expr}` and the result type is inferred from the SELECT list:
+
+```haskell
+import IHP.TypedSql (typedSql, sqlQueryTyped, sqlExecTyped)
+
+do
+    result <- sqlQueryTyped [typedSql|
+        SELECT id, title, body FROM projects WHERE id = ${id}
+    |]
+
+    -- WHERE id IN (...) via an array parameter
+    let ids :: [Id Project] = [id]
+    inList <- sqlQueryTyped [typedSql|
+        SELECT id, title, body FROM projects WHERE id = ANY(${ids})
+    |]
+
+    -- Post ids with their comment counts
+    commentsCount <- sqlQueryTyped [typedSql|
+        SELECT post_id, COUNT(*) FROM comments WHERE post_id = ANY(${postIds}) GROUP BY post_id
+    |]
+    -- commentsCount :: [(Id Post, Int64)]
+```
+
+For a single value use the same quoter and pick the first row:
 
 ```haskell
 do
-    result <- sqlQuery "SELECT * FROM projects WHERE id = ?" (Only id)
-
-    -- Query with WHERE id IN
-    result <- sqlQuery "SELECT * FROM projects WHERE id IN ?" (Only (In [id]))
-
-    -- Get a lists of posts with their Comment count
-    let postIds :: [Id Post] = ["1c3a81ff-55ca-42a8-82e0-31d04f642e53"]
-    commentsCount :: [(Id Post, Int)] <- sqlQuery "SELECT post_id, count(*) FROM comments WHERE post_id IN ? GROUP BY post_id" (Only (In postIds))
+    [count] <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM projects |]
+    -- count :: Int64
 ```
 
-You might need to specify the expected result type, as type inference might not be able to guess it:
+For `INSERT`/`UPDATE`/`DELETE` use [`sqlExecTyped`](https://ihp.digitallyinduced.com/api-docs/IHP-TypedSql.html#v:sqlExecTyped) to get the affected row count:
 
 ```haskell
 do
-    result :: [Project] <- sqlQuery "SELECT * FROM projects WHERE id = ?" (Only id)
+    rowsAffected <- sqlExecTyped [typedSql|
+        UPDATE projects SET archived = true WHERE id = ${projectId}
+    |]
 ```
 
-If you would like to have your query dynamically built with an argument you could:
+See the [Typed SQL Guide](typed-sql.html) for full details including RETURNING clauses, JOINs with nullable columns, and schema-change safety.
+
+### Unsafe raw SQL (escape hatch)
+
+Some queries cannot be expressed with `typedSql` — for example, queries whose table or column names are computed at runtime, or DDL statements that cannot be described without a dev database. For those, use [`unsafeSqlQuery`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:unsafeSqlQuery) and friends:
 
 ```haskell
 import qualified Database.PostgreSQL.Simple as PG
 import qualified Database.PostgreSQL.Simple.Types as PG
 
 do
-    -- Get all Projects
+    -- Dynamically-chosen table name — typedSql can't describe this
     let table :: Text = "projects"
-    -- Use PG.Identifier to prevent SQL injection
-    result :: [Project] <- sqlQuery "SELECT * FROM ?" [PG.Identifier table]
+    result :: [Project] <- unsafeSqlQuery "SELECT * FROM ?" [PG.Identifier table]
 ```
 
-If you need to fetch only a single column, for example only the ID of a record, you need to help the compiler and type hint
-the result, with an `Only` prefix. Here's an example of fetching only the IDs of a `project` table, and converting them to
-`Id Project`:
+If you need to fetch only a single column, type-hint the result with `Only`:
 
 ```haskell
 do
-    allProjectUuids :: [Only UUID] <- sqlQuery "SELECT projects.id FROM projects" ()
+    allProjectUuids :: [Only UUID] <- unsafeSqlQuery "SELECT projects.id FROM projects" ()
 
     let projectIds =
             allProjectUuids
-                -- Extract the UUIDs, and convert to an ID.
                 |> map (\(Only uuid) -> Id uuid :: Id Project)
 ```
 
+The `unsafe*` family skips compile-time checking; getting a column order or type wrong will fail only at runtime. Prefer `typedSql` whenever the query shape is known statically.
+
 ### Scalar Results
 
-The [`sqlQuery`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:sqlQuery) function always returns a list of rows as the result. When the result of your query is a single value (such as an integer or string) use [`sqlQueryScalar`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:sqlQueryScalar):
+Use [`unsafeSqlQueryScalar`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:unsafeSqlQueryScalar) when you have a raw query that returns a single value. When possible, prefer `sqlQueryTyped` with `[typedSql| ... |]` — it infers the type from the SELECT list automatically.
 
 ```haskell
 do
-    count :: Int <- sqlQueryScalar "SELECT COUNT(*) FROM projects" ()
+    count :: Int <- unsafeSqlQueryScalar "SELECT COUNT(*) FROM projects" ()
 
-    randomString :: Text <- sqlQueryScalar "SELECT md5(random()::text)" ()
+    randomString :: Text <- unsafeSqlQueryScalar "SELECT md5(random()::text)" ()
 ```
 
 ### Dealing With Complex Query Results
 
-Let's say you're querying posts and a count of comments on each post:
-
+With `typedSql`, complex result shapes are handled automatically — you do not need to define a `FromRow` instance. Selecting multiple columns returns a tuple or a labeled `SqlRow`:
 
 ```haskell
-do
-    result :: [Post] <- sqlQuery "SELECT posts.id, posts.title, (SELECT COUNT(*) FROM comments WHERE comments.post_id = posts.id) AS comments_count FROM posts" ()
+import IHP.TypedSql (typedSql, sqlQueryTyped)
+
+fetchPostsWithCommentsCount :: (?modelContext :: ModelContext) => IO [(Id Post, Text, Int64)]
+fetchPostsWithCommentsCount = sqlQueryTyped [typedSql|
+    SELECT posts.id, posts.title,
+        (SELECT COUNT(*) FROM comments WHERE comments.post_id = posts.id) AS comments_count
+    FROM posts
+|]
 ```
 
-This will fail at runtime because the result set cannot be decoded as expected. The result has the columns `id`, `title` and `comments_count` but a Post record consists of `id`, `title`, `body`.
+If you need a named record type for readability, map over the result:
 
-The solution here is to write our own data type and mapping code:
+```haskell
+data PostWithCommentsCount = PostWithCommentsCount
+    { id :: Id Post
+    , title :: Text
+    , commentsCount :: Int64
+    }
+    deriving (Eq, Show)
+
+fetchPostsWithCommentsCount :: (?modelContext :: ModelContext) => IO [PostWithCommentsCount]
+fetchPostsWithCommentsCount = do
+    rows <- sqlQueryTyped [typedSql|
+        SELECT posts.id, posts.title,
+            (SELECT COUNT(*) FROM comments WHERE comments.post_id = posts.id) AS comments_count
+        FROM posts
+    |]
+    pure (map (\(id, title, commentsCount) -> PostWithCommentsCount { id, title, commentsCount }) rows)
+```
+
+If you must use `unsafeSqlQuery` for a complex result, define a record type and a manual `FromRow` instance:
 
 ```haskell
 module Application.PostsQuery where
@@ -405,7 +451,7 @@ instance FromRow PostWithCommentsCount where
 fetchPostsWithCommentsCount :: (?modelContext :: ModelContext) => IO [PostWithCommentsCount]
 fetchPostsWithCommentsCount = do
     trackTableRead "posts" -- This is needed when using auto refresh, so auto refresh knows that your action is accessing the posts table
-    sqlQuery "SELECT posts.id, posts.title, (SELECT COUNT(*) FROM comments WHERE comments.post_id = posts.id) AS comments_count FROM posts" ()
+    unsafeSqlQuery "SELECT posts.id, posts.title, (SELECT COUNT(*) FROM comments WHERE comments.post_id = posts.id) AS comments_count FROM posts" ()
 ```
 
 You can now fetch posts with their comments count like this:
@@ -461,7 +507,7 @@ fetchActiveWorkers = do
     trackTableRead "worker_settings"
     trackTableRead "action_run_states"
     trackTableRead "send_message_actions"
-    sqlQuery query ()
+    unsafeSqlQuery query ()
 
 query :: Query
 query =

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -7,7 +7,7 @@ import qualified Data.Text.IO                      as Text
 import           IHP.Log.Types
 import           IHP.ModelSupport                  (createModelContext,
                                                     releaseModelContext,
-                                                    sqlExecDiscardResult)
+                                                    unsafeSqlExecDiscardResult)
 import           IHP.Prelude
 import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullableTables,
                                                     extractNonNullableComputedColumnsFromAst,
@@ -430,43 +430,43 @@ withTestModelContext action = do
 
 setupSchema :: (?modelContext :: ModelContext) => IO ()
 setupSchema = do
-    -- Use sqlExecDiscardResult for DDL (DROP/CREATE) since they have no rows-affected count
-    sqlExecDiscardResult "DROP TABLE IF EXISTS typed_sql_test_extras" ()
-    sqlExecDiscardResult "DROP TABLE IF EXISTS typed_sql_test_items" ()
-    sqlExecDiscardResult "DROP TABLE IF EXISTS typed_sql_test_authors" ()
-    sqlExecDiscardResult "DROP TYPE IF EXISTS typed_sql_test_pair" ()
+    -- Use unsafeSqlExecDiscardResult for DDL (DROP/CREATE) since they have no rows-affected count
+    unsafeSqlExecDiscardResult "DROP TABLE IF EXISTS typed_sql_test_extras" ()
+    unsafeSqlExecDiscardResult "DROP TABLE IF EXISTS typed_sql_test_items" ()
+    unsafeSqlExecDiscardResult "DROP TABLE IF EXISTS typed_sql_test_authors" ()
+    unsafeSqlExecDiscardResult "DROP TYPE IF EXISTS typed_sql_test_pair" ()
 
-    sqlExecDiscardResult "CREATE TYPE typed_sql_test_pair AS (name TEXT, views INT)" ()
+    unsafeSqlExecDiscardResult "CREATE TYPE typed_sql_test_pair AS (name TEXT, views INT)" ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "CREATE TABLE typed_sql_test_authors (id UUID PRIMARY KEY, name TEXT NOT NULL)"
         ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "CREATE TABLE typed_sql_test_items (id UUID PRIMARY KEY, author_id UUID REFERENCES typed_sql_test_authors(id), name TEXT NOT NULL, views INT NOT NULL, score DOUBLE PRECISION, tags TEXT[] NOT NULL DEFAULT '{}')"
         ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "INSERT INTO typed_sql_test_authors (id, name) VALUES ('00000000-0000-0000-0000-000000000001'::uuid, 'Alice')"
         ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "INSERT INTO typed_sql_test_authors (id, name) VALUES ('00000000-0000-0000-0000-000000000002'::uuid, 'Bob')"
         ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "INSERT INTO typed_sql_test_items (id, author_id, name, views, score, tags) VALUES ('10000000-0000-0000-0000-000000000001'::uuid, '00000000-0000-0000-0000-000000000001'::uuid, 'First', 5, 1.5, ARRAY['red', 'blue'])"
         ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "INSERT INTO typed_sql_test_items (id, author_id, name, views, score, tags) VALUES ('10000000-0000-0000-0000-000000000002'::uuid, '00000000-0000-0000-0000-000000000001'::uuid, 'Second', 8, NULL, ARRAY['green'])"
         ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "CREATE TABLE typed_sql_test_extras (id UUID PRIMARY KEY, small_count SMALLINT NOT NULL DEFAULT 0, big_count BIGINT NOT NULL DEFAULT 0, amount NUMERIC, payload BYTEA, metadata JSONB, created_at TIMESTAMPTZ NOT NULL DEFAULT '2025-06-15 12:00:00+00', due_date DATE, active BOOLEAN NOT NULL DEFAULT TRUE)"
         ()
 
-    sqlExecDiscardResult
+    unsafeSqlExecDiscardResult
         "INSERT INTO typed_sql_test_extras (id, small_count, big_count, amount, payload, metadata, created_at, due_date, active) VALUES ('20000000-0000-0000-0000-000000000001'::uuid, 7, 1000000000, 99.95, '\\xDEADBEEF', '{\"key\": \"value\"}', '2025-06-15 12:00:00+00', '2025-06-15', true)"
         ()
 

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -243,69 +243,98 @@ textToId text = case parsePrimaryKey (cs text) of
 {-# INLINE textToId #-}
 
 
--- | Runs a raw sql query
+-- | Runs a raw sql query. Untyped escape hatch — prefer the typed
+-- @[typedSql| ... |]@ quasi quoter (from "IHP.TypedSql") when the query is
+-- known at compile time.
 --
 -- __Example:__
 --
--- > users <- sqlQuery "SELECT id, firstname, lastname FROM users" ()
+-- > users <- unsafeSqlQuery "SELECT id, firstname, lastname FROM users" ()
 --
 -- Take a look at "IHP.QueryBuilder" for a typesafe approach on building simple queries.
 --
--- *AutoRefresh:* When using 'sqlQuery' with AutoRefresh, you need to use 'trackTableRead' to let AutoRefresh know that you have accessed a certain table. Otherwise AutoRefresh will not watch table of your custom sql query.
+-- *AutoRefresh:* When using 'unsafeSqlQuery' with AutoRefresh, you need to use 'trackTableRead' to let AutoRefresh know that you have accessed a certain table. Otherwise AutoRefresh will not watch table of your custom sql query.
 --
--- Use 'sqlQuerySingleRow' if you expect only a single row to be returned.
+-- Use 'unsafeSqlQuerySingleRow' if you expect only a single row to be returned.
 --
-sqlQuery :: (?modelContext :: ModelContext, ToSnippetParams q, FromRowHasql r) => Query -> q -> IO [r]
-sqlQuery theQuery theParameters = do
+unsafeSqlQuery :: (?modelContext :: ModelContext, ToSnippetParams q, FromRowHasql r) => Query -> q -> IO [r]
+unsafeSqlQuery theQuery theParameters = do
     let pool = ?modelContext.hasqlPool
     let snippet = sqlToSnippet (fromQuery theQuery) (toSnippetParams theParameters)
     sqlQueryHasql pool snippet (Decoders.rowList hasqlRowDecoder)
+{-# INLINABLE unsafeSqlQuery #-}
+
+-- | Deprecated alias of 'unsafeSqlQuery'. Prefer @[typedSql| ... |]@ via 'IHP.TypedSql.sqlQueryTyped'.
+{-# DEPRECATED sqlQuery "Use the typed quasi quoter '[typedSql| ... |]' with 'sqlQueryTyped' (from IHP.TypedSql) for compile-time type checking. If you really need untyped raw SQL (e.g. dynamic table names), use 'unsafeSqlQuery' instead." #-}
+sqlQuery :: (?modelContext :: ModelContext, ToSnippetParams q, FromRowHasql r) => Query -> q -> IO [r]
+sqlQuery = unsafeSqlQuery
 {-# INLINABLE sqlQuery #-}
 
 
--- | Runs a raw sql query, that is expected to return a single result row
+-- | Runs a raw sql query, that is expected to return a single result row.
+-- Untyped escape hatch — prefer the typed @[typedSql| ... |]@ quasi quoter.
 --
--- Like 'sqlQuery', but useful when you expect only a single row as the result
+-- Like 'unsafeSqlQuery', but useful when you expect only a single row as the result.
 --
 -- __Example:__
 --
--- > user <- sqlQuerySingleRow "SELECT id, firstname, lastname FROM users WHERE id = ?" (Only user.id)
+-- > user <- unsafeSqlQuerySingleRow "SELECT id, firstname, lastname FROM users WHERE id = ?" (Only user.id)
 --
 -- Take a look at "IHP.QueryBuilder" for a typesafe approach on building simple queries.
 --
--- *AutoRefresh:* When using 'sqlQuerySingleRow' with AutoRefresh, you need to use 'trackTableRead' to let AutoRefresh know that you have accessed a certain table. Otherwise AutoRefresh will not watch table of your custom sql query.
+-- *AutoRefresh:* When using 'unsafeSqlQuerySingleRow' with AutoRefresh, you need to use 'trackTableRead' to let AutoRefresh know that you have accessed a certain table. Otherwise AutoRefresh will not watch table of your custom sql query.
 --
-sqlQuerySingleRow :: (?modelContext :: ModelContext, ToSnippetParams query, FromRowHasql record) => Query -> query -> IO record
-sqlQuerySingleRow theQuery theParameters = do
-    result <- sqlQuery theQuery theParameters
+unsafeSqlQuerySingleRow :: (?modelContext :: ModelContext, ToSnippetParams query, FromRowHasql record) => Query -> query -> IO record
+unsafeSqlQuerySingleRow theQuery theParameters = do
+    result <- unsafeSqlQuery theQuery theParameters
     case result of
-        [] -> error ("sqlQuerySingleRow: Expected a single row to be returned. Query: " <> show theQuery)
+        [] -> error ("unsafeSqlQuerySingleRow: Expected a single row to be returned. Query: " <> show theQuery)
         [record] -> pure record
-        otherwise -> error ("sqlQuerySingleRow: Expected a single row to be returned. But got " <> show (length otherwise) <> " rows")
+        otherwise -> error ("unsafeSqlQuerySingleRow: Expected a single row to be returned. But got " <> show (length otherwise) <> " rows")
+{-# INLINABLE unsafeSqlQuerySingleRow #-}
+
+-- | Deprecated alias of 'unsafeSqlQuerySingleRow'.
+{-# DEPRECATED sqlQuerySingleRow "Use the typed quasi quoter '[typedSql| ... |]' with 'sqlQueryTyped' (from IHP.TypedSql) for compile-time type checking. If you really need untyped raw SQL, use 'unsafeSqlQuerySingleRow' instead." #-}
+sqlQuerySingleRow :: (?modelContext :: ModelContext, ToSnippetParams query, FromRowHasql record) => Query -> query -> IO record
+sqlQuerySingleRow = unsafeSqlQuerySingleRow
 {-# INLINABLE sqlQuerySingleRow #-}
 
--- | Runs a sql statement (like a CREATE statement)
+-- | Runs a sql statement (like a CREATE statement). Untyped escape hatch —
+-- prefer the typed @[typedSql| ... |]@ quasi quoter via 'IHP.TypedSql.sqlExecTyped'.
 --
 -- __Example:__
 --
--- > sqlExec "CREATE TABLE users ()" ()
-sqlExec :: (?modelContext :: ModelContext, ToSnippetParams q) => Query -> q -> IO Int64
-sqlExec theQuery theParameters = do
+-- > unsafeSqlExec "CREATE TABLE users ()" ()
+unsafeSqlExec :: (?modelContext :: ModelContext, ToSnippetParams q) => Query -> q -> IO Int64
+unsafeSqlExec theQuery theParameters = do
     let pool = ?modelContext.hasqlPool
     let snippet = sqlToSnippet (fromQuery theQuery) (toSnippetParams theParameters)
     sqlExecHasqlCount pool snippet
+{-# INLINABLE unsafeSqlExec #-}
+
+-- | Deprecated alias of 'unsafeSqlExec'.
+{-# DEPRECATED sqlExec "Use the typed quasi quoter '[typedSql| ... |]' with 'sqlExecTyped' (from IHP.TypedSql) for compile-time type checking. If you really need untyped raw SQL (e.g. DDL statements), use 'unsafeSqlExec' instead." #-}
+sqlExec :: (?modelContext :: ModelContext, ToSnippetParams q) => Query -> q -> IO Int64
+sqlExec = unsafeSqlExec
 {-# INLINABLE sqlExec #-}
 
--- | Runs a sql statement (like a CREATE statement), but doesn't return any result
+-- | Runs a sql statement (like a CREATE statement), but doesn't return any result.
+-- Untyped escape hatch — prefer the typed @[typedSql| ... |]@ quasi quoter via 'IHP.TypedSql.sqlExecTyped'.
 --
 -- __Example:__
 --
--- > sqlExecDiscardResult "CREATE TABLE users ()" ()
-sqlExecDiscardResult :: (?modelContext :: ModelContext, ToSnippetParams q) => Query -> q -> IO ()
-sqlExecDiscardResult theQuery theParameters = do
+-- > unsafeSqlExecDiscardResult "CREATE TABLE users ()" ()
+unsafeSqlExecDiscardResult :: (?modelContext :: ModelContext, ToSnippetParams q) => Query -> q -> IO ()
+unsafeSqlExecDiscardResult theQuery theParameters = do
     let pool = ?modelContext.hasqlPool
     let snippet = sqlToSnippet (fromQuery theQuery) (toSnippetParams theParameters)
     sqlExecHasql pool snippet
+{-# INLINABLE unsafeSqlExecDiscardResult #-}
+
+-- | Deprecated alias of 'unsafeSqlExecDiscardResult'.
+{-# DEPRECATED sqlExecDiscardResult "Use the typed quasi quoter '[typedSql| ... |]' with 'sqlExecTyped' (from IHP.TypedSql) for compile-time type checking. If you really need untyped raw SQL (e.g. DDL statements), use 'unsafeSqlExecDiscardResult' instead." #-}
+sqlExecDiscardResult :: (?modelContext :: ModelContext, ToSnippetParams q) => Query -> q -> IO ()
+sqlExecDiscardResult = unsafeSqlExecDiscardResult
 {-# INLINABLE sqlExecDiscardResult #-}
 
 
@@ -473,35 +502,49 @@ processRequests requestMVar = do
             processRequests requestMVar
         Nothing -> pure ()
 
--- | Runs a raw sql query which results in a single scalar value such as an integer or string
+-- | Runs a raw sql query which results in a single scalar value such as an integer or string.
+-- Untyped escape hatch — prefer the typed @[typedSql| ... |]@ quasi quoter.
 --
 -- __Example:__
 --
--- > usersCount <- sqlQueryScalar "SELECT COUNT(*) FROM users"
+-- > usersCount <- unsafeSqlQueryScalar "SELECT COUNT(*) FROM users" ()
 --
 -- Take a look at "IHP.QueryBuilder" for a typesafe approach on building simple queries.
-sqlQueryScalar :: (?modelContext :: ModelContext, ToSnippetParams q, HasqlDecodeColumn value) => Query -> q -> IO value
-sqlQueryScalar theQuery theParameters = do
-    result <- sqlQuery theQuery theParameters
+unsafeSqlQueryScalar :: (?modelContext :: ModelContext, ToSnippetParams q, HasqlDecodeColumn value) => Query -> q -> IO value
+unsafeSqlQueryScalar theQuery theParameters = do
+    result <- unsafeSqlQuery theQuery theParameters
     pure case result of
         [PG.Only result] -> result
-        _ -> error "sqlQueryScalar: Expected a scalar result value"
+        _ -> error "unsafeSqlQueryScalar: Expected a scalar result value"
+{-# INLINABLE unsafeSqlQueryScalar #-}
+
+-- | Deprecated alias of 'unsafeSqlQueryScalar'.
+{-# DEPRECATED sqlQueryScalar "Use the typed quasi quoter '[typedSql| ... |]' with 'sqlQueryTyped' (from IHP.TypedSql) for compile-time type checking. If you really need untyped raw SQL, use 'unsafeSqlQueryScalar' instead." #-}
+sqlQueryScalar :: (?modelContext :: ModelContext, ToSnippetParams q, HasqlDecodeColumn value) => Query -> q -> IO value
+sqlQueryScalar = unsafeSqlQueryScalar
 {-# INLINABLE sqlQueryScalar #-}
 
--- | Runs a raw sql query which results in a single scalar value such as an integer or string, or nothing
+-- | Runs a raw sql query which results in a single scalar value such as an integer or string, or nothing.
+-- Untyped escape hatch — prefer the typed @[typedSql| ... |]@ quasi quoter.
 --
 -- __Example:__
 --
--- > usersCount <- sqlQueryScalarOrNothing "SELECT COUNT(*) FROM users"
+-- > usersCount <- unsafeSqlQueryScalarOrNothing "SELECT COUNT(*) FROM users" ()
 --
 -- Take a look at "IHP.QueryBuilder" for a typesafe approach on building simple queries.
-sqlQueryScalarOrNothing :: (?modelContext :: ModelContext, ToSnippetParams q, HasqlDecodeColumn value) => Query -> q -> IO (Maybe value)
-sqlQueryScalarOrNothing theQuery theParameters = do
-    result <- sqlQuery theQuery theParameters
+unsafeSqlQueryScalarOrNothing :: (?modelContext :: ModelContext, ToSnippetParams q, HasqlDecodeColumn value) => Query -> q -> IO (Maybe value)
+unsafeSqlQueryScalarOrNothing theQuery theParameters = do
+    result <- unsafeSqlQuery theQuery theParameters
     pure case result of
         [] -> Nothing
         [PG.Only result] -> Just result
-        _ -> error "sqlQueryScalarOrNothing: Expected a scalar result value or an empty result set"
+        _ -> error "unsafeSqlQueryScalarOrNothing: Expected a scalar result value or an empty result set"
+{-# INLINABLE unsafeSqlQueryScalarOrNothing #-}
+
+-- | Deprecated alias of 'unsafeSqlQueryScalarOrNothing'.
+{-# DEPRECATED sqlQueryScalarOrNothing "Use the typed quasi quoter '[typedSql| ... |]' with 'sqlQueryTyped' (from IHP.TypedSql) for compile-time type checking. If you really need untyped raw SQL, use 'unsafeSqlQueryScalarOrNothing' instead." #-}
+sqlQueryScalarOrNothing :: (?modelContext :: ModelContext, ToSnippetParams q, HasqlDecodeColumn value) => Query -> q -> IO (Maybe value)
+sqlQueryScalarOrNothing = unsafeSqlQueryScalarOrNothing
 {-# INLINABLE sqlQueryScalarOrNothing #-}
 
 -- | Executes the given block with a database transaction


### PR DESCRIPTION
## Summary

AI agents and humans frequently reach for the string-based `sqlQuery` / `sqlExec` family instead of the type-safe `[typedSql| ... |]` quasi quoter. Because the string-based APIs only decode results at runtime, mistakes surface as production crashes rather than compile errors.

This PR keeps the old functions working but nudges callers toward the typed API:

- **Adds `unsafe*` variants** (`unsafeSqlQuery`, `unsafeSqlQuerySingleRow`, `unsafeSqlExec`, `unsafeSqlExecDiscardResult`, `unsafeSqlQueryScalar`, `unsafeSqlQueryScalarOrNothing`) in `IHP.ModelSupport`. These carry the real implementation.
- **Deprecates the old names** — they become thin aliases with `{-# DEPRECATED #-}` pragmas that point users at `[typedSql| ... |]` first (via `sqlQueryTyped`/`sqlExecTyped`) and `unsafeSql*` as an explicit escape hatch.
- **Repoints internal IHP callers** (just the TypedSql test fixtures that need raw DDL) at the `unsafe*` names so the library itself compiles without warnings.
- **Rewrites the "Raw SQL Queries" section of the database guide** to lead with `typedSql` and describe `unsafeSqlQuery` as the escape hatch for cases `typedSql` can't express (dynamic identifiers, DDL without a dev DB, etc.).

## Why

`typedSql` connects to the dev database at compile time and infers parameter and result types from the SQL itself, so schema drift and column mistakes become compile errors. Most callers of `sqlQuery`/`sqlExec` are writing queries that `typedSql` could handle — they just reach for the older API out of habit. A deprecation warning at every call site is the cheapest way to surface the better alternative without breaking anyone.

`-Werror=deprecations` is not enabled in IHP's cabal files, so existing user code continues to build — the warning is visible but non-fatal.

## Example of the warning

```
/path/to/MyController.hs:42:11: warning: [GHC-68441] [-Wdeprecations]
    In the use of ‘sqlQuery’ (imported from IHP.ModelSupport):
    Deprecated: "Use the typed quasi quoter '[typedSql| ... |]' with 'sqlQueryTyped' (from IHP.TypedSql) for compile-time type checking. If you really need untyped raw SQL (e.g. dynamic table names), use 'unsafeSqlQuery' instead."
```

## Test plan

- [x] `ghci` loads `ihp/IHP/ModelSupport.hs` cleanly
- [x] `ghci` loads `ihp-typed-sql/Test/Test/TypedSqlSpec.hs` cleanly (fixtures updated to `unsafeSqlExecDiscardResult`)
- [x] `ghci` loads `ihp-ide/Test/Main.hs` (208 modules) without any deprecation warnings from IHP's own sources
- [x] `ghci` loads `ihp-datasync/IHP/DataSync/RowLevelSecurity.hs` (94 modules) cleanly
- [x] Test compile of an external module confirms `sqlQuery`/`sqlQueryScalar`/`sqlExec` emit `-Wdeprecations` warnings with the migration hint, while `unsafeSqlQuery` is silent
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)