### PR TITLE
ihp-ide: declare missing test other-modules (forward-port from v1.5.1)

### DIFF
--- a/ihp-ide/changelog.md
+++ b/ihp-ide/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for `ihp-ide`
 
+## v1.5.1
+
+- Restore missing test sources in sdist: `Test.IDE.ToolServer.MiddlewareSpec` and `Test.IDE.Logs.ControllerSpec` were imported by `Test/Main.hs` but not declared in the cabal `test-suite > other-modules`, so they were excluded from the Hackage tarball and broke downstream builds (e.g. nixpkgs). No source changes — manifest fix only.
+
 ## v1.5.0
 
 - Add PostgreSQL table inheritance (`INHERITS`) support in Schema Designer

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                ihp-ide
-version:             1.5.0
+version:             1.5.1
 synopsis:            Dev tools for IHP
 description:         The Integrated Haskell Platform is a full stack framework focused on rapid application development while striving for robust code quality.
 license:             MIT
@@ -343,4 +343,6 @@ test-suite tests
         Test.IDE.SchemaDesigner.SchemaOperationsSpec
         Test.IDE.CodeGeneration.MigrationGenerator
         Test.SchemaCompilerSpec
+        Test.IDE.ToolServer.MiddlewareSpec
+        Test.IDE.Logs.ControllerSpec
         Test.ServerSpec


### PR DESCRIPTION
Forward-ports the manifest fix from [ihp-ide-1.5.1](https://hackage.haskell.org/package/ihp-ide-1.5.1) (commit `42cb40d5` on `v1.5`) onto master, so the bug doesn't ride into the next release.

## What

`Test.IDE.ToolServer.MiddlewareSpec` and `Test.IDE.Logs.ControllerSpec` are imported by [ihp-ide/Test/Main.hs](../blob/master/ihp-ide/Test/Main.hs) but were never listed in the cabal test-suite's `other-modules`. `cabal sdist` therefore excluded both `.hs` files from the 1.5.0 Hackage tarball, and downstream sdist-based builds (nixpkgs, etc.) failed with `GHC-87110: Could not find module`.

Local builds and `nix flake check` against the git tree worked because GHC picks the files up via `hs-source-dirs: .` regardless of `other-modules`, which masked the bug.

## Refs

- v1.5 patch release: tag [ihp-ide-1.5.1](https://github.com/digitallyinduced/ihp/releases/tag/ihp-ide-1.5.1), Hackage [ihp-ide-1.5.1](https://hackage.haskell.org/package/ihp-ide-1.5.1)
- Failing downstream: [NixOS/nixpkgs#505221](https://github.com/NixOS/nixpkgs/pull/505221)

## Verification

The v1.5.1 sdist was verified by extracting it and building through the IHP flake's `ghc912-ihp-ide` derivation (cabal2nix-style) against hasql-1.10.2.3 — built clean, exit 0, no GHC-87110. The published 1.5.1 tarball on Hackage contains both formerly-missing `.hs` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)