### PR TITLE
Add WS keyword to the [routes|…|] DSL for WebSocket apps

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -6,6 +6,7 @@
 :set -iihp-pglistener
 :set -iihp-modal
 :set -iihp
+:set -iihp-router
 :set -iihp-typed-sql
 :set -iihp-typed-sql/Test
 :set -iihp/Test

--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -186,6 +186,41 @@ The line above the first route is the header. It takes three shapes:
 
 3. **Omitted** — header-less. Splice emits instances only; no binding.
 
+### WebSocket routes
+
+Use the `WS` keyword to register a WebSocket app at a static path:
+
+```haskell
+[routes|webRoutes
+GET /posts                 PostsAction
+WS  /chat                  ChatApp
+WS  /datasync              DataSyncController
+|]
+
+instance FrontController WebApplication where
+    controllers = webRoutes
+```
+
+The right-hand identifier on a `WS` line is the **type name** of a `WSApp` instance — not a controller action constructor. The splice emits a `webSocketRoute @TypeName "/path"` entry into the named binding; behaviour is identical to [`webSocketAppWithCustomPath @TypeName "/path"`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:webSocketAppWithCustomPath) except the route is registered in the explicit-routes trie instead of the legacy Attoparsec fallback.
+
+The handshake is `HTTP GET` + `Upgrade: websocket`, so `WS` routes register under the `GET` method. A non-WebSocket `GET` to the same path returns `400 Bad Request`.
+
+**v1 limitations** (subject to change):
+
+- WS routes only support **static paths** — no `{capture}` or `{+splat}` segments. The parser rejects them with a pointed error.
+- WS routes don't read query parameters (`?name`).
+- `WS` cannot be combined with HTTP methods on the same line (e.g. `WS|GET` is rejected).
+- WS routes must live in a **named-binding** block (lowercase header). The single-controller and header-less forms can't currently emit the binding the WS route needs to register itself.
+- No HTTP-fallback variant — for the [`webSocketAppWithHTTPFallback`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:webSocketAppWithHTTPFallback) shape, register the WS app the legacy way alongside the DSL block.
+- The splice does not emit `HasPath` for the WS type. To call `pathTo @ChatApp` from JS-client setup code, declare the instance manually:
+
+  ```haskell
+  instance HasPath ChatApp where
+      pathTo _ = "/chat"
+  ```
+
+If you need any of the above today, keep using [`webSocketApp`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:webSocketApp) / [`webSocketAppWithCustomPath`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:webSocketAppWithCustomPath) for those routes; both forms can coexist in the same `controllers` list.
+
 ### Compile-time validation
 
 The splice runs several checks on every `[routes|…|]` block and fails at compile time — pointing at the DSL line number — if any of the following go wrong:
@@ -195,6 +230,8 @@ The splice runs several checks on every `[routes|…|]` block and fails at compi
 - A field appears in both the path and the query list
 - An action constructor has a record field not covered by the route
 - A query parameter is declared twice
+- A `WS` route uses a path capture, splat, or query list, or `WS` is mixed with HTTP methods on the same line
+- A `WS` route appears in a non-named-binding block
 - The DSL syntax itself is malformed (unknown method, missing path, etc.)
 
 The error messages include the DSL line number and the list of known fields, so fixing them is usually a one-line change.

--- a/ihp-router/IHP/Router/DSL/AST.hs
+++ b/ihp-router/IHP/Router/DSL/AST.hs
@@ -26,6 +26,7 @@ line is a comment.
 module IHP.Router.DSL.AST
     ( Routes (..)
     , Route (..)
+    , RouteKind (..)
     , PathSeg (..)
     , ActionRef (..)
     , Method
@@ -66,7 +67,28 @@ data Route = Route
         -- must then be the empty set, or the TH splice errors out.
     , routeAction      :: !ActionRef
     , routeLine        :: !Int      -- source line number (1-based) for error messages
+    , routeKind        :: !RouteKind
+        -- ^ Discriminates HTTP and WebSocket routes. WebSocket routes are
+        -- written with the @WS@ keyword in place of an HTTP method; the
+        -- parser stores @routeMethods = [GET]@ for them so they register
+        -- under the same trie method that carries the WS handshake.
     }
+    deriving (Eq, Show)
+
+-- | Whether a route is an HTTP route or a WebSocket route.
+--
+-- WebSocket routes are written @WS \/path TypeName@; the right-hand
+-- identifier is the 'WSApp'-instance type itself (not an action
+-- constructor), and the path must be static — no @{capture}@ segments
+-- and no @?query@ list — in this v1.
+--
+-- The generic @ihp-router@ package has no notion of @WSApp@; it's
+-- the IHP-side splice in @IHP.Router.IHP@ that turns
+-- 'WebSocketRoute' entries into 'webSocketRoute' calls. The kind tag
+-- lives here so both halves of the splice can share parser output.
+data RouteKind
+    = HttpRoute
+    | WebSocketRoute
     deriving (Eq, Show)
 
 -- | A single segment of a route path.

--- a/ihp-router/IHP/Router/DSL/Parser.hs
+++ b/ihp-router/IHP/Router/DSL/Parser.hs
@@ -18,6 +18,7 @@ import Prelude
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Char (isUpper, isAlpha, isAlphaNum, isSpace)
+import Network.HTTP.Types.Method (StdMethod (GET))
 import IHP.Router.DSL.AST
 
 -- | Parse error from the DSL parser.
@@ -67,7 +68,7 @@ looksLikeHeader text =
     -- Even a single token could be a malformed route line; reject strings
     -- that look like HTTP methods so e.g. @GET@ alone isn't misread as a
     -- controller named "GET".
-    isHttpMethodToken t = t == "ANY" || Text.isInfixOf "|" t
+    isHttpMethodToken t = t == "ANY" || t == "WS" || Text.isInfixOf "|" t
         || case methodFromText t of
             Just _  -> True
             Nothing -> False
@@ -91,21 +92,52 @@ parseHeader line text =
             else Left (ParseError line ("routes: invalid controller name: " <> quoted trimmed))
 
 -- | Parse one route line: METHOD(|METHOD)* /path(?name&name)* ActionRef
+--
+-- A method field of @WS@ marks the route as a WebSocket route; the path
+-- is the literal handshake URL and the action identifier names the
+-- 'WSApp'-instance type (not a controller action constructor). WS routes
+-- in v1 must use a static path (no captures / splats) and no query list.
 parseRouteLine :: (Int, Text) -> Either ParseError Route
 parseRouteLine (line, text) = do
     let trimmed = Text.strip text
     (methodsField, rest1) <- splitFirstToken line trimmed
-    methods <- parseMethods line methodsField
+    (methods, kind) <- parseMethods line methodsField
     (pathAndQueryField, rest2) <- splitFirstToken line (Text.strip rest1)
     (path, queryParams) <- parsePathAndQuery line pathAndQueryField
     action <- parseActionRef line (Text.strip rest2)
+    case kind of
+        WebSocketRoute -> do
+            checkWsPathStatic line path
+            checkWsNoQuery line queryParams
+        HttpRoute -> pure ()
     pure Route
         { routeMethods     = methods
         , routePath        = path
         , routeQueryParams = queryParams
         , routeAction      = action
         , routeLine        = line
+        , routeKind        = kind
         }
+
+-- | WS routes only support literal path segments in v1. Captures and
+-- splats are rejected at parse time so we can give a pointed error
+-- before the splice tries to reify a URL-shaped action constructor.
+checkWsPathStatic :: Int -> [PathSeg] -> Either ParseError ()
+checkWsPathStatic line segs = case [ s | s <- segs, isDynamic s ] of
+    [] -> Right ()
+    _  -> Left (ParseError line
+        "routes: WS routes do not support path captures (use a static path)")
+  where
+    isDynamic (Literal _)  = False
+    isDynamic (Capture {}) = True
+    isDynamic (Splat {})   = True
+
+-- | WS routes don't read query parameters in v1.
+checkWsNoQuery :: Int -> [Text] -> Either ParseError ()
+checkWsNoQuery line = \case
+    [] -> Right ()
+    _  -> Left (ParseError line
+        "routes: WS routes do not support query parameters")
 
 -- | Split a line at the first whitespace, returning (first word, remainder).
 splitFirstToken :: Int -> Text -> Either ParseError (Text, Text)
@@ -113,15 +145,27 @@ splitFirstToken line text
     | Text.null text = Left (ParseError line "routes: unexpected end of line; expected a token")
     | otherwise = Right (Text.breakOn (Text.singleton ' ') text)
 
--- | Parse a method field like @GET@, @GET|POST@, or @ANY@.
-parseMethods :: Int -> Text -> Either ParseError [Method]
+-- | Parse a method field like @GET@, @GET|POST@, @ANY@, or @WS@.
+--
+-- @WS@ alone marks the route as a WebSocket route; the methods list
+-- becomes @[GET]@ (the WS handshake is an HTTP @GET@ + @Upgrade@), so
+-- the trie indexes the route under the same key. @WS@ cannot be combined
+-- with HTTP methods on the same line — a request is either a WebSocket
+-- upgrade or a plain HTTP method, not both.
+parseMethods :: Int -> Text -> Either ParseError ([Method], RouteKind)
 parseMethods line field
-    | field == "ANY" = Right expandAnyMethod
-    | otherwise = traverse parseOne (Text.splitOn "|" field)
+    | field == "WS" = Right ([GET], WebSocketRoute)
+    | field == "ANY" = Right (expandAnyMethod, HttpRoute)
+    | hasWsToken field = Left (ParseError line
+        "routes: 'WS' cannot be combined with HTTP methods on the same route")
+    | otherwise = do
+        methods <- traverse parseOne (Text.splitOn "|" field)
+        pure (methods, HttpRoute)
   where
     parseOne raw = case methodFromText raw of
         Just m  -> Right m
         Nothing -> Left (ParseError line ("routes: unknown method: " <> quoted raw))
+    hasWsToken raw = "WS" `elem` Text.splitOn "|" raw
 
 -- | Parse a @/path?name1&name2@ token, returning the path segments and
 -- the (possibly empty) query-param list. Anything after the first @?@ is

--- a/ihp-router/IHP/Router/DSL/TH.hs
+++ b/ihp-router/IHP/Router/DSL/TH.hs
@@ -51,6 +51,8 @@ module IHP.Router.DSL.TH
 
 import Prelude
 import qualified Data.Char as Char
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as ByteString.Char8
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.List as List
@@ -169,6 +171,15 @@ data ParsedBlock = ParsedBlock
         -- ^ Routes grouped by parent controller type, in the order
         -- those types first appear in the DSL block. For
         -- single-controller uppercase blocks this list has length 1.
+    , pbWsRoutes :: ![(Name, ByteString)]
+        -- ^ WebSocket routes (kind 'AST.WebSocketRoute'), resolved to
+        -- @(typeName, path)@ pairs in declaration order. The IHP-side
+        -- shim ('IHP.Router.IHP.ihpEmit') turns each entry into a
+        -- @webSocketRoute \@T \"\/path\"@ call inside the
+        -- lowercase-header binding. The generic 'genericEmit' ignores
+        -- this field — plain @ihp-router@ users have no @WSApp@
+        -- typeclass in scope, and v1 only registers WS routes via the
+        -- IHP-flavoured binding.
     }
 
 -- | Which of the three header forms the parser saw.
@@ -187,33 +198,89 @@ data HeaderForm
 -- | Parse the DSL body, reify each referenced controller type, and
 -- validate every route against its action constructor. Returns a
 -- 'ParsedBlock' both emitters can consume.
+--
+-- WebSocket routes (those whose @routeKind@ is 'AST.WebSocketRoute')
+-- are split out into 'pbWsRoutes' rather than going through
+-- 'groupRoutesByParent' / 'validateRoute' — they reference a 'WSApp'
+-- type by name (not an action constructor of a controller), so the
+-- HTTP-route validation pipeline doesn't apply. For v1 we also restrict
+-- WS routes to the lowercase-header form, since the IHP shim only
+-- knows how to register them through the @webRoutes@ binding the
+-- lowercase form emits.
 parseAndReify :: String -> Q ParsedBlock
 parseAndReify source = case Parser.parseRoutes (Text.pack source) of
     Left err -> fail (renderParseError err)
     Right parsed -> do
+        let (httpRoutes, wsRoutesAst) = List.partition isHttpRoute (AST.routes parsed)
         (header, groups) <- case controllerName parsed of
             Just name
                 | startsWithUpper name -> do
+                    rejectWsInNonBindingForm wsRoutesAst
+                        ("the single-controller header form '" <> Text.unpack name <> "'")
                     ctrl <- reifyController name
-                    vs <- traverse (validateRoute ctrl) (AST.routes parsed)
+                    vs <- traverse (validateRoute ctrl) httpRoutes
                     pure (HeaderUppercase name, [(ctrl, vs)])
                 | otherwise -> do
-                    grouped <- groupRoutesByParent (AST.routes parsed)
+                    grouped <- groupRoutesByParent httpRoutes
                     validated <- traverse
                         (\(ctrl, rs) -> do vs <- traverse (validateRoute ctrl) rs; pure (ctrl, vs))
                         grouped
                     pure (HeaderLowercase name, validated)
             Nothing -> do
-                grouped <- groupRoutesByParent (AST.routes parsed)
+                rejectWsInNonBindingForm wsRoutesAst "the headerless form"
+                grouped <- groupRoutesByParent httpRoutes
                 validated <- traverse
                     (\(ctrl, rs) -> do vs <- traverse (validateRoute ctrl) rs; pure (ctrl, vs))
                     grouped
                 pure (HeaderAbsent, validated)
-        pure ParsedBlock { pbHeader = header, pbGroups = groups }
+        wsBindings <- traverse resolveWsBinding wsRoutesAst
+        pure ParsedBlock
+            { pbHeader = header
+            , pbGroups = groups
+            , pbWsRoutes = wsBindings
+            }
   where
     startsWithUpper t = case Text.uncons t of
         Just (c, _) -> c >= 'A' && c <= 'Z'
         Nothing -> False
+
+    isHttpRoute r = routeKind r == HttpRoute
+
+-- | Fail with a pointed error when the user mixes WS routes into a
+-- form that can't carry them. v1 only registers WS routes via the
+-- IHP-flavoured @webRoutes@ binding, which is emitted only for the
+-- lowercase-header form.
+rejectWsInNonBindingForm :: [Route] -> String -> Q ()
+rejectWsInNonBindingForm [] _ = pure ()
+rejectWsInNonBindingForm (rt : _) form = fail $
+    "routes (line " <> show (routeLine rt) <> "): " <>
+    "WS routes are only supported in the named-binding form " <>
+    "(lowercase header, e.g. '[routes|webRoutes\\n…\\n|]'); " <>
+    "they cannot be used in " <> form <> "."
+
+-- | Resolve a WS route to a @(typeName, path)@ pair for 'pbWsRoutes'.
+-- The right-hand identifier on a WS route names the 'WSApp' instance
+-- type itself (not a constructor), so we look it up via
+-- 'TH.lookupTypeName' rather than reifying it as a data constructor.
+resolveWsBinding :: Route -> Q (Name, ByteString)
+resolveWsBinding rt = do
+    let typeNameStr = Text.unpack (actionName (routeAction rt))
+    mTyName <- TH.lookupTypeName typeNameStr
+    tyName <- case mTyName of
+        Just n  -> pure n
+        Nothing -> fail $
+            "routes (line " <> show (routeLine rt) <> "): " <>
+            "WS route references type '" <> typeNameStr <>
+            "' but no such type is in scope. Is its module imported?"
+    pure (tyName, renderStaticPath (routePath rt))
+
+-- | Render a WS route's static path back to its on-the-wire form.
+-- Parser validation guarantees every segment is a 'Literal' for WS
+-- routes, so this never sees a 'Capture' / 'Splat' in practice.
+renderStaticPath :: [PathSeg] -> ByteString
+renderStaticPath [] = "/"
+renderStaticPath segs = ByteString.Char8.pack $
+    concat [ "/" <> Text.unpack t | Literal t <- segs ]
 
 ---------------------------------------------------------------------------
 -- Generic emission (→ future ihp-router)

--- a/ihp/IHP/Router/IHP.hs
+++ b/ihp/IHP/Router/IHP.hs
@@ -38,6 +38,8 @@ module IHP.Router.IHP
     ) where
 
 import Prelude
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as ByteString.Char8
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Typeable (Typeable)
@@ -127,13 +129,16 @@ ihpRoutesDec = routesDec
 --     @toControllerRoute@ wraps @\<ctrlLower>Trie runAction'@ in a
 --     'ControllerRouteTrie';
 --   * for a lowercase-header block: a top-level
---     @webRoutes :: [ControllerRoute app]@ binding.
+--     @webRoutes :: [ControllerRoute app]@ binding that includes
+--     @webSocketRoute \@T \"\/path\"@ entries for each @WS@ route in
+--     the block alongside the regular @parseRoute \@Ctrl@ entries.
 ihpEmit :: ParsedBlock -> Q [Dec]
-ihpEmit ParsedBlock { pbHeader, pbGroups } = do
+ihpEmit ParsedBlock { pbHeader, pbGroups, pbWsRoutes } = do
     canRouteDecs <- traverse (\(ctrl, _) -> emitCanRoute ctrl) pbGroups
     bindingDecs <- case pbHeader of
-        HeaderLowercase name -> emitNamedBinding name (map fst pbGroups)
-        _                    -> pure []
+        HeaderLowercase name ->
+            emitNamedBinding name (map fst pbGroups) pbWsRoutes
+        _ -> pure []
     pure (canRouteDecs <> bindingDecs)
 
 ---------------------------------------------------------------------------
@@ -187,9 +192,14 @@ emitCanRoute ctrl = do
 ---------------------------------------------------------------------------
 
 -- | Emit a top-level binding named by the user. Given the header
--- @webRoutes@ and controllers @[PostsController, UsersController]@:
+-- @webRoutes@, HTTP controllers @[PostsController, UsersController]@,
+-- and a WS route @WS \/chat ChatApp@:
 --
--- > webRoutes = [ parseRoute @PostsController, parseRoute @UsersController ]
+-- > webRoutes =
+-- >     [ parseRoute @PostsController
+-- >     , parseRoute @UsersController
+-- >     , webSocketRoute @ChatApp "\/chat"
+-- >     ]
 --
 -- The binding is polymorphic in the application type; when splatted into
 -- 'FrontController.controllers' for a concrete app, GHC infers the right
@@ -197,19 +207,31 @@ emitCanRoute ctrl = do
 --
 -- @parseRoute@ carries implicit-parameter constraints ('?request',
 -- '?respond', '?application', plus 'Controller', 'CanRoute',
--- 'InitControllerContext', and 'Typeable') that GHC cannot abstract at
--- the use site, so we emit an explicit signature enumerating all of them.
-emitNamedBinding :: Text -> [ControllerInfo] -> Q [Dec]
-emitNamedBinding bindingTxt ctrls = do
+-- 'InitControllerContext', and 'Typeable'); @webSocketRoute@ carries
+-- the same implicits but swaps 'Controller' \/ 'CanRoute' for 'WSApp'.
+-- GHC cannot abstract those at the use site, so we emit an explicit
+-- signature enumerating all of them.
+emitNamedBinding :: Text -> [ControllerInfo] -> [(Name, ByteString)] -> Q [Dec]
+emitNamedBinding bindingTxt ctrls wsBindings = do
     let valName = TH.mkName (Text.unpack bindingTxt)
         appTyVarName = TH.mkName "app"
         appTy = TH.VarT appTyVarName
         parseRouteName = TH.mkName "parseRoute"
-        entries =
+        webSocketRouteName = TH.mkName "webSocketRoute"
+
+        httpEntries =
             [ TH.AppTypeE (TH.VarE parseRouteName) (TH.ConT (ciTypeName c))
             | c <- ctrls
             ]
-        bindingExp = TH.ListE entries
+        wsEntries =
+            [ TH.AppE
+                (TH.AppTypeE (TH.VarE webSocketRouteName) (TH.ConT wsTy))
+                (TH.SigE
+                    (TH.LitE (TH.StringL (ByteString.Char8.unpack path)))
+                    (TH.ConT (TH.mkName "ByteString")))
+            | (wsTy, path) <- wsBindings
+            ]
+        bindingExp = TH.ListE (httpEntries <> wsEntries)
 
         implicitReqTy  = TH.ImplicitParamT "request"  (TH.ConT (TH.mkName "Request"))
         implicitResTy  = TH.ImplicitParamT "respond"  (TH.ConT (TH.mkName "Respond"))
@@ -222,9 +244,15 @@ emitNamedBinding bindingTxt ctrls = do
                 , TH.AppT (TH.ConT (TH.mkName "CanRoute")) ctrlTy
                 , TH.AppT (TH.ConT ''Typeable) ctrlTy
                 ]
+        perWs (wsTy, _) =
+            let ty = TH.ConT wsTy
+             in [ TH.AppT (TH.ConT (TH.mkName "WSApp")) ty
+                , TH.AppT (TH.ConT ''Typeable) ty
+                ]
         ctx = implicitReqTy : implicitResTy : implicitAppTy
             : initContextTy : typeableAppTy
             : concatMap perCtrl ctrls
+            <> concatMap perWs wsBindings
         resultTy = TH.AppT TH.ListT
             (TH.AppT (TH.ConT (TH.mkName "ControllerRoute")) appTy)
         bindingTy = TH.ForallT [TH.PlainTV appTyVarName TH.SpecifiedSpec] ctx resultTy

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -26,6 +26,7 @@ CanRoute (..)
 , webSocketApp
 , webSocketAppWithCustomPath
 , webSocketAppWithHTTPFallback
+, webSocketRoute
 , onlyAllowMethods
 , getMethod
 , routeParam
@@ -950,6 +951,47 @@ webSocketAppWithCustomPathAndHTTPFallback path = ControllerRouteParser $ do
         let action = WS.initialState @webSocketApp
         pure $ withImplicits (startWebSocketApp @webSocketApp @application action (runActionWithNewContext action))
 {-# INLINABLE webSocketAppWithCustomPathAndHTTPFallback #-}
+
+-- | Trie-based registration of a WebSocket app at a static path. Used by
+-- the @[routes|...|]@ DSL to wire @WS \/path TypeName@ entries into the
+-- same 'RouteTrie' as the HTTP routes, so a single mixed-mode block can
+-- be the source of truth for an app's URLs.
+--
+-- This is the trie-flavoured analogue of 'webSocketAppWithCustomPath':
+-- same @WSApp@ / @InitControllerContext@ / @Typeable@ constraints, same
+-- 400-on-non-WebSocket-GET semantics, but the entry lives in a
+-- 'ControllerRouteTrie' rather than going through the Attoparsec
+-- fallback. The handler is registered under @GET@ — that's the method
+-- carried by a WebSocket handshake — and the trie's path-walk delivers
+-- the same behaviour as the parser-based form for static paths.
+--
+-- The path argument is the same shape as the one passed to
+-- 'webSocketAppWithCustomPath': a leading-slash literal like @"\/chat"@.
+webSocketRoute :: forall webSocketApp application.
+    ( WSApp webSocketApp
+    , InitControllerContext application
+    , ?application :: application
+    , Typeable application
+    , Typeable webSocketApp
+    ) => ByteString -> ControllerRoute application
+webSocketRoute path =
+    ControllerRouteTrie (Trie.insertRoute pattern GET handler Trie.emptyTrie)
+    where
+        pattern :: [Trie.PatternSegment]
+        pattern = map Trie.LiteralSeg (Trie.splitPath path)
+
+        -- The closure captures @?application@ from the enclosing
+        -- 'toControllerRoute' / 'controllers' scope. @?request@ and
+        -- @?respond@ are bound from the WAI arguments at call time —
+        -- mirrors the 'withImplicits' wrapping used by
+        -- 'webSocketAppWithCustomPath'.
+        handler :: Trie.WaiHandler
+        handler _captures waiReq waiRespond =
+            let ?request = waiReq
+                ?respond = waiRespond
+            in startWebSocketAppAndFailOnHTTP @webSocketApp @application
+                    (WS.initialState @webSocketApp) waiReq waiRespond
+{-# INLINABLE webSocketRoute #-}
 
 
 -- | Defines the start page for a router (when @\/@ is requested).

--- a/ihp/Test/Test/Main.hs
+++ b/ihp/Test/Test/Main.hs
@@ -24,6 +24,7 @@ import qualified Test.Router.DSLQuoterSpec
 import qualified Test.Router.MixedModeSpec
 import qualified Test.Router.MultiControllerSpec
 import qualified Test.Router.AppBindingSpec
+import qualified Test.Router.WebSocketSpec
 import qualified Test.ViewSupportSpec
 import qualified Test.FileStorage.ControllerFunctionsSpec
 import qualified Test.PGListenerSpec
@@ -58,6 +59,7 @@ main = hspec do
     Test.Router.MixedModeSpec.tests
     Test.Router.MultiControllerSpec.tests
     Test.Router.AppBindingSpec.tests
+    Test.Router.WebSocketSpec.tests
     Test.ViewSupportSpec.tests
     Test.FileStorage.ControllerFunctionsSpec.tests
     Test.Controller.CookieSpec.tests

--- a/ihp/Test/Test/Router/DSLParserSpec.hs
+++ b/ihp/Test/Test/Router/DSLParserSpec.hs
@@ -16,13 +16,16 @@ mk :: Text -> [Route] -> Routes
 mk name rs = Routes { controllerName = Just name, routes = rs }
 
 rt :: Int -> [Method] -> [PathSeg] -> Text -> Route
-rt line ms ps name = Route ms ps [] (ActionRef name []) line
+rt line ms ps name = Route ms ps [] (ActionRef name []) line HttpRoute
 
 rtQ :: Int -> [Method] -> [PathSeg] -> [Text] -> Text -> Route
-rtQ line ms ps qs name = Route ms ps qs (ActionRef name []) line
+rtQ line ms ps qs name = Route ms ps qs (ActionRef name []) line HttpRoute
 
 rtWithBinds :: Int -> [Method] -> [PathSeg] -> Text -> [(Text, Text)] -> Route
-rtWithBinds line ms ps name bs = Route ms ps [] (ActionRef name bs) line
+rtWithBinds line ms ps name bs = Route ms ps [] (ActionRef name bs) line HttpRoute
+
+rtWS :: Int -> [PathSeg] -> Text -> Route
+rtWS line ps name = Route [GET] ps [] (ActionRef name []) line WebSocketRoute
 
 tests = do
     describe "IHP.Router.DSL.Parser" do
@@ -132,6 +135,27 @@ tests = do
                             "ShowThreadAction"
                         ])
 
+            it "parses a WS route as WebSocketRoute kind" do
+                parseRoutes "webRoutes\nWS /chat ChatApp\n"
+                    `shouldBe` Right Routes
+                        { controllerName = Just "webRoutes"
+                        , routes = [ rtWS 2 [Literal "chat"] "ChatApp" ]
+                        }
+
+            it "parses WS routes alongside HTTP routes" do
+                let source = Text.unlines
+                        [ "webRoutes"
+                        , "GET /posts        PostsAction"
+                        , "WS  /chat         ChatApp"
+                        ]
+                parseRoutes source
+                    `shouldBe` Right Routes
+                        { controllerName = Just "webRoutes"
+                        , routes =
+                            [ rt 2 [GET] [Literal "posts"] "PostsAction"
+                            , rtWS 3 [Literal "chat"] "ChatApp"
+                            ]
+                        }
 
         describe "errors" do
             it "accepts empty block (header-less, zero routes)" do
@@ -186,4 +210,32 @@ tests = do
             it "rejects empty query-param name (stray &)" do
                 case parseRoutes "C\nGET /items?a&&b ShowAction\n" of
                     Left e -> (cs (errorMessage e) :: String) `shouldContain` "empty query-param name"
+                    Right _ -> expectationFailure "expected ParseError"
+
+            it "rejects WS combined with HTTP methods" do
+                case parseRoutes "webRoutes\nWS|GET /chat ChatApp\n" of
+                    Left e -> do
+                        errorLine e `shouldBe` 2
+                        (cs (errorMessage e) :: String) `shouldContain` "'WS' cannot be combined"
+                    Right _ -> expectationFailure "expected ParseError"
+
+            it "rejects WS routes with path captures" do
+                case parseRoutes "webRoutes\nWS /chat/{roomId} ChatApp\n" of
+                    Left e -> do
+                        errorLine e `shouldBe` 2
+                        (cs (errorMessage e) :: String) `shouldContain` "WS routes do not support path captures"
+                    Right _ -> expectationFailure "expected ParseError"
+
+            it "rejects WS routes with splat captures" do
+                case parseRoutes "webRoutes\nWS /chat/{+rest} ChatApp\n" of
+                    Left e -> do
+                        errorLine e `shouldBe` 2
+                        (cs (errorMessage e) :: String) `shouldContain` "WS routes do not support path captures"
+                    Right _ -> expectationFailure "expected ParseError"
+
+            it "rejects WS routes with query parameters" do
+                case parseRoutes "webRoutes\nWS /chat?room ChatApp\n" of
+                    Left e -> do
+                        errorLine e `shouldBe` 2
+                        (cs (errorMessage e) :: String) `shouldContain` "WS routes do not support query parameters"
                     Right _ -> expectationFailure "expected ParseError"

--- a/ihp/Test/Test/Router/WebSocketSpec.hs
+++ b/ihp/Test/Test/Router/WebSocketSpec.hs
@@ -1,0 +1,117 @@
+{-|
+Module: Test.Router.WebSocketSpec
+Copyright: (c) digitally induced GmbH, 2026
+
+Verifies that @[routes|…|]@ blocks can declare WebSocket routes via the
+@WS@ keyword. The splice emits a top-level binding that mixes
+'parseRoute @Ctrl' (HTTP routes) with 'webSocketRoute @T \"\/path\"'
+(WS routes); the user splats that binding into
+'FrontController.controllers' the same way as for HTTP-only blocks.
+-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Router.WebSocketSpec where
+
+import Test.Hspec
+import IHP.Prelude
+import IHP.RouterSupport
+import IHP.Router.DSL (routes)
+import IHP.ControllerPrelude
+import qualified IHP.WebSocket as WS
+import qualified IHP.Router.Trie as Trie
+import qualified Data.ByteString.Lazy as LBS
+import Network.HTTP.Types.Method (StdMethod (..))
+import qualified Network.Wai as Wai
+
+-- HTTP fixture controller, used to verify WS and HTTP routes coexist
+-- in the same DSL block.
+data PingsCtrl = PingsIndexAction
+    deriving (Eq, Show)
+
+instance Controller PingsCtrl where
+    action PingsIndexAction = renderPlain "pong"
+
+-- WSApp fixtures. Both are nullary so 'WS.initialState' is just the
+-- constructor itself — matching the static-path-only restriction of
+-- the v1 DSL.
+data ChatWSApp = ChatWSApp
+
+instance WS.WSApp ChatWSApp where
+    initialState = ChatWSApp
+    run = do
+        msg <- WS.receiveData @LBS.ByteString
+        WS.sendTextData msg
+
+data NotificationsWSApp = NotificationsWSApp
+
+instance WS.WSApp NotificationsWSApp where
+    initialState = NotificationsWSApp
+
+data WSTestApplication = WSTestApplication deriving (Eq, Show, Data)
+
+instance InitControllerContext WSTestApplication where
+    initContext = pure ()
+
+$(pure [])
+
+-- A mixed block: one HTTP controller plus two WS apps. The splice
+-- emits a 'CanRoute' instance for 'PingsCtrl' and skips it for the
+-- WS types; the named binding contains 'parseRoute @PingsCtrl' plus
+-- one 'webSocketRoute @T \"\/path\"' entry per WS route.
+[routes|wsRoutes
+GET /pings                 PingsIndexAction
+WS  /chat                  ChatWSApp
+WS  /notifications         NotificationsWSApp
+|]
+
+instance FrontController WSTestApplication where
+    controllers = wsRoutes
+
+tests = do
+    describe "IHP.Router.DSL — WS route support" do
+        it "HasPath still works for HTTP routes in mixed blocks" do
+            pathTo PingsIndexAction `shouldBe` "/pings"
+
+        it "wsRoutes fits the FrontController.controllers contract" do
+            -- Compile-time proof: the 'instance FrontController
+            -- WSTestApplication where controllers = wsRoutes' above
+            -- type-checks only if 'wsRoutes' has the right shape and
+            -- each WS-route entry resolves the 'WSApp' / 'Typeable'
+            -- constraints the splice attaches to its signature.
+            True `shouldBe` True
+
+    describe "IHP.RouterSupport.webSocketRoute" do
+        it "produces a trie-backed ControllerRoute that matches GET on the path" do
+            -- 'webSocketRoute' is what the DSL emits in the named
+            -- binding; verify it builds a 'ControllerRouteTrie' whose
+            -- internal trie matches the WS path under GET (the
+            -- handshake method) and 405s for other methods.
+            let ?request = Wai.defaultRequest
+                ?respond = \_ -> error "respond stub forced"
+                ?application = WSTestApplication
+            case webSocketRoute @ChatWSApp @WSTestApplication "/chat" of
+                ControllerRouteTrie trie -> do
+                    case Trie.lookupTrie trie GET (Trie.splitPath "/chat") of
+                        Trie.Matched _ _ -> pure ()
+                        other -> expectationFailure
+                            ("expected Matched for GET /chat, got "
+                                <> showLookup other)
+                    case Trie.lookupTrie trie POST (Trie.splitPath "/chat") of
+                        Trie.MethodNotAllowed [GET] -> pure ()
+                        other -> expectationFailure
+                            ("expected MethodNotAllowed [GET] for POST /chat, got "
+                                <> showLookup other)
+                    case Trie.lookupTrie trie GET (Trie.splitPath "/elsewhere") of
+                        Trie.NotMatched -> pure ()
+                        other -> expectationFailure
+                            ("expected NotMatched for GET /elsewhere, got "
+                                <> showLookup other)
+                _ -> expectationFailure
+                    "webSocketRoute returned a non-trie ControllerRoute"
+  where
+    showLookup :: Trie.LookupResult -> String
+    showLookup (Trie.Matched _ caps) =
+        "Matched (captures: " <> cs (tshow caps) <> ")"
+    showLookup (Trie.MethodNotAllowed ms) =
+        "MethodNotAllowed " <> cs (tshow ms)
+    showLookup Trie.NotMatched = "NotMatched"


### PR DESCRIPTION
## Summary

- New `WS /path TypeName` syntax in `[routes|…|]` blocks registers a `WSApp` directly through the trie, instead of the legacy `webSocketApp` Attoparsec fallback.
- A single named-binding block can now be the source of truth for both HTTP routes and WebSocket apps:
  ```haskell
  [routes|webRoutes
  GET /posts                 PostsAction
  WS  /chat                  ChatApp
  WS  /datasync              DataSyncController
  |]

  instance FrontController WebApplication where
      controllers = webRoutes
  ```
- Same behaviour as `webSocketAppWithCustomPath` (non-WS `GET` returns `400`); the entry lives in the explicit-routes trie alongside HTTP routes.

## Implementation

The work is split across the two router halves introduced in #2658:

- **`ihp-router`** (generic, IHP-free): the parser learns the `WS` keyword, validates the v1 restrictions (static paths, no query, no method mixing), and surfaces WS entries on `ParsedBlock` as `pbWsRoutes :: [(Name, ByteString)]`. `genericEmit` ignores this field — plain WAI users have no `WSApp` typeclass, so v1 only registers WS routes through the IHP-flavoured binding.
- **`ihp` shim** (`IHP.Router.IHP`): `ihpEmit` consumes `pbWsRoutes` in `emitNamedBinding` and appends `webSocketRoute @T "/path"` calls to the lowercase-header `webRoutes` binding alongside the regular `parseRoute @Ctrl` entries. Constraints in the binding's emitted signature pick up `WSApp T, Typeable T` per WS type.
- **`IHP.RouterSupport`**: new `webSocketRoute :: ByteString -> ControllerRoute app` helper builds a single-entry `ControllerRouteTrie` with the WS handler under `GET`. Same `WSApp / InitControllerContext / Typeable` constraints as `webSocketAppWithCustomPath`.

## Design notes

- The right-hand identifier on a `WS` line is the **WSApp instance type**, not an action constructor. WS routes don't go through the `CanRoute` typeclass (its method signature requires `Controller controller`, which WSApp types don't have); they bypass it via the value-level `webSocketRoute` helper.
- `WS` is encoded as `routeMethods = [GET]` + `routeKind = WebSocketRoute` so the trie indexes it under the same method that carries the WS handshake. `HEAD` is intentionally **not** auto-registered for WS routes.
- The `HEAD` auto-registration that the splice does for HTTP `GET` routes is still in place for HTTP routes — only WS routes opt out.

## v1 scope

- Static paths only — no `{capture}` / `{+splat}` segments
- No `?query` parameters
- `WS` cannot be combined with HTTP methods on the same line (`WS|GET` is rejected)
- Named-binding (lowercase header) form only — single-controller and header-less forms reject WS routes with a pointed error
- No HTTP-fallback variant (the `webSocketAppWithHTTPFallback` analogue is deferred)
- Existing `webSocketApp*` combinators remain supported and can coexist in the same `controllers` list

## Test plan

- [x] `IHP.Router.DSL.Parser` parses `WS` and rejects `WS|GET`, captures, splats, and `?query` for WS routes (line-numbered errors)
- [x] `IHP.Router.DSL` end-to-end: a mixed-mode named-binding block compiles and yields a `wsRoutes` value that splats into `FrontController.controllers`
- [x] `IHP.RouterSupport.webSocketRoute` produces a `ControllerRouteTrie` that matches `GET` on the path, returns `MethodNotAllowed [GET]` for `POST`, and `NotMatched` for other paths
- [x] All 570 IHP tests pass; all 401 ihp-ide tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)