### PR TITLE
typedSql: improve error for polymorphic-argument parameters

### DIFF
--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -8,6 +8,7 @@ module IHP.TypedSql.Quoter
     , typedSqlStar
     ) where
 
+import qualified Control.Exception              as Exception
 import           Data.Coerce                    (coerce)
 import qualified Data.List                      as List
 import qualified Data.Map.Strict                as Map
@@ -16,6 +17,9 @@ import qualified Data.String.Conversions        as CS
 import qualified Hasql.DynamicStatements.Snippet as Snippet
 import qualified Language.Haskell.TH            as TH
 import qualified Language.Haskell.TH.Quote      as TH
+import           System.IO.Error                (ioeGetErrorString)
+import           Text.Read                      (readMaybe)
+import qualified Prelude
 import           IHP.Prelude
 import           IHP.Hasql.Encoders              ()
 
@@ -62,7 +66,11 @@ typedSqlExp allowStar rawSql = do
     let PlaceholderPlan { ppDescribeSql, ppRuntimeSql, ppExprs } = planPlaceholders rawSql
     parsedExprs <- mapM parseExpr ppExprs
 
-    describeResult <- TH.runIO $ describeStatement (CS.cs ppDescribeSql)
+    describeResultE <- TH.runIO $ Exception.try (describeStatement (CS.cs ppDescribeSql))
+    describeResult <- case describeResultE of
+        Right ok -> pure ok
+        Left (e :: Exception.IOException) ->
+            fail (rephraseDescribeError ppExprs (ioeGetErrorString e))
 
     let DescribeResult { drParams, drColumns, drTables, drTypes } = describeResult
     when (length drParams /= length parsedExprs) $
@@ -151,6 +159,37 @@ typedSqlExp allowStar rawSql = do
                 resultDecoder
 
     pure (TH.SigE typedQueryExpr (TH.AppT (TH.ConT ''TypedQuery) resultType))
+
+-- | Rephrase a describe-step error to point at the offending ${...} placeholder.
+-- Postgres reports type-inference failures as "could not determine data type of parameter $N".
+-- Map $N back to the corresponding ${expr} on the Haskell side and suggest the fix
+-- (an explicit ::type cast). Other errors are passed through unchanged.
+rephraseDescribeError :: [String] -> String -> String
+rephraseDescribeError exprs originalMsg =
+    case extractUnknownParamIndex originalMsg of
+        Just paramIdx
+            | paramIdx >= 1 && paramIdx <= length exprs ->
+                let expr = exprs !! (paramIdx - 1)
+                in "typedSql: could not determine the type of `${" <> expr <> "}` "
+                    <> "(parameter $" <> Prelude.show paramIdx <> "). "
+                    <> "Postgres cannot infer the type because the placeholder appears in a polymorphic-argument context "
+                    <> "(e.g. CONCAT, COALESCE, GREATEST, LEAST). "
+                    <> "Add an explicit cast, e.g. `${" <> expr <> "}::text`.\n"
+                    <> "Original error: " <> originalMsg
+        _ -> originalMsg
+
+-- | Parse the parameter index out of a Postgres "could not determine data type of parameter $N" error.
+extractUnknownParamIndex :: String -> Maybe Int
+extractUnknownParamIndex = go
+  where
+    needle = "could not determine data type of parameter $"
+    go [] = Nothing
+    go str
+        | needle `List.isPrefixOf` str =
+            let rest = drop (length needle) str
+                digits = takeWhile (\c -> c >= '0' && c <= '9') rest
+            in if null digits then Nothing else readMaybe digits
+        | otherwise = go (drop 1 str)
 
 buildSnippetExpression :: String -> [TH.Exp] -> TH.ExpQ
 buildSnippetExpression sql params = do

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -17,7 +17,6 @@ import qualified Data.String.Conversions        as CS
 import qualified Hasql.DynamicStatements.Snippet as Snippet
 import qualified Language.Haskell.TH            as TH
 import qualified Language.Haskell.TH.Quote      as TH
-import           System.IO.Error                (ioeGetErrorString)
 import           Text.Read                      (readMaybe)
 import qualified Prelude
 import           IHP.Prelude

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -178,6 +178,11 @@ tests = do
                 "[typedSql| SELECT NULLIF(name, 'First') FROM typed_sql_test_items LIMIT 1 |]")
             []
 
+        compileFailTest "explains polymorphic-argument inference failure with placeholder context"
+            (mkTestModule "TypedQuery Text"
+                "let chunk = (\"x\" :: Text) in [typedSql| SELECT CONCAT(name, ${chunk}) FROM typed_sql_test_items LIMIT 1 |]")
+            ["could not determine the type of `${chunk}`", "polymorphic-argument context", "::text"]
+
     describe "TypedSql macro compile-time success" do
         compilePassTest "primary key inferred as Id'"
             (mkTestModuleWithPK ["typed_sql_test_items"] "TypedQuery (Id' \"typed_sql_test_items\")"

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Better error message when a `${...}` placeholder appears in a polymorphic-argument
+  position (e.g. `CONCAT`, `COALESCE`, `GREATEST`, `LEAST`). Instead of surfacing
+  the raw Postgres `could not determine data type of parameter $N` text,
+  `typedSql` now points at the offending `${expr}` and suggests an explicit
+  `${expr}::text` cast (#2667).
+
 - **Breaking:** `int8` / `bigint` columns and placeholders now map to `Int64`
   instead of `Integer`, exactly matching PostgreSQL's 64-bit wire format.
   Migration: search for `Integer` values flowing through `typedSql` results


### PR DESCRIPTION
## Summary

Closes #2667.

When a `${...}` placeholder is used in a polymorphic-argument position like `CONCAT(col, ${chunk})`, Postgres' describe step fails with `could not determine data type of parameter $N`. The bare libpq error doesn't point at the right Haskell-side fix, so users have to guess.

This change catches the prepare-step error in the quasiquoter, maps `$N` back to the original `${expr}`, and rewrites the message to suggest an explicit `::type` cast:

```
typedSql: could not determine the type of `${chunk}` (parameter $1).
Postgres cannot infer the type because the placeholder appears in a
polymorphic-argument context (e.g. CONCAT, COALESCE, GREATEST, LEAST).
Add an explicit cast, e.g. `${chunk}::text`.
Original error: typedSql: prepare failed: ERROR:  could not determine data type of parameter $1
```

This is option 1 from the issue. Other prepare errors (missing relation, syntax errors, etc.) pass through unchanged.

## Test plan

- [x] New `compileFailTest` covers the rephrased message and the cast suggestion
- [x] Manual repro: `SELECT CONCAT(message, ${chunk}) FROM ...` now points at `${chunk}` and suggests `${chunk}::text`
- [x] Full ihp-typed-sql test suite passes (92 examples, 0 failures)