### PR TITLE
Parse VARIADIC function arguments in pg_dump indexes

### DIFF
--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -529,6 +529,7 @@ normalizeExpression (DotExpression a b) = DotExpression (normalizeExpression a) 
 normalizeExpression (ExistsExpression a) = ExistsExpression (normalizeExpression a)
 normalizeExpression (InArrayExpression exprs) = InArrayExpression (map normalizeExpression exprs)
 normalizeExpression (ArrayLiteralExpression exprs) = ArrayLiteralExpression (map normalizeExpression exprs)
+normalizeExpression (VariadicExpression expr) = VariadicExpression (normalizeExpression expr)
 
 -- | Replaces @table.field@ with just @field@
 --
@@ -566,6 +567,7 @@ unqualifyExpression scope expression = doUnqualify expression
         doUnqualify (ExistsExpression a) = ExistsExpression (doUnqualify a)
         doUnqualify (InArrayExpression exprs) = InArrayExpression (map doUnqualify exprs)
         doUnqualify (ArrayLiteralExpression exprs) = ArrayLiteralExpression (map doUnqualify exprs)
+        doUnqualify (VariadicExpression expr) = VariadicExpression (doUnqualify expr)
         doUnqualify (DotExpression (VarExpression scope') b) | scope == scope' = VarExpression b
         doUnqualify (DotExpression a b) = DotExpression (doUnqualify a) b
 
@@ -600,6 +602,7 @@ resolveAlias (Just alias) fromExpression expression =
         e@(ConcatenationExpression a b) -> ConcatenationExpression (rec a) (rec b)
         e@(InArrayExpression exprs) -> InArrayExpression (map rec exprs)
         e@(ArrayLiteralExpression exprs) -> ArrayLiteralExpression (map rec exprs)
+        e@(VariadicExpression expr) -> VariadicExpression (rec expr)
 resolveAlias Nothing fromExpression expression = expression
 
 normalizeSqlType :: PostgresType -> PostgresType

--- a/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
@@ -590,6 +590,7 @@ deleteColumn DeleteColumnOptions { .. } schema =
                 isRef (NotExpression a) = isRef a
                 isRef (ExistsExpression a) = isRef a
                 isRef (OrExpression a b) = isRef a || isRef b
+                isRef (VariadicExpression a) = isRef a
                 isRef (LessThanExpression a b) = isRef a || isRef b
                 isRef (LessThanOrEqualToExpression a b) = isRef a || isRef b
                 isRef (GreaterThanExpression a b) = isRef a || isRef b
@@ -651,6 +652,7 @@ isIndexStatementReferencingTableColumn statement tableName columnName = isRefere
             NotExpression a -> expressionReferencesColumn a
             ExistsExpression a -> expressionReferencesColumn a
             OrExpression a b -> expressionReferencesColumn a || expressionReferencesColumn b
+            VariadicExpression a -> expressionReferencesColumn a
             LessThanExpression a b -> expressionReferencesColumn a || expressionReferencesColumn b
             LessThanOrEqualToExpression a b -> expressionReferencesColumn a || expressionReferencesColumn b
             GreaterThanExpression a b -> expressionReferencesColumn a || expressionReferencesColumn b

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -1118,6 +1118,12 @@ CREATE POLICY "Users can read and edit their own record" ON public.users USING (
 
                 diffSchemas targetSchema actualSchema `shouldBe` migration 
 
+            it "should normalize variadic index expressions" do
+                let targetSchema = sql "CREATE INDEX agent_runs_source_idx ON agent_runs (jsonb_extract_path_text(input, VARIADIC ARRAY['source'::text]));"
+                let actualSchema = sql "CREATE INDEX agent_runs_source_idx ON agent_runs (JSONB_EXTRACT_PATH_TEXT(input, VARIADIC ARRAY['source'::TEXT]));"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "should handle complex renames" do
                 -- See https://github.com/digitallyinduced/thin-backend/issues/66
                 let targetSchema = sql $ cs [plain|

--- a/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -711,6 +711,46 @@ tests = do
                     , nullsDistinct = True
                     }
 
+        it "should parse a pg_dump CREATE INDEX with VARIADIC function arguments" do
+            let sql = cs [plain|
+CREATE INDEX agent_runs_ingest_gmail_message_latest_idx ON public.agent_runs USING btree (organization_id, jsonb_extract_path_text(input, VARIADIC ARRAY['gmailMessageId'::text]), COALESCE(completed_at, last_event_at, started_at, created_at) DESC, id DESC) WHERE ((type = 'ingest'::public.agent_run_type) AND (jsonb_extract_path_text(input, VARIADIC ARRAY['source'::text]) = 'gmail_email_ingest'::text));
+            |]
+            parseSql sql `shouldBe` CreateIndex
+                    { indexName = "agent_runs_ingest_gmail_message_latest_idx"
+                    , unique = False
+                    , tableName = "agent_runs"
+                    , columns =
+                            [ indexCol (VarExpression "organization_id")
+                            , indexCol (CallExpression "jsonb_extract_path_text"
+                                [ VarExpression "input"
+                                , VariadicExpression (ArrayLiteralExpression [TypeCastExpression (TextExpression "gmailMessageId") PText])
+                                ])
+                            , IndexColumn
+                                { column = CallExpression "COALESCE"
+                                    [ VarExpression "completed_at"
+                                    , VarExpression "last_event_at"
+                                    , VarExpression "started_at"
+                                    , VarExpression "created_at"
+                                    ]
+                                , columnOrder = [Desc]
+                                }
+                            , IndexColumn { column = VarExpression "id", columnOrder = [Desc] }
+                            ]
+                    , whereClause = Just
+                        (AndExpression
+                            (EqExpression
+                                (VarExpression "type")
+                                (TypeCastExpression (TextExpression "ingest") (PCustomType "agent_run_type")))
+                            (EqExpression
+                                (CallExpression "jsonb_extract_path_text"
+                                    [ VarExpression "input"
+                                    , VariadicExpression (ArrayLiteralExpression [TypeCastExpression (TextExpression "source") PText])
+                                    ])
+                                (TypeCastExpression (TextExpression "gmail_email_ingest") PText)))
+                    , indexType = Just Btree
+                    , nullsDistinct = True
+                    }
+
         it "should parse a CREATE OR REPLACE FUNCTION ..() RETURNS TRIGGER .." do
             parseSql "CREATE OR REPLACE FUNCTION notify_did_insert_webrtc_connection() RETURNS TRIGGER AS $$ BEGIN PERFORM pg_notify('did_insert_webrtc_connection', json_build_object('id', NEW.id, 'floor_id', NEW.floor_id, 'source_user_id', NEW.source_user_id, 'target_user_id', NEW.target_user_id)::text); RETURN NEW; END; $$ language plpgsql;" `shouldBe` (function "notify_did_insert_webrtc_connection")
                     { functionBody = " BEGIN PERFORM pg_notify('did_insert_webrtc_connection', json_build_object('id', NEW.id, 'floor_id', NEW.floor_id, 'source_user_id', NEW.source_user_id, 'target_user_id', NEW.target_user_id)::text); RETURN NEW; END; "

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -147,6 +147,7 @@ compileExpression (IsExpression a b) = compileExpressionWithOptionalParenthese a
 compileExpression (InExpression a b) = compileExpressionWithOptionalParenthese a <> " IN " <> compileExpressionWithOptionalParenthese b
 compileExpression (InArrayExpression values) = "(" <> intercalate ", " (map compileExpression values) <> ")"
 compileExpression (ArrayLiteralExpression values) = "ARRAY[" <> intercalate ", " (map compileExpression values) <> "]"
+compileExpression (VariadicExpression value) = "VARIADIC " <> compileExpressionWithOptionalParenthese value
 compileExpression (NotExpression a) = "NOT " <> compileExpressionWithOptionalParenthese a
 compileExpression (AndExpression a b) = compileExpressionWithOptionalParenthese a <> " AND " <> compileExpressionWithOptionalParenthese b
 compileExpression (OrExpression a b) = compileExpressionWithOptionalParenthese a <> " OR " <> compileExpressionWithOptionalParenthese b
@@ -178,6 +179,7 @@ compileExpressionWithOptionalParenthese expr@(DotExpression (VarExpression {}) b
 compileExpressionWithOptionalParenthese expr@(ConcatenationExpression a b ) = compileExpression expr
 compileExpressionWithOptionalParenthese expr@(InArrayExpression values) = compileExpression expr
 compileExpressionWithOptionalParenthese expr@(ArrayLiteralExpression _) = compileExpression expr
+compileExpressionWithOptionalParenthese expr@(VariadicExpression _) = compileExpression expr
 compileExpressionWithOptionalParenthese expression = "(" <> compileExpression expression <> ")"
 
 -- | Compare statements for sorting in schema output

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -477,7 +477,7 @@ intervalFields =  [ "YEAR TO MONTH", "DAY TO HOUR", "DAY TO MINUTE", "DAY TO SEC
                    , "YEAR",  "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"]
 
 
-term = parens expression <|> try arrayExpr <|> try callExpr <|> try doubleExpr <|> try intExpr <|> selectExpr <|> varExpr <|> (textExpr <* optional space)
+term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try callExpr <|> try doubleExpr <|> try intExpr <|> selectExpr <|> varExpr <|> (textExpr <* optional space)
     where
         parens f = between (char '(' >> space) (char ')' >> space) f
 
@@ -560,6 +560,14 @@ arrayExpr = do
     values <- between (char '[' >> space) (char ']') (expression `sepBy` (char ',' >> space))
     space
     pure (ArrayLiteralExpression values)
+
+-- | Parses a PostgreSQL VARIADIC function argument like @VARIADIC ARRAY['a']@.
+variadicExpr :: Parser Expression
+variadicExpr = do
+    lexeme do
+        string' "VARIADIC"
+        notFollowedBy (satisfy \c -> isAlphaNum c || c == '_')
+    VariadicExpression <$> expression
 
 textExpr :: Parser Expression
 textExpr = TextExpression <$> textExpr'

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -567,6 +567,8 @@ variadicExpr = do
     lexeme do
         string' "VARIADIC"
         notFollowedBy (satisfy \c -> isAlphaNum c || c == '_')
+    -- Use expression rather than term so postfix type casts stay part of the
+    -- variadic argument, e.g. VARIADIC ARRAY['a']::text[].
     VariadicExpression <$> expression
 
 textExpr :: Parser Expression

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -175,6 +175,8 @@ data Expression =
     | InArrayExpression [Expression]
     -- | ARRAY['a', 'b']
     | ArrayLiteralExpression [Expression]
+    -- | VARIADIC ARRAY['a', 'b']
+    | VariadicExpression Expression
     -- | NOT a
     | NotExpression Expression
     -- | EXISTS a

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -153,6 +153,45 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should compile a CREATE INDEX with VARIADIC function arguments" do
+            let sql = "CREATE INDEX agent_runs_ingest_gmail_message_latest_idx ON agent_runs USING BTREE (organization_id, jsonb_extract_path_text(input, VARIADIC ARRAY['gmailMessageId'::TEXT]), COALESCE(completed_at, last_event_at, started_at, created_at) DESC, id DESC) WHERE type = ('ingest'::agent_run_type) AND jsonb_extract_path_text(input, VARIADIC ARRAY['source'::TEXT]) = ('gmail_email_ingest'::TEXT);\n"
+            let statement = CreateIndex
+                    { indexName = "agent_runs_ingest_gmail_message_latest_idx"
+                    , unique = False
+                    , tableName = "agent_runs"
+                    , columns =
+                            [ indexCol (VarExpression "organization_id")
+                            , indexCol (CallExpression "jsonb_extract_path_text"
+                                [ VarExpression "input"
+                                , VariadicExpression (ArrayLiteralExpression [TypeCastExpression (TextExpression "gmailMessageId") PText])
+                                ])
+                            , IndexColumn
+                                { column = CallExpression "COALESCE"
+                                    [ VarExpression "completed_at"
+                                    , VarExpression "last_event_at"
+                                    , VarExpression "started_at"
+                                    , VarExpression "created_at"
+                                    ]
+                                , columnOrder = [Desc]
+                                }
+                            , IndexColumn { column = VarExpression "id", columnOrder = [Desc] }
+                            ]
+                    , whereClause = Just
+                        (AndExpression
+                            (EqExpression
+                                (VarExpression "type")
+                                (TypeCastExpression (TextExpression "ingest") (PCustomType "agent_run_type")))
+                            (EqExpression
+                                (CallExpression "jsonb_extract_path_text"
+                                    [ VarExpression "input"
+                                    , VariadicExpression (ArrayLiteralExpression [TypeCastExpression (TextExpression "source") PText])
+                                    ])
+                                (TypeCastExpression (TextExpression "gmail_email_ingest") PText)))
+                    , indexType = Just Btree
+                    , nullsDistinct = True
+                    }
+            compileSql [statement] `shouldBe` sql
+
         it "should compile 'ENABLE ROW LEVEL SECURITY' statements" do
             let sql = "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;\n"
             let statements = [EnableRowLevelSecurity { tableName = "tasks" }]

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -153,6 +153,44 @@ spec = do
                     , nullsDistinct = True
                     }
 
+        it "should parse a pg_dump CREATE INDEX with VARIADIC function arguments" do
+            let sql = "CREATE INDEX agent_runs_ingest_gmail_message_latest_idx ON public.agent_runs USING btree (organization_id, jsonb_extract_path_text(input, VARIADIC ARRAY['gmailMessageId'::text]), COALESCE(completed_at, last_event_at, started_at, created_at) DESC, id DESC) WHERE ((type = 'ingest'::public.agent_run_type) AND (jsonb_extract_path_text(input, VARIADIC ARRAY['source'::text]) = 'gmail_email_ingest'::text));"
+            parseSql sql `shouldBe` CreateIndex
+                    { indexName = "agent_runs_ingest_gmail_message_latest_idx"
+                    , unique = False
+                    , tableName = "agent_runs"
+                    , columns =
+                            [ indexCol (VarExpression "organization_id")
+                            , indexCol (CallExpression "jsonb_extract_path_text"
+                                [ VarExpression "input"
+                                , VariadicExpression (ArrayLiteralExpression [TypeCastExpression (TextExpression "gmailMessageId") PText])
+                                ])
+                            , IndexColumn
+                                { column = CallExpression "COALESCE"
+                                    [ VarExpression "completed_at"
+                                    , VarExpression "last_event_at"
+                                    , VarExpression "started_at"
+                                    , VarExpression "created_at"
+                                    ]
+                                , columnOrder = [Desc]
+                                }
+                            , IndexColumn { column = VarExpression "id", columnOrder = [Desc] }
+                            ]
+                    , whereClause = Just
+                        (AndExpression
+                            (EqExpression
+                                (VarExpression "type")
+                                (TypeCastExpression (TextExpression "ingest") (PCustomType "agent_run_type")))
+                            (EqExpression
+                                (CallExpression "jsonb_extract_path_text"
+                                    [ VarExpression "input"
+                                    , VariadicExpression (ArrayLiteralExpression [TypeCastExpression (TextExpression "source") PText])
+                                    ])
+                                (TypeCastExpression (TextExpression "gmail_email_ingest") PText)))
+                    , indexType = Just Btree
+                    , nullsDistinct = True
+                    }
+
         it "should parse 'ENABLE ROW LEVEL SECURITY' statements" do
             parseSql "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;" `shouldBe` EnableRowLevelSecurity { tableName = "tasks" }
 


### PR DESCRIPTION
## Summary
- add a `VariadicExpression` node to the postgres parser AST
- parse and compile `VARIADIC <expression>` function arguments
- teach schema diff/reference walkers to recurse through variadic arguments
- add parser/compiler/migration regressions for pg_dump expression indexes using `jsonb_extract_path_text(..., VARIADIC ARRAY[...])`

## Root Cause
pg_dump emits JSONB path calls as `jsonb_extract_path_text(input, VARIADIC ARRAY[...])`. The parser did not understand `VARIADIC` inside function arguments, so `callExpr` backtracked and the following `(` was reported as unexpected while parsing CREATE INDEX expressions.

## Validation
- `ghci ihp-postgres-parser/Test/Postgres/ParserSpec.hs`: 34 examples, 0 failures
- `ghci ihp-postgres-parser/Test/Postgres/CompilerSpec.hs`: 24 examples, 0 failures
- `ghci ihp-ide/Test/Main.hs`: 403 examples, 0 failures