### PR TITLE
Fix initAuthentication to read raw UUID ASCII bytes from session

### DIFF
--- a/ihp/IHP/LoginSupport/Middleware.hs
+++ b/ihp/IHP/LoginSupport/Middleware.hs
@@ -221,6 +221,13 @@ initAuthentication :: forall user normalizedModel.
         , KnownSymbol (GetModelName user)
     ) => IO ()
 initAuthentication = do
-    user <- getSession @(Id user) (sessionKey @user)
-            >>= fetchOneOrNothing
+    userId <- case lookupSessionVault ?request of
+        Just (lookupFn, _) -> do
+            rawValue <- lookupFn (sessionKey @user)
+            pure $ case rawValue of
+                Nothing -> Nothing
+                Just "" -> Nothing
+                Just bs -> Id <$> parseSessionUUID bs
+        Nothing -> pure Nothing
+    user <- fetchOneOrNothing userId
     putContext user

--- a/ihp/IHP/LoginSupport/Middleware.hs
+++ b/ihp/IHP/LoginSupport/Middleware.hs
@@ -221,13 +221,13 @@ initAuthentication :: forall user normalizedModel.
         , KnownSymbol (GetModelName user)
     ) => IO ()
 initAuthentication = do
-    userId <- case lookupSessionVault ?request of
+    maybeUuid <- case lookupSessionVault ?request of
         Just (lookupFn, _) -> do
             rawValue <- lookupFn (sessionKey @user)
             pure $ case rawValue of
                 Nothing -> Nothing
                 Just "" -> Nothing
-                Just bs -> Id <$> parseSessionUUID bs
+                Just bs -> parseSessionUUID bs
         Nothing -> pure Nothing
-    user <- fetchOneOrNothing userId
+    user <- fetchOneOrNothing (fmap Id maybeUuid :: Maybe (Id user))
     putContext user


### PR DESCRIPTION
Auth Login Broke silently on a legacy app I had which used initAuthentication. Claude diagnosed this:

The login function was changed to write raw UUID ASCII bytes via sessionInsert, but initAuthentication still used getSession which goes through Serialize.decode expecting a length-prefixed wire format. This caused a silent format mismatch where sessions written by login could never be read back by initAuthentication.

Use the same lookupSessionVault + parseSessionUUID pattern used by userIdMiddlewareFor to read raw ASCII bytes directly.