### PR TITLE
Parse pgvector column and index syntax

### DIFF
--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -738,9 +738,10 @@ normalizeIndexType (Just Btree) = Nothing
 normalizeIndexType indexType = indexType
 
 normalizeIndexColumn :: IndexColumn -> IndexColumn
-normalizeIndexColumn IndexColumn { column, columnOrder } =
+normalizeIndexColumn IndexColumn { column, columnOperatorClass, columnOrder } =
     IndexColumn
         { column = normalizeExpression column
+        , columnOperatorClass
         , columnOrder = normalizeIndexColumnOrder columnOrder
         }
 

--- a/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
@@ -230,7 +230,7 @@ newColumnIndex tableName columnName =
     { indexName = tableName <> "_" <> columnName <> "_index"
     , unique = False
     , tableName
-    , columns = [IndexColumn { column = VarExpression columnName, columnOrder = [] }]
+    , columns = [indexCol (VarExpression columnName)]
     , whereClause = Nothing
     , indexType = Nothing
     , nullsDistinct = True
@@ -257,7 +257,7 @@ addForeignKeyConstraint :: Text -> Text -> Text -> Text -> OnDelete -> [Statemen
 addForeignKeyConstraint tableName columnName constraintName referenceTable onDelete list = list <> [AddConstraint { tableName = tableName, constraint = ForeignKeyConstraint { name = Just constraintName, columnName = columnName, referenceTable = referenceTable, referenceColumn = "id", onDelete = (Just onDelete) }, deferrable = Nothing, deferrableType = Nothing }]
 
 addTableIndex :: Text -> Bool -> Text -> [Text] -> [Statement] -> [Statement]
-addTableIndex indexName unique tableName columnNames list = list <> [CreateIndex { indexName, unique, tableName, columns = columnNames |> map (\columnName -> IndexColumn { column = VarExpression columnName, columnOrder = [] }), whereClause = Nothing, indexType = Nothing, nullsDistinct = True }]
+addTableIndex indexName unique tableName columnNames list = list <> [CreateIndex { indexName, unique, tableName, columns = columnNames |> map (indexCol . VarExpression), whereClause = Nothing, indexType = Nothing, nullsDistinct = True }]
 
 -- | An enum is added after all existing enum statements, but right before @CREATE TABLE@ statements
 addEnum :: Text -> Schema -> Schema

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -771,6 +771,16 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "should not diff pgvector indexes with operator classes" do
+                let targetSchema = sql [i|
+                    CREATE INDEX knowledge_chunks_embedding_hnsw_idx ON knowledge_chunks USING HNSW (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;
+                |]
+                let actualSchema = sql [i|
+                    CREATE INDEX knowledge_chunks_embedding_hnsw_idx ON public.knowledge_chunks USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;
+                |]
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "should not detect a difference between two functions when the only difference is between 'CREATE' and 'CREATE OR REPLACE'" do
                 let targetSchema = sql [i|
                     CREATE OR REPLACE FUNCTION notify_did_insert_webrtc_connection() RETURNS TRIGGER AS $$

--- a/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
@@ -603,7 +603,7 @@ tests = do
                     { indexName = "users_index"
                     , unique = True
                     , tableName = "users"
-                    , columns = [IndexColumn { column = VarExpression "user_name", columnOrder = [Asc, NullsFirst]}]
+                    , columns = [IndexColumn { column = VarExpression "user_name", columnOperatorClass = Nothing, columnOrder = [Asc, NullsFirst]}]
                     , whereClause = Nothing
                     , indexType = Nothing
                     , nullsDistinct = True
@@ -616,9 +616,30 @@ tests = do
                     { indexName = "users_index"
                     , unique = True
                     , tableName = "users"
-                    , columns = [IndexColumn { column = VarExpression "user_name", columnOrder = [Desc, NullsLast]}]
+                    , columns = [IndexColumn { column = VarExpression "user_name", columnOperatorClass = Nothing, columnOrder = [Desc, NullsLast]}]
                     , whereClause = Nothing
                     , indexType = Nothing
+                    , nullsDistinct = True
+                    }
+            compileSql [statement] `shouldBe` sql
+
+        it "should compile pgvector column types with dimensions" do
+            let sql = "ALTER TABLE knowledge_chunks ADD COLUMN embedding VECTOR(1536) DEFAULT NULL;\n"
+            let statement = AddColumn
+                    { tableName = "knowledge_chunks"
+                    , column = (col "embedding" (PCustomType "VECTOR(1536)")) { defaultValue = Just (VarExpression "NULL") }
+                    }
+            compileSql [statement] `shouldBe` sql
+
+        it "should compile pgvector HNSW indexes with operator classes" do
+            let sql = "CREATE INDEX knowledge_chunks_embedding_hnsw_idx ON knowledge_chunks USING HNSW (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;\n"
+            let statement = CreateIndex
+                    { indexName = "knowledge_chunks_embedding_hnsw_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_cosine_ops", columnOrder = [] }]
+                    , whereClause = Just (IsExpression (VarExpression "embedding") (NotExpression (VarExpression "NULL")))
+                    , indexType = Just Hnsw
                     , nullsDistinct = True
                     }
             compileSql [statement] `shouldBe` sql

--- a/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
@@ -644,6 +644,19 @@ tests = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should compile pgvector IVFFLAT indexes with operator classes" do
+            let sql = "CREATE INDEX knowledge_chunks_embedding_ivfflat_idx ON knowledge_chunks USING IVFFLAT (embedding vector_l2_ops);\n"
+            let statement = CreateIndex
+                    { indexName = "knowledge_chunks_embedding_ivfflat_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_l2_ops", columnOrder = [] }]
+                    , whereClause = Nothing
+                    , indexType = Just Ivfflat
+                    , nullsDistinct = True
+                    }
+            compileSql [statement] `shouldBe` sql
+
         it "should compile a CREATE OR REPLACE FUNCTION ..() RETURNS TRIGGER .." do
             let sql = cs [plain|CREATE OR REPLACE FUNCTION notify_did_insert_webrtc_connection() RETURNS TRIGGER AS $$ BEGIN PERFORM pg_notify('did_insert_webrtc_connection', json_build_object('id', NEW.id, 'floor_id', NEW.floor_id, 'source_user_id', NEW.source_user_id, 'target_user_id', NEW.target_user_id)::text); RETURN NEW; END; $$ language plpgsql;\n|]
             let statement = (function "notify_did_insert_webrtc_connection")

--- a/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -679,7 +679,7 @@ tests = do
                     { indexName = "users_index"
                     , unique = True
                     , tableName = "users"
-                    , columns = [IndexColumn { column = VarExpression "user_name", columnOrder = [Asc, NullsFirst] }]
+                    , columns = [IndexColumn { column = VarExpression "user_name", columnOperatorClass = Nothing, columnOrder = [Asc, NullsFirst] }]
                     , whereClause = Nothing
                     , indexType = Nothing
                     , nullsDistinct = True
@@ -690,9 +690,26 @@ tests = do
                     { indexName = "users_index"
                     , unique = True
                     , tableName = "users"
-                    , columns = [IndexColumn { column = VarExpression "user_name", columnOrder = [Desc, NullsLast] }]
+                    , columns = [IndexColumn { column = VarExpression "user_name", columnOperatorClass = Nothing, columnOrder = [Desc, NullsLast] }]
                     , whereClause = Nothing
                     , indexType = Nothing
+                    , nullsDistinct = True
+                    }
+
+        it "should parse pgvector column types with dimensions" do
+            parseSql "ALTER TABLE knowledge_chunks ADD COLUMN embedding VECTOR(1536) DEFAULT NULL;" `shouldBe` AddColumn
+                    { tableName = "knowledge_chunks"
+                    , column = (col "embedding" (PCustomType "VECTOR(1536)")) { defaultValue = Just (VarExpression "NULL") }
+                    }
+
+        it "should parse pgvector HNSW indexes with operator classes" do
+            parseSql "CREATE INDEX knowledge_chunks_embedding_hnsw_idx ON knowledge_chunks USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;" `shouldBe` CreateIndex
+                    { indexName = "knowledge_chunks_embedding_hnsw_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_cosine_ops", columnOrder = [] }]
+                    , whereClause = Just (IsExpression (VarExpression "embedding") (NotExpression (VarExpression "NULL")))
+                    , indexType = Just Hnsw
                     , nullsDistinct = True
                     }
 

--- a/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -713,6 +713,17 @@ tests = do
                     , nullsDistinct = True
                     }
 
+        it "should parse pgvector IVFFLAT indexes with operator classes" do
+            parseSql "CREATE INDEX knowledge_chunks_embedding_ivfflat_idx ON knowledge_chunks USING ivfflat (embedding vector_l2_ops);" `shouldBe` CreateIndex
+                    { indexName = "knowledge_chunks_embedding_ivfflat_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_l2_ops", columnOrder = [] }]
+                    , whereClause = Nothing
+                    , indexType = Just Ivfflat
+                    , nullsDistinct = True
+                    }
+
         it "should parse a CREATE INDEX with a coalesce expression" do
             parseSql "CREATE UNIQUE INDEX user_invite_uniqueness ON user_invites (organization_id, email, coalesce(expires_at, '0001-01-01 01:01:01-04'));\n" `shouldBe` CreateIndex
                     { indexName = "user_invite_uniqueness"

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -518,7 +518,7 @@ compileIndexType Ivfflat = "IVFFLAT"
 
 compileIndexColumn :: IndexColumn -> Text
 compileIndexColumn IndexColumn { column, columnOperatorClass, columnOrder } =
-    unwords ([compileExpression column] <> maybeToList columnOperatorClass <> (columnOrder & map compileIndexColumnOrder))
+    unwords ([compileExpression column] <> maybeToList (compileIdentifier <$> columnOperatorClass) <> (columnOrder & map compileIndexColumnOrder))
 
 compileIndexColumnOrder :: IndexColumnOrder -> Text
 compileIndexColumnOrder Asc = "ASC"

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -7,7 +7,7 @@ module IHP.Postgres.Compiler (compileSql, compileIdentifier, compileExpression, 
 
 import Prelude hiding (unlines, unwords)
 import IHP.Postgres.Types
-import Data.Maybe (fromJust, isJust, catMaybes, fromMaybe)
+import Data.Maybe (fromJust, isJust, catMaybes, fromMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Function ((&))
@@ -507,13 +507,18 @@ compileGenerator ColumnGenerator { generate, stored } =
     <> (if stored then " STORED" else "")
 
 compileIndexType :: IndexType -> Text
-compileIndexType Gin = "GIN"
 compileIndexType Btree = "BTREE"
+compileIndexType Hash = "HASH"
 compileIndexType Gist = "GIST"
+compileIndexType Spgist = "SPGIST"
+compileIndexType Gin = "GIN"
+compileIndexType Brin = "BRIN"
+compileIndexType Hnsw = "HNSW"
+compileIndexType Ivfflat = "IVFFLAT"
 
 compileIndexColumn :: IndexColumn -> Text
-compileIndexColumn IndexColumn { column, columnOrder = [] } = compileExpression column
-compileIndexColumn IndexColumn { column, columnOrder } = compileExpression column <> " " <> unwords (columnOrder & map compileIndexColumnOrder)
+compileIndexColumn IndexColumn { column, columnOperatorClass, columnOrder } =
+    unwords ([compileExpression column] <> maybeToList columnOperatorClass <> (columnOrder & map compileIndexColumnOrder))
 
 compileIndexColumnOrder :: IndexColumnOrder -> Text
 compileIndexColumnOrder Asc = "ASC"

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -468,7 +468,14 @@ sqlType = choice $ map optionalArray
                         lexeme "public"
                         char '.'
                     theType <- try (takeWhile1P (Just "Custom type") (\c -> isAlphaNum c || c == '_'))
-                    pure (PCustomType theType)
+                    typeModifier <- optional do
+                        char '('
+                        space
+                        value <- Text.strip <$> takeWhile1P (Just "Custom type modifier") (/= ')')
+                        char ')'
+                        space
+                        pure value
+                    pure (PCustomType (maybe theType (\value -> theType <> "(" <> value <> ")") typeModifier))
 
 
 intervalFields :: [Text]
@@ -636,17 +643,29 @@ parseIndexColumns = parseIndexColumn `sepBy` (char ',' >> space)
 
 parseIndexColumn = do
     column <- expression
+    columnOperatorClass <- optional parseIndexColumnOperatorClass
     orderOption1 <- optional $ space *> lexeme "ASC" $> Asc <|> space *> lexeme "DESC" $> Desc
     orderOption2 <- optional $ space *> lexeme "NULLS FIRST" $> NullsFirst <|> space *> lexeme "NULLS LAST" $> NullsLast
-    pure IndexColumn { column, columnOrder = catMaybes [orderOption1, orderOption2] }
+    pure IndexColumn { column, columnOperatorClass, columnOrder = catMaybes [orderOption1, orderOption2] }
+
+parseIndexColumnOperatorClass = try do
+    operatorClass <- qualifiedIdentifier
+    when (Text.toUpper operatorClass `elem` ["ASC", "DESC", "NULLS"]) do
+        fail "Expected index operator class"
+    pure operatorClass
 
 parseIndexType = do
     lexeme "USING"
 
     choice $ map (\(s, v) -> do symbol' s; pure v)
         [ ("btree", Btree)
-        , ("gin", Gin)
+        , ("hash", Hash)
         , ("gist", Gist)
+        , ("spgist", Spgist)
+        , ("gin", Gin)
+        , ("brin", Brin)
+        , ("hnsw", Hnsw)
+        , ("ivfflat", Ivfflat)
         ]
 
 createFunction = do

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -468,10 +468,11 @@ sqlType = choice $ map optionalArray
                         lexeme "public"
                         char '.'
                     theType <- try (takeWhile1P (Just "Custom type") (\c -> isAlphaNum c || c == '_'))
-                    typeModifier <- optional do
+                    -- Custom typmods are flat here; nested parenthesized
+                    -- modifiers are not supported by this parser.
+                    typeModifier <- optional $ try do
                         char '('
-                        space
-                        value <- Text.strip <$> takeWhile1P (Just "Custom type modifier") (/= ')')
+                        value <- takeWhile1P (Just "Custom type modifier") (/= ')')
                         char ')'
                         space
                         pure value
@@ -650,6 +651,9 @@ parseIndexColumn = do
 
 parseIndexColumnOperatorClass = try do
     operatorClass <- qualifiedIdentifier
+    -- These tokens belong to index column ordering, not operator classes.
+    -- Extend this list if the parser grows support for more index-column
+    -- clauses such as COLLATE.
     when (Text.toUpper operatorClass `elem` ["ASC", "DESC", "NULLS"]) do
         fail "Expected index operator class"
     pure operatorClass
@@ -657,16 +661,23 @@ parseIndexColumnOperatorClass = try do
 parseIndexType = do
     lexeme "USING"
 
-    choice $ map (\(s, v) -> do symbol' s; pure v)
+    choice $ map (uncurry parseIndexTypeKeyword)
         [ ("btree", Btree)
         , ("hash", Hash)
-        , ("gist", Gist)
         , ("spgist", Spgist)
+        , ("gist", Gist)
         , ("gin", Gin)
         , ("brin", Brin)
         , ("hnsw", Hnsw)
         , ("ivfflat", Ivfflat)
         ]
+
+parseIndexTypeKeyword :: Text -> IndexType -> Parser IndexType
+parseIndexTypeKeyword keyword indexType = try do
+    string' keyword
+    notFollowedBy (satisfy \c -> isAlphaNum c || c == '_')
+    space
+    pure indexType
 
 createFunction = do
     lexeme "CREATE"

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -265,11 +265,11 @@ data PolicyAction
     | PolicyForDelete
     deriving (Eq, Show)
 
-data IndexType = Btree | Gin | Gist
+data IndexType = Btree | Hash | Gist | Spgist | Gin | Brin | Hnsw | Ivfflat
     deriving (Eq, Show)
 
 data IndexColumn
-    = IndexColumn { column :: Expression, columnOrder :: [IndexColumnOrder] }
+    = IndexColumn { column :: Expression, columnOperatorClass :: Maybe Text, columnOrder :: [IndexColumnOrder] }
     deriving (Eq, Show)
 
 data IndexColumnOrder
@@ -312,7 +312,7 @@ function functionName = CreateFunction
 
 -- | Helper to create an 'IndexColumn' with no column ordering.
 indexCol :: Expression -> IndexColumn
-indexCol column = IndexColumn { column = column, columnOrder = [] }
+indexCol column = IndexColumn { column = column, columnOperatorClass = Nothing, columnOrder = [] }
 
 -- | Helper to create a 'CreatePolicy' with sensible defaults (no action, no using, no check).
 policy :: Text -> Text -> Statement

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -153,6 +153,27 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should compile pgvector column types with dimensions" do
+            let sql = "ALTER TABLE knowledge_chunks ADD COLUMN embedding VECTOR(1536) DEFAULT NULL;\n"
+            let statement = AddColumn
+                    { tableName = "knowledge_chunks"
+                    , column = (col "embedding" (PCustomType "VECTOR(1536)")) { defaultValue = Just (VarExpression "NULL") }
+                    }
+            compileSql [statement] `shouldBe` sql
+
+        it "should compile pgvector HNSW indexes with operator classes" do
+            let sql = "CREATE INDEX knowledge_chunks_embedding_hnsw_idx ON knowledge_chunks USING HNSW (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;\n"
+            let statement = CreateIndex
+                    { indexName = "knowledge_chunks_embedding_hnsw_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_cosine_ops", columnOrder = [] }]
+                    , whereClause = Just (IsExpression (VarExpression "embedding") (NotExpression (VarExpression "NULL")))
+                    , indexType = Just Hnsw
+                    , nullsDistinct = True
+                    }
+            compileSql [statement] `shouldBe` sql
+
         it "should compile 'ENABLE ROW LEVEL SECURITY' statements" do
             let sql = "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;\n"
             let statements = [EnableRowLevelSecurity { tableName = "tasks" }]

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -174,6 +174,46 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should compile pgvector IVFFLAT indexes with operator classes" do
+            let sql = "CREATE INDEX knowledge_chunks_embedding_ivfflat_idx ON knowledge_chunks USING IVFFLAT (embedding vector_l2_ops);\n"
+            let statement = CreateIndex
+                    { indexName = "knowledge_chunks_embedding_ivfflat_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_l2_ops", columnOrder = [] }]
+                    , whereClause = Nothing
+                    , indexType = Just Ivfflat
+                    , nullsDistinct = True
+                    }
+            compileSql [statement] `shouldBe` sql
+
+        it "should compile additional PostgreSQL index methods" do
+            let compileMethod indexType = compileSql [CreateIndex
+                    { indexName = "users_email_idx"
+                    , unique = False
+                    , tableName = "users"
+                    , columns = [indexCol (VarExpression "email")]
+                    , whereClause = Nothing
+                    , indexType = Just indexType
+                    , nullsDistinct = True
+                    }]
+            compileMethod Hash `shouldBe` "CREATE INDEX users_email_idx ON users USING HASH (email);\n"
+            compileMethod Spgist `shouldBe` "CREATE INDEX users_email_idx ON users USING SPGIST (email);\n"
+            compileMethod Brin `shouldBe` "CREATE INDEX users_email_idx ON users USING BRIN (email);\n"
+
+        it "should quote index operator class identifiers" do
+            let sql = "CREATE INDEX knowledge_chunks_embedding_idx ON knowledge_chunks USING HNSW (embedding \"VectorOps\");\n"
+            let statement = CreateIndex
+                    { indexName = "knowledge_chunks_embedding_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "VectorOps", columnOrder = [] }]
+                    , whereClause = Nothing
+                    , indexType = Just Hnsw
+                    , nullsDistinct = True
+                    }
+            compileSql [statement] `shouldBe` sql
+
         it "should compile 'ENABLE ROW LEVEL SECURITY' statements" do
             let sql = "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;\n"
             let statements = [EnableRowLevelSecurity { tableName = "tasks" }]

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -159,6 +159,12 @@ spec = do
                     , column = (col "embedding" (PCustomType "VECTOR(1536)")) { defaultValue = Just (VarExpression "NULL") }
                     }
 
+        it "should preserve custom type modifier contents" do
+            parseSql "ALTER TABLE knowledge_chunks ADD COLUMN embedding VECTOR( 1536 ) DEFAULT NULL;" `shouldBe` AddColumn
+                    { tableName = "knowledge_chunks"
+                    , column = (col "embedding" (PCustomType "VECTOR( 1536 )")) { defaultValue = Just (VarExpression "NULL") }
+                    }
+
         it "should parse pgvector HNSW indexes with operator classes" do
             parseSql "CREATE INDEX knowledge_chunks_embedding_hnsw_idx ON knowledge_chunks USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;" `shouldBe` CreateIndex
                     { indexName = "knowledge_chunks_embedding_hnsw_idx"
@@ -180,6 +186,14 @@ spec = do
                     , indexType = Just Ivfflat
                     , nullsDistinct = True
                     }
+
+        it "should parse additional PostgreSQL index methods" do
+            let parseMethod method = case parseSql ("CREATE INDEX users_email_idx ON users USING " <> method <> " (email);") of
+                    CreateIndex { indexType } -> indexType
+                    _ -> error "Expected CreateIndex"
+            parseMethod "hash" `shouldBe` Just Hash
+            parseMethod "spgist" `shouldBe` Just Spgist
+            parseMethod "brin" `shouldBe` Just Brin
 
         it "should parse 'ENABLE ROW LEVEL SECURITY' statements" do
             parseSql "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;" `shouldBe` EnableRowLevelSecurity { tableName = "tasks" }

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -153,6 +153,34 @@ spec = do
                     , nullsDistinct = True
                     }
 
+        it "should parse pgvector column types with dimensions" do
+            parseSql "ALTER TABLE knowledge_chunks ADD COLUMN embedding VECTOR(1536) DEFAULT NULL;" `shouldBe` AddColumn
+                    { tableName = "knowledge_chunks"
+                    , column = (col "embedding" (PCustomType "VECTOR(1536)")) { defaultValue = Just (VarExpression "NULL") }
+                    }
+
+        it "should parse pgvector HNSW indexes with operator classes" do
+            parseSql "CREATE INDEX knowledge_chunks_embedding_hnsw_idx ON knowledge_chunks USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;" `shouldBe` CreateIndex
+                    { indexName = "knowledge_chunks_embedding_hnsw_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_cosine_ops", columnOrder = [] }]
+                    , whereClause = Just (IsExpression (VarExpression "embedding") (NotExpression (VarExpression "NULL")))
+                    , indexType = Just Hnsw
+                    , nullsDistinct = True
+                    }
+
+        it "should parse pgvector IVFFLAT indexes with operator classes" do
+            parseSql "CREATE INDEX knowledge_chunks_embedding_ivfflat_idx ON knowledge_chunks USING ivfflat (embedding vector_l2_ops);" `shouldBe` CreateIndex
+                    { indexName = "knowledge_chunks_embedding_ivfflat_idx"
+                    , unique = False
+                    , tableName = "knowledge_chunks"
+                    , columns = [IndexColumn { column = VarExpression "embedding", columnOperatorClass = Just "vector_l2_ops", columnOrder = [] }]
+                    , whereClause = Nothing
+                    , indexType = Just Ivfflat
+                    , nullsDistinct = True
+                    }
+
         it "should parse 'ENABLE ROW LEVEL SECURITY' statements" do
             parseSql "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;" `shouldBe` EnableRowLevelSecurity { tableName = "tasks" }
 


### PR DESCRIPTION
## Summary
- parse custom postgres type modifiers such as `VECTOR(1536)` and compile them back unchanged
- add parser/compiler support for additional index methods, including `HNSW` and `IVFFLAT`
- preserve index column operator classes such as `vector_cosine_ops`
- keep schema diff/index normalization preserving operator classes

## Root Cause
pg_dump and pgvector schemas can emit SQL like `ALTER TABLE ... ADD COLUMN embedding VECTOR(1536)` and `CREATE INDEX ... USING hnsw (embedding vector_cosine_ops)`. The parser previously stopped at the custom type modifier `(1536)`, only accepted btree/gin/gist index methods, and had no AST slot for index operator classes.

## Validation
- `ghci ihp-postgres-parser/Test/Postgres/ParserSpec.hs`: 38 examples, 0 failures
- `ghci ihp-postgres-parser/Test/Postgres/CompilerSpec.hs`: 28 examples, 0 failures
- `ghci ihp-ide/Test/Main.hs`: 408 examples, 0 failures