### PR TITLE
Extract AutoRoute into optional ihp-autoroute package

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -2,6 +2,7 @@
 :set -idev
 :set -iihp-context
 :set -iihp-pagehead
+:set -iihp-autoroute
 :set -iihp-log
 :set -iihp-pglistener
 :set -iihp-modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Breaking Changes
 
+- **`AutoRoute` extracted to optional `ihp-autoroute` package.** The `instance AutoRoute X` typeclass and its helpers (`applyConstr`, `buildAutoRouteMap`, `createAction`, `updateAction`, the overlappable `CanRoute`/`HasPath` instances, `customRoutes`/`customPathTo`, `parseUUIDOrTextId`, `QueryParam`) no longer ship in `ihp` core. Apps that still use `instance AutoRoute X` must add `ihp-autoroute` to their flake's `haskellPackages` and `import IHP.AutoRoute` in their routes module. New apps should use the `[routes|…|]` DSL instead.
 - Controller `action` now returns `IO ResponseReceived` instead of `IO ()` — response functions like `render`, `redirectTo`, `renderJson` return the WAI `ResponseReceived` directly instead of throwing exceptions. Use `earlyReturn` for conditional early exits (e.g. `when condition (earlyReturn $ redirectTo ...)`) ([#2205](https://github.com/digitallyinduced/ihp/pull/2205))
 - `ResponseException` removed — code that catches `ResponseException` will get a compiler error; use `earlyReturn`/`respondAndExit` instead
 - `respondAndExit` now requires `?request` and `?respond` implicit parameters (previously only needed `?context`)

--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -35,11 +35,27 @@ instance FrontController WebApplication where
 
 See [Explicit Routes DSL](#explicit-routes-dsl) below for the full syntax.
 
-### Option 2 — `AutoRoute` (legacy)
+### Option 2 — `AutoRoute` (legacy, opt-in)
 
-`AutoRoute` derives URLs from your action ADT without any explicit spec:
+`AutoRoute` derives URLs from your action ADT without any explicit spec. As of IHP 1.5 it ships in the optional **`ihp-autoroute`** package — apps that still want to use it must opt in.
+
+**1.** Add `ihp-autoroute` to your flake's `haskellPackages`:
+
+```nix
+ihp.haskellPackages = p: [
+    p.ihp
+    p.ihp-autoroute  # opt-in to AutoRoute
+    -- … other packages
+];
+```
+
+**2.** Import `IHP.AutoRoute` in your routes module:
 
 ```haskell
+-- Web/Routes.hs
+import IHP.RouterPrelude
+import IHP.AutoRoute
+
 instance AutoRoute PostsController
 ```
 
@@ -53,7 +69,7 @@ instance FrontController WebApplication where
         ]
 ```
 
-Now you can open e.g. `/Posts` to access the `PostsAction`.
+Now you can open e.g. `/Posts` to access the `PostsAction`. New apps should prefer the `[routes|…|]` DSL — it makes the URL ↔ action mapping explicit at the call site, gives compile-time validation, and avoids the `deriving Data` requirement.
 
 ## Explicit Routes DSL
 

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -387,13 +387,23 @@ The last action is dealing with `DELETE /DeletePost?postId=postId` requests. It'
 
 #### Routes
 
-The router is configured in `Web/Routes.hs`. The generator just places a single line there:
+The router is configured in `Web/Routes.hs`. The generator places a `[routes|...|]` block there that lists every action explicitly:
 
 ```haskell
-instance AutoRoute PostsController
+[routes|PostsController
+GET    /Posts                  PostsAction
+GET    /NewPost                NewPostAction
+POST   /CreatePost             CreatePostAction
+GET    /ShowPost?postId        ShowPostAction
+GET    /EditPost?postId        EditPostAction
+POST   /UpdatePost?postId      UpdatePostAction
+DELETE /DeletePost?postId      DeletePostAction
+|]
 ```
 
-This empty instance magically sets up the routing for all the actions. Later you will learn how you can customize the URLs according to your needs (e.g. "beautiful URLs" for SEO).
+The block ties URLs and HTTP methods to action constructors at compile time. Later you will learn how you can customize the URLs according to your needs (e.g. "beautiful URLs" for SEO).
+
+> **Tip:** Older IHP projects used `instance AutoRoute PostsController` instead. AutoRoute is still available in the optional `ihp-autoroute` package — see [Routing → Option 2 — `AutoRoute`](routing.html#option-2-autoroute-legacy-opt-in) for the migration path.
 
 _Note that the word 'Post' here still refers to a post on our blog and is unrelated to the HTTP-POST request method._
 

--- a/Main.hs
+++ b/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Main where
 
 import IHP.Prelude
@@ -5,21 +7,27 @@ import IHP.Environment
 import IHP.FrameworkConfig
 import qualified IHP.Server
 import IHP.RouterSupport
+import IHP.Router.DSL (routes)
 import IHP.ControllerPrelude
 import IHP.Mail
 
 data DemoController = DemoAction deriving (Eq, Show, Data)
 
-instance AutoRoute DemoController
 instance InitControllerContext RootApplication
 data WebApplication = WebApplication deriving (Eq, Show)
 
 instance InitControllerContext WebApplication where
     initContext = pure ()
 
+$(pure [])
+
+[routes|DemoController
+GET / DemoAction
+|]
+
 instance FrontController WebApplication where
     controllers =
-        [ startPage DemoAction
+        [ parseRoute @DemoController
         ]
 
 instance FrontController RootApplication where

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -55,6 +55,7 @@ let
             ihp-with-docs = localPackageWithHaddock "ihp";
             ihp-context = localPackage "ihp-context";
             ihp-pagehead = localPackage "ihp-pagehead";
+            ihp-autoroute = localPackage "ihp-autoroute";
             ihp-log = localPackage "ihp-log";
             ihp-pglistener = localPackage "ihp-pglistener";
             ihp-modal = localPackage "ihp-modal";

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,48 @@ After updating your project, please consult the segments from your current relea
 
 # Upgrade to 1.6.0 (unreleased) from 1.5.0
 
+## `AutoRoute` moved to optional `ihp-autoroute` package
+
+The `AutoRoute` typeclass (and its helpers — `applyConstr`, `buildAutoRouteMap`, `createAction`, `updateAction`, `customRoutes`, `customPathTo`, `QueryParam`, `parseUUIDOrTextId`) no longer ships in `ihp` core. New apps should use the `[routes|…|]` DSL. Existing apps can keep `instance AutoRoute X` by opting into the new `ihp-autoroute` package.
+
+**Migration steps for apps still using AutoRoute:**
+
+1. Add `ihp-autoroute` to your flake's `haskellPackages`:
+
+    ```diff
+    ihp.haskellPackages = p: [
+        p.ihp
+    +   p.ihp-autoroute
+        # … other packages
+    ];
+    ```
+
+2. Import `IHP.AutoRoute` in any module that defines `instance AutoRoute X`:
+
+    ```diff
+    -- Web/Routes.hs
+    import IHP.RouterPrelude
+    +import IHP.AutoRoute
+
+    instance AutoRoute PostsController
+    ```
+
+That's the entire change — URL shapes, `pathTo`, and HTTP-method dispatch behave exactly as before. The plan is to deprecate `ihp-autoroute` over the next major versions; migrate to the `[routes|…|]` DSL when convenient.
+
+If you want to migrate one controller at a time, the DSL pattern that mirrors AutoRoute's defaults is:
+
+```haskell
+[routes|PostsController
+GET    /Posts                  PostsAction
+GET    /NewPost                NewPostAction
+POST   /CreatePost             CreatePostAction
+GET    /ShowPost?postId        ShowPostAction
+GET    /EditPost?postId        EditPostAction
+POST   /UpdatePost?postId      UpdatePostAction
+DELETE /DeletePost?postId      DeletePostAction
+|]
+```
+
 ## `render` No Longer Handles JSON
 
 The `render` function now only renders HTML. Previously it used Accept header negotiation to serve both HTML and JSON, but the JSON path was unused in practice.

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -147,7 +147,7 @@ that is defined in flake-module.nix
                 ghc912 = pkgs.ghc912;
                 ihpPackageNames = [
                     "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
-                    "ihp-postgres-parser" "ihp-context" "ihp-pagehead"
+                    "ihp-postgres-parser" "ihp-context" "ihp-pagehead" "ihp-autoroute"
                     "ihp-log" "ihp-modal" "ihp-mail"
                     "ihp-migrate" "ihp-openai" "ihp-ssc" "ihp-graphql"
                     "ihp-datasync-typescript" "ihp-sitemap"
@@ -177,7 +177,7 @@ that is defined in flake-module.nix
                 ghc914 = pkgs.ghc914;
                 ihpPackageNames = [
                     "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
-                    "ihp-postgres-parser" "ihp-context" "ihp-pagehead"
+                    "ihp-postgres-parser" "ihp-context" "ihp-pagehead" "ihp-autoroute"
                     "ihp-log" "ihp-modal" "ihp-mail"
                     "ihp-migrate" "ihp-openai" "ihp-ssc" "ihp-graphql"
                     "ihp-datasync-typescript" "ihp-sitemap"

--- a/ihp-autoroute/IHP/AutoRoute.hs
+++ b/ihp-autoroute/IHP/AutoRoute.hs
@@ -37,7 +37,7 @@ import Network.HTTP.Types.Method
 import Network.Wai
 import IHP.RouterSupport
 import IHP.ControllerSupport
-import IHP.Router.Types (ControllerRoute (..), UnexpectedMethodException (..), TypedAutoRouteError (..))
+import IHP.Router.Types (UnexpectedMethodException (..), TypedAutoRouteError (..))
 import Data.Attoparsec.ByteString.Char8 (string, Parser, takeByteString)
 import Network.HTTP.Types.URI
 import GHC.TypeLits as T

--- a/ihp-autoroute/IHP/AutoRoute.hs
+++ b/ihp-autoroute/IHP/AutoRoute.hs
@@ -1,0 +1,501 @@
+{-# LANGUAGE AllowAmbiguousTypes, UndecidableInstances, LambdaCase, ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-|
+Module: IHP.AutoRoute
+
+The legacy AutoRoute typeclass for IHP. Was previously part of
+'IHP.RouterSupport'; extracted into the optional @ihp-autoroute@ package
+so apps that still depend on @instance AutoRoute X@ can opt in. New
+apps should prefer the @[routes|...|]@ DSL from 'IHP.Router.DSL'.
+
+To use this module, add @ihp-autoroute@ to your flake's
+@haskellPackages@ and @import IHP.AutoRoute@ in your @Web.Routes@
+module.
+-}
+module IHP.AutoRoute
+    ( AutoRoute (..)
+    , applyConstr
+    , buildAutoRouteMap
+    , createAction
+    , updateAction
+    , QueryParam (..)
+    , parseUUIDOrTextId
+    , parseRouteWithId
+    ) where
+
+import Prelude hiding (take)
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.List (isPrefixOf, find)
+import Control.Monad (unless, join)
+import Control.Applicative ((<|>), empty)
+import qualified Control.Exception as Exception
+import qualified IHP.ModelSupport as ModelSupport
+import Data.UUID
+import Network.HTTP.Types.Method
+import Network.Wai
+import IHP.RouterSupport
+import IHP.ControllerSupport
+import IHP.Router.Types (ControllerRoute (..), UnexpectedMethodException (..), TypedAutoRouteError (..))
+import Data.Attoparsec.ByteString.Char8 (string, Parser, takeByteString)
+import Network.HTTP.Types.URI
+import GHC.TypeLits as T
+import Data.Data
+import qualified Control.Monad.State.Strict as State
+import qualified Data.Text as Text
+import qualified Data.List as List
+import Unsafe.Coerce
+import IHP.HaskellSupport hiding (get)
+import qualified Data.ByteString.Char8 as ByteString
+import Data.String.Conversions (cs)
+import qualified Network.URI.Encode as URI
+import qualified Data.Text.Encoding as Text
+import Data.Dynamic
+import qualified Data.HashMap.Strict as HashMap
+
+
+-- | Each of these is tried when trying to parse an argument to a controller constructor (i.e. in IHP, an action).
+-- The type @d@ is an the type of the argument, and all we know about this type that its conforms to @Data@.
+--
+-- The approach taken here is to make use of the type equality operator @:~:@
+-- to check and see if @d@ happens to be a certain type. If it is,
+-- by matching on Just Refl, we are able to use @d@ as the type we matched it to.
+parseFuncs :: forall d idType. (Data d, Data idType) => (ByteString -> Maybe idType) -> [Maybe ByteString -> Either TypedAutoRouteError d]
+parseFuncs parseIdType = [
+            -- Try and parse @Int@ or @Maybe Int@
+            \case
+                Just queryValue -> case eqT :: Maybe (d :~: Int) of
+                    Just Refl -> case ByteString.readInt queryValue of
+                        Just (n, "") -> Right n
+                        _ -> Left BadType { field = "", value = Just queryValue, expectedType = "Int" }
+                    Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
+                        Just Refl -> Right $ case ByteString.readInt queryValue of
+                            Just (n, "") -> Just n
+                            _ -> Nothing
+                        Nothing -> Left NotMatched
+                Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
+                    Just Refl -> Right Nothing
+                    Nothing -> Left NotMatched,
+
+            \case
+                Just queryValue -> case eqT :: Maybe (d :~: Integer) of
+                    Just Refl -> case ByteString.readInteger queryValue of
+                        Just (n, "") -> Right n
+                        _ -> Left BadType { field = "", value = Just queryValue, expectedType = "Integer" }
+                    Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
+                        Just Refl -> Right $ case ByteString.readInteger queryValue of
+                            Just (n, "") -> Just n
+                            _ -> Nothing
+                        Nothing -> Left NotMatched
+                Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
+                    Just Refl -> Right Nothing
+                    Nothing -> Left NotMatched,
+
+            -- Try and parse @Text@ or @Maybe Text@
+            \case
+                Just queryValue -> case eqT :: Maybe (d :~: Text) of
+                    Just Refl -> Right $ cs queryValue
+                    Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
+                        Just Refl -> Right $ Just $ cs queryValue
+                        Nothing -> Left NotMatched
+                Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
+                    Just Refl -> Right Nothing
+                    Nothing -> Left NotMatched,
+            \case
+                Just queryValue -> case parseIdType queryValue of
+                    Just idValue -> case eqT :: Maybe (d :~: idType) of
+                        Just Refl -> Right idValue
+                        Nothing -> Left NotMatched
+                    Nothing -> Left NotMatched
+                Nothing -> Left NotMatched,
+
+            -- Try and parse @[Text]@. If value is not present then default to empty list.
+            \queryValue -> case eqT :: Maybe (d :~: [Text]) of
+                Just Refl -> case queryValue of
+                    Just queryValue -> Right $ Text.splitOn "," (cs queryValue)
+                    Nothing -> Right []
+                Nothing -> Left NotMatched,
+
+            -- Try and parse @[Int]@. If value is not present then default to empty list.
+            \queryValue -> case eqT :: Maybe (d :~: [Int]) of
+                Just Refl -> case queryValue of
+                    Just queryValue -> ByteString.split ',' queryValue
+                        |> mapMaybe (\b -> case ByteString.readInt b of Just (n, "") -> Just n; _ -> Nothing)
+                        |> Right
+                    Nothing -> Right []
+                Nothing -> Left NotMatched,
+
+            \queryValue -> case eqT :: Maybe (d :~: [Integer]) of
+                Just Refl -> case queryValue of
+                    Just queryValue -> ByteString.split ',' queryValue
+                        |> mapMaybe (\b -> case ByteString.readInteger b of Just (n, "") -> Just n; _ -> Nothing)
+                        |> Right
+                    Nothing -> Right []
+                Nothing -> Left NotMatched,
+
+            -- Try and parse a raw [UUID]
+            \queryValue -> case eqT :: Maybe (d :~: [UUID]) of
+                Just Refl -> case queryValue of
+                    Just queryValue -> ByteString.split ',' queryValue
+                        |> mapMaybe fromASCIIBytes
+                        |> Right
+                    Nothing -> Right []
+                Nothing -> Left NotMatched,
+
+            -- Try and parse a raw UUID
+            \queryValue -> case eqT :: Maybe (d :~: UUID) of
+                Just Refl -> case queryValue of
+                    Just queryValue -> queryValue
+                        |> fromASCIIBytes
+                        |> \case
+                            Just uuid -> uuid |> Right
+                            Nothing -> Left BadType { field = "", value = Just queryValue, expectedType = "UUID" }
+                    Nothing -> Left NotMatched
+                Nothing -> Left NotMatched,
+
+            -- This has to be last parser in the list
+            --
+            -- Try and parse a UUID wrapped with a Id. In IHP types these are wrapped in a newtype @Id@ such as @Id User@.
+            -- Since @Id@ is a newtype wrapping a UUID, it has the same data representation in GHC.
+            \queryValue -> case queryValue of
+                Just queryValue -> queryValue
+                    |> fromASCIIBytes
+                    |> \case
+                        Just uuid -> uuid |> unsafeCoerce |> Right
+                        Nothing -> Left BadType { field = "", value = Just queryValue, expectedType = "UUID" }
+                Nothing -> Left NotMatched
+            ]
+{-# NOINLINE parseFuncs #-}
+
+querySortedByFields :: Query -> Constr -> Query
+querySortedByFields query constructor = constrFields constructor
+        |> map cs
+        |> map (\field -> (field, join $ List.lookup field query))
+{-# NOINLINE querySortedByFields #-}
+
+-- | Given a constructor and a parsed query string, attempt to construct a value of the constructor's type.
+applyConstr :: (Data controller, Data idType) => (ByteString -> Maybe idType) -> Constr -> Query -> Either TypedAutoRouteError controller
+applyConstr parseIdType constructor query = let
+
+    attemptToParseArg :: forall d. (Data d) => (ByteString, Maybe ByteString) -> [Maybe ByteString -> Either TypedAutoRouteError d] -> State.StateT Query (Either TypedAutoRouteError) d
+    attemptToParseArg queryParam@(queryName, queryValue) [] = State.lift (Left NoConstructorMatched
+                { field = queryName
+                , value = queryValue
+                , expectedType = (dataTypeOf (Prelude.undefined :: d)) |> dataTypeName |> cs
+                })
+    attemptToParseArg queryParam@(k, v) (parseFunc:restFuncs) = case parseFunc v of
+            Right result -> pure result
+            Left badType@BadType{} -> State.lift (Left badType { field = k })
+            Left _ -> attemptToParseArg queryParam restFuncs
+
+    nextField :: forall d. (Data d) => State.StateT Query (Either TypedAutoRouteError) d
+    nextField = do
+            queryParams <- State.get
+            case queryParams of
+                [] -> State.lift (Left TooFewArguments)
+                (p@(key, value):rest) -> do
+                    State.put rest
+                    attemptToParseArg p (parseFuncs parseIdType)
+
+
+   in case State.runStateT (fromConstrM nextField constructor) (querySortedByFields query constructor) of
+        Right (x, []) -> pure x
+        Right (_) -> Left TooFewArguments
+        Left e -> Left e
+{-# NOINLINE applyConstr #-}
+
+class Data controller => AutoRoute controller where
+    autoRouteWithIdType :: (?request :: Request, ?respond :: Respond, Data idType) => (ByteString -> Maybe idType) -> Parser controller
+    autoRouteWithIdType parseIdFunc =
+        let
+            query :: Query
+            query = queryString ?request
+        in do
+            (constr, allowedMethods) <- routeMatchParser @controller
+            action <- case applyConstr parseIdFunc constr query of
+                    Right parsedAction -> pure parsedAction
+                    Left e -> Exception.throw e
+            method <- getMethod
+            unless (allowedMethods |> includes method) (Exception.throw UnexpectedMethodException { allowedMethods, method })
+            pure action
+    {-# INLINABLE autoRouteWithIdType #-}
+
+    autoRoute :: (?request :: Request, ?respond :: Respond) => Parser controller
+    autoRoute = autoRouteWithIdType (\_ -> Nothing :: Maybe Integer)
+    {-# INLINABLE autoRoute #-}
+
+    -- | Constructs a controller value from a matched constructor and query string.
+    applyAction :: Constr -> Query -> Either TypedAutoRouteError controller
+    applyAction = applyConstr (\_ -> Nothing :: Maybe Integer)
+    {-# INLINE applyAction #-}
+
+    -- | Specifies the allowed HTTP methods for a given action.
+    --
+    -- The default heuristic mirrors the one originally shipped with
+    -- 'IHP.RouterSupport':
+    --
+    -- * @Delete*@  — @[DELETE]@
+    -- * @Update*@  — @[POST, PATCH]@
+    -- * @Create*@  — @[POST]@
+    -- * @Show*@    — @[GET, HEAD]@
+    -- * everything else — @[GET, POST, HEAD]@
+    allowedMethodsForAction :: ByteString -> [StdMethod]
+    allowedMethodsForAction actionName =
+            case actionName of
+                a | "Delete" `ByteString.isPrefixOf` a -> [DELETE]
+                a | "Update" `ByteString.isPrefixOf` a -> [POST, PATCH]
+                a | "Create" `ByteString.isPrefixOf` a -> [POST]
+                a | "Show"   `ByteString.isPrefixOf` a -> [GET, HEAD]
+                _ -> [GET, POST, HEAD]
+    {-# INLINE allowedMethodsForAction #-}
+
+    -- | Custom route parser for overriding individual action routes.
+    customRoutes :: (?request :: Request, ?respond :: Respond) => Parser controller
+    customRoutes = empty
+    {-# INLINE customRoutes #-}
+
+    -- | Custom path generation for overriding individual action URLs.
+    customPathTo :: controller -> Maybe Text
+    customPathTo _ = Nothing
+    {-# INLINE customPathTo #-}
+
+-- | Static route-matching parser that becomes a CAF when specialized for a concrete
+-- controller type. Uses a 'HashMap' for O(1) action name lookup after matching the prefix.
+routeMatchParser :: forall controller. (Data controller, AutoRoute controller) => Parser (Constr, [StdMethod])
+routeMatchParser = do
+    string prefix
+    remaining <- takeByteString
+    case HashMap.lookup remaining actionMatchMap of
+        Just result -> pure result
+        Nothing -> fail "no matching action"
+    where
+        prefix :: ByteString
+        prefix = Text.encodeUtf8 (actionPrefixText @controller)
+
+        actionMatchMap :: HashMap.HashMap ByteString (Constr, [StdMethod])
+        actionMatchMap = HashMap.fromList
+            [ (actionPath, (constr, allowedMethods))
+            | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+            , let actionName = ByteString.pack (showConstr constr)
+                  actionPath = stripActionSuffixByteString actionName
+                  allowedMethods = allowedMethodsForAction @controller actionName
+            ]
+{-# NOINLINE routeMatchParser #-}
+
+stripActionSuffixByteString :: ByteString -> ByteString
+stripActionSuffixByteString actionName = fromMaybe actionName (ByteString.stripSuffix "Action" actionName)
+{-# INLINE stripActionSuffixByteString #-}
+
+stripActionSuffixText :: Text -> Text
+stripActionSuffixText actionName = fromMaybe actionName (Text.stripSuffix "Action" actionName)
+{-# INLINE stripActionSuffixText #-}
+
+-- | Returns the create action for a given controller.
+createAction :: forall controller. AutoRoute controller => Maybe controller
+createAction = fmap fromConstr createConstructor
+    where
+        createConstructor :: Maybe Constr
+        createConstructor = find isCreateConstructor allConstructors
+
+        allConstructors :: [Constr]
+        allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+
+        isCreateConstructor :: Constr -> Bool
+        isCreateConstructor constructor = "Create" `isPrefixOf` showConstr constructor && Prelude.null (constrFields constructor)
+{-# INLINE createAction #-}
+
+-- | Returns the update action when given a controller and id.
+updateAction :: forall controller id. AutoRoute controller => Maybe (id -> controller)
+updateAction =
+        case updateConstructor of
+            Just constructor -> Just $ \id -> buildInstance constructor id
+            Nothing -> Nothing
+    where
+        updateConstructor :: Maybe Constr
+        updateConstructor = find isUpdateConstructor allConstructors
+
+        buildInstance :: Constr -> id -> controller
+        buildInstance constructor id = State.evalState ((fromConstrM (do
+                i <- State.get
+
+                State.modify (+1)
+                pure (unsafeCoerce id)
+            )) constructor) 0
+
+        allConstructors :: [Constr]
+        allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+
+        isUpdateConstructor :: Constr -> Bool
+        isUpdateConstructor constructor = "Update" `isPrefixOf` (showConstr constructor) && (length (constrFields constructor) == 1)
+{-# INLINE updateAction #-}
+
+instance {-# OVERLAPPABLE #-} (AutoRoute controller, Controller controller) => CanRoute controller where
+    parseRoute' = customRoutes <|> autoRoute
+    {-# INLINABLE parseRoute' #-}
+
+    -- | This is only used as a fallback parser (via lazy thunk in 'ControllerRouteMap').
+    parseRouteWithAction toApp = (do
+        action <- customRoutes @controller
+        pure (toApp action)
+      ) <|> (do
+        (constr, allowedMethods) <- routeMatchParser @controller
+        pure $ \waiRequest waiRespond -> wrapRouterException do
+            case applyAction @controller constr (queryString waiRequest) of
+                Left e -> Exception.throw e
+                Right action -> do
+                    case parseMethod (requestMethod waiRequest) of
+                        Right method -> do
+                            unless (allowedMethods |> includes method)
+                                (Exception.throw UnexpectedMethodException { allowedMethods, method })
+                            toApp action waiRequest waiRespond
+                        Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
+      )
+    {-# INLINABLE parseRouteWithAction #-}
+
+    -- | Override to use 'ControllerRouteMap' for O(1) HashMap dispatch.
+    toControllerRoute :: forall application.
+        ( ?request :: Request, ?respond :: Respond, Controller controller
+        , InitControllerContext application, ?application :: application
+        , Typeable application, Typeable controller
+        ) => ControllerRoute application
+    toControllerRoute = ControllerRouteMap
+        (buildAutoRouteMap @controller @application)
+        (parseRouteWithAction @controller (runAction' @application))
+    {-# INLINABLE toControllerRoute #-}
+
+-- | Instances of the @QueryParam@ type class can be represented in URLs as query parameters.
+class Data a => QueryParam a where
+    showQueryParam :: a -> String
+
+instance QueryParam Text where
+    showQueryParam text = Text.unpack text
+
+instance QueryParam Int where
+    showQueryParam = show
+
+instance QueryParam Integer where
+    showQueryParam = show
+
+instance QueryParam UUID where
+    showQueryParam = show
+
+instance QueryParam a => QueryParam (Maybe a) where
+    showQueryParam (Just val) = showQueryParam val
+    showQueryParam Nothing = ""
+
+instance QueryParam a => QueryParam [a] where
+    showQueryParam = List.intercalate "," . map showQueryParam
+
+instance {-# OVERLAPPABLE #-} (Show controller, AutoRoute controller) => HasPath controller where
+    pathTo !action = case customPathTo action of
+        Just path -> path
+        Nothing ->
+            let !ci = constrIndex (toConstr action) - 1
+                (!basePath, !fieldNames) = constrInfoCache !! ci
+            in case fieldNames of
+                [] -> basePath
+                _ ->
+                    let !fieldValues = gmapQ renderFieldForUrl action
+                    in basePath <> buildQueryText fieldNames fieldValues
+        where
+            constrInfoCache :: [(Text, [Text])]
+            constrInfoCache = map mkInfo allConstrs
+                where
+                    allConstrs = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+                    !appPrefix = actionPrefixText @controller
+                    mkInfo c =
+                        let !bp = appPrefix <> stripActionSuffixText (Text.pack (showConstr c))
+                            !fns = map Text.pack (constrFields c)
+                        in (bp, fns)
+
+            buildQueryText :: [Text] -> [Text] -> Text
+            buildQueryText names values =
+                zip names values
+                |> filter (\(_, v) -> not (Text.null v))
+                |> map (\(k, v) -> k <> "=" <> URI.encodeText v)
+                |> Text.intercalate "&"
+                |> (\q -> if Text.null q then q else Text.cons '?' q)
+    {-# NOINLINE pathTo #-}
+
+-- | Render a controller field value as 'Text' for URL query parameter inclusion.
+renderFieldForUrl :: forall d. Data d => d -> Text
+renderFieldForUrl val
+    | Just Refl <- eqT @d @UUID = toText val
+    | Just Refl <- eqT @d @Text = val
+    | Just Refl <- eqT @d @Int = Text.pack (show val)
+    | Just Refl <- eqT @d @Integer = Text.pack (show val)
+    | Just Refl <- eqT @d @(Maybe UUID) = maybe "" toText val
+    | Just Refl <- eqT @d @(Maybe Text) = maybe "" id val
+    | Just Refl <- eqT @d @(Maybe Int) = maybe "" (Text.pack . show) val
+    | Just Refl <- eqT @d @(Maybe Integer) = maybe "" (Text.pack . show) val
+    | Just Refl <- eqT @d @[UUID] = Text.intercalate "," (map toText val)
+    | Just Refl <- eqT @d @[Text] = Text.intercalate "," (val :: [Text])
+    | Just Refl <- eqT @d @[Int] = Text.intercalate "," (map (Text.pack . show) val)
+    | Just Refl <- eqT @d @[Integer] = Text.intercalate "," (map (Text.pack . show) val)
+    | otherwise =
+        case gmapQ renderFieldForUrl val of
+            [inner] -> inner
+            _ -> ""
+{-# NOINLINE renderFieldForUrl #-}
+
+-- | Build a HashMap from full paths (prefix + action name) to Application closures.
+buildAutoRouteMap :: forall controller application.
+    ( AutoRoute controller
+    , Controller controller
+    , InitControllerContext application
+    , Typeable application
+    , Typeable controller
+    ) => HashMap.HashMap ByteString (application -> Application)
+buildAutoRouteMap = HashMap.fromList
+    [ (prefix <> actionPath, handler)
+    | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+    , let actionName = ByteString.pack (showConstr constr)
+          actionPath = stripActionSuffixByteString actionName
+          allowedMethods = allowedMethodsForAction @controller actionName
+          handler app waiRequest waiRespond =
+              let ?application = app
+              in wrapRouterException do
+                  case parseMethod (requestMethod waiRequest) of
+                      Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
+                      Right method -> do
+                          unless (allowedMethods |> includes method)
+                              (Exception.throw UnexpectedMethodException { allowedMethods, method })
+                          case applyAction @controller constr (queryString waiRequest) of
+                              Left e -> Exception.throw e
+                              Right action -> runAction' @application action waiRequest waiRespond
+    ]
+    where
+        prefix :: ByteString
+        prefix = Text.encodeUtf8 (actionPrefixText @controller)
+{-# NOINLINE buildAutoRouteMap #-}
+
+parseUUIDOrTextId :: ByteString -> Maybe Dynamic
+parseUUIDOrTextId queryVal = queryVal
+    |> fromASCIIBytes
+    |> \case
+        Just uuid -> uuid |> toDyn |> Just
+        Nothing -> Nothing
+
+parseRouteWithId
+    :: forall controller application.
+        ( ?request :: Request
+        , ?respond :: Respond
+        , CanRoute controller
+        , Controller controller
+        , InitControllerContext application
+        , ?application :: application
+        , Typeable application
+        , Typeable controller
+        )
+    => ControllerRoute application
+parseRouteWithId = parseRoute @controller @application
+
+-- | Display a better error when the user missed to pass an argument to an action.
+--
+-- E.g. when you forgot to pass a projectId to the ShowProjectAction:
+--
+-- > <a href={ShowProjectAction}>Show project</a>
+--
+-- See https://github.com/digitallyinduced/ihp/issues/840
+instance ((T.TypeError (T.Text "Looks like you forgot to pass a " :<>: (T.ShowType argument) :<>: T.Text " to this " :<>: (T.ShowType controller))), Data argument, Data controller, Data (argument -> controller)) => AutoRoute (argument -> controller) where

--- a/ihp-autoroute/IHP/AutoRoute.hs
+++ b/ihp-autoroute/IHP/AutoRoute.hs
@@ -31,7 +31,6 @@ import Data.List (isPrefixOf, find)
 import Control.Monad (unless, join)
 import Control.Applicative ((<|>), empty)
 import qualified Control.Exception as Exception
-import qualified IHP.ModelSupport as ModelSupport
 import Data.UUID
 import Network.HTTP.Types.Method
 import Network.Wai

--- a/ihp-autoroute/LICENSE
+++ b/ihp-autoroute/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 digitally induced GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ihp-autoroute/Test/AutoRoute/MixedModeSpec.hs
+++ b/ihp-autoroute/Test/AutoRoute/MixedModeSpec.hs
@@ -1,5 +1,5 @@
 {-|
-Module: Test.Router.MixedModeSpec
+Module: Test.AutoRoute.MixedModeSpec
 Copyright: (c) digitally induced GmbH, 2026
 
 Proves a single IHP app can mix controllers using the legacy 'AutoRoute'
@@ -7,11 +7,12 @@ and controllers using the new @[routes|…|]@ DSL.
 -}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Test.Router.MixedModeSpec where
+module Test.AutoRoute.MixedModeSpec where
 
 import Test.Hspec
 import IHP.Prelude
 import IHP.RouterSupport
+import IHP.AutoRoute (AutoRoute)
 import IHP.Router.DSL (routes)
 import IHP.Router.Capture (renderCapture, parseCapture)
 import IHP.ControllerPrelude

--- a/ihp-autoroute/Test/AutoRoute/RouterBench.hs
+++ b/ihp-autoroute/Test/AutoRoute/RouterBench.hs
@@ -9,6 +9,7 @@ import Network.Wai (defaultRequest, Request(..), responseLBS)
 import Network.HTTP.Types.Method (StdMethod(..))
 import Network.HTTP.Types (status200)
 import IHP.RouterSupport hiding (get)
+import IHP.AutoRoute (AutoRoute)
 import IHP.ControllerSupport
 import qualified IHP.Router.Trie as Trie
 import IHP.Router.Trie (RouteTrie, PatternSegment(..), LookupResult(..))

--- a/ihp-autoroute/Test/AutoRoute/RouterSupportSpec.hs
+++ b/ihp-autoroute/Test/AutoRoute/RouterSupportSpec.hs
@@ -1,11 +1,11 @@
 {-|
-Module: Test.RouterSupportSpec
+Module: Test.AutoRoute.RouterSupportSpec
 
-Tests for typed auto routing.
+Tests for typed auto routing (AutoRoute typeclass).
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
-module Test.RouterSupportSpec where
+module Test.AutoRoute.RouterSupportSpec where
 import ClassyPrelude
 import Test.Hspec
 import IHP.Test.Mocking
@@ -13,12 +13,13 @@ import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
 import IHP.RouterSupport hiding (get)
+import IHP.AutoRoute
 import Data.Attoparsec.ByteString.Char8 (string, endOfInput)
 import IHP.ViewPrelude
 import IHP.ControllerPrelude hiding (get, request)
 import Network.Wai.Test
 import Network.HTTP.Types
-import Test.Util (testGet)
+import Test.AutoRoute.Util (testGet)
 
 data Band' = Band {id :: (Id' "bands"), meta :: MetaBag} deriving (Eq, Show)
 type Band = Band'

--- a/ihp-autoroute/Test/AutoRoute/Util.hs
+++ b/ihp-autoroute/Test/AutoRoute/Util.hs
@@ -1,0 +1,41 @@
+module Test.AutoRoute.Util where
+
+import IHP.Prelude
+import Network.Wai (requestMethod, requestHeaders)
+import Network.Wai.Test (Session, SResponse(..), SRequest(..), request, srequest, defaultRequest, setPath)
+import Network.HTTP.Types (methodGet, methodPost, hContentType, renderSimpleQuery)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Test.Hspec (expectationFailure)
+
+testGet :: ByteString -> Session SResponse
+testGet url = request $ setPath defaultRequest { requestMethod = methodGet } url
+
+testPost :: ByteString -> Session SResponse
+testPost url = request $ setPath defaultRequest { requestMethod = methodPost } url
+
+-- | POST a form-encoded body to a URL.
+testPostForm :: ByteString -> [(ByteString, ByteString)] -> Session SResponse
+testPostForm url params = srequest $ SRequest req body
+  where
+    req = setPath defaultRequest
+        { requestMethod = methodPost
+        , requestHeaders = [(hContentType, "application/x-www-form-urlencoded")]
+        } url
+    body = cs $ renderSimpleQuery False params
+
+-- | POST a JSON body to a URL.
+testPostJSON :: ByteString -> LBS.ByteString -> Session SResponse
+testPostJSON url body = srequest $ SRequest req body
+  where
+    req = setPath defaultRequest
+        { requestMethod = methodPost
+        , requestHeaders = [(hContentType, "application/json")]
+        } url
+
+-- | Assert that the response body does NOT contain the given substring.
+assertBodyNotContains :: ByteString -> SResponse -> Session ()
+assertBodyNotContains needle SResponse { simpleBody }
+    | needle `BS.isInfixOf` LBS.toStrict simpleBody =
+        liftIO $ expectationFailure $ cs @Text $ "Expected body to not contain " <> tshow needle <> ", but it did"
+    | otherwise = pure ()

--- a/ihp-autoroute/Test/Main.hs
+++ b/ihp-autoroute/Test/Main.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Test.Hspec
+import IHP.Prelude
+
+import qualified Test.AutoRoute.RouterSupportSpec
+import qualified Test.AutoRoute.MixedModeSpec
+
+main :: IO ()
+main = hspec do
+    Test.AutoRoute.RouterSupportSpec.tests
+    Test.AutoRoute.MixedModeSpec.tests

--- a/ihp-autoroute/default.nix
+++ b/ihp-autoroute/default.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, attoparsec, base, blaze-html, bytestring
+, classy-prelude, hspec, http-types, ihp, lib, mtl
+, string-conversions, tasty-bench, text, unordered-containers
+, uri-encode, uuid, wai, wai-extra
+}:
+mkDerivation {
+  pname = "ihp-autoroute";
+  version = "1.5.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    attoparsec base blaze-html bytestring classy-prelude http-types ihp
+    mtl string-conversions text unordered-containers uri-encode uuid
+    wai
+  ];
+  testHaskellDepends = [
+    attoparsec base bytestring classy-prelude hspec http-types ihp
+    string-conversions text uuid wai wai-extra
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring http-types ihp tasty-bench wai
+  ];
+  homepage = "https://ihp.digitallyinduced.com/";
+  description = "Legacy AutoRoute typeclass for IHP";
+  license = lib.licenses.mit;
+}

--- a/ihp-autoroute/default.nix
+++ b/ihp-autoroute/default.nix
@@ -13,8 +13,9 @@ mkDerivation {
     wai
   ];
   testHaskellDepends = [
-    attoparsec base bytestring classy-prelude hspec http-types ihp
-    string-conversions text uuid wai wai-extra
+    attoparsec base blaze-html bytestring classy-prelude hspec
+    http-types ihp mtl string-conversions text unordered-containers
+    uri-encode uuid wai wai-extra
   ];
   benchmarkHaskellDepends = [
     base bytestring http-types ihp tasty-bench wai

--- a/ihp-autoroute/ihp-autoroute.cabal
+++ b/ihp-autoroute/ihp-autoroute.cabal
@@ -86,15 +86,20 @@ test-suite tests
             , classy-prelude
             , text
             , bytestring
+            , unordered-containers
+            , attoparsec
+            , http-types
+            , uri-encode
             , uuid
             , wai
             , wai-extra
-            , http-types
-            , attoparsec
+            , blaze-html
+            , mtl
             , string-conversions
     other-modules:
         Test.AutoRoute.RouterSupportSpec
         Test.AutoRoute.MixedModeSpec
+        Test.AutoRoute.Util
 
 benchmark ihp-autoroute-router-bench
     import: shared-properties

--- a/ihp-autoroute/ihp-autoroute.cabal
+++ b/ihp-autoroute/ihp-autoroute.cabal
@@ -1,0 +1,112 @@
+cabal-version:       2.2
+name:                ihp-autoroute
+version:             1.5.0
+synopsis:            Legacy AutoRoute typeclass for IHP
+description:
+    The legacy AutoRoute typeclass, extracted from `ihp` core. New apps
+    should use the `[routes|...|]` DSL from `IHP.Router.DSL`. Existing
+    apps that still rely on `instance AutoRoute X` add this package to
+    their flake's `haskellPackages` and `import IHP.AutoRoute` in their
+    routes module.
+license:             MIT
+license-file:        LICENSE
+author:              digitally induced GmbH
+maintainer:          hello@digitallyinduced.com
+homepage:            https://ihp.digitallyinduced.com/
+bug-reports:         https://github.com/digitallyinduced/ihp/issues
+copyright:           (c) digitally induced GmbH
+category:            Web, IHP
+stability:           Stable
+tested-with:         GHC == 9.8.4
+build-type:          Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/digitallyinduced/ihp
+
+common shared-properties
+    default-language: GHC2021
+    default-extensions:
+        OverloadedStrings
+        , NoImplicitPrelude
+        , ImplicitParams
+        , DisambiguateRecordFields
+        , DuplicateRecordFields
+        , OverloadedLabels
+        , DataKinds
+        , QuasiQuotes
+        , TypeFamilies
+        , PackageImports
+        , RecordWildCards
+        , DefaultSignatures
+        , FunctionalDependencies
+        , PartialTypeSignatures
+        , BlockArguments
+        , LambdaCase
+        , TemplateHaskell
+        , OverloadedRecordDot
+        , DeepSubsumption
+        , AllowAmbiguousTypes
+        , UndecidableInstances
+        , ScopedTypeVariables
+    ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields
+
+library
+    import: shared-properties
+    hs-source-dirs: .
+    build-depends:
+            base >= 4.17.0 && < 4.22
+            , ihp
+            , classy-prelude
+            , text
+            , bytestring
+            , unordered-containers
+            , attoparsec
+            , http-types
+            , uri-encode
+            , uuid
+            , wai
+            , blaze-html
+            , mtl
+            , string-conversions
+    exposed-modules:
+        IHP.AutoRoute
+
+test-suite tests
+    import: shared-properties
+    type: exitcode-stdio-1.0
+    main-is: Test/Main.hs
+    hs-source-dirs: .
+    ghc-options: -threaded
+    build-depends:
+            base >= 4.17.0 && < 4.22
+            , ihp
+            , ihp-autoroute
+            , hspec
+            , classy-prelude
+            , text
+            , bytestring
+            , uuid
+            , wai
+            , wai-extra
+            , http-types
+            , attoparsec
+            , string-conversions
+    other-modules:
+        Test.AutoRoute.RouterSupportSpec
+        Test.AutoRoute.MixedModeSpec
+
+benchmark ihp-autoroute-router-bench
+    import: shared-properties
+    type: exitcode-stdio-1.0
+    hs-source-dirs: .
+    main-is: Test/AutoRoute/RouterBench.hs
+    ghc-options: -fno-static-argument-transformation
+    build-depends:
+            base >= 4.17.0 && < 4.22
+            , ihp
+            , ihp-autoroute
+            , bytestring
+            , wai
+            , http-types
+            , tasty-bench

--- a/ihp-sitemap/Test/SEO/Sitemap.hs
+++ b/ihp-sitemap/Test/SEO/Sitemap.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Main where
 
 import Test.Hspec
@@ -5,6 +7,8 @@ import IHP.Test.Mocking
 import IHP.Environment
 import IHP.ViewPrelude
 import IHP.ControllerPrelude hiding (get, request)
+import IHP.Router.DSL (routes)
+import IHP.Router.Capture (renderCapture, parseCapture)
 import Network.Wai.Test
 import Network.HTTP.Types
 
@@ -25,7 +29,11 @@ data PostController
   = ShowPostAction { postId :: UUID }
   deriving (Eq, Show, Data)
 
-instance AutoRoute PostController
+$(pure [])
+
+[routes|PostController
+GET /main/ShowPost?postId ShowPostAction
+|]
 
 instance Controller SitemapController where
     action SitemapAction = do

--- a/ihp-sitemap/Test/SEO/Sitemap.hs
+++ b/ihp-sitemap/Test/SEO/Sitemap.hs
@@ -8,7 +8,7 @@ import IHP.Environment
 import IHP.ViewPrelude
 import IHP.ControllerPrelude hiding (get, request)
 import IHP.Router.DSL (routes)
-import IHP.Router.Capture (renderCapture, parseCapture)
+import IHP.Router.Capture (renderCapture)
 import Network.Wai.Test
 import Network.HTTP.Types
 

--- a/ihp-sitemap/Test/SEO/Sitemap.hs
+++ b/ihp-sitemap/Test/SEO/Sitemap.hs
@@ -16,10 +16,6 @@ import IHP.SEO.Sitemap.Types
 import IHP.SEO.Sitemap.Routes ()
 import IHP.SEO.Sitemap.ControllerFunctions
 
-main :: IO ()
-main = hspec do
-    tests
-
 data Post = Post
         { id :: UUID
         , updatedAt :: UTCTime
@@ -86,3 +82,7 @@ tests = aroundAll (withMockContextAndApp WebApplication config) do
             it "should render a XML Sitemap" $ withContextAndApp \application -> do
                 runSession (testGet "/sitemap.xml") application
                     >>= assertSuccess "<?xml version=\"1.0\" encoding=\"UTF-8\"?><urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"><url><loc>http://localhost:8000/main/ShowPost?postId=00000000-0000-0000-0000-000000000000</loc><lastmod>2105-04-16</lastmod><changefreq>hourly</changefreq></url></urlset>"
+
+main :: IO ()
+main = hspec do
+    tests

--- a/ihp/IHP/Router/Types.hs
+++ b/ihp/IHP/Router/Types.hs
@@ -40,6 +40,10 @@ data ControllerRoute application
         -- ^ Pre-built trie fragment from the @routes@ DSL. Method-aware; merged
         -- into the app-wide trie at startup.
 
+-- | Thrown by the AutoRoute query-string decoder (in the optional
+-- @ihp-autoroute@ package) when a constructor argument can't be parsed.
+-- Kept in core so 'IHP.ErrorController' can render a typed 400 page even
+-- without depending on @ihp-autoroute@.
 data TypedAutoRouteError
     = BadType
         { expectedType :: !ByteString
@@ -48,12 +52,6 @@ data TypedAutoRouteError
         }
     | TooFewArguments
     | NotMatched
-    -- | Thrown when 'IHP.RouterSupport.parseUUIDArgument', 'IHP.RouterSupport.parseIntArgument', etc. get passed an invalid value
-    --
-    -- Let's say we have a @ShowProjectAction { id :: Id Project }@.
-    --
-    -- When opening @/ShowProject?projectId=ab55d579-80cd-4608-9a8f-c76dea6c2332@ everything is fine.
-    -- But when opening @/ShowProject?projectId=not-an-uuid@ this exception will be thrown.
     | NoConstructorMatched
         { expectedType :: !ByteString
         , value :: !(Maybe ByteString)

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -2,7 +2,6 @@
 module IHP.RouterSupport (
 CanRoute (..)
 , HasPath (..)
-, AutoRoute (..)
 , runAction
 , runAction'
 , get
@@ -15,8 +14,6 @@ CanRoute (..)
 , parseRoute
 , catchAll
 , mountFrontController
-, createAction
-, updateAction
 , urlTo
 , parseUUID
 , parseId
@@ -30,20 +27,18 @@ CanRoute (..)
 , getMethod
 , routeParam
 , withImplicits
-, applyConstr
 , ControllerRoute (..)
 , findInRouteMaps
-, buildAutoRouteMap
+, actionPrefixText
+, wrapRouterException
 ) where
 
 import Prelude hiding (take)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
-import Data.Maybe (fromMaybe, mapMaybe)
-import Data.List (find, isPrefixOf)
-import Control.Monad (unless, join)
-import Control.Applicative ((<|>), empty)
+import Control.Monad (unless)
 import Text.Read (readMaybe)
+import Unsafe.Coerce
 import Control.Exception.Safe (SomeException, catch, throwIO)
 import Control.Exception (evaluate)
 import qualified IHP.ModelSupport as ModelSupport
@@ -56,29 +51,21 @@ import qualified IHP.Router.Middleware as RouterMiddleware
 import IHP.ControllerSupport
 import Data.Attoparsec.ByteString.Char8 (string, Parser, parseOnly, take, endOfInput, choice, takeTill, takeByteString)
 import qualified Data.Attoparsec.ByteString.Char8 as Attoparsec
-import GHC.TypeLits
 import Data.Data
-import qualified Control.Monad.State.Strict as State
 import qualified Data.Text as Text
-import Network.HTTP.Types.URI
 import qualified Data.List as List
-import Unsafe.Coerce
-import IHP.HaskellSupport hiding (get)
 import qualified Data.Typeable as Typeable
 import qualified Data.ByteString.Char8 as ByteString
 import Data.String.Conversions (ConvertibleStrings (convertString), cs)
 import qualified Text.Blaze.Html5 as Html5
 import qualified Control.Exception as Exception
 import qualified IHP.ErrorController as ErrorController
-import qualified Network.URI.Encode as URI
 import qualified Data.Text.Encoding as Text
-import Data.Dynamic
 import IHP.Router.Types
 import IHP.Router.UrlGenerator
 import qualified Data.HashMap.Strict as HashMap
 import IHP.WebSocket (WSApp)
 import qualified IHP.WebSocket as WS
-import GHC.TypeLits as T
 import IHP.Controller.Context
 import IHP.Controller.Param
 import Data.Kind
@@ -238,329 +225,6 @@ class HasPath controller => CanRoute controller where
     {-# INLINABLE toControllerRoute #-}
 
 
--- | Each of these is tried when trying to parse an argument to a controller constructor (i.e. in IHP, an action).
--- The type @d@ is an the type of the argument, and all we know about this type that its conforms to @Data@.
--- We cannot cast @d@ to some arbitrary type, since adding additional constraints to @d@ (such as Read)
--- will break the @fromConstrM@ function which actually constructs the action.
---
--- The approach taken here is to make use of the type equality operator @:~:@
--- to check and see if @d@ happens to be a certain type. If it is,
--- by matching on Just Refl, we are able to use @d@ as the type we matched it to.
---
--- Please consult your doctor before engaging in Haskell type programming.
-parseFuncs :: forall d idType. (Data d, Data idType) => (ByteString -> Maybe idType) -> [Maybe ByteString -> Either TypedAutoRouteError d]
-parseFuncs parseIdType = [
-            -- Try and parse @Int@ or @Maybe Int@
-            \case
-                Just queryValue -> case eqT :: Maybe (d :~: Int) of
-                    Just Refl -> case ByteString.readInt queryValue of
-                        Just (n, "") -> Right n
-                        _ -> Left BadType { field = "", value = Just queryValue, expectedType = "Int" }
-                    Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
-                        Just Refl -> Right $ case ByteString.readInt queryValue of
-                            Just (n, "") -> Just n
-                            _ -> Nothing
-                        Nothing -> Left NotMatched
-                Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
-                    Just Refl -> Right Nothing
-                    Nothing -> Left NotMatched,
-
-            \case
-                Just queryValue -> case eqT :: Maybe (d :~: Integer) of
-                    Just Refl -> case ByteString.readInteger queryValue of
-                        Just (n, "") -> Right n
-                        _ -> Left BadType { field = "", value = Just queryValue, expectedType = "Integer" }
-                    Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
-                        Just Refl -> Right $ case ByteString.readInteger queryValue of
-                            Just (n, "") -> Just n
-                            _ -> Nothing
-                        Nothing -> Left NotMatched
-                Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
-                    Just Refl -> Right Nothing
-                    Nothing -> Left NotMatched,
-
-            -- Try and parse @Text@ or @Maybe Text@
-            \case
-                Just queryValue -> case eqT :: Maybe (d :~: Text) of
-                    Just Refl -> Right $ cs queryValue
-                    Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
-                        Just Refl -> Right $ Just $ cs queryValue
-                        Nothing -> Left NotMatched
-                Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
-                    Just Refl -> Right Nothing
-                    Nothing -> Left NotMatched,
-            \case
-                Just queryValue -> case parseIdType queryValue of
-                    Just idValue -> case eqT :: Maybe (d :~: idType) of
-                        Just Refl -> Right idValue
-                        Nothing -> Left NotMatched
-                    Nothing -> Left NotMatched
-                Nothing -> Left NotMatched,
-
-            -- Try and parse @[Text]@. If value is not present then default to empty list.
-            \queryValue -> case eqT :: Maybe (d :~: [Text]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> Right $ Text.splitOn "," (cs queryValue)
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            -- Try and parse @[Int]@. If value is not present then default to empty list.
-            \queryValue -> case eqT :: Maybe (d :~: [Int]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> ByteString.split ',' queryValue
-                        |> mapMaybe (\b -> case ByteString.readInt b of Just (n, "") -> Just n; _ -> Nothing)
-                        |> Right
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            \queryValue -> case eqT :: Maybe (d :~: [Integer]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> ByteString.split ',' queryValue
-                        |> mapMaybe (\b -> case ByteString.readInteger b of Just (n, "") -> Just n; _ -> Nothing)
-                        |> Right
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            -- Try and parse a raw [UUID]
-            \queryValue -> case eqT :: Maybe (d :~: [UUID]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> ByteString.split ',' queryValue
-                        |> mapMaybe fromASCIIBytes
-                        |> Right
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            -- Try and parse a raw UUID
-            \queryValue -> case eqT :: Maybe (d :~: UUID) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> queryValue
-                        |> fromASCIIBytes
-                        |> \case
-                            Just uuid -> uuid |> Right
-                            Nothing -> Left BadType { field = "", value = Just queryValue, expectedType = "UUID" }
-                    Nothing -> Left NotMatched
-                Nothing -> Left NotMatched,
-
-            -- This has to be last parser in the list
-            --
-            -- Try and parse a UUID wrapped with a Id. In IHP types these are wrapped in a newtype @Id@ such as @Id User@.
-            -- Since @Id@ is a newtype wrapping a UUID, it has the same data representation in GHC.
-            -- Therefore, we're able to safely cast it to its @Id@ type with @unsafeCoerce@.
-            --
-            -- We cannot use 'eqT' here for checking the types, as it's wrapped inside the @Id@ type. We expect
-            -- that if it looks like a UUID, we can just treat it like an @Id@ type. For that to not overshadow other
-            -- parsers, we need to have this last.
-            \queryValue -> case queryValue of
-                Just queryValue -> queryValue
-                    |> fromASCIIBytes
-                    |> \case
-                        Just uuid -> uuid |> unsafeCoerce |> Right
-                        Nothing -> Left BadType { field = "", value = Just queryValue, expectedType = "UUID" }
-                Nothing -> Left NotMatched
-            ]
-{-# NOINLINE parseFuncs #-}
-
--- | As we fold over a constructor, we want the values parsed from the query string
--- to be in the same order as they are in the constructor.
--- This function uses the field labels from the constructor to sort the values from
--- the query string. As a consequence, constructors with basic record syntax will not work with auto types.
---
--- @data MyController = MyAction Text Int@
---
--- does not work. Instead use,
---
--- @data MyController = MyAction { textArg :: Text, intArg :: Int }@
-querySortedByFields :: Query -> Constr -> Query
-querySortedByFields query constructor = constrFields constructor
-        |> map cs
-        |> map (\field -> (field, join $ List.lookup field query))
-{-# NOINLINE querySortedByFields #-}
-
--- | Given a constructor and a parsed query string, attempt to construct a value of the constructor's type.
--- For example, given the controller
---
--- @data MyController = MyAction { textArg :: Text, intArg :: Int }@
---
--- this function will receive a representation of the @MyAction@ constructor as well as some query string
--- @[("textArg", "some text"), ("intArg", "123")]@.
---
--- By iterating through the query and attempting to match the type of each constructor argument
--- with some transformation of the query string, we attempt to call @MyAction@.
-applyConstr :: (Data controller, Data idType) => (ByteString -> Maybe idType) -> Constr -> Query -> Either TypedAutoRouteError controller
-applyConstr parseIdType constructor query = let
-
-    -- | Given some query item (key, optional value), try to parse into the current expected type
-    -- by iterating through the available parse functions.
-    attemptToParseArg :: forall d. (Data d) => (ByteString, Maybe ByteString) -> [Maybe ByteString -> Either TypedAutoRouteError d] -> State.StateT Query (Either TypedAutoRouteError) d
-    attemptToParseArg queryParam@(queryName, queryValue) [] = State.lift (Left NoConstructorMatched
-                { field = queryName
-                , value = queryValue
-                , expectedType = (dataTypeOf (Prelude.undefined :: d)) |> dataTypeName |> cs
-                })
-    attemptToParseArg queryParam@(k, v) (parseFunc:restFuncs) = case parseFunc v of
-            Right result -> pure result
-            -- BadType will be returned if, for example, a text is passed to a query parameter typed as int.
-            Left badType@BadType{} -> State.lift (Left badType { field = k })
-            -- otherwise, safe to assume the match just failed, so recurse on the rest of the functions and try to find one that matches.
-            Left _ -> attemptToParseArg queryParam restFuncs
-
-    -- | Attempt to parse the current expected type, and return its value.
-    -- For the example @MyController@ this is called twice by @fromConstrM@.
-    -- Once, it is called for @textArg@ where @d :: Text@. Then it is called
-    -- for @intArg@ with @d ::: Int@. With both of these values parsed from the query string,
-    -- the controller action is able to be created.
-    nextField :: forall d. (Data d) => State.StateT Query (Either TypedAutoRouteError) d
-    nextField = do
-            queryParams <- State.get
-            case queryParams of
-                [] -> State.lift (Left TooFewArguments)
-                (p@(key, value):rest) -> do
-                    State.put rest
-                    attemptToParseArg p (parseFuncs parseIdType)
-
-
-   in case State.runStateT (fromConstrM nextField constructor) (querySortedByFields query constructor) of
-        Right (x, []) -> pure x
-        Right (_) -> Left TooFewArguments
-        Left e -> Left e  -- runtime type error
-{-# NOINLINE applyConstr #-}
-
-class Data controller => AutoRoute controller where
-    autoRouteWithIdType :: (?request :: Request, ?respond :: Respond, Data idType) => (ByteString -> Maybe idType) -> Parser controller
-    autoRouteWithIdType parseIdFunc =
-        let
-            query :: Query
-            query = queryString ?request
-        in do
-            -- routeMatchParser is a CAF (no ?request dependency), computed once per controller type.
-            -- It handles the static string matching against URL paths.
-            (constr, allowedMethods) <- routeMatchParser @controller
-            action <- case applyConstr parseIdFunc constr query of
-                    Right parsedAction -> pure parsedAction
-                    Left e -> Exception.throw e
-            method <- getMethod
-            unless (allowedMethods |> includes method) (Exception.throw UnexpectedMethodException { allowedMethods, method })
-            pure action
-    {-# INLINABLE autoRouteWithIdType #-}
-
-    autoRoute :: (?request :: Request, ?respond :: Respond) => Parser controller
-    autoRoute = autoRouteWithIdType (\_ -> Nothing :: Maybe Integer)
-    {-# INLINABLE autoRoute #-}
-
-    -- | Constructs a controller value from a matched constructor and query string.
-    --
-    -- Uses the same id parser as 'autoRoute'. Override this when you override
-    -- 'autoRoute' with 'autoRouteWithIdType' to keep them in sync.
-    --
-    -- This is used by 'parseRoute' to defer query string parsing to the Application
-    -- closure while keeping path matching in the parser.
-    --
-    -- __Example:__
-    --
-    -- > instance AutoRoute MyController where
-    -- >     autoRoute = autoRouteWithIdType (parseIntegerId @(Id MyModel))
-    -- >     applyAction = applyConstr (parseIntegerId @(Id MyModel))
-    applyAction :: Constr -> Query -> Either TypedAutoRouteError controller
-    applyAction = applyConstr (\_ -> Nothing :: Maybe Integer)
-    {-# INLINE applyAction #-}
-
-    -- | Specifies the allowed HTTP methods for a given action
-    --
-    -- The default implementation does a smart guess based on the
-    -- usual naming conventions for controllers.
-    --
-    -- __Example (for default implementation):__
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "DeleteProjectAction"
-    -- [DELETE]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "UpdateProjectAction"
-    -- [POST, PATCH]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "CreateProjectAction"
-    -- [POST]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "ShowProjectAction"
-    -- [GET, HEAD]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "HelloAction"
-    -- [GET, POST, HEAD]
-    --
-    allowedMethodsForAction :: ByteString -> [StdMethod]
-    allowedMethodsForAction actionName =
-            case actionName of
-                a | "Delete" `ByteString.isPrefixOf` a -> [DELETE]
-                a | "Update" `ByteString.isPrefixOf` a -> [POST, PATCH]
-                a | "Create" `ByteString.isPrefixOf` a -> [POST]
-                a | "Show"   `ByteString.isPrefixOf` a -> [GET, HEAD]
-                _ -> [GET, POST, HEAD]
-    {-# INLINE allowedMethodsForAction #-}
-
-    -- | Custom route parser for overriding individual action routes.
-    --
-    -- Use this to provide custom URL patterns for specific actions while keeping
-    -- the auto-generated routes for all other actions.
-    --
-    -- The custom routes are tried first, before the auto-generated routes.
-    -- The auto-generated route for the overridden action still works as a fallback.
-    --
-    -- __Example:__
-    --
-    -- > instance AutoRoute PostsController where
-    -- >     customRoutes = do
-    -- >         string "/posts/"
-    -- >         postId <- parseId
-    -- >         endOfInput
-    -- >         onlyAllowMethods [GET, HEAD]
-    -- >         pure ShowPostAction { postId }
-    --
-    customRoutes :: (?request :: Request, ?respond :: Respond) => Parser controller
-    customRoutes = empty
-    {-# INLINE customRoutes #-}
-
-    -- | Custom path generation for overriding individual action URLs.
-    --
-    -- Use this together with 'customRoutes' to generate custom URLs for specific
-    -- actions while keeping the auto-generated URLs for all other actions.
-    --
-    -- Return @Just path@ for actions with custom URLs, or @Nothing@ to fall back
-    -- to the auto-generated URL.
-    --
-    -- __Example:__
-    --
-    -- > instance AutoRoute PostsController where
-    -- >     customPathTo ShowPostAction { postId } = Just ("/posts/" <> tshow postId)
-    -- >     customPathTo _ = Nothing
-    --
-    customPathTo :: controller -> Maybe Text
-    customPathTo _ = Nothing
-    {-# INLINE customPathTo #-}
-
--- | Static route-matching parser that becomes a CAF when specialized for a concrete
--- controller type. Uses a 'HashMap' for O(1) action name lookup after matching the prefix.
--- Since it doesn't reference @?request@ or @?respond@, GHC can float this out as a
--- top-level constant.
-routeMatchParser :: forall controller. (Data controller, AutoRoute controller) => Parser (Constr, [StdMethod])
-routeMatchParser = do
-    string prefix
-    remaining <- takeByteString
-    case HashMap.lookup remaining actionMatchMap of
-        Just result -> pure result
-        Nothing -> fail "no matching action"
-    where
-        prefix :: ByteString
-        prefix = Text.encodeUtf8 (actionPrefixText @controller)
-
-        actionMatchMap :: HashMap.HashMap ByteString (Constr, [StdMethod])
-        actionMatchMap = HashMap.fromList
-            [ (actionPath, (constr, allowedMethods))
-            | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-            , let actionName = ByteString.pack (showConstr constr)
-                  actionPath = stripActionSuffixByteString actionName
-                  allowedMethods = allowedMethodsForAction @controller actionName
-            ]
-{-# NOINLINE routeMatchParser #-}
-
 -- | Returns the url prefix for a controller. The prefix is based on the
 -- module where the controller is defined.
 --
@@ -583,198 +247,6 @@ actionPrefixText
         getPrefix t = fst (Text.breakOn "." t)
 {-# NOINLINE actionPrefixText #-}
 
--- | Strips the "Action" suffix from action names
---
--- >>> stripActionSuffixByteString "ShowUserAction"
--- "ShowUser"
---
--- >>> stripActionSuffixByteString "UsersAction"
--- "UsersAction"
---
--- >>> stripActionSuffixByteString "User"
--- "User"
-stripActionSuffixByteString :: ByteString -> ByteString
-stripActionSuffixByteString actionName = fromMaybe actionName (ByteString.stripSuffix "Action" actionName)
-{-# INLINE stripActionSuffixByteString #-}
-
--- | Strips the "Action" suffix from action names
---
--- >>> stripActionSuffixText "ShowUserAction"
--- "ShowUser"
---
--- >>> stripActionSuffixText "UsersAction"
--- "UsersAction"
---
--- >>> stripActionSuffixText "User"
--- "User"
-stripActionSuffixText :: Text -> Text
-stripActionSuffixText actionName = fromMaybe actionName (Text.stripSuffix "Action" actionName)
-{-# INLINE stripActionSuffixText #-}
-
-
--- | Returns the create action for a given controller.
--- Example: `createAction @UsersController == Just CreateUserAction`
-createAction :: forall controller. AutoRoute controller => Maybe controller
-createAction = fmap fromConstr createConstructor
-    where
-        createConstructor :: Maybe Constr
-        createConstructor = find isCreateConstructor allConstructors
-
-        allConstructors :: [Constr]
-        allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-
-        isCreateConstructor :: Constr -> Bool
-        isCreateConstructor constructor = "Create" `isPrefixOf` showConstr constructor && Prelude.null (constrFields constructor)
-{-# INLINE createAction #-}
-
--- | Returns the update action when given a controller and id.
--- Example: `updateAction @UsersController == Just (\id -> UpdateUserAction id)`
-updateAction :: forall controller id. AutoRoute controller => Maybe (id -> controller)
-updateAction =
-        case updateConstructor of
-            Just constructor -> Just $ \id -> buildInstance constructor id
-            Nothing -> Nothing
-    where
-        updateConstructor :: Maybe Constr
-        updateConstructor = find isUpdateConstructor allConstructors
-
-        buildInstance :: Constr -> id -> controller
-        buildInstance constructor id = State.evalState ((fromConstrM (do
-                i <- State.get
-
-                State.modify (+1)
-                pure (unsafeCoerce id)
-            )) constructor) 0
-
-        allConstructors :: [Constr]
-        allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-
-        isUpdateConstructor :: Constr -> Bool
-        isUpdateConstructor constructor = "Update" `isPrefixOf` (showConstr constructor) && (length (constrFields constructor) == 1)
-{-# INLINE updateAction #-}
-
-instance {-# OVERLAPPABLE #-} (AutoRoute controller, Controller controller) => CanRoute controller where
-    parseRoute' = customRoutes <|> autoRoute
-    {-# INLINABLE parseRoute' #-}
-
-    -- | This is only used as a fallback parser (via lazy thunk in 'ControllerRouteMap').
-    -- The primary routing path goes through 'findInRouteMaps' / 'buildAutoRouteMap' instead.
-    -- Performance here doesn't matter — keep it simple.
-    parseRouteWithAction toApp = (do
-        action <- customRoutes @controller
-        pure (toApp action)
-      ) <|> (do
-        (constr, allowedMethods) <- routeMatchParser @controller
-        pure $ \waiRequest waiRespond -> wrapRouterException do
-            case applyAction @controller constr (queryString waiRequest) of
-                Left e -> Exception.throw e
-                Right action -> do
-                    case parseMethod (requestMethod waiRequest) of
-                        Right method -> do
-                            unless (allowedMethods |> includes method)
-                                (Exception.throw UnexpectedMethodException { allowedMethods, method })
-                            toApp action waiRequest waiRespond
-                        Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
-      )
-    {-# INLINABLE parseRouteWithAction #-}
-
-    -- | Override to use 'ControllerRouteMap' for O(1) HashMap dispatch.
-    toControllerRoute :: forall application.
-        ( ?request :: Request, ?respond :: Respond, Controller controller
-        , InitControllerContext application, ?application :: application
-        , Typeable application, Typeable controller
-        ) => ControllerRoute application
-    toControllerRoute = ControllerRouteMap
-        (buildAutoRouteMap @controller @application)
-        (parseRouteWithAction @controller (runAction' @application))
-    {-# INLINABLE toControllerRoute #-}
-
--- | Instances of the @QueryParam@ type class can be represented in URLs as query parameters.
--- Currently this is only Int, Text, and both wrapped in List and Maybe.
--- IDs also are representable in a URL, but we are unable to match on polymorphic types using reflection,
--- so we fall back to the default "show" for these.
-class Data a => QueryParam a where
-    showQueryParam :: a -> String
-
-instance QueryParam Text where
-    showQueryParam text = Text.unpack text
-
-instance QueryParam Int where
-    showQueryParam = show
-
-instance QueryParam Integer where
-    showQueryParam = show
-
-instance QueryParam UUID where
-    showQueryParam = show
-
-instance QueryParam a => QueryParam (Maybe a) where
-    showQueryParam (Just val) = showQueryParam val
-    showQueryParam Nothing = ""
-
-instance QueryParam a => QueryParam [a] where
-    showQueryParam = List.intercalate "," . map showQueryParam
-
-instance {-# OVERLAPPABLE #-} (Show controller, AutoRoute controller) => HasPath controller where
-    pathTo !action = case customPathTo action of
-        Just path -> path
-        Nothing ->
-            let !ci = constrIndex (toConstr action) - 1
-                (!basePath, !fieldNames) = constrInfoCache !! ci
-            in case fieldNames of
-                [] -> basePath
-                _ ->
-                    let !fieldValues = gmapQ renderFieldForUrl action
-                    in basePath <> buildQueryText fieldNames fieldValues
-        where
-            -- Precomputed per constructor: (basePath, fieldNames).
-            -- Does not reference 'action', so GHC floats this out as a CAF
-            -- when the instance is specialized for a concrete controller type.
-            constrInfoCache :: [(Text, [Text])]
-            constrInfoCache = map mkInfo allConstrs
-                where
-                    allConstrs = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-                    !appPrefix = actionPrefixText @controller
-                    mkInfo c =
-                        let !bp = appPrefix <> stripActionSuffixText (Text.pack (showConstr c))
-                            !fns = map Text.pack (constrFields c)
-                        in (bp, fns)
-
-            buildQueryText :: [Text] -> [Text] -> Text
-            buildQueryText names values =
-                zip names values
-                |> filter (\(_, v) -> not (Text.null v))
-                |> map (\(k, v) -> k <> "=" <> URI.encodeText v)
-                |> Text.intercalate "&"
-                |> (\q -> if Text.null q then q else Text.cons '?' q)
-    {-# NOINLINE pathTo #-}
-
--- | Render a controller field value as 'Text' for URL query parameter inclusion.
---
--- Uses type reflection ('eqT') to match known types (Text, UUID, Int, Integer,
--- and their Maybe\/List variants). For newtypes like @Id'@ that wrap a known type,
--- falls back to recursive unwrap via 'gmapQ'.
-renderFieldForUrl :: forall d. Data d => d -> Text
-renderFieldForUrl val
-    -- UUID first: most common type after Id newtype unwrap
-    | Just Refl <- eqT @d @UUID = toText val
-    | Just Refl <- eqT @d @Text = val
-    | Just Refl <- eqT @d @Int = Text.pack (show val)
-    | Just Refl <- eqT @d @Integer = Text.pack (show val)
-    | Just Refl <- eqT @d @(Maybe UUID) = maybe "" toText val
-    | Just Refl <- eqT @d @(Maybe Text) = maybe "" id val
-    | Just Refl <- eqT @d @(Maybe Int) = maybe "" (Text.pack . show) val
-    | Just Refl <- eqT @d @(Maybe Integer) = maybe "" (Text.pack . show) val
-    | Just Refl <- eqT @d @[UUID] = Text.intercalate "," (map toText val)
-    | Just Refl <- eqT @d @[Text] = Text.intercalate "," (val :: [Text])
-    | Just Refl <- eqT @d @[Int] = Text.intercalate "," (map (Text.pack . show) val)
-    | Just Refl <- eqT @d @[Integer] = Text.intercalate "," (map (Text.pack . show) val)
-    | otherwise =
-        -- Unwrap one layer for newtypes (e.g., Id' wrapping UUID, Maybe (Id' table))
-        case gmapQ renderFieldForUrl val of
-            [inner] -> inner
-            _ -> ""
-{-# NOINLINE renderFieldForUrl #-}
 
 -- | Parses the HTTP Method from the request and returns it.
 getMethod :: (?request :: Request, ?respond :: Respond) => Parser StdMethod
@@ -1123,60 +595,6 @@ parseRoute :: forall controller application.
 parseRoute = toControllerRoute @controller @application
 {-# INLINABLE parseRoute #-}
 
--- | Build a HashMap from full paths (prefix + action name) to Application closures.
--- The Application closures take the application value explicitly and handle query string
--- parsing, method validation, and controller execution.
--- Computed once per (controller, application) type pair (NOINLINE CAF).
-buildAutoRouteMap :: forall controller application.
-    ( AutoRoute controller
-    , Controller controller
-    , InitControllerContext application
-    , Typeable application
-    , Typeable controller
-    ) => HashMap.HashMap ByteString (application -> Application)
-buildAutoRouteMap = HashMap.fromList
-    [ (prefix <> actionPath, handler)
-    | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-    , let actionName = ByteString.pack (showConstr constr)
-          actionPath = stripActionSuffixByteString actionName
-          allowedMethods = allowedMethodsForAction @controller actionName
-          handler app waiRequest waiRespond =
-              let ?application = app
-              in wrapRouterException do
-                  case parseMethod (requestMethod waiRequest) of
-                      Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
-                      Right method -> do
-                          unless (allowedMethods |> includes method)
-                              (Exception.throw UnexpectedMethodException { allowedMethods, method })
-                          case applyAction @controller constr (queryString waiRequest) of
-                              Left e -> Exception.throw e
-                              Right action -> runAction' @application action waiRequest waiRespond
-    ]
-    where
-        prefix :: ByteString
-        prefix = Text.encodeUtf8 (actionPrefixText @controller)
-{-# NOINLINE buildAutoRouteMap #-}
-
-parseUUIDOrTextId ::  ByteString -> Maybe Dynamic
-parseUUIDOrTextId queryVal = queryVal
-    |> fromASCIIBytes
-    |> \case
-        Just uuid -> uuid |> toDyn |> Just
-        Nothing -> Nothing
-
-parseRouteWithId
-    :: forall controller application.
-        (
-            ?request :: Request,
-            ?respond :: Respond,
-            CanRoute controller,
-            Controller controller,
-            InitControllerContext application,
-            ?application :: application,
-            Typeable application,
-            Typeable controller)
-        => ControllerRoute application
-parseRouteWithId = parseRoute @controller @application
 
 catchAll :: forall action application. (Controller action, InitControllerContext application, Typeable action, ?application :: application, Typeable application, Data action) => action -> ControllerRoute application
 catchAll action = ControllerRouteParser $ do
@@ -1241,15 +659,3 @@ routeParam paramName =
         let ?context = FrozenControllerContext { customFields }
         in param paramName
 
--- | Display a better error when the user missed to pass an argument to an action.
---
--- E.g. when you forgot to pass a projectId to the ShowProjectAction:
---
--- > <a href={ShowProjectAction}>Show project</a>
---
--- The correct code would be this:
---
--- > <a href={ShowProjectAction projectId}>Show project</a>
---
--- See https://github.com/digitallyinduced/ihp/issues/840
-instance ((T.TypeError (T.Text "Looks like you forgot to pass a " :<>: (T.ShowType argument) :<>: T.Text " to this " :<>: (T.ShowType controller))), Data argument, Data controller, Data (argument -> controller)) => AutoRoute (argument -> controller) where

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -4,6 +4,8 @@ Tests that AutoRefresh preserves query parameters when re-rendering
 with a bare WebSocket request (no query params).
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.AutoRefreshSpec where
 import Test.Hspec
@@ -11,8 +13,10 @@ import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
 import IHP.ControllerPrelude hiding (get, request)
+import IHP.Router.DSL (routes)
 import Network.Wai
 import Network.HTTP.Types
+import Network.HTTP.Types.Method (StdMethod (..))
 import IHP.AutoRefresh (globalAutoRefreshServerVar, sessionResponseHasChanged, updateSession)
 import IHP.AutoRefresh.Types
 import IHP.AutoRefresh.View (autoRefreshMeta)
@@ -43,7 +47,12 @@ instance Controller TestController where
         let meta = autoRefreshMeta
         respondHtml [hsx|<html><head>{meta}</head><body>{marketId}</body></html>|]
 
-instance AutoRoute TestController
+$(pure [])
+
+[routes|TestController
+GET /test/ShowItem     ShowItemAction
+GET /test/ShowItemHtml ShowItemHtmlAction
+|]
 
 instance FrontController WebApplication where
   controllers = [ parseRoute @TestController ]

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -16,7 +16,6 @@ import IHP.ControllerPrelude hiding (get, request)
 import IHP.Router.DSL (routes)
 import Network.Wai
 import Network.HTTP.Types
-import Network.HTTP.Types.Method (StdMethod (..))
 import IHP.AutoRefresh (globalAutoRefreshServerVar, sessionResponseHasChanged, updateSession)
 import IHP.AutoRefresh.Types
 import IHP.AutoRefresh.View (autoRefreshMeta)

--- a/ihp/Test/Test/Controller/AccessDeniedSpec.hs
+++ b/ihp/Test/Test/Controller/AccessDeniedSpec.hs
@@ -3,6 +3,8 @@ Module: Test.Controller.AccessDeniedSpec
 Tests for Access denied functions.
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.Controller.AccessDeniedSpec where
 import ClassyPrelude
@@ -11,9 +13,11 @@ import IHP.Test.Mocking
 import IHP.Prelude
 import IHP.Environment
 import IHP.RouterSupport hiding (get)
+import IHP.Router.DSL (routes)
 import IHP.FrameworkConfig
 import IHP.ViewPrelude
 import IHP.ControllerPrelude hiding (get, request)
+import Network.HTTP.Types.Method (StdMethod (..))
 import Network.Wai.Test
 import Test.Util (testGet)
 
@@ -32,7 +36,12 @@ instance Controller TestController where
         accessDeniedUnless False
         renderPlain "Test"
 
-instance AutoRoute TestController
+$(pure [])
+
+[routes|TestController
+GET /test/TestActionAccessDeniedWhen   TestActionAccessDeniedWhen
+GET /test/TestActionAccessDeniedUnless TestActionAccessDeniedUnless
+|]
 
 instance FrontController WebApplication where
   controllers = [ parseRoute @TestController ]

--- a/ihp/Test/Test/Controller/CookieSpec.hs
+++ b/ihp/Test/Test/Controller/CookieSpec.hs
@@ -3,6 +3,8 @@ Module: Test.Controller.CookieSpec
 Copyright: (c) digitally induced GmbH, 2022
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.Controller.CookieSpec where
 
@@ -12,6 +14,8 @@ import IHP.Test.Mocking
 import IHP.Environment
 import IHP.FrameworkConfig
 import IHP.ControllerPrelude hiding (get, request)
+import IHP.Router.DSL (routes)
+import Network.HTTP.Types.Method (StdMethod (..))
 import Web.Cookie
 import Network.Wai.Test
 import Test.Util (testGet)
@@ -30,7 +34,11 @@ instance Controller CookieTestController where
             }
         renderPlain "ok"
 
-instance AutoRoute CookieTestController
+$(pure [])
+
+[routes|CookieTestController
+GET /test/SetCookie SetCookieAction
+|]
 
 instance FrontController WebApplication where
     controllers = [parseRoute @CookieTestController]

--- a/ihp/Test/Test/Controller/NotFoundSpec.hs
+++ b/ihp/Test/Test/Controller/NotFoundSpec.hs
@@ -3,6 +3,8 @@ Module: Test.Controller.NotFoundSpec
 Tests for Not found functions.
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.Controller.NotFoundSpec where
 import ClassyPrelude
@@ -11,9 +13,11 @@ import IHP.Test.Mocking
 import IHP.Prelude
 import IHP.Environment
 import IHP.RouterSupport hiding (get)
+import IHP.Router.DSL (routes)
 import IHP.FrameworkConfig
 import IHP.ViewPrelude
 import IHP.ControllerPrelude hiding (get, request)
+import Network.HTTP.Types.Method (StdMethod (..))
 import Network.Wai.Test
 import Test.Util (testGet)
 
@@ -32,7 +36,12 @@ instance Controller TestController where
         notFoundUnless False
         renderPlain "Test"
 
-instance AutoRoute TestController
+$(pure [])
+
+[routes|TestController
+GET /test/TestActionNotFoundWhen   TestActionNotFoundWhen
+GET /test/TestActionNotFoundUnless TestActionNotFoundUnless
+|]
 
 instance FrontController WebApplication where
   controllers = [ parseRoute @TestController ]

--- a/ihp/Test/Test/Main.hs
+++ b/ihp/Test/Test/Main.hs
@@ -15,13 +15,11 @@ import qualified Test.Controller.AccessDeniedSpec
 import qualified Test.Controller.NotFoundSpec
 import qualified Test.ModelSupportSpec
 import qualified Test.QueryBuilderSpec
-import qualified Test.RouterSupportSpec
 import qualified Test.Router.CaptureSpec
 import qualified Test.Router.TrieSpec
 import qualified Test.Router.MiddlewareSpec
 import qualified Test.Router.DSLParserSpec
 import qualified Test.Router.DSLQuoterSpec
-import qualified Test.Router.MixedModeSpec
 import qualified Test.Router.MultiControllerSpec
 import qualified Test.Router.AppBindingSpec
 import qualified Test.ViewSupportSpec
@@ -49,13 +47,11 @@ main = hspec do
     Test.Controller.NotFoundSpec.tests
     Test.ModelSupportSpec.tests
     Test.QueryBuilderSpec.tests
-    Test.RouterSupportSpec.tests
     Test.Router.CaptureSpec.tests
     Test.Router.TrieSpec.tests
     Test.Router.MiddlewareSpec.tests
     Test.Router.DSLParserSpec.tests
     Test.Router.DSLQuoterSpec.tests
-    Test.Router.MixedModeSpec.tests
     Test.Router.MultiControllerSpec.tests
     Test.Router.AppBindingSpec.tests
     Test.ViewSupportSpec.tests

--- a/ihp/Test/Test/MockingSpec.hs
+++ b/ihp/Test/Test/MockingSpec.hs
@@ -5,6 +5,8 @@ through the middleware stack and that redirect responses preserve
 their status codes.
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.MockingSpec where
 import ClassyPrelude
@@ -14,7 +16,9 @@ import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
 import IHP.ControllerPrelude hiding (get, request)
+import IHP.Router.DSL (routes)
 import IHP.HSX.Markup (Html)
+import Network.HTTP.Types.Method (StdMethod (..))
 import Network.Wai.Test
 import Test.Util (testGet, testPostForm)
 
@@ -49,7 +53,13 @@ instance Controller TestController where
             Just (TestUser { id = Id uuid }) -> renderPlain (cs (UUID.toASCIIBytes uuid))
             Nothing -> renderPlain "anonymous"
 
-instance AutoRoute TestController
+$(pure [])
+
+[routes|TestController
+POST /test/EchoParam   EchoParamAction
+GET  /test/Redirect    RedirectAction
+GET  /test/RequireUser RequireUserAction
+|]
 
 instance FrontController WebApplication where
   controllers = [ parseRoute @TestController ]

--- a/ihp/Test/Test/ViewSupportSpec.hs
+++ b/ihp/Test/Test/ViewSupportSpec.hs
@@ -4,6 +4,8 @@ Module: Test.ViewSupportSpec
 Tests for view support functions.
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.ViewSupportSpec where
 import ClassyPrelude
@@ -13,8 +15,11 @@ import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
 import IHP.RouterSupport hiding (get)
+import IHP.Router.DSL (routes)
 import IHP.ViewPrelude
 import IHP.ControllerPrelude hiding (get, request)
+import IHP.Router.Capture (renderCapture, parseCapture)
+import Network.HTTP.Types.Method (StdMethod (..))
 import Network.Wai.Test
 import Test.Util (testGet)
 
@@ -34,27 +39,18 @@ data CustomPathController
     | CustomPathWithIdAction { customId :: Text }
   deriving (Eq, Show, Data)
 
-instance Controller TestController where
-    action TestAction = do
-        renderPlain "TestAction"
-    action TestWithParamAction { .. } = do
-        render ShowView { .. }
-
-instance Controller AnotherTestController where
-    action AnotherTestAction = do
-        renderPlain "AnotherTestAction"
-
-instance AutoRoute TestController
-instance AutoRoute AnotherTestController
-
-instance HasPath CustomPathController where
-    pathTo CustomPathAction = "/custom/path"
-    pathTo CustomPathWithIdAction { customId } = "/custom/path/" <> customId
-
-instance FrontController WebApplication where
-  controllers = [ parseRoute @TestController, parseRoute @AnotherTestController ]
-
 data ShowView = ShowView { param :: Text}
+
+$(pure [])
+
+[routes|TestController
+GET /test/Test                TestAction
+GET /test/TestWithParam?param TestWithParamAction
+|]
+
+[routes|AnotherTestController
+GET /test/AnotherTest AnotherTestAction
+|]
 
 instance View ShowView where
     html ShowView { .. }= [hsx|
@@ -67,6 +63,23 @@ instance View ShowView where
         isActiveController TestController: {isActiveController @TestController}
         isActiveController AnotherTestAction: {isActiveController @AnotherTestController}
     |]
+
+instance Controller TestController where
+    action TestAction = do
+        renderPlain "TestAction"
+    action TestWithParamAction { .. } = do
+        render ShowView { .. }
+
+instance Controller AnotherTestController where
+    action AnotherTestAction = do
+        renderPlain "AnotherTestAction"
+
+instance HasPath CustomPathController where
+    pathTo CustomPathAction = "/custom/path"
+    pathTo CustomPathWithIdAction { customId } = "/custom/path/" <> customId
+
+instance FrontController WebApplication where
+  controllers = [ parseRoute @TestController, parseRoute @AnotherTestController ]
 
 defaultLayout :: Html -> Html
 defaultLayout inner =  [hsx|{inner}|]

--- a/ihp/Test/Test/ViewSupportSpec.hs
+++ b/ihp/Test/Test/ViewSupportSpec.hs
@@ -18,7 +18,7 @@ import IHP.RouterSupport hiding (get)
 import IHP.Router.DSL (routes)
 import IHP.ViewPrelude
 import IHP.ControllerPrelude hiding (get, request)
-import IHP.Router.Capture (renderCapture, parseCapture)
+import IHP.Router.Capture (renderCapture)
 import Network.HTTP.Types.Method (StdMethod (..))
 import Network.Wai.Test
 import Test.Util (testGet)

--- a/ihp/default.nix
+++ b/ihp/default.nix
@@ -14,11 +14,11 @@
 , postgresql-simple-postgresql-types, postgresql-types, process
 , pwstore-fast, random, random-strings, regex-tdfa, resource-pool
 , resourcet, safe-exceptions, scientific, slugger, split, stm
-, string-conversions, tasty-bench, template-haskell, text, time
-, transformers, typerep-map, unagi-chan, unix, unliftio
-, unordered-containers, uri-encode, uuid, vault, vector, wai
-, wai-app-static, wai-asset-path, wai-cors, wai-early-return
-, wai-extra, wai-flash-messages, wai-request-params
+, string-conversions, template-haskell, text, time, transformers
+, typerep-map, unagi-chan, unix, unliftio, unordered-containers
+, uri-encode, uuid, vault, vector, wai, wai-app-static
+, wai-asset-path, wai-cors, wai-early-return, wai-extra
+, wai-flash-messages, wai-request-params
 , wai-session-clientsession-deferred, wai-session-maybe, wai-util
 , wai-websockets, warp, warp-systemd, websockets, with-utf8
 }:
@@ -74,30 +74,6 @@ mkDerivation {
     wai-request-params wai-session-clientsession-deferred
     wai-session-maybe wai-util wai-websockets warp warp-systemd
     websockets with-utf8
-  ];
-  benchmarkHaskellDepends = [
-    aeson async attoparsec base basic-prelude binary blaze-html
-    blaze-markup bytestring case-insensitive cereal cereal-text
-    classy-prelude clientsession conduit-extra containers contravariant
-    cookie countable-inflections data-default deepseq directory
-    fast-logger filepath ghc-prim hashable haskell-src-exts
-    haskell-src-meta hasql hasql-dynamic-statements hasql-implicits
-    hasql-mapping hasql-pool hasql-postgresql-types hasql-transaction
-    http-client http-client-tls http-media http-types ihp-context
-    ihp-hsx ihp-imagemagick ihp-log ihp-modal ihp-pagehead
-    ihp-pglistener inflections interpolate mime-types minio-hs
-    mono-traversable mtl neat-interpolation network network-uri
-    parser-combinators postgresql-simple
-    postgresql-simple-postgresql-types postgresql-types process
-    pwstore-fast random random-strings regex-tdfa resource-pool
-    resourcet safe-exceptions scientific slugger split stm
-    string-conversions tasty-bench template-haskell text time
-    transformers typerep-map unagi-chan unix unliftio
-    unordered-containers uri-encode uuid vault vector wai
-    wai-app-static wai-asset-path wai-cors wai-early-return wai-extra
-    wai-flash-messages wai-request-params
-    wai-session-clientsession-deferred wai-session-maybe wai-util
-    wai-websockets warp warp-systemd websockets with-utf8
   ];
   homepage = "https://ihp.digitallyinduced.com/";
   description = "Haskell Web Framework";

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -308,7 +308,6 @@ test-suite tests
         Test.Controller.NotFoundSpec
         Test.ModelSupportSpec
         Test.QueryBuilderSpec
-        Test.RouterSupportSpec
         Test.ViewSupportSpec
         Test.FileStorage.ControllerFunctionsSpec
         Test.Controller.CookieSpec
@@ -323,15 +322,3 @@ test-suite tests
         Test.LoginSupport.AuthVaultSpec
         Test.ModelFixtures
         Test.Util
-
-benchmark ihp-router-bench
-    import: shared-properties
-    type: exitcode-stdio-1.0
-    hs-source-dirs: .
-    main-is: Test/RouterBench.hs
-    -- tasty-bench requires -fno-static-argument-transformation to prevent
-    -- GHC from defeating the re-evaluation trick used for measurement
-    ghc-options: -fno-static-argument-transformation
-    build-depends:
-        , ihp
-        , tasty-bench

--- a/integration-test/Web/Routes.hs
+++ b/integration-test/Web/Routes.hs
@@ -1,7 +1,18 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Web.Routes where
 
 import IHP.RouterPrelude
+import IHP.Router.DSL (routes)
 import Generated.Types
 import Web.Types
 
-instance AutoRoute PostsController
+[routes|PostsController
+GET    /Posts                  PostsAction
+GET    /NewPost                NewPostAction
+POST   /CreatePost             CreatePostAction
+GET    /ShowPost?postId        ShowPostAction
+GET    /EditPost?postId        EditPostAction
+POST   /UpdatePost?postId      UpdatePostAction
+DELETE /DeletePost?postId      DeletePostAction
+|]


### PR DESCRIPTION
## Summary

- Extracts the legacy `AutoRoute` typeclass and its query-string decoder out of `ihp` core into a new sibling package `ihp-autoroute`.
- Apps that still use `instance AutoRoute X` opt in by adding `p.ihp-autoroute` to their flake's `haskellPackages` and `import IHP.AutoRoute` in their routes module.
- New apps should use the `[routes|...|]` DSL — no source change for them; the codegen already emits DSL.

**Stacked on [#2661](https://github.com/digitallyinduced/ihp/pull/2661)** (ihp-ide DSL migration). Merge that one first.

## What moved to `ihp-autoroute`

- `class AutoRoute` (incl. `autoRoute`, `autoRouteWithIdType`, `applyAction`, `allowedMethodsForAction`, `customRoutes`, `customPathTo`)
- query-string decoder (`parseFuncs`, `querySortedByFields`, `applyConstr`)
- `routeMatchParser`, `stripActionSuffix*`
- `createAction`, `updateAction`
- overlappable `CanRoute` / `HasPath` instances for AutoRoute controllers
- `class QueryParam`, `renderFieldForUrl`
- `buildAutoRouteMap`, `parseUUIDOrTextId`, `parseRouteWithId`
- the `TypeError` helper that renders "you forgot to pass an argument"
- the AutoRoute-specific spec + benchmark (`Test/Test/RouterSupportSpec.hs`, `Test/Test/Router/MixedModeSpec.hs`, `Test/RouterBench.hs`)

## What stays in `ihp` core

- `class CanRoute`, `class HasPath`, `class FrontController`
- `data ControllerRoute` (`Map` / `Parser` / `Trie` variants — `Map` is now only produced by `ihp-autoroute`)
- `data UnexpectedMethodException`, `data TypedAutoRouteError` (kept so `IHP.ErrorController` can render typed 400s without depending on `ihp-autoroute`)
- `actionPrefixText`, `wrapRouterException` — used by `startPage`, `catchAll`, error handler
- `parseRoute`, dispatch helpers, all non-AutoRoute parsing helpers

## Migration for apps

Two-step:

1. Add `p.ihp-autoroute` to `ihp.haskellPackages` in `flake.nix`.
2. `import IHP.AutoRoute` wherever you have `instance AutoRoute X`.

URL shapes, `pathTo`, HTTP-method dispatch all behave identically to before. Documented in [`UPGRADE.md`](UPGRADE.md) and [`CHANGELOG.md`](CHANGELOG.md).

## Test plan

- [x] `ihp` test suite (513 examples, 0 failures, 23 pending without DB) via `echo -e ':l ihp/Test/Test/Main.hs\nmain' | ghci`
- [x] `ihp-autoroute` test suite (48 examples, 0 failures) via `echo -e ':l ihp-autoroute/Test/Main.hs\nmain' | ghci` — covers the moved `RouterSupportSpec` (typed query-string decoding) and `MixedModeSpec` (AutoRoute + DSL coexist)
- [x] `ihp-ide` test suite (401 examples, 0 failures)
- [ ] CI (`nix flake check`) passes on this branch
- [ ] Manual smoke: in a scratch app, add `p.ihp-autoroute` + `import IHP.AutoRoute` + `instance AutoRoute SomeController`, verify `/Posts`, `/ShowPost?postId=…`, etc. routes still resolve and `pathTo` still produces the same URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)