### PR TITLE
Guide: document the self-hosted binary cache alongside cachix

### DIFF
--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -694,6 +694,19 @@ To switch back to GHC 9.10, remove the overlay and run `direnv reload`.
 
 ### Binary Cache
 
-When installing IHP, the `ihp-new` tool will add the `digitallyinduced.cachix.org` binary cache to your nix system. This binary cache provides binaries for all IHP packages and commonly used dependencies for all nixpkgs versions used by IHP.
+IHP projects come with the digitally induced binary cache pre-configured in `flake.nix` (`nixConfig`). It provides prebuilt binaries for all IHP packages and commonly used dependencies for `x86_64-linux` and `aarch64-darwin`, so you don't have to compile them from source.
 
-When you are using packages that are not in the binary cache and thus are compiled from source code very often, we highly recommend setting up your own [cachix binary cache](https://cachix.org/) and use it next to the default `digitallyinduced.cachix.org` cache.
+To add it to an existing project, add the substituter and its public key to your `flake.nix`:
+
+```nix
+nixConfig = {
+    extra-substituters = [
+        "https://cache.digitallyinduced.com/public"
+    ];
+    extra-trusted-public-keys = [
+        "public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ="
+    ];
+};
+```
+
+When you are using packages that are not in the binary cache and thus are compiled from source code very often, we highly recommend setting up your own [cachix binary cache](https://cachix.org/) and using it next to the digitally induced cache.

--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -694,19 +694,23 @@ To switch back to GHC 9.10, remove the overlay and run `direnv reload`.
 
 ### Binary Cache
 
-IHP projects come with the digitally induced binary cache pre-configured in `flake.nix` (`nixConfig`). It provides prebuilt binaries for all IHP packages and commonly used dependencies for `x86_64-linux` and `aarch64-darwin`, so you don't have to compile them from source.
+When installing IHP, the `ihp-new` tool will add the `digitallyinduced.cachix.org` binary cache to your nix system. This binary cache provides binaries for all IHP packages and commonly used dependencies for all nixpkgs versions used by IHP.
 
-To add it to an existing project, add the substituter and its public key to your `flake.nix`:
+IHP projects additionally come with the digitally induced binary cache at `https://cache.digitallyinduced.com/public` pre-configured in `flake.nix` (`nixConfig`). It serves the same IHP packages for `x86_64-linux` and `aarch64-darwin` and provides extra capacity beyond the cachix cache.
+
+To add the caches to an existing project, add the substituters and public keys to your `flake.nix`:
 
 ```nix
 nixConfig = {
     extra-substituters = [
+        "https://digitallyinduced.cachix.org"
         "https://cache.digitallyinduced.com/public"
     ];
     extra-trusted-public-keys = [
+        "digitallyinduced.cachix.org-1:y+wQvrnxQ+PdEsCt91rmvv39qRCYzEgGQaldK26hCKE="
         "public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ="
     ];
 };
 ```
 
-When you are using packages that are not in the binary cache and thus are compiled from source code very often, we highly recommend setting up your own [cachix binary cache](https://cachix.org/) and using it next to the digitally induced cache.
+When you are using packages that are not in the binary cache and thus are compiled from source code very often, we highly recommend setting up your own [cachix binary cache](https://cachix.org/) and using it next to the default caches.


### PR DESCRIPTION
Documents the additional self-hosted binary cache (`https://cache.digitallyinduced.com/public`, x86_64-linux + aarch64-darwin) in the Binary Cache section, **alongside** the existing `digitallyinduced.cachix.org` cache (which stays — it's still active, just 50GB-capped). The self-hosted cache provides extra capacity.

New projects get both via digitallyinduced/ihp-boilerplate#65; existing projects can add them with the snippet shown. The self-hosted cache is populated by CI (#2700).

🤖 Generated with [Claude Code](https://claude.com/claude-code)