### PR TITLE
ci: also push built closures to the self-hosted Attic cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - master
       - 'v.+'
     tags: ['**']
+  workflow_dispatch:
 jobs:
   build:
     strategy:
@@ -30,10 +31,11 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       if: matrix.os != 'ARM64'
-    # ARM64 (self-hosted) runs the full check suite including multi-GHC checks
+    # ARM64 (self-hosted) runs the full check suite including multi-GHC checks.
+    # It also pushes to the self-hosted Attic cache via a daemon post-build-hook.
     - run: nix flake check --impure --override-input ihp-boilerplate/ihp "github:${{ github.event.repository.full_name }}/${{ github.sha }}" -L
       if: matrix.os == 'ARM64'
-    # GitHub-hosted runners only build packages to populate the cachix cache.
+    # GitHub-hosted runners only build packages to populate the binary caches.
     # All checks (tests, benchmarks, multi-GHC) are already covered by ARM64.
     # Uses --max-jobs 1 to build one derivation at a time, preventing OOM on
     # the 16GB ubuntu-latest runners where nothing-but-nix reduces available memory.
@@ -48,5 +50,19 @@ jobs:
         for p in $packages; do
           targets="$targets .#packages.$system.$p"
         done
-        nix build --impure --max-jobs 1 $override -L $targets
+        nix build --impure --max-jobs 1 $override -L --print-out-paths $targets > built-paths.txt
+        cat built-paths.txt
+      if: matrix.os != 'ARM64'
+    # Also push the freshly-built closures to the self-hosted Attic binary cache
+    # (https://cache.digitallyinduced.com/public), alongside cachix. This is what
+    # gives the Attic cache x86_64-linux + aarch64-darwin coverage (the ARM64
+    # self-hosted job only covers aarch64-darwin).
+    - name: Push to Attic cache
+      run: |
+        if [ ! -s built-paths.txt ]; then echo "no built paths to push"; exit 0; fi
+        nix profile install nixpkgs#attic-client
+        attic login di https://cache.digitallyinduced.com "$ATTIC_TOKEN"
+        xargs attic push public < built-paths.txt
+      env:
+        ATTIC_TOKEN: ${{ secrets.ATTIC_CI_TOKEN }}
       if: matrix.os != 'ARM64'


### PR DESCRIPTION
Mirrors the existing cachix push to the self-hosted Attic cache so it gets **x86_64-linux + aarch64-darwin** coverage from CI.

## What
- GitHub-hosted matrix jobs (`ubuntu-latest`, `macos-latest`) now also push their built closures to `https://cache.digitallyinduced.com/public` (in addition to `digitallyinduced.cachix.org`).
- Captures built paths via `--print-out-paths`, then `attic push public` using the `ATTIC_CI_TOKEN` repo secret (push-only, scoped to the public cache).
- Adds a `workflow_dispatch` trigger so the build can be run on demand (useful for testing/backfill).
- The self-hosted `ARM64` job is unchanged — it already pushes to Attic via the Mac's daemon post-build-hook (aarch64-darwin).

## Why
The self-hosted Attic cache (`cache.digitallyinduced.com`) currently only contains aarch64-darwin paths (from the ARM64 self-hosted runner). x86_64-linux users got no cache hits. This closes that gap so the Attic cache can eventually serve IHP users / replace Cachix.

## Note
Requires the `ATTIC_CI_TOKEN` secret (already set on this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)