### PR TITLE
Parse pg_dump CREATE FUNCTION SET TO options

### DIFF
--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -698,7 +698,7 @@ createFunction = do
     lexeme "CREATE"
     orReplace <- isJust <$> optional (lexeme "OR" >> lexeme "REPLACE")
     lexeme "FUNCTION"
-    functionName <- qualifiedIdentifier
+    functionName <- functionIdentifier
     functionArguments <- between (char '(') (char ')') (functionArgument `sepBy` (char ',' >> space))
     space
     lexeme "RETURNS"
@@ -752,7 +752,7 @@ parseFunctionSetting :: Parser FunctionOption
 parseFunctionSetting = do
     symbol' "SET"
     settingName <- qualifiedIdentifier
-    symbol "="
+    symbol "=" <|> symbol' "TO"
     settingValue <- Text.strip . cs <$> someTill anySingle (lookAhead functionOptionBoundary)
     space
     pure (FunctionSettingOption FunctionSetting { settingName, settingValue })
@@ -982,6 +982,10 @@ qualifiedIdentifier = do
         lexeme "public"
         char '.'
     identifier
+
+functionIdentifier = do
+    schemaOrName <- identifier
+    maybe schemaOrName (\name -> schemaOrName <> "." <> name) <$> optional (char '.' >> identifier)
 
 addColumn tableName = do
     lexeme "COLUMN"

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -231,6 +231,24 @@ spec = do
                         ]
                     }
 
+        it "should parse pg_dump CREATE FUNCTION SET options with TO" do
+            let sql = "CREATE OR REPLACE FUNCTION private.sync_access()\nRETURNS TRIGGER\nLANGUAGE plpgsql\nSECURITY DEFINER\nSET search_path TO 'public', 'private', 'pg_temp'\nAS $$BEGIN\n    RETURN NEW;\nEND;$$;"
+            parseSql sql `shouldBe` CreateFunction
+                    { functionName = "private.sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = True
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "search_path"
+                            , settingValue = "'public', 'private', 'pg_temp'"
+                            }
+                        ]
+                    }
+
         it "should parse a pg_dump CREATE INDEX with VARIADIC function arguments" do
             let sql = "CREATE INDEX agent_runs_ingest_gmail_message_latest_idx ON public.agent_runs USING btree (organization_id, jsonb_extract_path_text(input, VARIADIC ARRAY['gmailMessageId'::text]), COALESCE(completed_at, last_event_at, started_at, created_at) DESC, id DESC) WHERE ((type = 'ingest'::public.agent_run_type) AND (jsonb_extract_path_text(input, VARIADIC ARRAY['source'::text]) = 'gmail_email_ingest'::text));"
             parseSql sql `shouldBe` CreateIndex


### PR DESCRIPTION
## What changed

- Accept `SET <name> TO <value>` inside `CREATE FUNCTION` options in `ihp-postgres-parser`.
- Preserve schema-qualified function names such as `private.sync_access` when parsing `CREATE FUNCTION`.
- Add a parser spec covering pg_dump-style `CREATE FUNCTION ... SET search_path TO ...` output.

## Why

PostgreSQL pg_dump can emit function options with `TO` instead of `=`, and can qualify functions with a non-public schema. The parser previously failed before IHP could load this schema output.

## Validation

- `direnv exec . cabal test --project-dir=ihp-postgres-parser spec` passed: 72 examples, 0 failures.