### PR TITLE
FileWatcher: ignore .claude directory

### DIFF
--- a/ihp-ide/IHP/IDE/FileWatcher.hs
+++ b/ihp-ide/IHP/IDE/FileWatcher.hs
@@ -94,9 +94,10 @@ shouldWatchDirectory path = do
     osPath <- encodeUtf path
     Directory.doesDirectoryExist osPath
 
--- | Filter out directories that are git-ignored.
--- Falls back to the old hardcoded exclusion list if git is not available
--- or the project is not a git repo.
+-- | Filter out directories that are git-ignored or in the always-excluded list
+-- (.devenv, .direnv, .claude). The always-excluded list applies even when
+-- git check-ignore succeeds, so directories like .claude (used by Claude Code
+-- for worktrees) are skipped regardless of their .gitignore status.
 filterGitIgnored :: [String] -> IO [String]
 filterGitIgnored [] = pure []
 filterGitIgnored dirs = do
@@ -112,12 +113,12 @@ filterGitIgnored dirs = do
             _ <- Process.waitForProcess processHandle
             pure ignored
     case result of
-        Right ignored -> pure (filter (`notElem` ignored) dirs)
+        Right ignored -> pure (filter (\d -> d `notElem` ignored && isDirectoryWatchable d) dirs)
         Left _ -> pure (filter isDirectoryWatchable dirs)
 
 isDirectoryWatchable :: String -> Bool
 isDirectoryWatchable path =
-    path /= ".devenv" && path /= ".direnv"
+    path /= ".devenv" && path /= ".direnv" && path /= ".claude"
 
 fileWatcherConfig :: FS.WatchConfig
 fileWatcherConfig = FS.defaultConfig


### PR DESCRIPTION
## Summary

- Claude Code creates git worktrees inside `.claude/worktrees/`, which caused the IHP dev-server file watcher to fire spurious GHCi reloads and asset/schema events for every file change in those subtrees.
- Adds `.claude` to the always-excluded list (alongside `.devenv`, `.direnv`) in `isDirectoryWatchable`.
- Applies that hardcoded list even when `git check-ignore` succeeds, so the exclusion works regardless of whether `.claude` is in `.gitignore`. `isDirectoryWatchable` is also called by `handleRootFileChange`/`shouldActOnRootFileChange`, so directories created at runtime (e.g., `git worktree add .claude/worktrees/foo` while the dev server is running) are also covered without further changes.

## Test plan

- [x] `ghci :l ihp-ide/IHP/IDE/FileWatcher.hs` — type-checks (16 modules loaded, no errors)
- [ ] In a host IHP project, start the dev server, then run `git worktree add .claude/worktrees/test-watcher` and touch a `.hs` file inside it — confirm the dev server's GHCi does not reload and no schema/asset events fire
- [ ] Regression: edit a real `.hs` file in the project root and confirm GHCi still reloads as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)