### PR TITLE
Fix benchmark CI: point ihp-forum to master

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
         nix build .#default \
           --impure \
           --override-input ihp "github:${{ github.event.repository.full_name }}/${{ github.event.pull_request.head.sha }}" \
-          --override-input ihp-forum "github:digitallyinduced/ihp-forum/claude/new-routing-dsl" \
+          --override-input ihp-forum "github:digitallyinduced/ihp-forum" \
           -o result-pr -L &
         PID_PR=$!
         wait $PID_BASELINE


### PR DESCRIPTION
The benchmark workflow hardcoded `--override-input ihp-forum "github:digitallyinduced/ihp-forum/claude/new-routing-dsl"` which still uses the removed `fromFrozenContext` API. ihp-forum master already has both the auth migration (#21) and new routing DSL (#22) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)