### PR TITLE
[codex] Fix job worker shutdown draining

### DIFF
--- a/ihp/IHP/Job/Runner/MainLoop.hs
+++ b/ihp/IHP/Job/Runner/MainLoop.hs
@@ -16,7 +16,8 @@ import qualified System.Exit as Exit
 import qualified IHP.PGListener as PGListener
 import Control.Monad.Trans.Resource
 import System.Log.FastLogger (toLogStr)
-import Control.Concurrent.STM (atomically, writeTBQueue)
+import Control.Concurrent.STM (atomically, writeTVar)
+import IHP.Job.Queue (tryWriteTBQueue)
 
 -- | Used by the RunJobs binary
 runJobWorkers :: [JobWorker] -> Script
@@ -50,16 +51,22 @@ dedicatedProcessMainLoop jobWorkers = do
 
             liftIO $ ?context.logger (toLogStr ("Waiting for jobs to complete. CTRL+C again to force exit" :: Text))
 
+            -- Mark all workers as stopping before releasing producers, so running workers
+            -- finish their current job but don't fetch another one during shutdown.
+            liftIO $ forEach processes \JobWorkerProcess { action, isStopping } -> do
+                atomically do
+                    writeTVar isStopping True
+                    _ <- tryWriteTBQueue action Stop
+                    pure ()
+
             -- Stop subscriptions and poller already
             -- This will stop all producers for the queue
-            liftIO $ forEach processes \JobWorkerProcess { pollerReleaseKey, subscription, action, staleRecoveryReleaseKey } -> do
+            liftIO $ forEach processes \JobWorkerProcess { pollerReleaseKey, subscription, staleRecoveryReleaseKey } -> do
                 PGListener.unsubscribe subscription pgListener
                 release pollerReleaseKey
                 case staleRecoveryReleaseKey of
                     Just key -> release key
                     Nothing -> pure ()
-                -- Single Stop for the dispatcher (it waits for active workers internally)
-                atomically $ writeTBQueue action Stop
 
             liftIO $ PGListener.stop pgListener
 

--- a/ihp/IHP/Job/Runner/WorkerLoop.hs
+++ b/ihp/IHP/Job/Runner/WorkerLoop.hs
@@ -57,61 +57,71 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
 
     activeCount <- liftIO $ newTVarIO (0 :: Int)
     activeWorkers <- liftIO $ newTVarIO ([] :: [Async ()])
+    isStopping <- liftIO $ newTVarIO False
 
     let runJobLoop = do
-            fetchResult <- Exception.tryAny (Queue.fetchNextJob @job pool workerId)
-            case fetchResult of
-                Left exception -> do
-                    ?context.logger (toLogStr ("Job worker: Failed to fetch next job: " <> tshow exception))
-                    Concurrent.threadDelay 1000000  -- 1s backoff to avoid tight error loops
-                    runJobLoop -- retry after transient error
-                Right (Just job) -> do
-                    ?context.logger (toLogStr ("Starting job: " <> tshow job))
+            stopping <- readTVarIO isStopping
+            unless stopping do
+                fetchResult <- Exception.tryAny (Queue.fetchNextJob @job pool workerId)
+                case fetchResult of
+                    Left exception -> do
+                        ?context.logger (toLogStr ("Job worker: Failed to fetch next job: " <> tshow exception))
+                        Concurrent.threadDelay 1000000  -- 1s backoff to avoid tight error loops
+                        runJobLoop -- retry after transient error
+                    Right (Just job) -> do
+                        ?context.logger (toLogStr ("Starting job: " <> tshow job))
 
-                    let ?job = job
-                    let timeout :: Int = fromMaybe (-1) (timeoutInMicroseconds @job)
-                    resultOrException <- Exception.tryAsync (Timeout.timeout timeout (perform job))
-                    case resultOrException of
-                        Left exception -> do
-                            Queue.jobDidFail pool job exception
-                            when (Exception.isAsyncException exception) (Exception.throwIO exception)
-                        Right Nothing -> Queue.jobDidTimeout pool job
-                        Right (Just _) -> Queue.jobDidSucceed pool job
+                        let ?job = job
+                        let timeout :: Int = fromMaybe (-1) (timeoutInMicroseconds @job)
+                        resultOrException <- Exception.tryAsync (Timeout.timeout timeout (perform job))
+                        case resultOrException of
+                            Left exception -> do
+                                Queue.jobDidFail pool job exception
+                                when (Exception.isAsyncException exception) (Exception.throwIO exception)
+                            Right Nothing -> Queue.jobDidTimeout pool job
+                            Right (Just _) -> Queue.jobDidSucceed pool job
 
-                    runJobLoop -- try next job immediately
-                Right Nothing -> pure ()
+                        runJobLoop -- try next job immediately
+                    Right Nothing -> pure ()
+
+    let waitForActiveWorkers = atomically do
+            count <- readTVar activeCount
+            check (count == 0)
 
     let dispatcherLoop = do
-            msg <- atomically $ readTBQueue action
-            case msg of
-                Stop -> do
-                    -- Wait for all active workers to finish
-                    atomically $ do
-                        count <- readTVar activeCount
-                        check (count == 0)
-                JobAvailable -> do
-                    acquired <- atomically $ do
-                        count <- readTVar activeCount
-                        if count < maxConcurrency @job
-                            then do
-                                writeTVar activeCount (count + 1)
-                                pure True
-                            else pure False
-                    when acquired do
-                        selfVar <- Concurrent.newEmptyMVar
-                        workerAsync <- async $
-                            (do self <- Concurrent.readMVar selfVar
-                                runJobLoop)
-                            `Exception.finally`
-                                (do maybeSelf <- Concurrent.tryReadMVar selfVar
-                                    atomically do
-                                        modifyTVar' activeCount (subtract 1)
-                                        case maybeSelf of
-                                            Just self -> modifyTVar' activeWorkers (filter (/= self))
-                                            Nothing -> pure ())
-                        Concurrent.putMVar selfVar workerAsync
-                        atomically $ modifyTVar' activeWorkers (workerAsync :)
-                    dispatcherLoop
+            stopping <- readTVarIO isStopping
+            if stopping
+                then waitForActiveWorkers
+                else do
+                    msg <- atomically $ readTBQueue action
+                    case msg of
+                        Stop -> do
+                            atomically $ writeTVar isStopping True
+                            waitForActiveWorkers
+                        JobAvailable -> do
+                            acquired <- atomically do
+                                stopping <- readTVar isStopping
+                                count <- readTVar activeCount
+                                if not stopping && count < maxConcurrency @job
+                                    then do
+                                        writeTVar activeCount (count + 1)
+                                        pure True
+                                    else pure False
+                            when acquired do
+                                selfVar <- Concurrent.newEmptyMVar
+                                workerAsync <- async $
+                                    (do self <- Concurrent.readMVar selfVar
+                                        runJobLoop)
+                                    `Exception.finally`
+                                        (do maybeSelf <- Concurrent.tryReadMVar selfVar
+                                            atomically do
+                                                modifyTVar' activeCount (subtract 1)
+                                                case maybeSelf of
+                                                    Just self -> modifyTVar' activeWorkers (filter (/= self))
+                                                    Nothing -> pure ())
+                                Concurrent.putMVar selfVar workerAsync
+                                atomically $ modifyTVar' activeWorkers (workerAsync :)
+                            dispatcherLoop
 
     let cancelAllWorkers = do
             workers <- readTVarIO activeWorkers
@@ -136,4 +146,4 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
             pure (Just key)
         Nothing -> pure Nothing
 
-    pure JobWorkerProcess { dispatcher, subscription, pollerReleaseKey, action, staleRecoveryReleaseKey, activeCount }
+    pure JobWorkerProcess { dispatcher, subscription, pollerReleaseKey, action, staleRecoveryReleaseKey, activeCount, isStopping }

--- a/ihp/IHP/Job/Types/Worker.hs
+++ b/ihp/IHP/Job/Types/Worker.hs
@@ -32,6 +32,9 @@ data JobWorkerProcess
     , action :: TBQueue JobWorkerProcessMessage
     , staleRecoveryReleaseKey :: Maybe ReleaseKey
     , activeCount :: TVar Int
+    , isStopping :: TVar Bool
+    -- ^ Set when the worker process is shutting down. Dispatchers stop
+    -- accepting queued work and active workers stop fetching another job.
     }
 
 data JobWorkerProcessMessage


### PR DESCRIPTION
## Summary

Fixes job worker shutdown so a stopping worker process stops accepting queued wakeups immediately and active workers finish their current job without reserving another one.

## Root Cause

The dedicated worker main loop previously signaled shutdown by appending a `Stop` message to each worker action queue. If `JobAvailable` messages were already queued, the dispatcher could process those first and start new worker tasks after shutdown had begun. Active worker loops also recursively called `fetchNextJob` after each completed job, with no shared shutdown state, so an already-running worker could reserve additional jobs while systemd was waiting for the service to stop.

## Changes

- Add `isStopping :: TVar Bool` to `JobWorkerProcess` as shared shutdown state.
- Mark workers as stopping before releasing pollers/subscriptions during signal handling.
- Wake dispatchers with a non-blocking `Stop` queue write.
- Have dispatchers ignore queued `JobAvailable` messages once stopping starts.
- Have active worker loops check `isStopping` before fetching another job.

## Validation

- `git diff --check`
- `echo ':load ihp/IHP/Job/Runner/MainLoop.hs ihp/IHP/Job/Runner/WorkerLoop.hs' | direnv exec . ghci` loaded 99 modules successfully.

A broader `echo ':load ihp/Test/Test/Main.hs' | direnv exec . ghci` currently stops on the existing `ihp-pglistener/Test/PGListenerSpec.hs` module-name/path mismatch before reaching this change.
