### PR TITLE
Guide: escape [routes|...|] in editors.markdown to fix CI

### DIFF
--- a/Guide/editors.markdown
+++ b/Guide/editors.markdown
@@ -17,7 +17,7 @@ You will also find steps on how to get autocompletion and smart IDE features. Th
 - [`direnv`](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv), this loads the project `.envrc` file, so all the right Haskell packages are available to VSCode
 - [`Haskell`](https://marketplace.visualstudio.com/items?itemName=haskell.haskell), this gets smart IDE features with haskell-language-server
 - [`Haskell HSX`](https://marketplace.visualstudio.com/items?itemName=s0kil.vscode-hsx), provides support for [HSX](https://ihp.digitallyinduced.com/Guide/hsx.html)
-- [`IHP Routes QQ`](https://marketplace.visualstudio.com/items?itemName=avitkauskas.ihp-routes-quasi), provides support for IHP [routes|...|] quasiquote syntax highlighting
+- [`IHP Routes QQ`](https://marketplace.visualstudio.com/items?itemName=avitkauskas.ihp-routes-quasi), provides support for IHP `[routes|...|]` quasiquote syntax highlighting
 
 To make file paths clickable inside the web browser (e.g. when a type error happens), export this env var in your shell (e.g. in `.bashrc`):
 


### PR DESCRIPTION
## Summary

- Master CI has been failing on `nix flake check` since #2674 merged: the `ihp-guide` build can't parse `Guide/editors.markdown:20`.
- mmark interpreted the bare `[routes|...|]` as a reference link with no matching definition.
- Wrapping in backticks fixes the parse and matches the surrounding entries in the same list — `[routes|...|]` is a quasiquoter, so code formatting fits.

Error from the failing run:
```
ihp-guide> /Guide/editors.markdown:20:130:
ihp-guide> 20 | - [`IHP Routes QQ`](...), provides support for IHP [routes|...|] quasiquote syntax highlighting
ihp-guide> could not find a matching reference definition for "routes|...|"
```

## Test plan

- [ ] `nix flake check --impure` passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)