### PR TITLE
postgres-parser: chain postfix ops so qualified columns work with IN/::/.

### DIFF
--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -492,11 +492,13 @@ table = [
             , binary "||" ConcatenationExpression
 
             , binary "IS" IsExpression
-            , inExpr
             , prefix "NOT" NotExpression
             , prefix "EXISTS" ExistsExpression
-            , typeCast
-            , dot
+            -- Chain multiple postfix operators at the same precedence so we can
+            -- parse e.g. `table.col IN (SELECT …)` — pg_dump qualifies columns
+            -- with their table name and `makeExprParser`'s `Postfix` only
+            -- applies one postfix per term.
+            , Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp <|> inOp))
             ],
             [ binary "AND" AndExpression, binary "OR" OrExpression ]
         ]
@@ -507,17 +509,17 @@ table = [
 
         -- Cannot be implemented as a infix operator as that requires two expression operands,
         -- but the second is the type-cast type which is not an expression
-        typeCast = Postfix do
+        typeCastOp = do
             symbol "::"
             castType <- sqlType
             pure $ \expr -> TypeCastExpression expr castType
 
-        dot = Postfix do
+        dotOp = do
             char '.'
             name <- identifier
             pure $ \expr -> DotExpression expr name
 
-        inExpr = Postfix do
+        inOp = do
             lexeme "IN"
             right <- try inArrayExpression <|> expression
             pure $ \expr -> InExpression expr right

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -171,6 +171,29 @@ spec = do
                         )
                     }
 
+        -- pg_dump qualifies every column with its table name, so policies
+        -- exporting `col IN (SELECT …)` come back as `tab.col IN (SELECT …)`.
+        -- Both `dot` and `IN` are postfix at the same precedence; without
+        -- chaining, only `dot` would apply and `IN` would be left dangling.
+        it "should parse 'CREATE POLICY' with qualified column and IN (SELECT …)" do
+            parseSql "CREATE POLICY \"p\" ON tasks USING (tasks.user_id IN (SELECT users.id FROM users WHERE users.active));" `shouldBe`
+                    (policy "p" "tasks")
+                    { using = Just (
+                        InExpression
+                            (DotExpression (VarExpression "tasks") "user_id")
+                            (InArrayExpression
+                                [ SelectExpression Select
+                                    { columns = [DotExpression (VarExpression "users") "id"]
+                                    , from = VarExpression "users"
+                                    , alias = Nothing
+                                    , whereClause = DotExpression (VarExpression "users") "active"
+                                    }
+                                ]
+                            )
+                        )
+                    , check = Nothing
+                    }
+
         it "should parse 'DROP TABLE ..' statements" do
             parseSql "DROP TABLE tasks;" `shouldBe` DropTable { tableName = "tasks" }
 


### PR DESCRIPTION
## Bug

`makeExprParser`'s `Postfix` only applies one postfix per term. The parser has `dot`, `::`, and `IN` all as `Postfix` operators at the same precedence row, so any expression that needs more than one — e.g. `tab.col IN (SELECT …)` — fails with `unexpected 'I' expecting … IS, OR, AND, …` (`IN` is missing from the expected set because `dot` already consumed the term's single postfix slot).

This is exactly what pg_dump produces for nested-IN policies: every column is qualified with its table name. So the dev server's `updateDatabaseIsOutdated` choked on every nested-IN policy in a real schema once pg_dump round-tripped it.

Reproducer (against pre-fix parser):
```haskell
runParser (expression <* eof) "test"
    "(revolut_transactions.bank_connection_id IN ( SELECT bank_connections.id FROM public.bank_connections WHERE (bank_connections.user_id = ihp_user_id())))"
-- FAIL: unexpected 'I' expecting "<=", "<>", ">=", "AND", "IS", "OR", "||", '<', '=', '>', or white space
```

## Fix

Combine the same-level postfix operators into a single chained `Postfix` via `some` + `foldl1 (flip (.))`, as suggested by the parser-combinators haddock for chaining unary operators of the same precedence.

## Test plan

- [x] Added `should parse 'CREATE POLICY' with qualified column and IN (SELECT …)` test
- [x] All 32 existing `Postgres.ParserSpec` tests still pass