### PR TITLE
Use Int64 for LIMIT/OFFSET to match PostgreSQL's int8 wire type

### DIFF
--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -187,7 +187,7 @@ Computed expressions (aggregates, CASE, arithmetic, literals, etc.) are always w
 
 ```haskell
 counts <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM items |]
--- counts :: [Maybe Integer]
+-- counts :: [Maybe Int64]
 
 results <- sqlQueryTyped [typedSql|
     SELECT CASE WHEN views > 5 THEN name ELSE 'low' END FROM items
@@ -303,7 +303,7 @@ rows <- sqlQueryTyped [typedSql|
     SELECT name, row_number() OVER (ORDER BY views DESC)
     FROM items
 |]
--- rows :: [(Text, Maybe Integer)]
+-- rows :: [(Text, Maybe Int64)]
 ```
 
 ### GROUP BY with Aggregates
@@ -315,7 +315,7 @@ rows <- sqlQueryTyped [typedSql|
     GROUP BY name
     ORDER BY name
 |]
--- rows :: [(Text, Maybe Integer)]
+-- rows :: [(Text, Maybe Int64)]
 ```
 
 ## Type Mapping Reference
@@ -325,7 +325,7 @@ The following table shows how PostgreSQL types map to Haskell types:
 | PostgreSQL Type | Haskell Type |
 |---|---|
 | `int2`, `int4` | `Int` |
-| `int8` | `Integer` |
+| `int8` | `Int64` |
 | `text`, `varchar`, `bpchar`, `citext` | `Text` |
 | `bool` | `Bool` |
 | `uuid` | `UUID` (or `Id' "table"` for primary/foreign keys) |

--- a/ihp-typed-sql/IHP/TypedSql/TypeMapping.hs
+++ b/ihp-typed-sql/IHP/TypedSql/TypeMapping.hs
@@ -120,7 +120,7 @@ hsTypeForPg typeInfo nullable PgTypeInfo { ptiName, ptiElem, ptiType } = do
             elemTy <- hsTypeForPg typeInfo False elemInfo
             pure (TH.AppT TH.ListT elemTy)
         _ | ptiName `elem` ["int2", "int4"] -> pure (TH.ConT ''Int)
-        _ | ptiName == "int8" -> pure (TH.ConT ''Integer)
+        _ | ptiName == "int8" -> pure (TH.ConT ''Int64)
         _ | ptiName `elem` ["text", "varchar", "bpchar", "citext"] -> pure (TH.ConT ''Text)
         _ | ptiName == "bool" -> pure (TH.ConT ''Bool)
         _ | ptiName == "uuid" -> pure (TH.ConT ''UUID)

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -108,8 +108,8 @@ tests = do
                 "[typedSql| SELECT author_id IS NULL FROM typed_sql_test_items LIMIT 1 |]")
             []
 
-        compileFailTest "fails when COUNT(*) result is annotated as Maybe Integer"
-            (mkTestModule "TypedQuery (Maybe Integer)"
+        compileFailTest "fails when COUNT(*) result is annotated as Maybe Int64"
+            (mkTestModule "TypedQuery (Maybe Int64)"
                 "[typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]")
             []
 
@@ -158,13 +158,13 @@ tests = do
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views > 6 UNION ALL SELECT name FROM typed_sql_test_items WHERE views < 6 |]")
             []
 
-        compileFailTest "fails when window function result is annotated as Maybe Integer"
-            (mkTestModule "TypedQuery (Maybe Integer)"
+        compileFailTest "fails when window function result is annotated as Maybe Int64"
+            (mkTestModule "TypedQuery (Maybe Int64)"
                 "[typedSql| SELECT row_number() OVER (ORDER BY name) FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when grouped COUNT(*) result is annotated as a tuple"
-            (mkTestModule "TypedQuery (Text, Maybe Integer)"
+            (mkTestModule "TypedQuery (Text, Maybe Int64)"
                 "[typedSql| SELECT name, COUNT(*) FROM typed_sql_test_items GROUP BY name ORDER BY name LIMIT 1 |]")
             []
 
@@ -203,8 +203,8 @@ tests = do
             (mkTestModule "TypedQuery (Maybe Bool)"
                 "[typedSql| SELECT author_id IS NULL FROM typed_sql_test_items LIMIT 1 |]")
 
-        compilePassTest "COUNT(*) inferred as Integer"
-            (mkTestModule "TypedQuery Integer"
+        compilePassTest "COUNT(*) inferred as Int64"
+            (mkTestModule "TypedQuery Int64"
                 "[typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]")
 
         compilePassTest "COALESCE with non-null fallback inferred as non-Maybe"
@@ -243,12 +243,12 @@ tests = do
             (mkTestModule "TypedQuery (Maybe Text)"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views > 6 UNION ALL SELECT name FROM typed_sql_test_items WHERE views < 6 |]")
 
-        compilePassTest "window function inferred as Integer"
-            (mkTestModule "TypedQuery Integer"
+        compilePassTest "window function inferred as Int64"
+            (mkTestModule "TypedQuery Int64"
                 "[typedSql| SELECT row_number() OVER (ORDER BY name) FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "grouped COUNT(*) returns SqlRow"
-            (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Text), '(\"count\", Integer) ])"
+            (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Text), '(\"count\", Int64) ])"
                 "[typedSql| SELECT name, COUNT(*) FROM typed_sql_test_items GROUP BY name ORDER BY name LIMIT 1 |]")
 
         compilePassTest "array literal inferred as Maybe [Text]"
@@ -271,16 +271,16 @@ tests = do
             (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Text), '(\"name_1\", Text) ])"
                 "[typedSql| SELECT i.name, a.name FROM typed_sql_test_items i INNER JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]")
 
-        compilePassTest "COUNT through subquery alias inferred as Integer"
-            (mkTestModule "TypedQuery Integer"
+        compilePassTest "COUNT through subquery alias inferred as Int64"
+            (mkTestModule "TypedQuery Int64"
                 "[typedSql| SELECT p.c FROM (SELECT count(*) AS c FROM typed_sql_test_items) AS p |]")
 
         compilePassTest "SUM through subquery alias remains Maybe"
-            (mkTestModule "TypedQuery (Maybe Integer)"
+            (mkTestModule "TypedQuery (Maybe Int64)"
                 "[typedSql| SELECT p.s FROM (SELECT sum(views) AS s FROM typed_sql_test_items) AS p |]")
 
-        compilePassTest "COUNT through CTE inferred as Integer"
-            (mkTestModule "TypedQuery Integer"
+        compilePassTest "COUNT through CTE inferred as Int64"
+            (mkTestModule "TypedQuery Int64"
                 "[typedSql| WITH item_counts AS (SELECT count(*) AS c FROM typed_sql_test_items) SELECT c FROM item_counts |]")
 
     describe "TypedSql macro runtime execution" do
@@ -802,7 +802,7 @@ compilePassModule = Text.unlines
     , "qBoolExpr :: TypedQuery (Maybe Bool)"
     , "qBoolExpr = [typedSql| SELECT author_id IS NULL FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qCountExpr :: TypedQuery Integer"
+    , "qCountExpr :: TypedQuery Int64"
     , "qCountExpr = [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
     , ""
     , "qLiteralInt :: TypedQuery Int"
@@ -829,10 +829,10 @@ compilePassModule = Text.unlines
     , "qUnion :: TypedQuery (Maybe Text)"
     , "qUnion = [typedSql| SELECT name FROM typed_sql_test_items WHERE views > 6 UNION ALL SELECT name FROM typed_sql_test_items WHERE views < 6 |]"
     , ""
-    , "qWindow :: TypedQuery Integer"
+    , "qWindow :: TypedQuery Int64"
     , "qWindow = [typedSql| SELECT row_number() OVER (ORDER BY name) FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qGroupedCount :: TypedQuery (SqlRow '[ '(\"name\", Text), '(\"count\", Integer) ])"
+    , "qGroupedCount :: TypedQuery (SqlRow '[ '(\"name\", Text), '(\"count\", Int64) ])"
     , "qGroupedCount = [typedSql| SELECT name, COUNT(*) FROM typed_sql_test_items GROUP BY name ORDER BY name LIMIT 1 |]"
     , ""
     , "qArrayLiteral :: TypedQuery (Maybe [Text])"
@@ -968,7 +968,7 @@ runtimeModule = Text.unlines
     , ""
     , "        countRows <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
     , ""
-    , "        when ((countRows :: [Integer]) /= [2]) do"
+    , "        when ((countRows :: [Int64]) /= [2]) do"
     , "            error (\"unexpected rows from count query: \" <> show countRows)"
     , ""
     , "        literalRows <- sqlQueryTyped [typedSql| SELECT 1 |]"
@@ -1035,7 +1035,7 @@ runtimeModule = Text.unlines
     , "            ORDER BY name"
     , "        |]"
     , ""
-    , "        when ((windowRows :: [Integer]) /= [1, 2]) do"
+    , "        when ((windowRows :: [Int64]) /= [1, 2]) do"
     , "            error (\"unexpected rows from window function: \" <> show windowRows)"
     , ""
     , "        groupedCountRows <- sqlQueryTyped [typedSql|"
@@ -1046,7 +1046,7 @@ runtimeModule = Text.unlines
     , "        |]"
     , ""
     , "        let groupedCountValues = map (\\r -> (r.name, r.count)) groupedCountRows"
-    , "        when (groupedCountValues /= [(\"First\", 1 :: Integer), (\"Second\", 1)]) do"
+    , "        when (groupedCountValues /= [(\"First\", 1 :: Int64), (\"Second\", 1)]) do"
     , "            error (\"unexpected rows from grouped count: \" <> show groupedCountRows)"
     , ""
     , "        arrayLiteralRows <- sqlQueryTyped [typedSql| SELECT ARRAY['x','y']::text[] |]"
@@ -1247,7 +1247,7 @@ runtimeEdgeCasesModule = Text.unlines
     , ""
     , "        -- COUNT on empty table"
     , "        countEmpty <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
-    , "        assertTest \"COUNT on empty table\" ((countEmpty :: [Integer]) == [0])"
+    , "        assertTest \"COUNT on empty table\" ((countEmpty :: [Int64]) == [0])"
     , ""
     , "        -- Re-insert rows for further tests"
     , "        _ <- sqlExecTyped [typedSql|"
@@ -1328,9 +1328,9 @@ runtimeExtraTypesModule = Text.unlines
     , "        smallRows <- sqlQueryTyped [typedSql| SELECT small_count FROM typed_sql_test_extras LIMIT 1 |]"
     , "        assertTest \"smallint -> Int\" ((smallRows :: [Int]) == [7])"
     , ""
-    , "        -- bigint -> Integer"
+    , "        -- bigint -> Int64"
     , "        bigRows <- sqlQueryTyped [typedSql| SELECT big_count FROM typed_sql_test_extras LIMIT 1 |]"
-    , "        assertTest \"bigint -> Integer\" ((bigRows :: [Integer]) == [1000000000])"
+    , "        assertTest \"bigint -> Int64\" ((bigRows :: [Int64]) == [1000000000])"
     , ""
     , "        -- numeric -> Scientific"
     , "        numericRows <- sqlQueryTyped [typedSql| SELECT amount FROM typed_sql_test_extras LIMIT 1 |]"
@@ -1365,7 +1365,7 @@ runtimeExtraTypesModule = Text.unlines
     , "            FROM typed_sql_test_extras LIMIT 1"
     , "        |]"
     , "        let multiTypeValues = map (\\r -> (r.small_count, r.big_count, r.active)) multiTypeRows"
-    , "        assertTest \"multi-type record\" (multiTypeValues == [(7 :: Int, 1000000000 :: Integer, True)])"
+    , "        assertTest \"multi-type record\" (multiTypeValues == [(7 :: Int, 1000000000 :: Int64, True)])"
     , ""
     , "        putStrLn \"RUNTIME_OK\""
     ]

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -1,5 +1,16 @@
 # Changelog for `ihp-typed-sql`
 
+## Unreleased
+
+- **Breaking:** `int8` / `bigint` columns and placeholders now map to `Int64`
+  instead of `Integer`, exactly matching PostgreSQL's 64-bit wire format.
+  Migration: search for `Integer` values flowing through `typedSql` results
+  (e.g. `COUNT(*)`, `row_number()`, `bigint` columns) and replace with
+  `Int64`. Callers holding `Int` values (e.g. from `limit` / `offset` in the
+  query builder) still need `fromIntegral` when passing into `typedSql`
+  placeholders, but the conversion target is now precise rather than
+  arbitrary-precision.
+
 ## v1.5.0
 
 - Improve error messages and developer experience

--- a/ihp/CHANGELOG.md
+++ b/ihp/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 - [Removed option: 'WORKING_DIRECTORY' no longer required on deployment static assets wrapped automatically](https://github.com/digitallyinduced/ihp/commit/9c54588d983d74bdc28b063d1132952deb57dc16)
 - Experimental GHC 9.12 support via `pkgs.ghc912` overlay attribute ([#2264](https://github.com/digitallyinduced/ihp/pull/2264))
+- **Breaking:** `limit` and `offset` from `IHP.QueryBuilder` now take `Int64` instead of `Int`, matching PostgreSQL's `LIMIT` / `OFFSET` wire type and composing directly with `typedSql` placeholders (e.g. `[typedSql| … LIMIT ${n} |]`) without `fromIntegral`. Polymorphic numeric literals (`|> limit 10`) continue to work. Callers passing an `Int` variable need `fromIntegral` once, or change the binding to `Int64`.
 
 # v1.4.0 (unreleased)
 ## Highlights

--- a/ihp/IHP/Pagination/ControllerFunctions.hs
+++ b/ihp/IHP/Pagination/ControllerFunctions.hs
@@ -102,8 +102,8 @@ paginateWithOptions options query = do
             }
 
     let results = query
-            |> limit pageSize
-            |> offset (offset' pageSize page)
+            |> limit (fromIntegral pageSize)
+            |> offset (fromIntegral (offset' pageSize page))
 
     pure
         ( results

--- a/ihp/IHP/QueryBuilder/HasqlCompiler.hs
+++ b/ihp/IHP/QueryBuilder/HasqlCompiler.hs
@@ -92,7 +92,7 @@ compileQuery cc0 SQLQuery { selectFrom, distinctClause, distinctOnClause, whereC
         (withLimit, cc2) = case limitClause of
             Nothing -> (withOrderBy, cc1)
             Just n ->
-                let enc = contramap (const (fromIntegral n :: Int32)) (Encoders.param (Encoders.nonNullable Encoders.int4))
+                let enc = contramap (const n) (Encoders.param (Encoders.nonNullable Encoders.int8))
                     (placeholder, cc') = nextParam enc cc1
                 in (withOrderBy <> " LIMIT " <> placeholder, cc')
 
@@ -100,7 +100,7 @@ compileQuery cc0 SQLQuery { selectFrom, distinctClause, distinctOnClause, whereC
         (result, cc3) = case offsetClause of
             Nothing -> (withLimit, cc2)
             Just n ->
-                let enc = contramap (const (fromIntegral n :: Int32)) (Encoders.param (Encoders.nonNullable Encoders.int4))
+                let enc = contramap (const n) (Encoders.param (Encoders.nonNullable Encoders.int8))
                     (placeholder, cc') = nextParam enc cc2
                 in (withLimit <> " OFFSET " <> placeholder, cc')
 

--- a/ihp/IHP/QueryBuilder/Order.hs
+++ b/ihp/IHP/QueryBuilder/Order.hs
@@ -70,7 +70,7 @@ orderBy !name = orderByAsc name
 -- >     |> limit 10
 -- >     |> fetch
 -- > -- SELECT * FROM posts LIMIT 10
-limit :: Int -> QueryBuilder model -> QueryBuilder model
+limit :: Int64 -> QueryBuilder model -> QueryBuilder model
 limit !queryLimit (QueryBuilder sq) =
     QueryBuilder sq { limitClause = Just queryLimit }
 {-# INLINE limit #-}
@@ -85,7 +85,7 @@ limit !queryLimit (QueryBuilder sq) =
 -- >     |> offset 10
 -- >     |> fetch
 -- > -- SELECT * FROM posts LIMIT 10 OFFSET 10
-offset :: Int -> QueryBuilder model -> QueryBuilder model
+offset :: Int64 -> QueryBuilder model -> QueryBuilder model
 offset !queryOffset (QueryBuilder sq) =
     QueryBuilder sq { offsetClause = Just queryOffset }
 {-# INLINE offset #-}

--- a/ihp/IHP/QueryBuilder/Types.hs
+++ b/ihp/IHP/QueryBuilder/Types.hs
@@ -148,8 +148,8 @@ data SQLQuery = SQLQuery
     , distinctOnClause :: !(Maybe Text)
     , whereCondition :: !(Maybe Condition)
     , orderByClause :: ![OrderByClause]
-    , limitClause :: !(Maybe Int)
-    , offsetClause :: !(Maybe Int)
+    , limitClause :: !(Maybe Int64)
+    , offsetClause :: !(Maybe Int64)
     , columns :: ![Text]
     , columnsSql :: !Text
     -- ^ Pre-computed qualified column selector, e.g. @"users.id, users.name"@.
@@ -163,8 +163,8 @@ instance SetField "distinctClause" SQLQuery Bool where setField value sqlQuery =
 instance SetField "distinctOnClause" SQLQuery (Maybe Text) where setField value sqlQuery = sqlQuery { distinctOnClause = value }
 instance SetField "whereCondition" SQLQuery (Maybe Condition) where setField value sqlQuery = sqlQuery { whereCondition = value }
 instance SetField "orderByClause" SQLQuery [OrderByClause] where setField value sqlQuery = sqlQuery { orderByClause = value }
-instance SetField "limitClause" SQLQuery (Maybe Int) where setField value sqlQuery = sqlQuery { limitClause = value }
-instance SetField "offsetClause" SQLQuery (Maybe Int) where setField value sqlQuery = sqlQuery { offsetClause = value }
+instance SetField "limitClause" SQLQuery (Maybe Int64) where setField value sqlQuery = sqlQuery { limitClause = value }
+instance SetField "offsetClause" SQLQuery (Maybe Int64) where setField value sqlQuery = sqlQuery { offsetClause = value }
 
 -- | Type class for default scoping of queries
 class DefaultScope table where


### PR DESCRIPTION
## Summary

- typedSql: `int8` / `bigint` now maps to `Int64` (was `Integer`). Matches PostgreSQL's 64-bit wire format precisely. Covers `bigint` columns, `COUNT(*)`, `row_number()`, etc.
- QueryBuilder: `limit` / `offset` now take `Int64` (was `Int`); `limitClause` / `offsetClause` in `SQLQuery` become `Maybe Int64`; `HasqlCompiler` encodes as `int8` instead of `int4`.
- Pagination: single `fromIntegral` at the one internal call site so the user-facing `Pagination` record keeps its `Int` fields (view templates unaffected).

Together these let an `Int64` value flow straight into both APIs without `fromIntegral`. Polymorphic numeric literals (`|> limit 10`) still work. Callers binding `pageSize :: Int` and then calling `limit pageSize` need one `fromIntegral`, or can switch the binding to `Int64`.

## Context

From a Slack thread — [Alvydas](https://digitallyinduced.slack.com) reported that migrating pagination to `typedSql` forced `fromIntegral` between the `|> limit pageSize` path (expects `Int`) and `[typedSql| … LIMIT ${pageSize} |]` (expected `Integer` pre-PR). Aligning both sides on `Int64` — the natural Haskell type for PG `int8` — removes the conversion.

## Test plan

- [x] ghci type-checks cleanly: `IHP.QueryBuilder` (22 mods), `IHP.Pagination.ControllerFunctions` + `IHP.Fetch.Statement` + `IHP.TypedSql` (59 mods), `Test.QueryBuilderSpec` (60 mods), `ihp-typed-sql/Test/Test/Main.hs` (31 mods).
- [ ] Run the full `ihp-typed-sql` test suite against a live Postgres (`devenv up`), confirming the updated `Int64` assertions pass and compile-fail tests still fail.
- [ ] Manual check: `let pageSize :: Int64 = 10 in query @Post |> limit pageSize` and `[typedSql| SELECT … LIMIT ${pageSize} |]` both compile without `fromIntegral`.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)