### PR TITLE
ci: drop cachix push (digitallyinduced.cachix.org decommissioned)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,17 +25,11 @@ jobs:
       if: matrix.os != 'ARM64'
     - uses: DeterminateSystems/magic-nix-cache-action@main
       if: matrix.os != 'ARM64'
-    - uses: cachix/cachix-action@v17
-      with:
-        name: digitallyinduced
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      if: matrix.os != 'ARM64'
     # ARM64 (self-hosted) runs the full check suite including multi-GHC checks.
     # It also pushes to the self-hosted Attic cache via a daemon post-build-hook.
     - run: nix flake check --impure --override-input ihp-boilerplate/ihp "github:${{ github.event.repository.full_name }}/${{ github.sha }}" -L
       if: matrix.os == 'ARM64'
-    # GitHub-hosted runners only build packages to populate the binary caches.
+    # GitHub-hosted runners only build packages to populate the Attic binary cache.
     # All checks (tests, benchmarks, multi-GHC) are already covered by ARM64.
     # Uses --max-jobs 1 to build one derivation at a time, preventing OOM on
     # the 16GB ubuntu-latest runners where nothing-but-nix reduces available memory.
@@ -53,10 +47,10 @@ jobs:
         nix build --impure --max-jobs 1 $override -L --print-out-paths $targets > built-paths.txt
         cat built-paths.txt
       if: matrix.os != 'ARM64'
-    # Also push the freshly-built closures to the self-hosted Attic binary cache
-    # (https://cache.digitallyinduced.com/public), alongside cachix. This is what
-    # gives the Attic cache x86_64-linux + aarch64-darwin coverage (the ARM64
-    # self-hosted job only covers aarch64-darwin).
+    # Push the freshly-built closures to the self-hosted Attic binary cache
+    # (https://cache.digitallyinduced.com/public). This gives the Attic cache
+    # x86_64-linux + aarch64-darwin coverage (the ARM64 self-hosted job only
+    # covers aarch64-darwin).
     - name: Push to Attic cache
       run: |
         if [ ! -s built-paths.txt ]; then echo "no built paths to push"; exit 0; fi


### PR DESCRIPTION
`digitallyinduced.cachix.org` is no longer active. The self-hosted Attic cache now receives all build outputs (#2700), so the `cachix-action` push step is redundant — this removes it.

Part of decommissioning digitallyinduced.cachix.org (see also ihp-boilerplate#65 and the Guide update #2701). The `CACHIX_SIGNING_KEY` / `CACHIX_AUTH_TOKEN` secrets become unused and can be deleted from the repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)