### PR TITLE
ci: also pull from the self-hosted binary cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,10 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
       with:
         determinate: true
-        extra-conf: "lazy-trees = true"
+        extra-conf: |
+          lazy-trees = true
+          extra-substituters = https://cache.digitallyinduced.com/public
+          extra-trusted-public-keys = public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ=
       if: matrix.os != 'ARM64'
     - uses: DeterminateSystems/magic-nix-cache-action@main
       if: matrix.os != 'ARM64'


### PR DESCRIPTION
CI currently only *pushes* to the self-hosted cache; it pulls from cachix + FlakeHub + cache.nixos.org. This adds `cache.digitallyinduced.com/public` as a substituter on the GitHub-hosted runners too (via `nix-installer-action`'s `extra-conf`).

Benefit: cachix is 50GB-capped (LRU eviction), so artifacts dropped from cachix may still live in the larger self-hosted cache — CI can then pull them instead of rebuilding. Non-fatal if the cache is slow/down (nix falls back).

The self-hosted ARM64 runner already pulls from it (added to its `nix.custom.conf`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)