### PR TITLE
Make formFor work with the lowercase routes DSL

### DIFF
--- a/Guide/form.markdown
+++ b/Guide/form.markdown
@@ -756,7 +756,21 @@ renderForm post = formFor post [hsx|
 |]
 ```
 
-To override the auto-generated `action` attribute use the [`formFor'`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor-39-) function:
+`formFor` works out of the box for both routing styles:
+
+- **AutoRoute**: the form action defaults to `/CreatePost` or `/UpdatePost?postId=…`.
+- **Routes DSL** (`[routes|…|]`): when both submit actions are declared in the routes block and follow the standard scaffold shape — a nullary `Create<X>Action` and an `Update<X>Action { <x>Id :: Id <X> }` — the splice automatically emits a per-model `ModelFormAction` instance that resolves the form action via `pathTo`. New-record forms submit to the `Create<X>Action` route, and existing-record forms submit to the `Update<X>Action` route.
+
+If your action constructors don't fit that shape (e.g. `CreatePostAction { teamId :: Id Team }` taking extra parameters), provide a manual `ModelFormAction` instance once per model. Put the manual instance before the `[routes|…|]` splice that declares the controller, so the splice can detect it and avoid generating another instance:
+
+```haskell
+instance {-# OVERLAPPING #-} ModelFormAction Post where
+    modelFormAction post
+      | isNew post = pathTo (CreatePostAction { teamId = currentTeamId })
+      | otherwise  = pathTo (UpdatePostAction { postId = post.id })
+```
+
+To override the auto-generated `action` attribute at a single call site, use the [`formFor'`](https://ihp.digitallyinduced.com/api-docs/IHP-View-Form.html#v:formFor-39-) function:
 
 ```haskell
 renderForm :: Post -> Html

--- a/ihp/IHP/Router/IHP.hs
+++ b/ihp/IHP/Router/IHP.hs
@@ -53,6 +53,9 @@ import qualified Language.Haskell.TH.Quote as TH
 
 import IHP.Router.Capture (UrlCapture (..))
 import qualified IHP.ModelSupport as ModelSupport
+import IHP.ModelSupport (isNew)
+import IHP.Router.UrlGenerator (pathTo)
+import IHP.View.Form.FormFor (ModelFormAction (..))
 import IHP.Router.DSL.TH
     ( ParsedBlock (..)
     , HeaderForm (..)
@@ -274,13 +277,16 @@ emitNamedBinding bindingTxt ctrls wsBindings = do
 ---------------------------------------------------------------------------
 
 -- | TH names referenced from the emitted @ModelFormAction@ instance.
--- All resolved at the splice use-site so the emitted code only needs the
--- standard IHP imports a controller/view module already has.
+-- We use fully-qualified names (resolved here at TH compile time) rather
+-- than 'TH.mkName', so the emitted instance keeps compiling regardless
+-- of what a user's @Web/Routes.hs@ happens to import. 'IHP.RouterPrelude'
+-- doesn't re-export 'ModelFormAction' or 'isNew', so 'mkName' references
+-- would fail in real apps.
 modelFormActionClass, modelFormActionFn, isNewFn, pathToFn :: Name
-modelFormActionClass = TH.mkName "ModelFormAction"
-modelFormActionFn    = TH.mkName "modelFormAction"
-isNewFn              = TH.mkName "isNew"
-pathToFn             = TH.mkName "pathTo"
+modelFormActionClass = ''ModelFormAction
+modelFormActionFn    = 'modelFormAction
+isNewFn              = 'isNew
+pathToFn             = 'pathTo
 
 -- | Emit a per-model @instance \{-\# OVERLAPPING \#-\} ModelFormAction X@
 -- for each controller whose routed actions follow the standard scaffold shape:

--- a/ihp/IHP/Router/IHP.hs
+++ b/ihp/IHP/Router/IHP.hs
@@ -40,11 +40,15 @@ module IHP.Router.IHP
 import Prelude
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as ByteString.Char8
+import qualified Data.Char as Char
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Typeable (Typeable)
+import qualified GHC.Records
 import qualified Language.Haskell.TH as TH
-import Language.Haskell.TH (Q, Dec, Name)
+import Language.Haskell.TH (Q, Dec, Name, Type)
 import qualified Language.Haskell.TH.Quote as TH
 
 import IHP.Router.Capture (UrlCapture (..))
@@ -53,6 +57,8 @@ import IHP.Router.DSL.TH
     ( ParsedBlock (..)
     , HeaderForm (..)
     , ControllerInfo (..)
+    , ConstructorInfo (..)
+    , ValidatedRoute (..)
     , parseAndReify
     , genericEmit
     , trieValueName
@@ -135,11 +141,12 @@ ihpRoutesDec = routesDec
 ihpEmit :: ParsedBlock -> Q [Dec]
 ihpEmit ParsedBlock { pbHeader, pbGroups, pbWsRoutes } = do
     canRouteDecs <- traverse (\(ctrl, _) -> emitCanRoute ctrl) pbGroups
+    formActionDecs <- fmap concat (traverse (uncurry emitModelFormAction) pbGroups)
     bindingDecs <- case pbHeader of
         HeaderLowercase name ->
             emitNamedBinding name (map fst pbGroups) pbWsRoutes
         _ -> pure []
-    pure (canRouteDecs <> bindingDecs)
+    pure (canRouteDecs <> formActionDecs <> bindingDecs)
 
 ---------------------------------------------------------------------------
 -- IHP-specific TH names (resolved at splice use-site)
@@ -261,3 +268,141 @@ emitNamedBinding bindingTxt ctrls wsBindings = do
         [ TH.SigD valName bindingTy
         , TH.FunD valName [TH.Clause [] (TH.NormalB bindingExp) []]
         ]
+
+---------------------------------------------------------------------------
+-- Code generation — ModelFormAction
+---------------------------------------------------------------------------
+
+-- | TH names referenced from the emitted @ModelFormAction@ instance.
+-- All resolved at the splice use-site so the emitted code only needs the
+-- standard IHP imports a controller/view module already has.
+modelFormActionClass, modelFormActionFn, isNewFn, pathToFn :: Name
+modelFormActionClass = TH.mkName "ModelFormAction"
+modelFormActionFn    = TH.mkName "modelFormAction"
+isNewFn              = TH.mkName "isNew"
+pathToFn             = TH.mkName "pathTo"
+
+-- | Emit a per-model @instance \{-\# OVERLAPPING \#-\} ModelFormAction X@
+-- for each controller whose routed actions follow the standard scaffold shape:
+--
+-- > Create<X>Action                          -- nullary
+-- > Update<X>Action { <x>Id :: Id <X> }      -- single field, conventional name
+--
+-- The instance body delegates to the 'HasPath' instances 'genericEmit' has
+-- already produced:
+--
+-- > instance {-# OVERLAPPING #-} ModelFormAction X where
+-- >     modelFormAction record =
+-- >         if isNew record
+-- >             then pathTo Create<X>Action
+-- >             else pathTo (Update<X>Action (getField @"id" record))
+--
+-- Emission is opportunistic: if any check fails (constructor route missing,
+-- extra fields, non-conventional id field name, incompatible id type, existing
+-- exact override, or @\<X\>@ not in scope), the splice silently skips that
+-- controller and the OVERLAPPABLE default or manual instance handles 'formFor'.
+emitModelFormAction :: ControllerInfo -> [ValidatedRoute] -> Q [Dec]
+emitModelFormAction ctrl routes =
+    let coveredConstructors =
+            Set.fromList
+                [ Text.pack (TH.nameBase (coName (vrCon route)))
+                | route <- routes
+                ]
+        candidates =
+            [ stripped
+            | name <- Set.toList coveredConstructors
+            , Just stripped <- [Text.stripPrefix "Create" name >>= Text.stripSuffix "Action"]
+            , not (Text.null stripped)
+            ]
+    in fmap concat (traverse (tryEmitModelFormAction ctrl coveredConstructors) candidates)
+
+tryEmitModelFormAction :: ControllerInfo -> Set.Set Text -> Text -> Q [Dec]
+tryEmitModelFormAction ctrl coveredConstructors modelText = do
+    let createName  = "Create" <> modelText <> "Action"
+        updateName  = "Update" <> modelText <> "Action"
+        expectedFld = lcfirstText modelText <> "Id"
+    case (Map.lookup createName (ciConstructors ctrl), Map.lookup updateName (ciConstructors ctrl)) of
+        (Just createCon, Just updateCon)
+            | null (coFieldsOrder createCon)
+            , [(fieldName, fieldTy)] <- coFieldsOrder updateCon
+            , fieldName == expectedFld
+            , Set.member createName coveredConstructors
+            , Set.member updateName coveredConstructors -> do
+                mTy <- TH.lookupTypeName (Text.unpack modelText)
+                case mTy of
+                    Nothing      -> pure []
+                    Just modelTy -> do
+                        modelTypes <- modelTypeVariants modelTy
+                        hasExactInstance <- hasExactModelFormActionInstance modelTypes
+                        if updateFieldTypeMatches modelTypes fieldTy && not hasExactInstance
+                            then pure [buildModelFormActionInstance modelTy (coName createCon) (coName updateCon)]
+                            else pure []
+        _ -> pure []
+
+modelTypeVariants :: Name -> Q [Type]
+modelTypeVariants modelTy = do
+    info <- TH.reify modelTy
+    let direct = TH.ConT modelTy
+    pure case info of
+        TH.TyConI (TH.TySynD _ _ rhs) -> [direct, stripType rhs]
+        _ -> [direct]
+
+hasExactModelFormActionInstance :: [Type] -> Q Bool
+hasExactModelFormActionInstance modelTypes = do
+    instances <- fmap concat $
+        traverse (\modelTy -> TH.reifyInstances modelFormActionClass [modelTy]) modelTypes
+    pure (any (isExactModelFormActionInstance modelTypes) instances)
+
+isExactModelFormActionInstance :: [Type] -> Dec -> Bool
+isExactModelFormActionInstance modelTypes = \case
+    TH.InstanceD _ _ instanceHead _ ->
+        case stripType instanceHead of
+            TH.AppT (TH.ConT className) modelTy
+                | className == modelFormActionClass ->
+                    stripType modelTy `elem` modelTypes
+            _ -> False
+    _ -> False
+
+updateFieldTypeMatches :: [Type] -> Type -> Bool
+updateFieldTypeMatches modelTypes fieldTy =
+    case stripType fieldTy of
+        TH.AppT (TH.ConT idName) modelTy
+            | idName == ''ModelSupport.Id
+            , isModelType modelTy -> True
+        TH.AppT (TH.ConT idPrimeName) (TH.AppT (TH.ConT getTableNameName) modelTy)
+            | idPrimeName == ''ModelSupport.Id'
+            , getTableNameName == ''ModelSupport.GetTableName
+            , isModelType modelTy -> True
+        _ -> False
+    where
+        isModelType ty = stripType ty `elem` modelTypes
+
+stripType :: Type -> Type
+stripType = \case
+    TH.SigT ty _ -> stripType ty
+    TH.ParensT ty -> stripType ty
+    TH.ForallT _ _ ty -> stripType ty
+    ty -> ty
+
+buildModelFormActionInstance :: Name -> Name -> Name -> Dec
+buildModelFormActionInstance modelTy createCon updateCon =
+    let recordVar = TH.mkName "record"
+        getIdExpr =
+            TH.AppE
+                (TH.AppTypeE (TH.VarE 'GHC.Records.getField) (TH.LitT (TH.StrTyLit "id")))
+                (TH.VarE recordVar)
+        body = TH.CondE
+            (TH.AppE (TH.VarE isNewFn) (TH.VarE recordVar))
+            (TH.AppE (TH.VarE pathToFn) (TH.ConE createCon))
+            (TH.AppE (TH.VarE pathToFn)
+                (TH.AppE (TH.ConE updateCon) getIdExpr))
+        method = TH.FunD modelFormActionFn
+            [TH.Clause [TH.VarP recordVar] (TH.NormalB body) []]
+    in TH.InstanceD (Just TH.Overlapping) []
+        (TH.AppT (TH.ConT modelFormActionClass) (TH.ConT modelTy))
+        [method]
+
+lcfirstText :: Text -> Text
+lcfirstText t = case Text.uncons t of
+    Just (c, rest) -> Text.cons (Char.toLower c) rest
+    Nothing        -> t

--- a/ihp/IHP/View/Form/FormFor.hs
+++ b/ihp/IHP/View/Form/FormFor.hs
@@ -324,7 +324,7 @@ submitButton =
 class ModelFormAction record where
     modelFormAction :: (?request :: Request) => record -> Text
 
-instance
+instance {-# OVERLAPPABLE #-}
     ( HasField "id" record (Id' (GetTableName record))
     , HasField "meta" record MetaBag
     , KnownSymbol (GetModelName record)
@@ -332,15 +332,17 @@ instance
     ) => ModelFormAction record where
     -- | Returns the form's action attribute for a given record.
     --
-    -- Expects that AutoRoute is used. Otherwise you need to use @formFor'@ or specify
-    -- a manual ModelFormAction instance.
+    -- This default fallback expects AutoRoute. It guesses the form submit
+    -- target by mangling the current URL: a @New..Action@ becomes a
+    -- @Create..Action@ and an @Edit..Action@ becomes an @Update..Action@.
     --
-    -- We guess the form submit action based on the current url
-    -- It's a @New..Action@ or @Edit..Action@. We guess the corresponding
-    -- @Create..Action@ name or @Update..Action@ name based on the AutoRoute rules
+    -- The IHP @[routes|…|]@ DSL automatically emits an OVERLAPPING instance
+    -- when both submit actions are routed and follow the standard
+    -- @Create<X>Action@ / @Update<X>Action { <x>Id :: Id <X> }@ shape.
     --
-    -- In case the routing is not based on AutoRoute, a manual ModelFormAction instance needs
-    -- to be defined
+    -- For irregular routing (custom action shapes, non-conventional names),
+    -- either define your own @instance {-# OVERLAPPING #-} ModelFormAction X@
+    -- before the routes splice or call @formFor'@ with @pathTo@ at the call site.
     modelFormAction record =
         let
             path = theRequest.pathInfo

--- a/ihp/Test/Test/Main.hs
+++ b/ihp/Test/Test/Main.hs
@@ -8,6 +8,7 @@ import qualified Test.NameSupportSpec
 import qualified Test.HaskellSupportSpec
 import qualified Test.View.CSSFrameworkSpec
 import qualified Test.View.FormSpec
+import qualified Test.View.FormForDSLSpec
 import qualified Test.Controller.ParamSpec
 import qualified Test.Controller.CookieSpec
 import qualified Test.Controller.AccessDeniedSpec
@@ -43,6 +44,7 @@ main = hspec do
     Test.HaskellSupportSpec.tests
     Test.View.CSSFrameworkSpec.tests
     Test.View.FormSpec.tests
+    Test.View.FormForDSLSpec.tests
     Test.Controller.ParamSpec.tests
     Test.Controller.AccessDeniedSpec.tests
     Test.Controller.NotFoundSpec.tests

--- a/ihp/Test/Test/View/FormForDSLSpec.hs
+++ b/ihp/Test/Test/View/FormForDSLSpec.hs
@@ -1,0 +1,270 @@
+{-|
+Module: Test.View.FormForDSLSpec
+Copyright: (c) digitally induced GmbH, 2026
+
+Verifies that 'formFor' picks up the per-model 'ModelFormAction' instance
+emitted by the @[routes|…|]@ splice. Without that override, the
+'OVERLAPPABLE' default would string-mangle the request path against
+AutoRoute conventions and produce wrong URLs for lowercase DSL routes.
+-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.View.FormForDSLSpec where
+
+import Test.Hspec
+import IHP.FrameworkConfig as FrameworkConfig
+import Wai.Request.Params.Middleware (RequestBody (..))
+import IHP.HSX.Markup (renderMarkupText)
+import IHP.ModelSupport
+import Data.Bits ((.|.))
+import qualified Data.Dynamic as Dynamic
+import qualified Data.UUID as UUID
+import qualified Network.Wai as Wai
+import IHP.ViewPrelude
+import qualified Data.Vault.Lazy as Vault
+import qualified IHP.RequestVault
+import IHP.RouterSupport
+import IHP.Router.DSL (routes)
+import IHP.Router.Capture (renderCapture, parseCapture)
+import IHP.ControllerPrelude (Controller (..), renderPlain)
+import Network.HTTP.Types.Method (StdMethod (..))
+
+-- A Project model dedicated to this spec so it doesn't collide with
+-- 'Test.View.FormSpec'\'s AutoRoute-style fixture (which asserts
+-- @/CreateProject@). Two modules wiring the same model into different
+-- routing styles would produce overlapping 'ModelFormAction' instances.
+data DslProject' = DslProject
+    { id :: (Id' "dsl_projects")
+    , title :: Text
+    , meta :: MetaBag
+    } deriving (Eq, Show)
+type DslProject = DslProject'
+
+instance InputValue DslProject where inputValue = recordToInputValue
+
+type instance GetTableName DslProject' = "dsl_projects"
+type instance GetModelByTableName "dsl_projects" = DslProject
+type instance GetModelName DslProject' = "DslProject"
+type instance PrimaryKey "dsl_projects" = UUID
+
+instance Record DslProject where
+    {-# INLINE newRecord #-}
+    newRecord = DslProject def def def
+instance Default (Id' "dsl_projects") where def = Id def
+
+instance SetField "id" DslProject' (Id' "dsl_projects") where
+    {-# INLINE setField #-}
+    setField newValue (DslProject _ title meta) =
+        DslProject newValue title (meta { touchedFields = touchedFields meta .|. 1 })
+instance SetField "title" DslProject' Text where
+    {-# INLINE setField #-}
+    setField newValue (DslProject id title meta) =
+        DslProject id newValue (meta { touchedFields = touchedFields meta .|. 2 })
+instance SetField "meta" DslProject' MetaBag where
+    {-# INLINE setField #-}
+    setField newValue (DslProject id title _) = DslProject id title newValue
+
+instance UpdateField "id" DslProject' DslProject' (Id' "dsl_projects") (Id' "dsl_projects") where
+    {-# INLINE updateField #-}
+    updateField newValue (DslProject _ title meta) =
+        DslProject newValue title (meta { touchedFields = touchedFields meta .|. 1 })
+instance UpdateField "title" DslProject' DslProject' Text Text where
+    {-# INLINE updateField #-}
+    updateField newValue (DslProject id title meta) =
+        DslProject id newValue (meta { touchedFields = touchedFields meta .|. 2 })
+instance UpdateField "meta" DslProject' DslProject' MetaBag MetaBag where
+    {-# INLINE updateField #-}
+    updateField newValue (DslProject id title _) = DslProject id title newValue
+
+instance FieldBit "id" DslProject' where fieldBit = 1
+instance FieldBit "title" DslProject' where fieldBit = 2
+
+-- Controller exercising the standard scaffold shape:
+--   nullary CreateDslProjectAction
+--   UpdateDslProjectAction { dslProjectId :: Id DslProject }
+data DslProjectsController
+    = DslProjectsAction
+    | NewDslProjectAction
+    | EditDslProjectAction { dslProjectId :: Id DslProject }
+    | CreateDslProjectAction
+    | UpdateDslProjectAction { dslProjectId :: Id DslProject }
+    deriving (Eq, Show)
+
+instance Controller DslProjectsController where
+    action DslProjectsAction       = renderPlain "index"
+    action NewDslProjectAction     = renderPlain "new"
+    action EditDslProjectAction {} = renderPlain "edit"
+    action CreateDslProjectAction  = renderPlain "create"
+    action UpdateDslProjectAction {} = renderPlain "update"
+
+data PartialProject' = PartialProject
+    { id :: Id' "partial_projects"
+    , meta :: MetaBag
+    } deriving (Eq, Show)
+type PartialProject = PartialProject'
+
+type instance GetTableName PartialProject' = "partial_projects"
+type instance GetModelByTableName "partial_projects" = PartialProject
+type instance GetModelName PartialProject' = "PartialProject"
+type instance PrimaryKey "partial_projects" = UUID
+
+instance Record PartialProject where
+    {-# INLINE newRecord #-}
+    newRecord = PartialProject def def
+instance Default (Id' "partial_projects") where def = Id def
+
+data PartialProjectsController
+    = CreatePartialProjectAction
+    | UpdatePartialProjectAction { partialProjectId :: Id PartialProject }
+    deriving (Eq, Show)
+
+instance Controller PartialProjectsController where
+    action CreatePartialProjectAction = renderPlain "create"
+    action UpdatePartialProjectAction {} = renderPlain "update"
+
+data WrongIdProject' = WrongIdProject
+    { id :: Id' "wrong_id_projects"
+    , meta :: MetaBag
+    } deriving (Eq, Show)
+type WrongIdProject = WrongIdProject'
+
+type instance GetTableName WrongIdProject' = "wrong_id_projects"
+type instance GetModelByTableName "wrong_id_projects" = WrongIdProject
+type instance GetModelName WrongIdProject' = "WrongIdProject"
+type instance PrimaryKey "wrong_id_projects" = UUID
+
+instance Record WrongIdProject where
+    {-# INLINE newRecord #-}
+    newRecord = WrongIdProject def def
+instance Default (Id' "wrong_id_projects") where def = Id def
+
+data WrongIdProjectsController
+    = CreateWrongIdProjectAction
+    | UpdateWrongIdProjectAction { wrongIdProjectId :: Text }
+    deriving (Eq, Show)
+
+instance Controller WrongIdProjectsController where
+    action CreateWrongIdProjectAction = renderPlain "create"
+    action UpdateWrongIdProjectAction {} = renderPlain "update"
+
+data ManualProject' = ManualProject
+    { id :: Id' "manual_projects"
+    , meta :: MetaBag
+    } deriving (Eq, Show)
+type ManualProject = ManualProject'
+
+type instance GetTableName ManualProject' = "manual_projects"
+type instance GetModelByTableName "manual_projects" = ManualProject
+type instance GetModelName ManualProject' = "ManualProject"
+type instance PrimaryKey "manual_projects" = UUID
+
+instance Record ManualProject where
+    {-# INLINE newRecord #-}
+    newRecord = ManualProject def def
+instance Default (Id' "manual_projects") where def = Id def
+
+instance {-# OVERLAPPING #-} ModelFormAction ManualProject where
+    modelFormAction record
+        | isNew record = "/manual-projects/custom-new"
+        | otherwise = "/manual-projects/custom-update"
+
+data ManualProjectsController
+    = CreateManualProjectAction
+    | UpdateManualProjectAction { manualProjectId :: Id ManualProject }
+    deriving (Eq, Show)
+
+instance Controller ManualProjectsController where
+    action CreateManualProjectAction = renderPlain "create"
+    action UpdateManualProjectAction {} = renderPlain "update"
+
+-- Force a TH declaration-group boundary so the controller type is visible
+-- to the [routes|…|] splice (mirrors the pattern in DSLQuoterSpec).
+$(pure [])
+
+-- The splice will emit:
+--   * HasPath / CanRoute for the controller (always)
+--   * instance {-# OVERLAPPING #-} ModelFormAction DslProject  (because
+--     CreateDslProjectAction and UpdateDslProjectAction match the convention)
+[routes|DslProjectsController
+GET    /dsl-projects                       DslProjectsAction
+GET    /dsl-projects/new                   NewDslProjectAction
+POST   /dsl-projects                       CreateDslProjectAction
+GET    /dsl-projects/{dslProjectId}/edit   EditDslProjectAction
+PATCH  /dsl-projects/{dslProjectId}        UpdateDslProjectAction
+|]
+
+[routes|PartialProjectsController
+PATCH  /partial-projects/{partialProjectId}  UpdatePartialProjectAction
+|]
+
+[routes|WrongIdProjectsController
+POST   /wrong-id-projects                   CreateWrongIdProjectAction
+PATCH  /wrong-id-projects/{wrongIdProjectId} UpdateWrongIdProjectAction
+|]
+
+[routes|ManualProjectsController
+POST   /manual-projects                    CreateManualProjectAction
+PATCH  /manual-projects/{manualProjectId}  UpdateManualProjectAction
+|]
+
+tests = do
+    describe "IHP.View.FormFor (lowercase routes-DSL)" do
+        it "uses the DSL path for new records" do
+            context <- createControllerContext
+            let ?context = context
+            let ?request = ?context
+
+            let project = newRecord @DslProject
+            let form = formFor project [hsx| {textField #title} |]
+            renderMarkupText form `shouldSatisfy` (\t -> "action=\"/dsl-projects\"" `isInfixOf` t)
+
+        it "uses the DSL path with id for existing records" do
+            context <- createControllerContext
+            let ?context = context
+            let ?request = ?context
+
+            let savedId :: Id' "dsl_projects"
+                savedId = Id (UUID.fromWords 0x12345678 0x9abcdef0 0x12345678 0x9abcdef0)
+            let savedMeta = def { originalDatabaseRecord = Just (Dynamic.toDyn ()) }
+            let project = DslProject { id = savedId, title = "Saved", meta = savedMeta }
+            let form = formFor project [hsx| {textField #title} |]
+            renderMarkupText form `shouldSatisfy`
+                (\t -> "action=\"/dsl-projects/12345678-9abc-def0-1234-56789abcdef0\"" `isInfixOf` t)
+
+        it "falls back when the standard create/update pair is not fully routed" do
+            context <- createControllerContext
+            let ?context = context
+            let ?request = ?context
+
+            let project = newRecord @PartialProject
+            let form = formFor project [hsx||]
+            renderMarkupText form `shouldSatisfy`
+                (\t -> "action=\"/CreatePartialProject\"" `isInfixOf` t)
+
+        it "falls back when the update action id field has the wrong type" do
+            context <- createControllerContext
+            let ?context = context
+            let ?request = ?context
+
+            let project = newRecord @WrongIdProject
+            let form = formFor project [hsx||]
+            renderMarkupText form `shouldSatisfy`
+                (\t -> "action=\"/CreateWrongIdProject\"" `isInfixOf` t)
+
+        it "keeps a manual ModelFormAction override declared before the routes splice" do
+            context <- createControllerContext
+            let ?context = context
+            let ?request = ?context
+
+            let project = newRecord @ManualProject
+            let form = formFor project [hsx||]
+            renderMarkupText form `shouldSatisfy`
+                (\t -> "action=\"/manual-projects/custom-new\"" `isInfixOf` t)
+
+createControllerContext :: IO Wai.Request
+createControllerContext = do
+    frameworkConfig <- FrameworkConfig.buildFrameworkConfig noopLogger (pure ())
+    let requestBody = FormBody { params = [], files = [], rawPayload = "" }
+    let request = Wai.defaultRequest { Wai.vault = Vault.insert IHP.RequestVault.frameworkConfigVaultKey frameworkConfig
+                                                 $ Vault.insert IHP.RequestVault.requestBodyVaultKey requestBody Vault.empty }
+    pure request


### PR DESCRIPTION
## Summary

When an app's routes are migrated from AutoRoute to the lowercase routes DSL (e.g. `/users/{userId}/edit`), every `formFor record` call has to be rewritten as `formFor' record (pathTo …)` to get a correct form `action` URL — the default `ModelFormAction` instance synthesizes AutoRoute-style URLs (`/CreateUser`, `/UpdateUser?userId=…`) by string-mangling the current request path, which produces nonsense like `/users/123/UpdateUser?userId=123` on lowercase DSL routes.

This PR makes `formFor` "just work" after a routes-DSL migration:

- **Default instance becomes overridable.** [ihp/IHP/View/Form/FormFor.hs](https://github.com/digitallyinduced/ihp/blob/claude/naughty-sinoussi-f06561/ihp/IHP/View/Form/FormFor.hs) — adds `{-# OVERLAPPABLE #-}` to the existing `ModelFormAction` instance and updates the doc comment. Body is unchanged; AutoRoute apps see no behavioural difference.
- **`ihpEmit` emits per-model overrides.** [ihp/IHP/Router/IHP.hs](https://github.com/digitallyinduced/ihp/blob/claude/naughty-sinoussi-f06561/ihp/IHP/Router/IHP.hs) — for each controller whose actions match the standard scaffold shape (nullary `Create<X>Action`, `Update<X>Action { <x>Id :: Id <X> }`, and `<X>` resolves via `lookupTypeName`), the splice now emits:
  ```haskell
  instance {-# OVERLAPPING #-} ModelFormAction X where
      modelFormAction record
        | isNew record = pathTo Create<X>Action
        | otherwise    = pathTo (Update<X>Action (record.id))
  ```
  Emission is opportunistic — irregular shapes (extra params on the action constructors, non-conventional names) silently fall through to the OVERLAPPABLE default or to a user-defined override.
- **Documentation.** [Guide/form.markdown](https://github.com/digitallyinduced/ihp/blob/claude/naughty-sinoussi-f06561/Guide/form.markdown) — explains the auto-emission convention and shows the manual `{-# OVERLAPPING #-}` override for irregular cases.

## Test plan

- [x] New spec `Test.View.FormForDSLSpec` — defines a `DslProject` model + a `[routes|…|]`-routed controller and asserts forms render `action="/dsl-projects"` for new records and `action="/dsl-projects/<uuid>"` for existing records.
- [x] Existing `Test.View.FormSpec` AutoRoute test (`/CreateProject`) still passes — confirms backward compatibility.
- [x] Full `ihp` test suite: 572 examples, 0 failures.
- [ ] Watch CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)