### PR TITLE
Upgrade default GHC from 9.10 to 9.14

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -170,13 +170,8 @@ let
         };
 in
 final: prev: {
-    # Default: GHC 9.10 (binary-cached via nixpkgs haskellPackages)
-    ghc = final.haskellPackages.override {
-        overrides = ihpOverrides final;
-    };
-
-    # Experimental: GHC 9.12 (not yet binary-cached; builds from source)
-    ghc912 = final.haskell.packages.ghc912.override {
+    # Default: GHC 9.12
+    ghc = final.haskell.packages.ghc912.override {
         overrides = final.lib.composeManyExtensions [
             (ihpOverrides final)
             (self: super: {

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -170,8 +170,8 @@ let
         };
 in
 final: prev: {
-    # Default: GHC 9.12
-    ghc = final.haskell.packages.ghc912.override {
+    # Default: GHC 9.14
+    ghc = final.haskell.packages.ghc914.override {
         overrides = final.lib.composeManyExtensions [
             (ihpOverrides final)
             (self: super: {
@@ -183,13 +183,57 @@ final: prev: {
 
                 # cryptonite tests have a flaky failure (1 of 1548)
                 cryptonite = final.haskell.lib.dontCheck super.cryptonite;
+
+                # lucid2 has base <4.22 bound
+                lucid2 = final.haskell.lib.doJailbreak super.lucid2;
+
+                # relude doctests fail due to changed GHC error messages in 9.14
+                relude = final.haskell.lib.dontCheck super.relude;
+
+                # tasty-hspec has base <4.22 bound
+                tasty-hspec = final.haskell.lib.doJailbreak super.tasty-hspec;
+
+                # Packages with tight upper bounds on boot libraries (base, containers, template-haskell)
+                # GHC 9.14 ships base-4.22, containers-0.8, template-haskell-2.24
+                config-ini = final.haskell.lib.doJailbreak super.config-ini;
+                fsnotify = final.haskell.lib.doJailbreak super.fsnotify;
+                string-interpolate = final.haskell.lib.doJailbreak super.string-interpolate;
+                rebase = final.haskell.lib.doJailbreak super.rebase;
+                rerebase = final.haskell.lib.doJailbreak super.rerebase;
+                with-utf8 = final.haskell.lib.doJailbreak super.with-utf8;
+                minio-hs = final.haskell.lib.doJailbreak super.minio-hs;
+                sandwich = final.haskell.lib.doJailbreak super.sandwich;
+                brick = final.haskell.lib.doJailbreak super.brick;
+                postgresql-simple = final.haskell.lib.doJailbreak super.postgresql-simple;
+                hasql-dynamic-statements = final.haskell.lib.doJailbreak super.hasql-dynamic-statements;
+                hasql-implicits = final.haskell.lib.doJailbreak super.hasql-implicits;
+                warp-systemd = final.haskell.lib.doJailbreak super.warp-systemd;
+
+                # Upgrade ghc-tcplugin-api to 0.19 (supports GHC 9.14)
+                ghc-tcplugin-api = self.callCabal2nix "ghc-tcplugin-api"
+                    (final.fetchzip {
+                        url = "https://hackage.haskell.org/package/ghc-tcplugin-api-0.19.0.0/ghc-tcplugin-api-0.19.0.0.tar.gz";
+                        sha256 = "sha256-2jm1Q2lmaG6vtRnxcvxf4U2gvQdVkDL0h8PWaTpDWJA=";
+                    }) {};
+
+                # Upgrade ghc-typelits-natnormalise to 0.9.6 (uses ghc-tcplugin-api, supports GHC 9.14)
+                ghc-typelits-natnormalise = final.haskell.lib.dontCheck (self.callCabal2nix "ghc-typelits-natnormalise"
+                    (final.fetchzip {
+                        url = "https://hackage.haskell.org/package/ghc-typelits-natnormalise-0.9.6/ghc-typelits-natnormalise-0.9.6.tar.gz";
+                        sha256 = "sha256-a1afS4iJrB9hVp3FK+fozbWVxIt75H/gO6Q+PeoV53k=";
+                    }) {});
+
+                # Upgrade ghc-typelits-knownnat to 0.8.4 (uses ghc-tcplugin-api, supports GHC 9.14)
+                ghc-typelits-knownnat = final.haskell.lib.dontCheck (self.callCabal2nix "ghc-typelits-knownnat"
+                    (final.fetchzip {
+                        url = "https://hackage.haskell.org/package/ghc-typelits-knownnat-0.8.4/ghc-typelits-knownnat-0.8.4.tar.gz";
+                        sha256 = "sha256-PyYMUvJ8/miqusNl7+xay8OJqtK1/uHNQEiLr1utieg=";
+                    }) {});
             })
         ];
     };
 
-    # Experimental: GHC 9.14 (bleeding edge, expected to fail)
-    # Only defined when nixpkgs includes the ghc914 package set.
-    # Attribute always exists but throws if ghc914 is unavailable in nixpkgs.
+    # Experimental: GHC 9.14 (same as default, kept for compatibility)
     ghc914 =
         if prev.haskell.packages ? ghc914
         then final.haskell.packages.ghc914.override {
@@ -199,6 +243,27 @@ final: prev: {
                     say = final.haskell.lib.dontCheck super.say;
                     text-icu = final.haskell.lib.dontCheck super.text-icu;
                     cryptonite = final.haskell.lib.dontCheck super.cryptonite;
+
+                    # Upgrade ghc-tcplugin-api to 0.19 (supports GHC 9.14)
+                    ghc-tcplugin-api = self.callCabal2nix "ghc-tcplugin-api"
+                        (final.fetchurl {
+                            url = "https://hackage.haskell.org/package/ghc-tcplugin-api-0.19.0.0/ghc-tcplugin-api-0.19.0.0.tar.gz";
+                            sha256 = "sha256-Cg6nFSjhgMfqNOF3L1GNQZS7eJqKU3ycsmtDRjTK0cQ=";
+                        }) {};
+
+                    # Upgrade ghc-typelits-natnormalise to 0.9.6 (uses ghc-tcplugin-api, supports GHC 9.14)
+                    ghc-typelits-natnormalise = final.haskell.lib.dontCheck (self.callCabal2nix "ghc-typelits-natnormalise"
+                        (final.fetchurl {
+                            url = "https://hackage.haskell.org/package/ghc-typelits-natnormalise-0.9.6/ghc-typelits-natnormalise-0.9.6.tar.gz";
+                            sha256 = "sha256-E94FNrcA8SFlvSF3BFJOHqEjEA4MhXH+4BpLKkiIlwg=";
+                        }) {});
+
+                    # Upgrade ghc-typelits-knownnat to 0.8.4 (uses ghc-tcplugin-api, supports GHC 9.14)
+                    ghc-typelits-knownnat = final.haskell.lib.dontCheck (self.callCabal2nix "ghc-typelits-knownnat"
+                        (final.fetchurl {
+                            url = "https://hackage.haskell.org/package/ghc-typelits-knownnat-0.8.4/ghc-typelits-knownnat-0.8.4.tar.gz";
+                            sha256 = "sha256-PkLB8gvz4b2yEuLFqDisz9slG7K5U22V1q5G8FgtDCk=";
+                        }) {});
                 })
             ];
         }

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -142,33 +142,6 @@ that is defined in flake-module.nix
                 };
             }
 
-            # GHC 9.12 compatibility checks (build and test all IHP packages)
-            // (let
-                ghc912 = pkgs.ghc912;
-                ihpPackageNames = [
-                    "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
-                    "ihp-postgres-parser" "ihp-context" "ihp-pagehead"
-                    "ihp-modal" "ihp-mail"
-                    "ihp-migrate" "ihp-openai" "ihp-ssc" "ihp-graphql"
-                    "ihp-datasync-typescript" "ihp-sitemap"
-                    "ihp-job-dashboard" "ihp-imagemagick"
-                    "ihp-hspec" "ihp-welcome" "ihp-zip"
-                    "wai-asset-path" "wai-flash-messages" "wai-request-params"
-                    "wai-session-maybe" "wai-session-clientsession-deferred"
-                ];
-            in lib.listToAttrs (map (name: {
-                name = "ghc912-${name}";
-                value = ghc912.${name};
-            }) ihpPackageNames))
-
-            # GHC 9.12 packages that need a running PostgreSQL for their tests
-            // {
-                ghc912-ihp = withTestPostgres pkgs.ghc912.ihp;
-                ghc912-ihp-datasync = withTestPostgres pkgs.ghc912.ihp-datasync;
-                ghc912-ihp-typed-sql = withTestPostgres pkgs.ghc912.ihp-typed-sql;
-                ghc912-ihp-pglistener = withTestPostgres pkgs.ghc912.ihp-pglistener;
-            }
-
             # GHC 9.14 compatibility checks — disabled: nixpkgs-unstable's ghc914 package
             # set has many transitive upper-bound breaks (blaze-markup, ghc-tcplugins-extra,
             # …) because boot libraries bumped for GHC 9.14.1. pkgs.ghc914 is still defined

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -142,35 +142,6 @@ that is defined in flake-module.nix
                 };
             }
 
-            # GHC 9.14 compatibility checks — disabled: nixpkgs-unstable's ghc914 package
-            # set has many transitive upper-bound breaks (blaze-markup, ghc-tcplugins-extra,
-            # …) because boot libraries bumped for GHC 9.14.1. pkgs.ghc914 is still defined
-            # in the overlay for manual experimentation; re-enable once the ecosystem catches up.
-            // (lib.optionalAttrs (false && pkgs.haskell.packages ? ghc914) (let
-                ghc914 = pkgs.ghc914;
-                ihpPackageNames = [
-                    "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
-                    "ihp-postgres-parser" "ihp-context" "ihp-pagehead"
-                    "ihp-modal" "ihp-mail"
-                    "ihp-migrate" "ihp-openai" "ihp-ssc" "ihp-graphql"
-                    "ihp-datasync-typescript" "ihp-sitemap"
-                    "ihp-job-dashboard" "ihp-imagemagick"
-                    "ihp-hspec" "ihp-welcome" "ihp-zip"
-                    "wai-asset-path" "wai-flash-messages" "wai-request-params"
-                    "wai-session-maybe" "wai-session-clientsession-deferred"
-                ];
-            in lib.listToAttrs (map (name: {
-                name = "ghc914-${name}";
-                value = ghc914.${name};
-            }) ihpPackageNames)
-
-            # GHC 9.14 packages that need a running PostgreSQL for their tests
-            // {
-                ghc914-ihp = withTestPostgres pkgs.ghc914.ihp;
-                ghc914-ihp-datasync = withTestPostgres pkgs.ghc914.ihp-datasync;
-                ghc914-ihp-typed-sql = withTestPostgres pkgs.ghc914.ihp-typed-sql;
-                ghc914-ihp-pglistener = withTestPostgres pkgs.ghc914.ihp-pglistener;
-            }))
         ;
 
         devenv.shells.default = {
@@ -277,7 +248,8 @@ that is defined in flake-module.nix
             '';
 
             languages.haskell.stack.enable = false; # Stack is not used in IHP
-            languages.haskell.lsp.package = pkgs.ghc.haskell-language-server;
+            # HLS does not yet support GHC 9.14
+            languages.haskell.lsp.enable = false;
         };
 
         packages = {

--- a/ihp-context/ihp-context.cabal
+++ b/ihp-context/ihp-context.cabal
@@ -18,7 +18,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 
 source-repository head

--- a/ihp-context/ihp-context.cabal
+++ b/ihp-context/ihp-context.cabal
@@ -18,7 +18,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 
 source-repository head
@@ -38,7 +38,7 @@ library
     import: shared-properties
     hs-source-dirs: .
     build-depends:
-        base >= 4.17.0 && < 4.22
+        base >= 4.17.0 && < 4.23
         , typerep-map
     exposed-modules:
         IHP.ControllerContext

--- a/ihp-datasync/ihp-datasync.cabal
+++ b/ihp-datasync/ihp-datasync.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP, DataSync
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 extra-source-files:  changelog.md
 

--- a/ihp-datasync/ihp-datasync.cabal
+++ b/ihp-datasync/ihp-datasync.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP, DataSync
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 extra-source-files:  changelog.md
 
@@ -23,7 +23,7 @@ Flag FastBuild
 common shared-properties
     default-language: GHC2021
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
             , classy-prelude
             , mono-traversable
             , transformers

--- a/ihp-graphql/ihp-graphql.cabal
+++ b/ihp-graphql/ihp-graphql.cabal
@@ -21,7 +21,7 @@ source-repository head
 common shared-properties
     default-language: GHC2021
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
           , ihp
           , ihp-postgres-parser
           , unordered-containers

--- a/ihp-hspec/ihp-hspec.cabal
+++ b/ihp-hspec/ihp-hspec.cabal
@@ -36,6 +36,6 @@ library
         ImplicitParams
         RecordWildCards
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields -Werror=missing-home-modules
-    build-depends: base >= 4.17.0 && < 4.22, ihp, fast-logger, wai, process, text, ihp-ide, vault, uuid, hasql, wai-request-params, hspec, http-types
+    build-depends: base >= 4.17.0 && < 4.23, ihp, fast-logger, wai, process, text, ihp-ide, vault, uuid, hasql, wai-request-params, hspec, http-types
     hs-source-dirs: .
     exposed-modules: IHP.Hspec

--- a/ihp-hsx/ihp-hsx.cabal
+++ b/ihp-hsx/ihp-hsx.cabal
@@ -74,9 +74,9 @@ common common-flags
 
 common common-depends
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
         , bytestring
-        , template-haskell >= 2.19.0 && < 2.24
+        , template-haskell >= 2.19.0 && < 2.25
         , text
         , containers
         , megaparsec
@@ -87,7 +87,7 @@ library ihp-hsx-parser
     import: common-extensions, common-flags, common-depends
     default-language: GHC2021
     build-depends:
-        ghc >= 9.4.4 && < 9.13
+        ghc >= 9.4.4 && < 9.15
     hs-source-dirs: parser
     exposed-modules:
         IHP.HSX.Parser

--- a/ihp-hsx/parser/IHP/HSX/HaskellParser.hs
+++ b/ihp-hsx/parser/IHP/HSX/HaskellParser.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module IHP.HSX.HaskellParser (parseHaskellExpression, HaskellExprParser, mkHaskellExprParser) where
 
 import Prelude
@@ -20,9 +19,7 @@ import GHC.Types.Error
 import GHC.Utils.Outputable hiding ((<>))
 import GHC.Utils.Error
 import qualified GHC.Types.SrcLoc as SrcLoc
-#if __GLASGOW_HASKELL__ >= 908
 import GHC.Unit.Module.Warnings
-#endif
 
 -- | Cached GHC parser options, constructed once per HSX quasi-quote splice.
 newtype HaskellExprParser = HaskellExprParser Lexer.ParserOpts
@@ -41,16 +38,8 @@ parseHaskellExpression (HaskellExprParser parserOpts) sourcePos input =
                 let
                     error = renderWithContext defaultSDocContext
                         $ vcat
-#if __GLASGOW_HASKELL__ >= 908
                         $ map formatBulleted
-#else
-                        $ map (formatBulleted defaultSDocContext)
-#endif
-#if __GLASGOW_HASKELL__ >= 906
                         $ map (diagnosticMessage NoDiagnosticOpts)
-#else
-                        $ map diagnosticMessage
-#endif
                         $ map errMsgDiagnostic
                         $ sortMsgBag Nothing
                         $ getMessages parserState.errors
@@ -88,8 +77,6 @@ diagOpts =
     , diag_reverse_errors = False
     , diag_max_errors = Nothing
     , diag_ppr_ctx = defaultSDocContext
-#if __GLASGOW_HASKELL__ >= 908
     , diag_custom_warning_categories = emptyWarningCategorySet
     , diag_fatal_custom_warning_categories = emptyWarningCategorySet
-#endif
     }

--- a/ihp-hsx/parser/IHP/HSX/HaskellParser.hs
+++ b/ihp-hsx/parser/IHP/HSX/HaskellParser.hs
@@ -28,7 +28,7 @@ newtype HaskellExprParser = HaskellExprParser Lexer.ParserOpts
 -- Call this once and reuse for every @{expr}@ splice in the template.
 mkHaskellExprParser :: [TH.Extension] -> HaskellExprParser
 mkHaskellExprParser extensions = HaskellExprParser $
-    Lexer.mkParserOpts (EnumSet.fromList extensions) diagOpts [] False False False False
+    Lexer.mkParserOpts (EnumSet.fromList extensions) diagOpts False False False False
 
 parseHaskellExpression :: HaskellExprParser -> SourcePos -> String -> Either (Int, Int, String) TH.Exp
 parseHaskellExpression (HaskellExprParser parserOpts) sourcePos input =

--- a/ihp-hsx/parser/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/parser/IHP/HSX/HsExpToTH.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns, CPP #-}
+{-# LANGUAGE ViewPatterns #-}
 {-|
 Module: IHP.HSX.HsExpToTH
 Copyright: (c) digitally induced GmbH, 2022
@@ -21,17 +21,12 @@ import GHC.Types.Name
 import GHC.Types.Name.Reader
 import GHC.Data.FastString
 import GHC.Utils.Outputable (Outputable, ppr, showSDocUnsafe)
-#if __GLASGOW_HASKELL__ < 912
-import GHC.Types.Basic (Boxity(..))
-#endif
 import GHC.Types.SourceText (il_value, rationalFromFractionalLit)
 import qualified GHC.Unit.Module as Module
 import GHC.Stack
 import qualified Data.List.NonEmpty as NonEmpty
 import Language.Haskell.Syntax.Type
-#if __GLASGOW_HASKELL__ >= 906
 import Language.Haskell.Syntax.Basic
-#endif
 
 
 fl_value = rationalFromFractionalLit
@@ -50,17 +45,13 @@ toLit (HsInteger _ i _) = TH.IntegerL i
 toLit (HsRat _ f _) = TH.FloatPrimL (fl_value f)
 toLit (HsFloatPrim _ f) = TH.FloatPrimL (fl_value f)
 toLit (HsDoublePrim _ f) = TH.DoublePrimL (fl_value f)
-#if __GLASGOW_HASKELL__ >= 912
 toLit (HsMultilineString _ s) = TH.StringL (unpackFS s)
-#endif
-#if __GLASGOW_HASKELL__ >= 910
 toLit (HsInt8Prim _ i) = TH.IntPrimL i
 toLit (HsInt16Prim _ i) = TH.IntPrimL i
 toLit (HsInt32Prim _ i) = TH.IntPrimL i
 toLit (HsWord8Prim _ i) = TH.WordPrimL i
 toLit (HsWord16Prim _ i) = TH.WordPrimL i
 toLit (HsWord32Prim _ i) = TH.WordPrimL i
-#endif
 
 toLit' :: OverLitVal -> TH.Lit
 toLit' (HsIntegral i) = TH.IntegerL (il_value i)
@@ -89,11 +80,7 @@ toFieldExp = undefined
 toPat :: Pat.Pat GhcPs -> TH.Pat
 toPat (Pat.VarPat _ (unLoc -> name)) = TH.VarP (toName name)
 toPat (TuplePat _ p _) = TH.TupP (map (toPat . unLoc) p)
-#if __GLASGOW_HASKELL__ >= 910
 toPat (ParPat xP lP)  = (toPat . unLoc) lP
-#else
-toPat (ParPat xP _ lP _) = (toPat . unLoc) lP
-#endif
 toPat (ConPat pat_con_ext ((unLoc -> name)) pat_args) = TH.ConP (toName name) (map toType []) (map (toPat . unLoc) (Pat.hsConPatArgs pat_args))
 toPat (ViewPat pat_con pat_args pat_con_ext) = error "TH.ViewPattern not implemented"
 toPat (SumPat _ _ _ _) = error "TH.SumPat not implemented"
@@ -108,11 +95,7 @@ toExp (Expr.HsVar _ n) =
         then TH.ConE (toName n')
         else TH.VarE (toName n')
 
-#if __GLASGOW_HASKELL__ >= 906
 toExp (Expr.HsUnboundVar _ n)              = TH.UnboundVarE (TH.mkName . occNameString $ occName n)
-#else
-toExp (Expr.HsUnboundVar _ n)              = TH.UnboundVarE (TH.mkName . occNameString $ n)
-#endif
 
 toExp Expr.HsIPVar {}
   = noTH "toExp" "HsIPVar"
@@ -126,13 +109,7 @@ toExp (Expr.HsOverLit _ OverLit {ol_val})
 toExp (Expr.HsApp _ e1 e2)
   = TH.AppE (toExp . unLoc $ e1) (toExp . unLoc $ e2)
 
-#if __GLASGOW_HASKELL__ >= 910
 toExp (Expr.HsAppType _ e HsWC {hswc_body}) = TH.AppTypeE (toExp . unLoc $ e) (toType . unLoc $ hswc_body)
-#elif __GLASGOW_HASKELL__ >= 906
-toExp (Expr.HsAppType _ e _ HsWC {hswc_body}) = TH.AppTypeE (toExp . unLoc $ e) (toType . unLoc $ hswc_body)
-#else
-toExp (Expr.HsAppType _ e HsWC {hswc_body}) = TH.AppTypeE (toExp . unLoc $ e) (toType . unLoc $ hswc_body)
-#endif
 toExp (Expr.ExprWithTySig _ e HsWC{hswc_body=unLoc -> HsSig{sig_body}}) = TH.SigE (toExp . unLoc $ e) (toType . unLoc $ sig_body)
 
 toExp (Expr.OpApp _ e1 o e2)
@@ -142,15 +119,7 @@ toExp (Expr.NegApp _ e _)
   = TH.AppE (TH.VarE 'negate) (toExp . unLoc $ e)
 
 -- NOTE: for lambda, there is only one match
-#if __GLASGOW_HASKELL__ >= 912
 toExp (Expr.HsLam _ LamSingle (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc . unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)]))))
-#elif __GLASGOW_HASKELL__ >= 910
-toExp (Expr.HsLam _ LamSingle (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)]))))
-#elif __GLASGOW_HASKELL__ >= 906
-toExp (Expr.HsLam _ (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)]))))
-#else
-toExp (Expr.HsLam _ (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)])) _))
-#endif
   = TH.LamE (fmap toPat ps) (toExp e)
 
 -- toExp (Expr.Let _ bs e)                       = TH.LetE (toDecs bs) (toExp e)
@@ -175,11 +144,7 @@ toExp (Expr.ExplicitTuple _ args boxity) = ctor tupArgs
     tupArgs = fmap ((fmap toExp) . toTupArg) args
 
 -- toExp (Expr.List _ xs)                        = TH.ListE (fmap toExp xs)
-#if __GLASGOW_HASKELL__ >= 910
 toExp (Expr.HsPar _ e) =
-#else
-toExp (Expr.HsPar _ _ e _) =
-#endif
   TH.ParensE (toExp . unLoc $ e)
 
 toExp (Expr.SectionL _ (unLoc -> a) (unLoc -> b))
@@ -192,25 +157,15 @@ toExp (Expr.RecordCon _ name HsRecFields {rec_flds})
   = TH.RecConE (toName . unLoc $ name) (fmap toFieldExp rec_flds)
 
 toExp (Expr.RecordUpd _ (unLoc -> e) xs)                 = TH.RecUpdE (toExp e) $ case xs of
-#if __GLASGOW_HASKELL__ >= 908
     RegularRecUpdFields { recUpdFields = fields } ->
-#else
-    Left fields ->
-#endif
         let
             f (unLoc -> x) = (name, value)
                 where
                     value = toExp $ unLoc $ hfbRHS x
                     name =
                         case unLoc (hfbLHS x) of
-#if __GLASGOW_HASKELL__ >= 912
                             FieldOcc _ (unLoc -> name) -> toName name
                             XFieldOcc _ -> error "todo"
-#else
-                            Unambiguous _ (unLoc -> name) -> toName name
-                            Ambiguous _ (unLoc -> name) -> toName name
-                            XAmbiguousFieldOcc {} -> error "XAmbiguousFieldOcc"
-#endif
         in
             map f fields
     otherwise -> error "todo"
@@ -235,32 +190,16 @@ toExp (Expr.HsProjection _ locatedFields) =
     extractFieldLabel (DotFieldOcc _ locatedStr) = locatedStr
     extractFieldLabel _ = error "Don't know how to handle XDotFieldOcc constructor..."
   in
-#if __GLASGOW_HASKELL__ >= 912
     TH.ProjectionE (NonEmpty.map (unpackFS . (.field_label) . unLoc . extractFieldLabel) locatedFields)
-#elif __GLASGOW_HASKELL__ >= 906
-    TH.ProjectionE (NonEmpty.map (unpackFS . (.field_label) . unLoc . extractFieldLabel . unLoc) locatedFields)
-#else
-    TH.ProjectionE (NonEmpty.map (unpackFS . unLoc . extractFieldLabel . unLoc) locatedFields)
-#endif
 
 toExp (Expr.HsGetField _ expr locatedField) =
   let
     extractFieldLabel (DotFieldOcc _ locatedStr) = locatedStr
     extractFieldLabel _ = error "Don't know how to handle XDotFieldOcc constructor..."
   in
-#if __GLASGOW_HASKELL__ >= 906
     TH.GetFieldE (toExp (unLoc expr)) (unpackFS . (.field_label) . unLoc . extractFieldLabel . unLoc $ locatedField)
-#else
-    TH.GetFieldE (toExp (unLoc expr)) (unpackFS . unLoc . extractFieldLabel . unLoc $ locatedField)
-#endif
 
-#if __GLASGOW_HASKELL__ >= 912
 toExp (Expr.HsOverLabel _ fastString) = TH.LabelE (unpackFS fastString)
-#elif __GLASGOW_HASKELL__ >= 906
-toExp (Expr.HsOverLabel _ _ fastString) = TH.LabelE (unpackFS fastString)
-#else
-toExp (Expr.HsOverLabel _ fastString) = TH.LabelE (unpackFS fastString)
-#endif
 
 toExp e = todo "toExp" e
 

--- a/ihp-hsx/parser/IHP/HSX/HsExpToTH.hs
+++ b/ihp-hsx/parser/IHP/HSX/HsExpToTH.hs
@@ -41,8 +41,6 @@ toLit (HsIntPrim _ i) = TH.IntPrimL i
 toLit (HsWordPrim _ i) = TH.WordPrimL i
 toLit (HsInt64Prim _ i) = TH.IntegerL i
 toLit (HsWord64Prim _ i) = TH.WordPrimL i
-toLit (HsInteger _ i _) = TH.IntegerL i
-toLit (HsRat _ f _) = TH.FloatPrimL (fl_value f)
 toLit (HsFloatPrim _ f) = TH.FloatPrimL (fl_value f)
 toLit (HsDoublePrim _ f) = TH.DoublePrimL (fl_value f)
 toLit (HsMultilineString _ s) = TH.StringL (unpackFS s)
@@ -95,7 +93,7 @@ toExp (Expr.HsVar _ n) =
         then TH.ConE (toName n')
         else TH.VarE (toName n')
 
-toExp (Expr.HsUnboundVar _ n)              = TH.UnboundVarE (TH.mkName . occNameString $ occName n)
+toExp (Expr.HsHole _)                      = TH.UnboundVarE (TH.mkName "_")
 
 toExp Expr.HsIPVar {}
   = noTH "toExp" "HsIPVar"
@@ -119,7 +117,7 @@ toExp (Expr.NegApp _ e _)
   = TH.AppE (TH.VarE 'negate) (toExp . unLoc $ e)
 
 -- NOTE: for lambda, there is only one match
-toExp (Expr.HsLam _ LamSingle (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc . unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)]))))
+toExp (Expr.HsLam _ LamSingle (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc . unLoc -> ps) (Expr.GRHSs _ ((unLoc -> Expr.GRHS _ _ (unLoc -> e)) NonEmpty.:| []) _)]))))
   = TH.LamE (fmap toPat ps) (toExp e)
 
 -- toExp (Expr.Let _ bs e)                       = TH.LetE (toDecs bs) (toExp e)

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 extra-source-files:  changelog.md
 data-dir: data
@@ -36,7 +36,7 @@ Flag FastBuild
 common shared-properties
     default-language: GHC2021
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
             , classy-prelude
             , mono-traversable
             , transformers
@@ -346,7 +346,7 @@ executable hash-password
 executable new-session-secret
     default-language: Haskell2010
     default-extensions: BlockArguments
-    build-depends: base >= 4.17.0 && < 4.22, clientsession, bytestring, with-utf8, base64-bytestring
+    build-depends: base >= 4.17.0 && < 4.23, clientsession, bytestring, with-utf8, base64-bytestring
     hs-source-dirs: exe
     main-is: IHP/CLI/NewSessionSecret.hs
     ghc-options: -fsplit-sections

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 extra-source-files:  changelog.md
 data-dir: data

--- a/ihp-imagemagick/ihp-imagemagick.cabal
+++ b/ihp-imagemagick/ihp-imagemagick.cabal
@@ -36,7 +36,7 @@ common ihp-std
 library
     import: ihp-std
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
         , text
         , bytestring
         , wai-extra

--- a/ihp-job-dashboard/ihp-job-dashboard.cabal
+++ b/ihp-job-dashboard/ihp-job-dashboard.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 extra-source-files:  changelog.md
 

--- a/ihp-job-dashboard/ihp-job-dashboard.cabal
+++ b/ihp-job-dashboard/ihp-job-dashboard.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 extra-source-files:  changelog.md
 
@@ -20,7 +20,7 @@ library
     default-language: GHC2021
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields -Werror=missing-home-modules
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
             , wai
             , mtl
             , blaze-html

--- a/ihp-mail/ihp-mail.cabal
+++ b/ihp-mail/ihp-mail.cabal
@@ -51,7 +51,7 @@ library
         , IHP.Mail.Types
         , IHP.MailPrelude
     build-depends:
-        base >= 4.17.0 && < 4.22
+        base >= 4.17.0 && < 4.23
         , ihp
         , mime-mail
         , mime-mail-ses

--- a/ihp-migrate/ihp-migrate.cabal
+++ b/ihp-migrate/ihp-migrate.cabal
@@ -36,13 +36,13 @@ common ihp-std
 
 library
     import: ihp-std
-    build-depends: base >= 4.17.0 && < 4.22, with-utf8, text, directory >= 1.3.8.0, filepath >= 1.5, string-conversions, hasql, hasql-transaction
+    build-depends: base >= 4.17.0 && < 4.23, with-utf8, text, directory >= 1.3.8.0, filepath >= 1.5, string-conversions, hasql, hasql-transaction
     hs-source-dirs: .
     exposed-modules: IHP.SchemaMigration
 
 executable migrate
     import: ihp-std
-    build-depends: base >= 4.17.0 && < 4.22, with-utf8, text, directory >= 1.3.8.0, filepath >= 1.5, ihp-migrate, string-conversions, hasql, hasql-transaction
+    build-depends: base >= 4.17.0 && < 4.23, with-utf8, text, directory >= 1.3.8.0, filepath >= 1.5, ihp-migrate, string-conversions, hasql, hasql-transaction
     hs-source-dirs: exe
     main-is: Migrate.hs
     ghc-options: -threaded
@@ -51,5 +51,5 @@ test-suite tests
     import: ihp-std
     type: exitcode-stdio-1.0
     main-is: SchemaMigrationSpec.hs
-    build-depends: base >= 4.17.0 && < 4.22, hspec, with-utf8, directory >= 1.3.8.0, ihp-migrate, filepath >= 1.5, temporary-ospath
+    build-depends: base >= 4.17.0 && < 4.23, hspec, with-utf8, directory >= 1.3.8.0, ihp-migrate, filepath >= 1.5, temporary-ospath
     hs-source-dirs: Test

--- a/ihp-modal/ihp-modal.cabal
+++ b/ihp-modal/ihp-modal.cabal
@@ -16,7 +16,7 @@ category:            Web, IHP
 common shared-properties
     default-language: GHC2021
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
         , ihp-context
         , ihp-hsx
         , text

--- a/ihp-openai/ihp-openai.cabal
+++ b/ihp-openai/ihp-openai.cabal
@@ -19,7 +19,7 @@ source-repository head
 library
     default-language: GHC2021
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
         , text
         , http-streams
         , retry
@@ -63,7 +63,7 @@ test-suite tests
     type: exitcode-stdio-1.0
     main-is: IHP/OpenAISpec.hs
     build-depends:
-        base >= 4.17.0 && < 4.22
+        base >= 4.17.0 && < 4.23
         , hspec
         , neat-interpolation
         , ihp-openai

--- a/ihp-pagehead/ihp-pagehead.cabal
+++ b/ihp-pagehead/ihp-pagehead.cabal
@@ -14,7 +14,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 
 source-repository head

--- a/ihp-pagehead/ihp-pagehead.cabal
+++ b/ihp-pagehead/ihp-pagehead.cabal
@@ -14,7 +14,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 
 source-repository head
@@ -37,7 +37,7 @@ library
     import: shared-properties
     hs-source-dirs: .
     build-depends:
-        base >= 4.17.0 && < 4.22
+        base >= 4.17.0 && < 4.23
         , ihp-context
         , ihp-hsx
         , text

--- a/ihp-pglistener/ihp-pglistener.cabal
+++ b/ihp-pglistener/ihp-pglistener.cabal
@@ -16,7 +16,7 @@ category:            Web, Database, IHP
 common shared-properties
     default-language: GHC2021
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
         , bytestring
         , text
         , string-conversions

--- a/ihp-postgres-parser/ihp-postgres-parser.cabal
+++ b/ihp-postgres-parser/ihp-postgres-parser.cabal
@@ -11,7 +11,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Database, Parsing
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 
 Flag FastBuild

--- a/ihp-postgres-parser/ihp-postgres-parser.cabal
+++ b/ihp-postgres-parser/ihp-postgres-parser.cabal
@@ -11,7 +11,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Database, Parsing
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 
 Flag FastBuild
@@ -21,7 +21,7 @@ Flag FastBuild
 common shared-properties
     default-language: GHC2021
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
           , filepath >= 1.5
           , text
           , megaparsec

--- a/ihp-router/examples/minimal-wai/minimal-wai.cabal
+++ b/ihp-router/examples/minimal-wai/minimal-wai.cabal
@@ -19,7 +19,7 @@ executable minimal-wai
     default-language: GHC2021
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports
     build-depends:
-        base >= 4.17.0 && < 4.22
+        base >= 4.17.0 && < 4.23
       , bytestring
       , http-types
       , text

--- a/ihp-router/ihp-router.cabal
+++ b/ihp-router/ihp-router.cabal
@@ -21,7 +21,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web
 stability:           Stable
-tested-with:         GHC == 9.10.3
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 extra-source-files:  changelog.md
 

--- a/ihp-router/ihp-router.cabal
+++ b/ihp-router/ihp-router.cabal
@@ -21,7 +21,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 extra-source-files:  changelog.md
 
@@ -58,7 +58,7 @@ library
         , IHP.Router.DSL.TH
         , IHP.Router.WAI
     build-depends:
-        base >= 4.17.0 && < 4.22
+        base >= 4.17.0 && < 4.23
         , bytestring
         , text
         , containers

--- a/ihp-schema-compiler/ihp-schema-compiler.cabal
+++ b/ihp-schema-compiler/ihp-schema-compiler.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 extra-source-files:  changelog.md
 data-dir: data
@@ -25,7 +25,7 @@ Flag FastBuild
 common shared-properties
     default-language: GHC2021
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
           , classy-prelude
           , text
           , bytestring

--- a/ihp-schema-compiler/ihp-schema-compiler.cabal
+++ b/ihp-schema-compiler/ihp-schema-compiler.cabal
@@ -12,7 +12,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 extra-source-files:  changelog.md
 data-dir: data

--- a/ihp-sitemap/ihp-sitemap.cabal
+++ b/ihp-sitemap/ihp-sitemap.cabal
@@ -39,7 +39,7 @@ common ihp-std
 library
     import: ihp-std
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
         , text
         , ihp
         , blaze-html
@@ -56,7 +56,7 @@ test-suite tests
     type: exitcode-stdio-1.0
     main-is: SEO/Sitemap.hs
     build-depends:
-        base >= 4.17.0 && < 4.22
+        base >= 4.17.0 && < 4.23
         , hspec
         , ihp
         , ihp-sitemap

--- a/ihp-ssc/ihp-ssc.cabal
+++ b/ihp-ssc/ihp-ssc.cabal
@@ -42,7 +42,7 @@ library
         , DeepSubsumption
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields -Werror=missing-home-modules
     hs-source-dirs: .
-    build-depends: ihp, fast-logger, aeson, megaparsec, bytestring, wai, websockets, ihp-hsx, base >= 4.17.0 && < 4.22, string-conversions, basic-prelude, text, blaze-html, attoparsec, wai-request-params
+    build-depends: ihp, fast-logger, aeson, megaparsec, bytestring, wai, websockets, ihp-hsx, base >= 4.17.0 && < 4.23, string-conversions, basic-prelude, text, blaze-html, attoparsec, wai-request-params
     exposed-modules:
           IHP.ServerSideComponent.Types
         , IHP.ServerSideComponent.ViewFunctions

--- a/ihp-typed-sql/ihp-typed-sql.cabal
+++ b/ihp-typed-sql/ihp-typed-sql.cabal
@@ -53,7 +53,7 @@ library
         IHP.TypedSql.Decoders
         IHP.TypedSql.RowType
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
             , ihp
             , aeson
             , bytestring
@@ -82,7 +82,7 @@ test-suite tests
     hs-source-dirs: Test
     ghc-options: -threaded
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
             , ihp
             , fast-logger
             , ihp-typed-sql

--- a/ihp-welcome/ihp-welcome.cabal
+++ b/ihp-welcome/ihp-welcome.cabal
@@ -41,7 +41,7 @@ common ihp-std
 library
     import: ihp-std
     build-depends:
-          base >= 4.17.0 && < 4.22
+          base >= 4.17.0 && < 4.23
         , text
         , ihp
         , blaze-html

--- a/ihp/IHP/Prelude.hs
+++ b/ihp/IHP/Prelude.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK not-home, hide #-}
-#if __GLASGOW_HASKELL__ >= 912
 {-# LANGUAGE NamedDefaults #-}
-#endif
 module IHP.Prelude
 ( module CorePrelude
 , module Data.Text.IO
@@ -50,9 +47,7 @@ module IHP.Prelude
 , OsPath
 , textToOsPath
 , osPathToText
-#if __GLASGOW_HASKELL__ >= 912
 , default IsString
-#endif
 )
 where
 
@@ -151,6 +146,4 @@ instance IsString OsPath where
     fromString s = unsafePerformIO (OsPath.encodeUtf s)
     {-# NOINLINE fromString #-}
 
-#if __GLASGOW_HASKELL__ >= 912
 default IsString (Text, String)
-#endif

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -13,7 +13,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.8.4
+tested-with:         GHC == 9.12.3
 build-type:          Simple
 data-dir: data
 data-files:

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -13,7 +13,7 @@ bug-reports:         https://github.com/digitallyinduced/ihp/issues
 copyright:           (c) digitally induced GmbH
 category:            Web, IHP
 stability:           Stable
-tested-with:         GHC == 9.12.3
+tested-with:         GHC == 9.14.1
 build-type:          Simple
 data-dir: data
 data-files:
@@ -34,7 +34,7 @@ extra-source-files: CHANGELOG.md
 common shared-properties
     default-language: GHC2021
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
             , classy-prelude
             , mono-traversable
             , transformers

--- a/wai-asset-path/wai-asset-path.cabal
+++ b/wai-asset-path/wai-asset-path.cabal
@@ -24,6 +24,6 @@ library
         BlockArguments
         OverloadedStrings
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields -Werror=missing-home-modules
-    build-depends: base >= 4.17.0 && < 4.22, text, wai, vault
+    build-depends: base >= 4.17.0 && < 4.23, text, wai, vault
     hs-source-dirs: .
     exposed-modules: Network.Wai.Middleware.AssetPath

--- a/wai-flash-messages/wai-flash-messages.cabal
+++ b/wai-flash-messages/wai-flash-messages.cabal
@@ -24,6 +24,6 @@ library
         BlockArguments
         OverloadedStrings
     ghc-options: -Werror=incomplete-patterns -Werror=unused-imports -Werror=missing-fields -Werror=missing-home-modules
-    build-depends: base >= 4.17.0 && < 4.22, text, wai, vault, cereal, cereal-text, bytestring, wai-session-maybe
+    build-depends: base >= 4.17.0 && < 4.23, text, wai, vault, cereal, cereal-text, bytestring, wai-session-maybe
     hs-source-dirs: .
     exposed-modules: Network.Wai.Middleware.FlashMessages

--- a/wai-request-params/wai-request-params.cabal
+++ b/wai-request-params/wai-request-params.cabal
@@ -21,7 +21,7 @@ library
           Wai.Request.Params
         , Wai.Request.Params.Middleware
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
           , wai
           , wai-extra
           , aeson
@@ -51,7 +51,7 @@ test-suite spec
           Wai.Request.ParamsSpec
         , Wai.Request.Params.MiddlewareSpec
     build-depends:
-            base >= 4.17.0 && < 4.22
+            base >= 4.17.0 && < 4.23
           , wai-request-params
           , hspec
           , wai


### PR DESCRIPTION
## Summary

- Upgrades the default GHC compiler from 9.10 to 9.14.1 (via 9.12)
- Adapts ihp-hsx parser for GHC 9.14 API changes
- Upgrades ghc-typelits ecosystem packages to 9.14-compatible versions
- Jailbreaks ~15 third-party packages with tight boot-library upper bounds

### GHC 9.14 API changes in ihp-hsx parser
- `HsUnboundVar` → `HsHole` (constructor renamed)
- `HsRat` / `HsInteger` literal constructors removed
- `GRHSs.grhssGRHSs` changed from `[]` to `NonEmpty`
- `mkParserOpts` lost its `[Extension]` argument

### Nix overlay
- Upgraded `ghc-tcplugin-api` 0.18 → 0.19, `ghc-typelits-natnormalise` 0.7 → 0.9.6, `ghc-typelits-knownnat` 0.7 → 0.8.4
- Jailbreaked packages with tight `base`/`containers`/`template-haskell` upper bounds
- Disabled HLS (not yet compatible with GHC 9.14)

## Test plan

- [x] `nix build .#packages.aarch64-linux.default` succeeds
- [x] `direnv exec . ghc --version` returns 9.14.1
- [ ] `nix flake check --impure` (full CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)