### PR TITLE
Disallow INSERT without explicit column list in typedSql

### DIFF
--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -100,6 +100,25 @@ items <- sqlQueryTyped [typedSqlStar|
 |]
 ```
 
+## Inserting Rows
+
+### Why `INSERT … VALUES` without a column list is disallowed by default
+
+`INSERT INTO table VALUES (...)` and `INSERT INTO table SELECT ...` without an explicit column list are not allowed in `typedSql` by default. They rely on the positional order of columns matching the schema, but column order can drift between development and production (e.g., when migrations are applied in a different sequence). This causes values to be silently inserted into the wrong columns at runtime.
+
+Instead, list the target columns explicitly:
+
+```haskell
+sqlExecTyped [typedSql|
+    INSERT INTO items (id, name, views)
+    VALUES (${itemId}, ${name}, ${views})
+|]
+```
+
+`INSERT INTO table DEFAULT VALUES` is allowed since it has no positional binding.
+
+The same `[typedSqlStar| ... |]` escape hatch applies here if you understand the risk.
+
 ## Parameters
 
 Use `${expr}` to splice Haskell expressions into your SQL as parameters:

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -8,6 +8,7 @@ module IHP.TypedSql.ParamHints
     , extractNonNullableComputedColumnsFromAst
     , resolveParamHintTypes
     , detectStarSelects
+    , detectInsertWithoutColumns
     ) where
 
 import           Data.Foldable                (foldMap, toList)
@@ -719,3 +720,20 @@ starFromExpr = \case
   where
     isAllIndirection Ast.AllIndirectionEl = True
     isAllIndirection _ = False
+
+----------------------------------------------------------------------
+-- INSERT without explicit column list detection
+----------------------------------------------------------------------
+
+-- | Detect INSERT statements without an explicit column list.
+-- Returns descriptive strings (e.g. ["INSERT INTO foo"]) for use in error messages.
+-- Allows `INSERT INTO foo DEFAULT VALUES` since it has no positional column binding.
+detectInsertWithoutColumns :: Ast.PreparableStmt -> [String]
+detectInsertWithoutColumns = \case
+    Ast.InsertPreparableStmt (Ast.InsertStmt _with target rest _onConflict _ret) ->
+        case rest of
+            Ast.SelectInsertRest Nothing _override _selectStmt ->
+                let Ast.InsertTarget qname _alias = target
+                in ["INSERT INTO " <> Text.unpack (qualifiedNameToText qname)]
+            _ -> []
+    _ -> []

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -27,7 +27,8 @@ import           IHP.TypedSql.Metadata          (DescribeColumn (..), DescribeRe
                                                  describeStatement)
 import           IHP.TypedSql.ParamHints        (extractParamHintsFromAst, extractJoinNullableTablesFromAst,
                                                  extractNonNullableComputedColumnsFromAst,
-                                                 parseSql, resolveParamHintTypes, detectStarSelects)
+                                                 parseSql, resolveParamHintTypes, detectStarSelects,
+                                                 detectInsertWithoutColumns)
 import           IHP.TypedSql.Placeholders      (PlaceholderPlan (..), parseExpr,
                                                  planPlaceholders)
 import           IHP.TypedSql.RowType           (SqlRow (..), sanitizeColumnName, deduplicateNames, sqlRowType)
@@ -91,6 +92,13 @@ typedSqlExp allowStar rawSql = do
                     fail ("typedSql: SELECT " <> List.intercalate ", " stars
                         <> " is not allowed because it can break at runtime when the schema changes. "
                         <> "List columns explicitly:\n  SELECT " <> suggestion <> " FROM ...\n"
+                        <> "Or use [typedSqlStar| ... |] if you understand the risk.")
+                let inserts = detectInsertWithoutColumns ast
+                unless (null inserts) do
+                    fail ("typedSql: " <> List.intercalate ", " inserts
+                        <> " without an explicit column list is not allowed because "
+                        <> "column order can drift between dev and production. "
+                        <> "List columns explicitly:\n  INSERT INTO table (col1, col2, ...) VALUES (...)\n"
                         <> "Or use [typedSqlStar| ... |] if you understand the risk.")
             Nothing -> pure ()
 

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -11,7 +11,8 @@ import           IHP.ModelSupport                  (createModelContext,
 import           IHP.Prelude
 import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullableTables,
                                                     extractNonNullableComputedColumnsFromAst,
-                                                    detectStarSelects)
+                                                    detectStarSelects,
+                                                    detectInsertWithoutColumns)
 import           System.Directory                  (doesFileExist,
                                                     getCurrentDirectory)
 import           System.Environment                (getEnvironment, lookupEnv)
@@ -72,6 +73,11 @@ tests = do
             (mkTestModule "TypedQuery Text"
                 "[typedSql| SELECT typed_sql_test_items.* FROM typed_sql_test_items LIMIT 1 |]")
             ["is not allowed"]
+
+        compileFailTest "fails when INSERT VALUES has no explicit column list"
+            (mkTestModule "TypedQuery Text"
+                "[typedSql| INSERT INTO typed_sql_test_items VALUES ('00000000-0000-0000-0000-000000000099'::uuid, '00000000-0000-0000-0000-000000000001'::uuid, 'X', 1, 1.0, ARRAY['x']::text[]) RETURNING name |]")
+            ["explicit column list"]
 
         compileFailTest "fails when SQL references an unknown column"
             (mkTestModule "TypedQuery Text"
@@ -416,6 +422,26 @@ tests = do
         it "detectStarSelects detects star in parenthesized SELECT" do
             let Just ast = parseSql "(SELECT * FROM items)"
             detectStarSelects ast `shouldBe` ["*"]
+
+        it "detectInsertWithoutColumns detects INSERT VALUES without column list" do
+            let Just ast = parseSql "INSERT INTO items VALUES (1, 'name')"
+            detectInsertWithoutColumns ast `shouldBe` ["INSERT INTO items"]
+
+        it "detectInsertWithoutColumns detects INSERT SELECT without column list" do
+            let Just ast = parseSql "INSERT INTO items SELECT 1, 'name'"
+            detectInsertWithoutColumns ast `shouldBe` ["INSERT INTO items"]
+
+        it "detectInsertWithoutColumns does not flag INSERT with column list" do
+            let Just ast = parseSql "INSERT INTO items (id, name) VALUES (1, 'name')"
+            detectInsertWithoutColumns ast `shouldBe` []
+
+        it "detectInsertWithoutColumns does not flag INSERT DEFAULT VALUES" do
+            let Just ast = parseSql "INSERT INTO items DEFAULT VALUES"
+            detectInsertWithoutColumns ast `shouldBe` []
+
+        it "detectInsertWithoutColumns does not flag SELECT" do
+            let Just ast = parseSql "SELECT * FROM items"
+            detectInsertWithoutColumns ast `shouldBe` []
 
 -- Test helpers ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extends the `SELECT *` compile-time guard from #2621 to INSERT statements that omit the column list — they have the same column-order drift risk between dev and production.

```haskell
-- ❌ Now a compile error
[typedSql| INSERT INTO foo VALUES (${a}, ${b}, ${c}) |]
[typedSql| INSERT INTO foo SELECT a, b, c FROM bar |]

-- ✅ Safe — explicit column binding
[typedSql| INSERT INTO foo (col1, col2, col3) VALUES (${a}, ${b}, ${c}) |]
[typedSql| INSERT INTO foo DEFAULT VALUES |]

-- ✅ Escape hatch (existing)
[typedSqlStar| INSERT INTO foo VALUES (...) |]
```

Addresses https://github.com/digitallyinduced/ihp/pull/2621#issuecomment-4364049158.

`RETURNING *` (raised in [comment 4363993810](https://github.com/digitallyinduced/ihp/pull/2621#issuecomment-4363993810)) is the same risk class but left as a separate follow-up.

## Test plan

- [x] 5 new pure unit tests for `detectInsertWithoutColumns` (VALUES without cols, SELECT without cols, with explicit cols, DEFAULT VALUES, plain SELECT)
- [x] 1 new compile-fail test covering the end-to-end TH path
- [x] All 98 tests pass (was 97; new compile-fail test adds 1)
- [x] No regressions — every existing INSERT in the test suite already uses an explicit column list

🤖 Generated with [Claude Code](https://claude.com/claude-code)