### PR TITLE
Guide: document the self-hosted Attic binary cache

### DIFF
--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -697,3 +697,20 @@ To switch back to GHC 9.10, remove the overlay and run `direnv reload`.
 When installing IHP, the `ihp-new` tool will add the `digitallyinduced.cachix.org` binary cache to your nix system. This binary cache provides binaries for all IHP packages and commonly used dependencies for all nixpkgs versions used by IHP.
 
 When you are using packages that are not in the binary cache and thus are compiled from source code very often, we highly recommend setting up your own [cachix binary cache](https://cachix.org/) and use it next to the default `digitallyinduced.cachix.org` cache.
+
+#### Self-hosted Attic cache
+
+In addition to Cachix, digitally induced also runs a self-hosted [Attic](https://github.com/zhaofengli/attic) binary cache at `https://cache.digitallyinduced.com/public`. It is populated by IHP's CI for both `x86_64-linux` and `aarch64-darwin`, is public (no token required), and serves the same IHP packages and dependencies.
+
+Projects created from the IHP boilerplate already include it in `flake.nix`'s `nixConfig`. To add it to an existing project, add the substituter and its public key to your `flake.nix`:
+
+```nix
+nixConfig = {
+    extra-substituters = [
+        "https://cache.digitallyinduced.com/public"
+    ];
+    extra-trusted-public-keys = [
+        "public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ="
+    ];
+};
+```


### PR DESCRIPTION
Documents the new self-hosted Attic cache (`https://cache.digitallyinduced.com/public`) in the Binary Cache section of the package-management guide: what it is, that it's public + covers x86_64-linux/aarch64-darwin, and how to opt an existing project in.

New projects get it automatically via digitallyinduced/ihp-boilerplate#65. The cache is populated by CI via digitallyinduced/ihp#2700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)