### PR TITLE
ihp-ide: regenerate default.nix for version 1.5.1

### DIFF
--- a/ihp-ide/default.nix
+++ b/ihp-ide/default.nix
@@ -16,7 +16,7 @@
 }:
 mkDerivation {
   pname = "ihp-ide";
-  version = "1.5.0";
+  version = "1.5.1";
   src = ./.;
   isLibrary = true;
   isExecutable = true;


### PR DESCRIPTION
## Problem

Commit 8dcb6e75 ("ihp-ide 1.5.1: declare missing test other-modules") bumped `ihp-ide/ihp-ide.cabal` from `1.5.0` to `1.5.1`, but `ihp-ide/default.nix` was not regenerated and still declared `version = "1.5.0"`.

Cabal writes data-files (e.g. `lib/IHP/Makefile.dist`) to `share/$ghc/$sys/ihp-ide-1.5.1/`, while consumers of the nix derivation (e.g. [`ihp/Bench/flake.nix`](https://github.com/digitallyinduced/ihp/blob/master/ihp/Bench/flake.nix)) compose the path from `package.name` — which uses the version baked into `default.nix` — and so look up `share/.../ihp-ide-1.5.0/` and find nothing.

This breaks the Core Size Benchmark GitHub Actions workflow on every PR, with `forum-core-size-bench-baseline` failing on the same drv hash (`yh4aq598snar2nm9la559ijvyqck714n`). Examples:

- https://github.com/digitallyinduced/ihp/actions/runs/25808749717
- https://github.com/digitallyinduced/ihp/actions/runs/25805445272

## Fix

Regenerated via:

```bash
cd ihp-ide
cabal2nix . > default.nix
```

The diff is a single line: `version = "1.5.0"` → `version = "1.5.1"`.

## A note on this PR's own CI

The benchmark workflow's **baseline** step uses `--override-input ihp "github:digitallyinduced/ihp"` to build IHP from `master`. Since `master` still carries the stale `default.nix`, that baseline will keep failing on this PR's checks until this fix is merged. The PR-side build (`ihp-ide-1.5.1.drv`) builds successfully with the fix in place (visible in the failing run's log just before the baseline error).

In other words: **the baseline failure on this PR is self-resolving on merge.** Admin-merging is appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)