### PR TITLE
[codex] Enable incomplete pattern errors for apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Breaking Changes
 
+- IHP apps now treat incomplete pattern matches as compile errors in the default GHCi, generated Makefile, and generated Cabal configuration. This makes local development and agent-assisted coding fail fast when a pattern match misses a constructor.
 - Controller `action` now returns `IO ResponseReceived` instead of `IO ()` — response functions like `render`, `redirectTo`, `renderJson` return the WAI `ResponseReceived` directly instead of throwing exceptions. Use `earlyReturn` for conditional early exits (e.g. `when condition (earlyReturn $ redirectTo ...)`) ([#2205](https://github.com/digitallyinduced/ihp/pull/2205))
 - `ResponseException` removed — code that catches `ResponseException` will get a compiler error; use `earlyReturn`/`respondAndExit` instead
 - `respondAndExit` now requires `?request` and `?respond` implicit parameters (previously only needed `?context`)

--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -309,7 +309,7 @@ CABAL_HEADER
         -Wno-missing-home-modules
         -Wno-partial-type-signatures
         -Werror=missing-fields
-        -fwarn-incomplete-patterns
+        -Werror=incomplete-patterns
 CABAL_EOF
         '';
         installPhase = ''

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,24 @@ After updating your project, please consult the segments from your current relea
 
 # Upgrade to 1.6.0 (unreleased) from 1.5.0
 
+## Incomplete Pattern Matches Are Now App Compile Errors
+
+IHP now promotes incomplete pattern match warnings to compile errors in app-facing defaults:
+
+- `applicationGhciConfig`, used by the default app `.ghci`
+- the generated `Makefile`
+- the generated Cabal configuration used by `NixSupport`
+
+This makes missing pattern matches fail fast during local development and agent-assisted coding.
+
+If you want to temporarily keep warning-only behavior while exploring incomplete code, add an override after loading IHP's GHCi config in your app `.ghci`:
+
+```haskell
+:set -Wwarn=incomplete-patterns
+```
+
+For app package builds, add `-Wwarn=incomplete-patterns` after IHP's generated `ghc-options` or replace `-Werror=incomplete-patterns` with `-fwarn-incomplete-patterns` in your local generated configuration.
+
 ## Dev mode now runs the web server and the job worker as separate processes
 
 `devenv up` previously launched a single `ihp` process that ran both the web server and the in-process job worker. It now launches two processes: `web` (the existing `RunDevServer`) and `worker` (a new `RunDevWorker`). They each own one GHCi session and reload independently. This mirrors the production split between `RunProdServer` and `RunJobs`.

--- a/ihp-ide/data/lib/IHP/Makefile.dist
+++ b/ihp-ide/data/lib/IHP/Makefile.dist
@@ -58,7 +58,7 @@ GHC_EXTENSIONS+= -XPartialTypeSignatures
 GHC_EXTENSIONS+= -XStandaloneDeriving
 GHC_EXTENSIONS+= -XDerivingVia
 GHC_EXTENSIONS+= -Werror=missing-fields
-GHC_EXTENSIONS+= -fwarn-incomplete-patterns
+GHC_EXTENSIONS+= -Werror=incomplete-patterns
 GHC_EXTENSIONS+= -XTemplateHaskell
 GHC_EXTENSIONS+= -XDeepSubsumption
 GHC_EXTENSIONS+= -XOverloadedRecordDot

--- a/ihp-ide/data/lib/IHP/applicationGhciConfig
+++ b/ihp-ide/data/lib/IHP/applicationGhciConfig
@@ -49,7 +49,7 @@
 :set -XDeepSubsumption
 :set -XOverloadedRecordDot
 :set -Werror=missing-fields
-:set -fwarn-incomplete-patterns
+:set -Werror=incomplete-patterns
 :set -package ghc
 :set -fno-warn-ambiguous-fields 
 :l Main.hs


### PR DESCRIPTION
## Summary
- promote incomplete pattern warnings to compile errors in app-facing GHCi defaults
- update the generated Makefile and NixSupport Cabal configuration to use `-Werror=incomplete-patterns`
- document the behavior change and the `-Wwarn=incomplete-patterns` escape hatch for exploratory development

## Why
IHP framework packages already use `-Werror=incomplete-patterns` after #2260, but app-facing defaults still only warned. With agent-assisted coding, missing pattern matches should fail fast instead of being easy-to-miss warnings.

Follow-up to #2047 and #1681.

## Validation
- `git diff --check`
- `printf ':set -Werror=incomplete-patterns\n:set -Wwarn=incomplete-patterns\n:quit\n' | ghci -v0`
- verified a tiny incomplete-pattern module fails with `-Werror=incomplete-patterns`
- verified the same module compiles with a warning when `-Wwarn=incomplete-patterns` is added after the error flag

`nix develop --command ghci -v0` was not usable in this worktree: devenv failed before starting GHC because it could not determine the current directory. `direnv exec .` was also blocked because this worktree has not been allowed.
