### PR TITLE
Fix broken /api-docs/* links from the Guide

### DIFF
--- a/Guide/controller.markdown
+++ b/Guide/controller.markdown
@@ -26,7 +26,7 @@ data PostsController
     deriving (Eq, Show, Data)
 ```
 
-This defines a type `PostsController` with a data constructor `ShowPostAction { postId :: !(Id Post) }`. The argument `postId` will later be filled with the `postId` parameter of the request URL. This is done automatically by the IHP router. IHP also requires the controller to have [`Eq`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Eq), [`Show`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Show) and [`Data`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Data) instances. Therefore we derive them here.
+This defines a type `PostsController` with a data constructor `ShowPostAction { postId :: !(Id Post) }`. The argument `postId` will later be filled with the `postId` parameter of the request URL. This is done automatically by the IHP router. IHP also requires the controller to have `Eq`, `Show` and `Data` instances. Therefore we derive them here.
 
 After we have defined the "interface" for our controller, we need to implement the actual request handling logic. IHP expects to find this inside the [`action`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#v:action) function of the [`Controller`](https://ihp.digitallyinduced.com/api-docs/IHP-ControllerSupport.html#t:Controller) instance. We can define this instance in `Web/Controller/Posts.hs`:
 
@@ -61,7 +61,7 @@ An alternative request to that action can use a form for passing the `maxItems`:
 </form>
 ```
 
-The value is automatically transformed to an [`Int`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Int). This parsing works out of the box for [Ids](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Id), [UUID](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:UUID), [Bools](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Bool), [Timestamps](https://ihp.digitallyinduced.com/api-docs/IHP-RouterPrelude.html#t:UTCTime), etc. Here are some more examples:
+The value is automatically transformed to an `Int`. This parsing works out of the box for [Ids](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Id), UUID, Bools, Timestamps, etc. Here are some more examples:
 
 ```haskell
 action ExampleAction = do
@@ -83,7 +83,7 @@ action UsersAction = do
 
 When this action is called without the `maxItems` parameter being set (or when invalid), it will fall back to the default value `50`.
 
-There is also [`paramOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:paramOrNothing) which will return [`Nothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) when the parameter is missing and [`Just theValue`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) otherwise.
+There is also [`paramOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:paramOrNothing) which will return `Nothing` when the parameter is missing and `Just theValue` otherwise.
 
 ### Multiple Params With Same Name (Checkboxes)
 
@@ -106,7 +106,7 @@ action BuildFood = do
 
 When this action is called with both checkboxes checked `ingredients` will be set to `["milk", "egg"]`. When no checkbox is checked it will return an empty list.
 
-Similar to [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param) this works out of the box for [Ids](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Id), [UUID](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:UUID), [Bools](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Bool), [Timestamps](https://ihp.digitallyinduced.com/api-docs/IHP-RouterPrelude.html#t:UTCTime), etc.
+Similar to [`param`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Param.html#v:param) this works out of the box for [Ids](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Id), UUID, Bools, Timestamps, etc.
 
 ### Passing Data from the Action to the View
 
@@ -310,7 +310,7 @@ action ExampleAction = do
     respondHtml [hsx|<div>Hello World</div>|]
 ```
 
-You will need to import [`hsx`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx) into your controller: [`import IHP.ViewPrelude (hsx)`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx).
+You will need to import [`hsx`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-QQ.html#v:hsx) into your controller: [`import IHP.ViewPrelude (hsx)`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-QQ.html#v:hsx).
 
 ### Rendering a Static File
 

--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -210,7 +210,7 @@ action ShowTask { taskId } = do
             Nothing -> pure Nothing
 ```
 
-This contains a lot of boilerplate for wrapping and unwrapping the [`Maybe`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) value. Therefore you can just call [`fetchOneOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOneOrNothing) directly on the `Maybe (Id User)` value:
+This contains a lot of boilerplate for wrapping and unwrapping the `Maybe` value. Therefore you can just call [`fetchOneOrNothing`](https://ihp.digitallyinduced.com/api-docs/IHP-Fetch.html#v:fetchOneOrNothing) directly on the `Maybe (Id User)` value:
 
 ```haskell
 action ShowTask { taskId } = do

--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -226,7 +226,7 @@ buildCompany company = company
 
 The call to [`uploadToStorage #logoUrl`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorage) will upload the file provided by the user. It will be saved as `companies/<some uuid>` on the configured storage. The the file url will be written to the `logoUrl` attribute.
 
-After calling [`uploadToStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorage) inside a action, you typically need to use [`>>=`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:-62--62--61-) instead of [`|>`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:-124--62-):
+After calling [`uploadToStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-ControllerFunctions.html#v:uploadToStorage) inside a action, you typically need to use `>>=` instead of [`|>`](https://ihp.digitallyinduced.com/api-docs/IHP-HaskellSupport.html#v:-124--62-):
 
 ```haskell
 -- Bad, will cause a type error:

--- a/Guide/form.markdown
+++ b/Guide/form.markdown
@@ -763,7 +763,7 @@ renderForm :: Post -> Html
 renderForm post = formFor' post "/my-custom-endpoint" [hsx||]
 ```
 
-If you pass an action to that, you need to wrap it with [`pathTo`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo):
+If you pass an action to that, you need to wrap it with [`pathTo`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:pathTo):
 
 ```haskell
 renderForm :: Post -> Html

--- a/Guide/hsx.markdown
+++ b/Guide/hsx.markdown
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-HSX can be written pretty much like normal HTML. You can write an HSX expression inside your Haskell code by wrapping it with [`[hsx|YOUR HSX CODE|]`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx). HSX expressions are just a syntax for [BlazeHtml](https://jaspervdj.be/blaze/) and thus are automatically escaped as described in the blaze documentation.
+HSX can be written pretty much like normal HTML. You can write an HSX expression inside your Haskell code by wrapping it with [`[hsx|YOUR HSX CODE|]`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-QQ.html#v:hsx). HSX expressions are just a syntax for [BlazeHtml](https://jaspervdj.be/blaze/) and thus are automatically escaped as described in the blaze documentation.
 
 Because the HSX is parsed, you will get a syntax error when you type in invalid HTML.
 
@@ -23,7 +23,7 @@ in
 
 **If the variable is another HSX expression, a blaze HTML element, a text or string**: it is just included as you would expect.
 
-**If the variable is any other custom Haskell data structure**: it will first be converted to a string representation by calling [`show`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:show) on it. You can add a custom [`ToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-ToHtml.html#t:ToHtml) (import it from `IHP.HSX.ToHtml`) instance, to customize rendering a data structure.
+**If the variable is any other custom Haskell data structure**: it will first be converted to a string representation by calling `show` on it. You can add a custom [`ToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-ToHtml.html#t:ToHtml) (import it from `IHP.HSX.ToHtml`) instance, to customize rendering a data structure.
 
 You can also write more complex code like:
 
@@ -379,7 +379,7 @@ This approach is particularly useful for:
 
 ### Dealing with Maybe Values
 
-When dealing with [`Maybe`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) values you sometimes want to conditionally render something. E.g. in react to render a tag with JSX you would do it like this:
+When dealing with `Maybe` values you sometimes want to conditionally render something. E.g. in react to render a tag with JSX you would do it like this:
 
 ```html
 <p>Hi {user.name}</p>
@@ -437,7 +437,7 @@ Let's say we have variable `myVariable = "<script>alert(1)</script>"`. This is h
 
 Sometimes you want to insert some actual HTML code to your HSX using a variable. E.g. when your app is rendering markdown, the generated HTML by the markdown library should not be escaped, the markdown library typically already takes care of that.
 
-In these cases you can use [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) to mark a text as already escaped:
+In these cases you can use `preEscapedToHtml` to mark a text as already escaped:
 
 ```html
 <div>{markdownHtml |> preEscapedToHtml}</div>
@@ -448,10 +448,10 @@ In these cases you can use [`preEscapedToHtml`](https://ihp.digitallyinduced.com
 <div><p>hello</p></div>
 ```
 
-Be careful when using [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) as it can easily introduce security issues.
+Be careful when using `preEscapedToHtml` as it can easily introduce security issues.
 
-The [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) function can also be used to output HTML code that is not supported by HSX:
-The [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) function can also be used to output HTML code that is not supported by HSX:
+The `preEscapedToHtml` function can also be used to output HTML code that is not supported by HSX:
+The `preEscapedToHtml` function can also be used to output HTML code that is not supported by HSX:
 
 ```html
 {"<!--[if IE]> Internet Explorer Conditional Comments <![endif]-->" |> preEscapedToHtml}

--- a/Guide/oauth.markdown
+++ b/Guide/oauth.markdown
@@ -394,7 +394,7 @@ import IHP.ViewPrelude
 import IHP.OAuth.Github.Types  -- <---- ADD THIS
 ```
 
-This ensures that we can write [`pathTo NewSessionWithGithubAction`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo) and similar calls without always manually needing to add import statements.
+This ensures that we can write [`pathTo NewSessionWithGithubAction`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:pathTo) and similar calls without always manually needing to add import statements.
 
 
 ### Config

--- a/Guide/relationships.markdown
+++ b/Guide/relationships.markdown
@@ -57,9 +57,9 @@ In the view we can just access the comments like this:
 
 The `post.comments` returns a list of the comments belonging to the post.
 
-The type of `post` is [`Include "comments" Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) instead of the usual `Post`. This way the state of a fetched nested resource is tracked at the type level.
+The type of `post` is [`Include "comments" Post`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include) instead of the usual `Post`. This way the state of a fetched nested resource is tracked at the type level.
 
-It is possible to have multiple nested resources. For example, if Post had a list of comments and tags related to it, it can be defined as [`Include "comments" (Include "tags" Post)`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) or with the more convenient way as [`Include' ["comments", "tags"] Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include-39-).
+It is possible to have multiple nested resources. For example, if Post had a list of comments and tags related to it, it can be defined as [`Include "comments" (Include "tags" Post)`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include) or with the more convenient way as [`Include' ["comments", "tags"] Post`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include-39-).
 
 Note that for the above example, it is expected that the query will change as-well:
 
@@ -111,7 +111,7 @@ posts <- query @Post
     >>= collectionFetchRelated #comments
 ```
 
-This will query all posts with all their comments. The type of `posts` is [`[Include "comments" Post]`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include).
+This will query all posts with all their comments. The type of `posts` is [`[Include "comments" Post]`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include).
 
 The above Haskell code will trigger the following two SQL queries to be executed:
 
@@ -152,7 +152,7 @@ comments <- query @Comment
     >>= collectionFetchRelated #postId
 ```
 
-This will query all comments and their respective posts. The type of `comments` is [`[Include "postId" Comment]`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include).
+This will query all comments and their respective posts. The type of `comments` is [`[Include "postId" Comment]`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include).
 
 The Haskell code will trigger the following two SQL queries:
 

--- a/Guide/routing.markdown
+++ b/Guide/routing.markdown
@@ -264,14 +264,14 @@ In a new IHP project, you usually have a [`startPage WelcomeAction`](https://ihp
 
 ## URL Generation
 
-Use [`pathTo`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:pathTo) to generate a path to a given action:
+Use [`pathTo`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:pathTo) to generate a path to a given action:
 
 ```haskell
 pathTo ShowPostAction { postId = "adddfb12-da34-44ef-a743-797e54ce3786" }
 -- /ShowPost?postId=adddfb12-da34-44ef-a743-797e54ce3786
 ```
 
-To generate a full URL, use [`urlTo`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:urlTo):
+To generate a full URL, use [`urlTo`](https://ihp.digitallyinduced.com/api-docs/IHP-RouterSupport.html#v:urlTo):
 
 ```haskell
 urlTo NewUserAction

--- a/Guide/validation.markdown
+++ b/Guide/validation.markdown
@@ -128,7 +128,7 @@ For example, when dealing with users, you usually want to make sure that an emai
 
 This function queries the database and checks whether there exists a record with the same email value. The function ignores the current entity of course.
 
-This function does IO, so any further arrows have to be [`>>=`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:-62--62--61-), like this:
+This function does IO, so any further arrows have to be `>>=`, like this:
 
 ```haskell
 action CreateUserAction = do

--- a/Guide/view.markdown
+++ b/Guide/view.markdown
@@ -504,9 +504,9 @@ instance View IndexView where
     json IndexView { .. } = toJSON posts -- <---- The new json render function
 ```
 
-In the above code, our [`json`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:json) function has access to all arguments passed to the view. Here we call [`toJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:toJSON), which is provided by the [aeson](https://hackage.haskell.org/package/aeson) Haskell library. This simply encodes all the `posts` given to this view as JSON.
+In the above code, our [`json`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:json) function has access to all arguments passed to the view. Here we call `toJSON`, which is provided by the [aeson](https://hackage.haskell.org/package/aeson) Haskell library. This simply encodes all the `posts` given to this view as JSON.
 
-Additionally we need to define a [`ToJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#t:ToJSON) instance which describes how the `Post` record is going to be transformed to JSON. We need to add this to our view:
+Additionally we need to define a `ToJSON` instance which describes how the `Post` record is going to be transformed to JSON. We need to add this to our view:
 
 ```haskell
 instance ToJSON Post where
@@ -614,7 +614,7 @@ instance ToJSON Post where
 
 In this example, no content negotiation takes place as the [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) is used instead of the normal `render` function.
 
-The [`ToJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#t:ToJSON) instances have to be defined somewhere, so it's usually placed inside the controller file. This often makes the file harder to read. We recommend not using [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) most times and instead stick with a separate view file as described in the section above. Using [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) makes sense only when the controller is very small or you already have a predefined [`ToJSON`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#t:ToJSON) instance which is not defined in your controller.
+The `ToJSON` instances have to be defined somewhere, so it's usually placed inside the controller file. This often makes the file harder to read. We recommend not using [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) most times and instead stick with a separate view file as described in the section above. Using [`renderJson`](https://ihp.digitallyinduced.com/api-docs/IHP-Controller-Render.html#v:renderJson) makes sense only when the controller is very small or you already have a predefined `ToJSON` instance which is not defined in your controller.
 
 ## Troubleshooting
 

--- a/Guide/your-first-project.markdown
+++ b/Guide/your-first-project.markdown
@@ -423,7 +423,7 @@ instance View ShowView where
                             ]
 ```
 
-We can see that `ShowView` is just a data definition. There is also a `View ShowView` instance. The HTML-like syntax inside the [`html`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:html) function is [`hsx`](https://ihp.digitallyinduced.com/Guide/hsx.html) code. It's similar to React's [JSX](https://reactjs.org/docs/introducing-jsx.html). You can write HTML code as usual there. Everything inside the [`[hsx|...|]`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx) block is also type-checked and converted to Haskell code at compile-time.
+We can see that `ShowView` is just a data definition. There is also a `View ShowView` instance. The HTML-like syntax inside the [`html`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewSupport.html#v:html) function is [`hsx`](https://ihp.digitallyinduced.com/Guide/hsx.html) code. It's similar to React's [JSX](https://reactjs.org/docs/introducing-jsx.html). You can write HTML code as usual there. Everything inside the [`[hsx|...|]`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-QQ.html#v:hsx) block is also type-checked and converted to Haskell code at compile-time.
 
 Now that we have a rough overview of all the parts belonging to our `Post`, it's time to do some coding ourselves.
 
@@ -961,7 +961,7 @@ Inside the `Show.hs` we need to update the type signature to tell our action wha
 data ShowView = ShowView { post :: Post }
 ```
 
-Add an [`Include "comments"`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) like this:
+Add an [`Include "comments"`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include) like this:
 
 ```haskell
 data ShowView = ShowView { post :: Include "comments" Post }
@@ -982,7 +982,7 @@ post <- fetch postId
     >>= fetchRelated #comments
 ```
 
-The type of `post` has changed from `Post` to [`Include "comments" Post`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include). In general, when you're dealing with has-many relationships, use [`Include "relatedRecords"`](https://ihp.digitallyinduced.com/api-docs/IHP-MailPrelude.html#t:Include) and [`fetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated) to specify and fetch data according to your needs.
+The type of `post` has changed from `Post` to [`Include "comments" Post`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include). In general, when you're dealing with has-many relationships, use [`Include "relatedRecords"`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport-Types.html#t:Include) and [`fetchRelated`](https://ihp.digitallyinduced.com/api-docs/IHP-FetchRelated.html#v:fetchRelated) to specify and fetch data according to your needs.
 
 The type error is fixed now. When opening the Show View of a post, you will see that the comments are displayed. When you take a look at the [`Logs` in the Dev tools](http://localhost:8001/AppLogs) you can see, that when opening a Post, two SQL queries will be fired:
 

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -462,12 +462,45 @@ that is defined in flake-module.nix
 
 
             reference =
+                let
+                    # Subpackages whose Haddock should be merged into the reference docs.
+                    # Order matters: ihp-with-docs MUST be first so its index.html /
+                    # doc-index-*.html / linuwial.css / quick-jump.js win on conflicts.
+                    # Subpackages contribute their unique IHP-*.html module pages.
+                    docPackages = with pkgs.ghc; [
+                        ihp-with-docs
+                        ihp-mail
+                        ihp-log
+                        ihp-modal
+                        ihp-ssc
+                        # ihp-hsx ships with `doHaddock = false` in its default.nix
+                        # (multi-library cabal makes the default haddock build messy).
+                        # Re-enable it here so IHP-HSX-QQ.html etc. land in api-docs.
+                        (pkgs.haskell.lib.overrideCabal ihp-hsx (old: { doHaddock = true; }))
+                        ihp-pagehead
+                        ihp-job-dashboard
+                        ihp-imagemagick
+                        ihp-typed-sql
+                    ];
+                in
                 pkgs.stdenv.mkDerivation {
                     name = "ihp-reference";
                     src = self;
-                    nativeBuildInputs = with pkgs; [ pkgs.ghc.ihp-with-docs ];
+                    nativeBuildInputs = docPackages;
                     buildPhase = ''
-                        cp -r ${pkgs.ghc.ihp-with-docs.doc}/share/doc/ihp-*/html haddock-build
+                        mkdir -p haddock-build
+
+                        # Merge each package's Haddock html dir into haddock-build/.
+                        # cp -rn ("recursive, no clobber") = first-writer-wins, so the
+                        # core ihp-with-docs index/css/js stay authoritative.
+                        for src in ${lib.concatMapStringsSep " " (p: p.doc.outPath or "") (lib.filter (p: p ? doc) docPackages)}; do
+                            for html_dir in "$src"/share/doc/*/html; do
+                                if [ -d "$html_dir" ]; then
+                                    cp -rn "$html_dir"/. haddock-build/ 2>/dev/null || true
+                                fi
+                            done
+                        done
+
                         chmod -R u+w haddock-build
 
                         cd haddock-build

--- a/ihp-hsx/README.md
+++ b/ihp-hsx/README.md
@@ -25,7 +25,7 @@ rendered = renderHtml view
 
 ## Introduction
 
-HSX can be written pretty much like normal HTML. You can write an HSX expression inside your Haskell code by wrapping it with [`[hsx|YOUR HSX CODE|]`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:hsx). HSX expressions are just a syntax for [BlazeHtml](https://jaspervdj.be/blaze/) and thus are automatically escaped as described in the blaze documentation.
+HSX can be written pretty much like normal HTML. You can write an HSX expression inside your Haskell code by wrapping it with [`[hsx|YOUR HSX CODE|]`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-QQ.html#v:hsx). HSX expressions are just a syntax for [BlazeHtml](https://jaspervdj.be/blaze/) and thus are automatically escaped as described in the blaze documentation.
 
 Because the HSX is parsed, you will get a syntax error when you type in invalid HTML.
 
@@ -42,7 +42,7 @@ in
 
 **If the variable is another HSX expression, a blaze HTML element, a text or string**: it is just included as you would expect.
 
-**If the variable is any other custom Haskell data structure**: it will first be converted to a string representation by calling [`show`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#v:show) on it. You can add a custom [`ToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-ToHtml.html#t:ToHtml) (import it from `IHP.HSX.ToHtml`) instance, to customize rendering a data structure.
+**If the variable is any other custom Haskell data structure**: it will first be converted to a string representation by calling `show` on it. You can add a custom [`ToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-HSX-ToHtml.html#t:ToHtml) (import it from `IHP.HSX.ToHtml`) instance, to customize rendering a data structure.
 
 You can also write more complex code like:
 
@@ -375,7 +375,7 @@ This approach is particularly useful for:
 
 ### Dealing with Maybe Values
 
-When dealing with [`Maybe`](https://ihp.digitallyinduced.com/api-docs/IHP-Prelude.html#t:Maybe) values you sometimes want to conditionally render something. E.g. in react to render a tag with JSX you would do it like this:
+When dealing with `Maybe` values you sometimes want to conditionally render something. E.g. in react to render a tag with JSX you would do it like this:
 
 ```html
 <p>Hi {user.name}</p>
@@ -435,7 +435,7 @@ Let's say we have variable `myVariable = "<script>alert(1)</script>"`. This is h
 
 Sometimes you want to insert some actual HTML code to your HSX using a variable. E.g. when your app is rendering markdown, the generated HTML by the markdown library should not be escaped, the markdown library typically already takes care of that.
 
-In these cases you can use [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) to mark a text as already escaped:
+In these cases you can use `preEscapedToHtml` to mark a text as already escaped:
 
 ```html
 <div>{markdownHtml |> preEscapedToHtml}</div>
@@ -446,10 +446,10 @@ In these cases you can use [`preEscapedToHtml`](https://ihp.digitallyinduced.com
 <div><p>hello</p></div>
 ```
 
-Be careful when using [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) as it can easily introduce security issues.
+Be careful when using `preEscapedToHtml` as it can easily introduce security issues.
 
-The [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) function can also be used to output HTML code that is not supported by HSX:
-The [`preEscapedToHtml`](https://ihp.digitallyinduced.com/api-docs/IHP-ViewPrelude.html#v:preEscapedToHtml) function can also be used to output HTML code that is not supported by HSX:
+The `preEscapedToHtml` function can also be used to output HTML code that is not supported by HSX:
+The `preEscapedToHtml` function can also be used to output HTML code that is not supported by HSX:
 
 ```html
 {"<!--[if IE]> Internet Explorer Conditional Comments <![endif]-->" |> preEscapedToHtml}


### PR DESCRIPTION
## Summary

Two changes that together resurrect ~60 of the ~84 broken `/api-docs/IHP-*.html` links in the Guide. (The remaining ~22 point at modules that don't exist in source under those names — separate follow-up.)

### 1. Merge subpackage Haddock into the api-docs reference build (`devenv-module.nix`)

The `reference` derivation only haddocked the core `ihp` package. Subpackage modules (`IHP-Mail.html`, `IHP-Log{,-Types}.html`, `IHP-Modal-*`, `IHP-HSX-{QQ,ToHtml}`, `IHP-PageHead-*`, `IHP-Job-Dashboard{,-Types,-Auth}`, `IHP-FileStorage-Preprocessor-ImageMagick`, `IHP-TypedSql`, `IHP-ServerSideComponent-*`) never made it into the reference docs.

Extended the buildPhase to merge the haddock html dirs from `ihp-with-docs`, `ihp-mail`, `ihp-log`, `ihp-modal`, `ihp-ssc`, `ihp-hsx`, `ihp-pagehead`, `ihp-job-dashboard`, `ihp-imagemagick`, `ihp-typed-sql`. `cp -rn` keeps `ihp-with-docs` first so its `index.html` / `doc-index-*.html` / `linuwial.css` / `quick-jump.js` win on conflicts; subpackages contribute their unique `IHP-*.html` pages (no name collisions because module namespaces are unique).

`ihp-hsx` ships with `doHaddock = false;` in its `default.nix` (multi-library cabal), so re-enabled haddock for it via `pkgs.haskell.lib.overrideCabal`.

### 2. Retarget Guide links from hidden Prelude modules (`Guide/*.markdown`, `ihp-hsx/README.md`)

`IHP.{View,Router,Mail,}Prelude` carry `{-# OPTIONS_HADDOCK hide #-}` per ede39926 — those whole-module re-export pages are huge and not useful. Respecting that decision instead of resurrecting the pages.

Retarget table:

| Old | New |
|---|---|
| `IHP-ViewPrelude.html#v:hsx` | `IHP-HSX-QQ.html#v:hsx` |
| `IHP-ViewPrelude.html#v:pathTo` | `IHP-RouterSupport.html#v:pathTo` |
| `IHP-ViewPrelude.html#v:urlTo` | `IHP-RouterSupport.html#v:urlTo` |
| `IHP-Prelude.html#t:Id` | `IHP-ModelSupport-Types.html#t:Id` |
| `IHP-MailPrelude.html#t:Include[-39-]` | `IHP-ModelSupport-Types.html#t:Include[-39-]` |

Drop-link (keep inline-code text, remove the markdown `[X](url)` wrapper) for stdlib types that aren't in IHP api-docs at all: `Eq`, `Show`, `Data`, `Maybe`, `Int`, `Bool`, `UUID`, `UTCTime`, `show`, `>>=`, `toJSON`, `ToJSON`, `preEscapedToHtml`.

## Verification

Built locally with `nix build .#reference --out-link result-reference` and confirmed:

- All retargeted anchors exist in the build (`grep -c 'id="v:hsx"' result-reference/IHP-HSX-QQ.html` = 1, etc.)
- Hidden Preludes are still hidden (no `IHP-{View,Router,Mail}Prelude.html` in `result-reference/`)
- All non-Prelude `api-docs/IHP-*` URLs the Guide now references resolve to existing pages
- Existing favicon / `ihp-haddock.css` / title-link insertions still apply across the merged output

## Test plan

- [ ] CI green on this branch
- [ ] After merge, bump `ihpDocs` flake input in `digitallyinduced/ihp-website` and redeploy; spot-check `https://ihp.digitallyinduced.com/api-docs/IHP-HSX-QQ.html#v:hsx` resolves to the hsx docs and the Guide deep-links from `Guide/hsx.html` etc. all hit `200`

## Out of scope

- 5 remaining stale Guide refs to modules that don't exist in source at all under those names: `IHP-Assets-ViewFunctions`, `IHP-AuthSupport-Authorization`, `IHP-FlashMessages-{Types,ControllerFunctions,ViewFunctions}`. Each function lives somewhere — needs separate detective work to retarget per link.
- Properly-merged Haddock indexes via `--gen-index --gen-contents --read-interface=...` so the global `doc-index-*.html` lists subpackage modules too. Current MVP makes deep-links work; index-page navigation polish is a later improvement.
- Adding remaining `ihp-*` libraries (`ihp-context`, `ihp-router`, `ihp-pglistener`, `ihp-postgres-parser`, `ihp-graphql`, `ihp-sitemap`, `ihp-datasync`, `ihp-zip`, `ihp-openai`, `ihp-welcome`) to `docPackages`. The Guide doesn't link to them today; trivial to extend the list when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)