### PR TITLE
[codex] Stop auto-opening browser in dev server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Breaking Changes
 
+- `devenv up` no longer opens the IHP development tooling in a browser by default. The ToolServer URL is printed to the terminal instead, which is friendlier for coding agents, remote workspaces, and shared development environments. Set `IHP_BROWSER=firefox`, `IHP_BROWSER=open` (macOS), or `IHP_BROWSER=xdg-open` (Linux) to restore automatic browser opening.
 - The `ihp-log` package and `IHP.Log.*` modules have been removed. Use `fast-logger` directly via `?context.logger`, `?modelContext.logger`, or `FrameworkConfig.logger`. See the [Logging Guide](Guide/logging.markdown) for examples. ([#2600](https://github.com/digitallyinduced/ihp/pull/2600))
 - IHP apps now treat incomplete pattern matches as compile errors in the default GHCi, generated Makefile, and generated Cabal configuration. This makes local development and agent-assisted coding fail fast when a pattern match misses a constructor.
 - Controller `action` now returns `IO ResponseReceived` instead of `IO ()` — response functions like `render`, `redirectTo`, `renderJson` return the WAI `ResponseReceived` directly instead of throwing exceptions. Use `earlyReturn` for conditional early exits (e.g. `when condition (earlyReturn $ redirectTo ...)`) ([#2205](https://github.com/digitallyinduced/ihp/pull/2205))

--- a/Guide/editors.markdown
+++ b/Guide/editors.markdown
@@ -255,18 +255,22 @@ When something goes wrong you can also run `haskell-language-server` inside the 
 
 ## IHP Dev Server
 
-### Customizing the Web Browser used by IHP
+### Opening the IHP Dev Server in a Browser
 
-When running `devenv up` the application will automatically be opened in your default browser. You can manually specify a browser by setting the env var `IHP_BROWSER` in `.envrc`:
+When running `devenv up`, IHP prints the development tooling URL to the terminal. To open it automatically in a browser, set the env var `IHP_BROWSER` in `.envrc`:
 
 ```bash
 export IHP_BROWSER=firefox
 ```
 
-You can disable the auto-start of the browser completely using `echo` as your browser:
+You can also use the system browser opener for your platform:
 
 ```bash
-export IHP_BROWSER=echo
+# macOS
+export IHP_BROWSER=open
+
+# Linux
+export IHP_BROWSER=xdg-open
 ```
 
 ### Running the IHP Dev Server On a Host Different From `localhost`

--- a/Guide/recipes.markdown
+++ b/Guide/recipes.markdown
@@ -178,16 +178,16 @@ This is also useful if you need the messages to be in another language.
 
 Use [`validateIsUnique`](https://ihp.digitallyinduced.com/api-docs/IHP-ValidationSupport-ValidateIsUnique.html#v:validateIsUnique).
 
-## Don't auto-open the app in the browser
+## Auto-open the app in the browser
 
-To prevent the IHP development server from automatically opening the development tooling in your web browser when running `devenv up`, set the `IHP_BROWSER` environment variable to `echo`:
+By default, the IHP development server prints the development tooling URL when running `devenv up`. To automatically open it in a browser, set the `IHP_BROWSER` environment variable:
 
 ```bash
-export IHP_BROWSER=echo
+export IHP_BROWSER=firefox
 devenv up
 ```
 
-This will then just print out the URL which would be opened on start.
+You can also set `IHP_BROWSER=open` on macOS or `IHP_BROWSER=xdg-open` on Linux to use the default system browser.
 
 ## Getting an `Id Something` from a `UUID`
 

--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -1,7 +1,7 @@
 module IHP.IDE.ToolServer (runToolServer, withToolServerApplication, ToolServerApplicationWithConfig(..)) where
 
 import IHP.Prelude
-import System.Log.FastLogger (LogType'(..), withFastLogger, defaultBufSize)
+import System.Log.FastLogger (LogType'(..), withFastLogger, defaultBufSize, toLogStr)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import IHP.IDE.Types
@@ -32,7 +32,6 @@ import IHP.IDE.ToolServer.Types
 import IHP.IDE.ToolServer.Helper.Controller as Helper
 import IHP.IDE.ToolServer.Routes ()
 import qualified System.Process as Process
-import System.Info
 import qualified IHP.EnvVar as EnvVar
 import qualified IHP.AutoRefresh as AutoRefresh
 import qualified IHP.IDE.ToolServer.Layout as Layout
@@ -171,16 +170,16 @@ initStaticApp = do
             }
     pure (Static.staticApp toolServerStaticSettings)
 
-openUrl :: Text -> IO ()
+openUrl :: (?context :: Context) => Text -> IO ()
 openUrl url = do
     selectedBrowser <- EnvVar.envOrNothing "IHP_BROWSER"
-    let defaultOSBrowser = case os of
-            "linux" -> "xdg-open"
-            "darwin" -> "open"
-            _ -> "xdg-open"
-    let browser = selectedBrowser |> fromMaybe defaultOSBrowser
-    async $ Process.callCommand (browser <> " " <> cs url)
-    pure ()
+    case selectedBrowser of
+        Just browser | shouldOpenBrowser browser -> do
+            async $ Process.callCommand (browser <> " " <> cs url)
+            pure ()
+        _ -> ?context.logger (toLogStr ("IHP development tooling is available at " <> url))
+    where
+        shouldOpenBrowser browser = browser /= "" && browser /= "none" && browser /= "false"
 
 instance FrontController ToolServerApplication where
     controllers =


### PR DESCRIPTION
## Summary

- Stop the IHP ToolServer from launching a browser automatically when `devenv up` starts.
- Print the development tooling URL to the terminal by default.
- Keep automatic browser opening opt-in via `IHP_BROWSER`, and update the guide/changelog text.

## Why

Automatically opening a desktop browser is awkward in coding-agent runs, remote workspaces, and shared development environments. Printing the URL keeps startup non-invasive while still making the tooling easy to reach.

## Validation

- `direnv exec . sh -c "printf ':l ihp-ide/IHP/IDE/ToolServer.hs\n' | ghci"`
- `git diff --check`
