### PR TITLE
Revert temporary nixpkgs staging-next pin

### DIFF
--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -106,18 +106,11 @@ let
 
             # Hasql 1.10 ecosystem.
             #
-            # nixpkgs is pinned (see flake.nix) to a staging-next commit
-            # containing NixOS/nixpkgs#519795, which (a) adds `dontCheck` for
-            # the versioned hasql attrs in configuration-nix.nix and (b) unmarks
-            # hasql-mapping / postgresql-simple-postgresql-types inside its
-            # upstream IHP scope. We therefore consume these attrs verbatim
-            # (no local dontCheck) so the derivations are bit-identical to
-            # nixpkgs' Hydra-built `haskellPackages.ihp` closure and resolve
-            # straight from cache.nixos.org instead of rebuilding hasql + GHC
-            # + the Haskell dep tree from source. The mirrored attrs below
-            # match the upstream `ihpHasqlScope` exactly — keep them in sync
-            # with configuration-common.nix. Revert together with the flake.nix
-            # pin once #519795 reaches the nixpkgs-unstable channel.
+            # These attrs mirror the upstream `ihpHasqlScope` from
+            # NixOS/nixpkgs#519795 (configuration-common.nix) so that
+            # derivations are bit-identical to nixpkgs' Hydra-built
+            # `haskellPackages.ihp` closure and resolve straight from
+            # cache.nixos.org. Keep in sync with configuration-common.nix.
             postgresql-connection-string = hackagePackage "postgresql-connection-string";
 
             hasql                    = super.hasql_1_10_3;
@@ -144,27 +137,10 @@ let
             # Fork of temporary using OsPath instead of FilePath
             temporary-ospath = hackagePackage "temporary-ospath";
 
-            # postgresql-types / ptr-peeker bridge stack.
-            #
-            # At the pinned #519795 nixpkgs rev, Hydra builds IHP's entire
-            # third-party closure green (haskellPackages.ihp) and uploads it to
-            # cache.nixos.org — including ptr-peeker 0.2.0.1, postgresql-types
-            # 0.1.3.2, postgresql-types-algebra and hasql-postgresql-types.
-            # ptr-peeker is no longer in broken.yaml and the `ptr-peeker ^>=0.1`
-            # bound problems that needed doJailbreak are gone at these versions,
-            # so ptr-peeker, postgresql-types, postgresql-types-algebra and
-            # hasql-postgresql-types are consumed verbatim from `super` (no
-            # entry here at all). Any transform would change the derivation hash
-            # and force a from-source rebuild of that package *and its whole
-            # reverse-dependency cone*, defeating the cache. Keep in sync with
-            # the upstream IHP scope; revert with the flake.nix pin.
-            #
-            # postgresql-simple-postgresql-types and hasql-mapping are the only
-            # exceptions: both are genuinely in broken.yaml, so they need
-            # markUnbroken — mirroring upstream ihpHasqlScope's `unmarkBroken`
-            # exactly (configuration-nix.nix already applies the dontCheck for
-            # postgresql-simple-postgresql-types). No doJailbreak / dontHaddock:
-            # those would diverge from the cached upstream derivations.
+            # postgresql-simple-postgresql-types and hasql-mapping are marked
+            # broken in nixpkgs; unmark them to mirror upstream ihpHasqlScope's
+            # `unmarkBroken` (configuration-nix.nix applies dontCheck for
+            # postgresql-simple-postgresql-types).
             postgresql-simple-postgresql-types = final.haskell.lib.markUnbroken super.postgresql-simple-postgresql-types;
             hasql-mapping = final.haskell.lib.markUnbroken super.hasql-mapping;
         };

--- a/flake.lock
+++ b/flake.lock
@@ -1815,17 +1815,17 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1779088067,
-        "narHash": "sha256-Qw3/WyO1CmPKyQtzR1W4iPTN0Z9fImpibGXn1aLAIT4=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23efd5e6fcd2ebf02486146f141d5348449694ab",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "23efd5e6fcd2ebf02486146f141d5348449694ab",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,21 +2,7 @@
     description = "IHP is a modern batteries-included haskell web framework, built on top of Haskell and Nix.";
 
     inputs = {
-        # TEMPORARY PIN — not the nixpkgs-unstable channel branch.
-        #
-        # Pinned to a staging-next commit that contains NixOS/nixpkgs#519795
-        # ("haskellPackages.ihp: pin to hasql 1.10"), which adds the upstream
-        # IHP hasql-1.10 scope + dontCheck for the versioned hasql attrs.
-        # Hydra has already built haskellPackages.ihp green at this rev, so the
-        # entire hasql 1.10 closure (+ GHC + the Haskell dep tree) is prebuilt
-        # in cache.nixos.org for aarch64-darwin / x86_64-linux / aarch64-linux.
-        # That lets NixSupport/overlay.nix drop its local dontCheck workarounds
-        # and get binary-cache hits instead of rebuilding the stack from source.
-        #
-        # Revert to "github:NixOS/nixpkgs/nixpkgs-unstable" once #519795 has
-        # propagated through staging-next -> master -> the nixpkgs-unstable
-        # channel (tracked by NixOS/nixpkgs#517946).
-        nixpkgs.url = "github:NixOS/nixpkgs/23efd5e6fcd2ebf02486146f141d5348449694ab";      # for Haskell packages
+        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";             # for Haskell packages
         nixpkgs-nixos.url = "github:NixOS/nixpkgs/nixos-25.11";     # for NixOS deployments (pin independently)
 
         # pre-defined set of default target systems


### PR DESCRIPTION
## Summary

- Reverts the temporary nixpkgs pin to `staging-next` (introduced in #2689) back to `github:NixOS/nixpkgs/nixpkgs-unstable`
- NixOS/nixpkgs#519795 has propagated to `nixpkgs-unstable` — the hasql 1.10 closure is now binary-cached on the channel
- Updates overlay comments to remove references to the temporary pin

## Verification

`nix build --dry-run` confirms only IHP's own 12 packages build from source; all third-party deps (GHC, hasql 1.10 stack, postgresql-types bridge) are cache hits from `cache.nixos.org`.

## Test plan

- [ ] `nix flake check --impure` passes
- [ ] `nix build --dry-run` shows only IHP monorepo packages building from source

Closes #2691

🤖 Generated with [Claude Code](https://claude.com/claude-code)