### PR TITLE
Wire up ihp.ghcCompiler option (was hardcoded to GHC 9.10)

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -25,8 +25,11 @@ ihpFlake:
                 ghcCompiler = lib.mkOption {
                     description = ''
                         The GHC compiler to use for IHP.
+
+                        Defaults to `pkgs.ghc` (GHC 9.10, binary-cached). Set to
+                        `pkgs.ghc914` to opt into GHC 9.14 (built from source).
                     '';
-                    default = pkgs.haskellPackages;
+                    default = pkgs.ghc;
                 };
 
                 packages = lib.mkOption {
@@ -167,7 +170,7 @@ ihpFlake:
         perSystem = { self', lib, pkgs, system, config, ... }: let
             cfg = config.ihp;
             ihp = ihpFlake.inputs.self;
-            ghcCompiler = pkgs.ghc;
+            ghcCompiler = cfg.ghcCompiler;
             ihpLib = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
             # Auto-detect whether a build-time PostgreSQL is needed (e.g. ihp-typed-sql)
             buildWithPostgres = builtins.any (p: (p.pname or "") == "ihp-typed-sql") (cfg.haskellPackages ghcCompiler);


### PR DESCRIPTION
## Problem

A user reported that setting `ihp.ghcCompiler = pkgs.ghc914;` in their app's flake-module config (as documented) had no effect — their app kept compiling with GHC 9.10.3 even after `nix flake update`.

The `ihp.ghcCompiler` option is **defined** ([`flake-module.nix:25`](https://github.com/digitallyinduced/ihp/blob/master/flake-module.nix#L25)) and **documented** — [`NixSupport/overlay.nix:172`](https://github.com/digitallyinduced/ihp/blob/master/NixSupport/overlay.nix#L172) literally tells users to *"set `ihp.ghcCompiler = pkgs.ghc914;` in your flake-module config"* — but it was **read nowhere**. `flake-module.nix` hardcoded `ghcCompiler = pkgs.ghc;`, so the option was silently ignored and every consumer (prod build, tests, `migrate`, and the devenv/ghci dev shell) always used GHC 9.10.

`grep -rn "cfg.ghcCompiler\|config.ihp.ghcCompiler"` returned zero matches before this change.

This regressed in `03675cea` ("use flake overlays instead of our manual mkGhcCompiler approach"), which replaced the old `mkGhcCompiler.nix` call that consumed `cfg.ghcCompiler` with a flat `pkgs.ghc`.

## Fix

- Read `cfg.ghcCompiler` instead of hardcoding `pkgs.ghc`.
- Change the option default from `pkgs.haskellPackages` (plain nixpkgs — has no `.ihp`/`.ihp-ide` attrs) to `pkgs.ghc` (the overlay set, GHC 9.10), so the **default build is byte-for-byte unchanged**.

With this, `ihp.ghcCompiler = pkgs.ghc914;` now flows through to prod builds, tests, and the dev shell. `pkgs.ghc` and `pkgs.ghc914` are both overlay-provided and expose the same interface (`.ihp`, `.ghcWithPackages`, `.ihp-migrate`, …), so swapping between them is safe.

> Note: GHC 9.14 is not in the binary cache yet, so opting in builds the 9.14 closure (incl. the jailbroken deps from the overlay) from source.

## Verification

`nix-instantiate --parse flake-module.nix` passes. The default path is unchanged (`pkgs.ghc`); only the opt-in path is newly enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)