### PR TITLE
Parse function SET options

### DIFF
--- a/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
@@ -534,6 +534,7 @@ addUpdatedAtTrigger tableName schema =
                 , returns = PTrigger
                 , language = "plpgsql"
                 , securityDefiner = False
+                , functionSettings = []
                 }
 
 deleteTriggerIfExists :: Text -> [Statement] -> [Statement]

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -43,7 +43,7 @@ compileStatement RenameColumn { tableName, from, to } = "ALTER TABLE " <> compil
 compileStatement DropTable { tableName } = "DROP TABLE " <> compileIdentifier tableName <> ";"
 compileStatement Comment { content } = "--" <> content
 compileStatement CreateIndex { indexName, unique, tableName, columns, whereClause, indexType, nullsDistinct } = "CREATE" <> (if unique then " UNIQUE " else " ") <> "INDEX " <> compileIdentifier indexName <> " ON " <> compileIdentifier tableName <> (maybe "" (\indexType -> " USING " <> compileIndexType indexType) indexType) <> " (" <> (intercalate ", " (map compileIndexColumn columns)) <> ")" <> (if nullsDistinct then "" else " NULLS NOT DISTINCT") <> (case whereClause of Just expression -> " WHERE " <> compileExpression expression; Nothing -> "") <> ";"
-compileStatement CreateFunction { functionName, functionArguments, functionBody, orReplace, returns, language, securityDefiner } = "CREATE " <> (if orReplace then "OR REPLACE " else "") <> "FUNCTION " <> functionName <> "(" <> (functionArguments & map (\(argName, argType) -> argName <> " " <> compilePostgresType argType) & intercalate  ", ") <> ")" <> " RETURNS " <> compilePostgresType returns <> (if securityDefiner then " SECURITY DEFINER" else "") <> " AS $$" <> functionBody <> "$$ language " <> language <> ";"
+compileStatement CreateFunction { functionName, functionArguments, functionBody, orReplace, returns, language, securityDefiner, functionSettings } = "CREATE " <> (if orReplace then "OR REPLACE " else "") <> "FUNCTION " <> functionName <> "(" <> (functionArguments & map (\(argName, argType) -> argName <> " " <> compilePostgresType argType) & intercalate  ", ") <> ")" <> " RETURNS " <> compilePostgresType returns <> (if securityDefiner then " SECURITY DEFINER" else "") <> mconcat (map compileFunctionSetting functionSettings) <> " AS $$" <> functionBody <> "$$ language " <> language <> ";"
 compileStatement EnableRowLevelSecurity { tableName } = "ALTER TABLE " <> compileIdentifier tableName <> " ENABLE ROW LEVEL SECURITY;"
 compileStatement CreatePolicy { name, action, tableName, using, check } = "CREATE POLICY " <> compileIdentifier name <> " ON " <> compileIdentifier tableName <> maybe "" (\action -> " FOR " <> compilePolicyAction action) action  <> maybe "" (\expr -> " USING (" <> compileExpression expr <> ")") using <> maybe "" (\expr -> " WITH CHECK (" <> compileExpression expr <> ")") check <> ";"
 compileStatement CreateSequence { name } = "CREATE SEQUENCE " <> compileIdentifier name <> ";"
@@ -510,6 +510,9 @@ compileIndexType :: IndexType -> Text
 compileIndexType Gin = "GIN"
 compileIndexType Btree = "BTREE"
 compileIndexType Gist = "GIST"
+
+compileFunctionSetting :: FunctionSetting -> Text
+compileFunctionSetting FunctionSetting { settingName, settingValue } = " SET " <> settingName <> " = " <> settingValue
 
 compileIndexColumn :: IndexColumn -> Text
 compileIndexColumn IndexColumn { column, columnOrder = [] } = compileExpression column

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -720,11 +720,17 @@ parseFunctionSetting = do
 functionOptionBoundary :: Parser ()
 functionOptionBoundary =
     choice
-        [ try (space >> symbol' "LANGUAGE" $> ())
-        , try (space >> symbol' "SECURITY" $> ())
-        , try (space >> symbol' "SET" $> ())
-        , try (space >> symbol' "AS" $> ())
+        [ try (space1 >> functionOptionBoundaryKeyword "LANGUAGE")
+        , try (space1 >> functionOptionBoundaryKeyword "SECURITY")
+        , try (space1 >> functionOptionBoundaryKeyword "SET")
+        , try (space1 >> functionOptionBoundaryKeyword "AS")
         ]
+
+functionOptionBoundaryKeyword :: Text -> Parser ()
+functionOptionBoundaryKeyword keyword = do
+    string' keyword
+    notFollowedBy (satisfy \c -> isAlphaNum c || c == '_')
+    space
 
 createTrigger = do
     lexeme "CREATE"

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -19,7 +19,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.ByteString (ByteString)
 import Data.String.Conversions (cs)
-import Data.Maybe (isJust, catMaybes, isNothing)
+import Data.Maybe (isJust, catMaybes, isNothing, listToMaybe)
 import Data.Either (lefts, rights)
 import Data.Functor (($>))
 import Data.Char (isAlphaNum)
@@ -649,6 +649,11 @@ parseIndexType = do
         , ("gist", Gist)
         ]
 
+data FunctionOption
+    = FunctionLanguage Text
+    | FunctionSecurityDefiner
+    | FunctionSettingOption FunctionSetting
+
 createFunction = do
     lexeme "CREATE"
     orReplace <- isJust <$> optional (lexeme "OR" >> lexeme "REPLACE")
@@ -660,32 +665,66 @@ createFunction = do
     returns <- sqlType
     space
 
-    language <- optional do
-        lexeme "language" <|> lexeme "LANGUAGE"
-        symbol' "plpgsql" <|> symbol' "SQL"
-
-    securityDefiner <- isJust <$> optional do
-        lexeme "SECURITY"
-        lexeme "DEFINER"
+    functionOptions <- many parseFunctionOption
+    let languageBeforeBody = listToMaybe [language | FunctionLanguage language <- functionOptions]
+    let securityDefiner = any isSecurityDefiner functionOptions
+    let functionSettings = [functionSetting | FunctionSettingOption functionSetting <- functionOptions]
 
     lexeme "AS"
     space
     functionBody <- cs <$> between (char '$' >> char '$') (char '$' >> char '$') (many (anySingleBut '$'))
     space
 
-    language <- case language of
+    language <- case languageBeforeBody of
         Just language -> pure language
         Nothing -> do
-            lexeme "language" <|> lexeme "LANGUAGE"
+            symbol' "language"
             symbol' "plpgsql" <|> symbol' "SQL"
     char ';'
-    pure CreateFunction { functionName, functionArguments, functionBody, orReplace, returns, language, securityDefiner }
+    pure CreateFunction { functionName, functionArguments, functionBody, orReplace, returns, language, securityDefiner, functionSettings }
     where
         functionArgument = do
             argumentName <- qualifiedIdentifier
             space
             argumentType <- sqlType
             pure (argumentName, argumentType)
+        isSecurityDefiner FunctionSecurityDefiner = True
+        isSecurityDefiner _ = False
+
+parseFunctionOption :: Parser FunctionOption
+parseFunctionOption =
+    try parseFunctionLanguage
+    <|> try parseFunctionSecurityDefiner
+    <|> try parseFunctionSetting
+
+parseFunctionLanguage :: Parser FunctionOption
+parseFunctionLanguage = do
+    symbol' "language"
+    FunctionLanguage <$> (symbol' "plpgsql" <|> symbol' "SQL")
+
+parseFunctionSecurityDefiner :: Parser FunctionOption
+parseFunctionSecurityDefiner = do
+    symbol' "SECURITY"
+    symbol' "DEFINER"
+    pure FunctionSecurityDefiner
+
+parseFunctionSetting :: Parser FunctionOption
+parseFunctionSetting = do
+    symbol' "SET"
+    settingName <- qualifiedIdentifier
+    symbol "="
+    settingValue <- Text.strip . cs <$> someTill anySingle (lookAhead functionOptionBoundary)
+    space
+    pure (FunctionSettingOption FunctionSetting { settingName, settingValue })
+
+functionOptionBoundary :: Parser ()
+functionOptionBoundary =
+    choice
+        [ try (space >> symbol' "LANGUAGE" $> ())
+        , try (space >> symbol' "SECURITY" $> ())
+        , try (space >> symbol' "SET" $> ())
+        , try (space >> symbol' "AS" $> ())
+        ]
 
 createTrigger = do
     lexeme "CREATE"

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -36,7 +36,7 @@ data Statement
     -- | DROP INDEX indexName;
     | DropIndex { indexName :: Text }
     -- | CREATE OR REPLACE FUNCTION functionName(param1 TEXT, param2 INT) RETURNS TRIGGER AS $$functionBody$$ language plpgsql;
-    | CreateFunction { functionName :: Text, functionArguments :: [(Text, PostgresType)], functionBody :: Text, orReplace :: Bool, returns :: PostgresType, language :: Text, securityDefiner :: Bool }
+    | CreateFunction { functionName :: Text, functionArguments :: [(Text, PostgresType)], functionBody :: Text, orReplace :: Bool, returns :: PostgresType, language :: Text, securityDefiner :: Bool, functionSettings :: [FunctionSetting] }
     -- | ALTER TABLE tableName ENABLE ROW LEVEL SECURITY;
     | EnableRowLevelSecurity { tableName :: Text }
     -- CREATE POLICY name ON tableName USING using WITH CHECK check;
@@ -81,6 +81,12 @@ data Statement
 data DeferrableType
     = InitiallyImmediate
     | InitiallyDeferred
+    deriving (Eq, Show)
+
+data FunctionSetting = FunctionSetting
+    { settingName :: Text
+    , settingValue :: Text
+    }
     deriving (Eq, Show)
 
 data CreateTable
@@ -308,6 +314,7 @@ function functionName = CreateFunction
     , returns = PTrigger
     , language = "plpgsql"
     , securityDefiner = False
+    , functionSettings = []
     }
 
 -- | Helper to create an 'IndexColumn' with no column ordering.

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -153,6 +153,25 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should compile a CREATE FUNCTION with SET options" do
+            let sql = "CREATE OR REPLACE FUNCTION sync_access() RETURNS TRIGGER SECURITY DEFINER SET search_path = public, private, pg_temp AS $$BEGIN\n    RETURN NEW;\nEND;$$ language plpgsql;\n"
+            let statement = CreateFunction
+                    { functionName = "sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = True
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "search_path"
+                            , settingValue = "public, private, pg_temp"
+                            }
+                        ]
+                    }
+            compileSql [statement] `shouldBe` sql
+
         it "should compile 'ENABLE ROW LEVEL SECURITY' statements" do
             let sql = "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;\n"
             let statements = [EnableRowLevelSecurity { tableName = "tasks" }]

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -171,6 +171,24 @@ spec = do
                         ]
                     }
 
+        it "should not stop CREATE FUNCTION SET values at keyword prefixes" do
+            let sql = "CREATE OR REPLACE FUNCTION set_tz()\nRETURNS TRIGGER\nSET TimeZone = 'Asia/Tokyo'\nAS $$BEGIN\n    RETURN NEW;\nEND;$$ language plpgsql;"
+            parseSql sql `shouldBe` CreateFunction
+                    { functionName = "set_tz"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = False
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "TimeZone"
+                            , settingValue = "'Asia/Tokyo'"
+                            }
+                        ]
+                    }
+
         it "should parse 'ENABLE ROW LEVEL SECURITY' statements" do
             parseSql "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;" `shouldBe` EnableRowLevelSecurity { tableName = "tasks" }
 

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -153,6 +153,24 @@ spec = do
                     , nullsDistinct = True
                     }
 
+        it "should parse CREATE FUNCTION with SET options before AS" do
+            let sql = "CREATE OR REPLACE FUNCTION sync_access()\nRETURNS TRIGGER\nLANGUAGE plpgsql\nSECURITY DEFINER\nSET search_path = public, private, pg_temp\nAS $$BEGIN\n    RETURN NEW;\nEND;$$;"
+            parseSql sql `shouldBe` CreateFunction
+                    { functionName = "sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = True
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "search_path"
+                            , settingValue = "public, private, pg_temp"
+                            }
+                        ]
+                    }
+
         it "should parse 'ENABLE ROW LEVEL SECURITY' statements" do
             parseSql "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;" `shouldBe` EnableRowLevelSecurity { tableName = "tasks" }
 


### PR DESCRIPTION
## Summary
- parse PostgreSQL function SET options such as SET search_path before AS
- preserve function SET options in the AST/compiler instead of dropping them
- keep schema designer generated functions explicit with no settings

## Test
- ghci ihp-postgres-parser/Test/Postgres/ParserSpec.hs: hspec spec
- ghci ihp-postgres-parser/Test/Postgres/CompilerSpec.hs: hspec spec
- ghci ihp-ide/Test/Main.hs: main