### PR TITLE
[codex] Add typedSql compile-time auto database

### DIFF
--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -24,7 +24,7 @@ import IHP.TypedSql (typedSql, sqlQueryTyped, sqlExecTyped)
 
 The `QuasiQuotes` extension is required but already enabled by default in IHP projects.
 
-**Important**: Your development database must be running during compilation, because `typedSql` uses `DATABASE_URL` to connect and describe queries at compile time. For `nix build`, this is handled automatically — see [Production Builds](#production-builds) below.
+**Important**: `typedSql` describes queries against PostgreSQL during compilation. It first uses `DATABASE_URL`, so an already-running `devenv up` database is preferred. In the IHP dev shell, `typedSql` can also start a temporary private PostgreSQL automatically for non-interactive typechecking, e.g. in coding-agent workspaces where `devenv up` is not running. For `nix build`, this is handled automatically — see [Production Builds](#production-builds) below.
 
 ## Basic Queries
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -429,6 +429,9 @@ ihpFlake:
                 env.IHP_DEVENV = "1";
                 env.DATABASE_URL = "postgres:///app?host=${config.devenv.shells.default.env.PGHOST}";
                 env.PGDATABASE = "app";
+                # Lets typedSql typecheck in non-interactive GHCi/build sessions
+                # even when `devenv up` is not currently running.
+                env.IHP_TYPED_SQL_AUTO_DB = "1";
 
                 services.postgres.enable = true;
                 services.postgres.settings = {

--- a/ihp-typed-sql/IHP/TypedSql/CompileTimeDatabase.hs
+++ b/ihp-typed-sql/IHP/TypedSql/CompileTimeDatabase.hs
@@ -1,0 +1,257 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module IHP.TypedSql.CompileTimeDatabase
+    ( AutoDatabase (..)
+    , autoDatabaseEnabled
+    , dependentSchemaFiles
+    , ensureAutoDatabase
+    ) where
+
+import qualified Control.Exception       as Exception
+import           Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
+import           Control.Monad           (filterM)
+import           Data.Bits               (xor)
+import qualified Data.ByteString         as BS
+import qualified Data.ByteString.Char8   as BSC
+import qualified Data.Char               as Char
+import           Data.Functor            ((<&>))
+import qualified Data.List               as List
+import qualified Data.String.Conversions as CS
+import           IHP.Prelude
+import           Numeric                 (showHex)
+import           System.Directory        (createDirectoryIfMissing, doesFileExist,
+                                          findExecutable, getCurrentDirectory,
+                                          getTemporaryDirectory,
+                                          removePathForcibly)
+import           System.Environment      (lookupEnv)
+import           System.Exit             (ExitCode (ExitFailure, ExitSuccess))
+import           System.FilePath         (takeDirectory)
+import           System.IO               (appendFile)
+import           System.IO.Temp          (createTempDirectory)
+import           System.Process          (createProcess, proc,
+                                          readProcessWithExitCode)
+import qualified System.IO.Unsafe        as Unsafe
+import qualified Prelude
+
+data AutoDatabase = AutoDatabase
+    { adbUrl        :: !BS.ByteString
+    , adbRoot       :: !FilePath
+    , adbPgData     :: !FilePath
+    , adbSchemaHash :: !String
+    }
+
+data SchemaInputs = SchemaInputs
+    { siAppSchema :: !FilePath
+    , siIhpSchema :: !(Maybe FilePath)
+    , siHash      :: !String
+    }
+
+autoDatabaseState :: MVar (Maybe AutoDatabase)
+autoDatabaseState = Unsafe.unsafePerformIO (newMVar Nothing)
+{-# NOINLINE autoDatabaseState #-}
+
+autoDatabaseEnabled :: IO Bool
+autoDatabaseEnabled =
+    lookupEnv "IHP_TYPED_SQL_AUTO_DB" <&> \case
+        Just value -> map Char.toLower value `elem` ["1", "true", "yes", "on"]
+        Nothing -> False
+
+ensureAutoDatabase :: IO AutoDatabase
+ensureAutoDatabase = do
+    schemaInputs <- discoverSchemaInputs
+    modifyMVar autoDatabaseState \case
+        Just cached | adbSchemaHash cached == siHash schemaInputs -> do
+            ready <- databaseIsReady cached
+            if ready
+                then pure (Just cached, cached)
+                else do
+                    stopAutoDatabase cached
+                    fresh <- startAutoDatabase schemaInputs
+                    pure (Just fresh, fresh)
+        Just cached -> do
+            stopAutoDatabase cached
+            fresh <- startAutoDatabase schemaInputs
+            pure (Just fresh, fresh)
+        Nothing -> do
+            fresh <- startAutoDatabase schemaInputs
+            pure (Just fresh, fresh)
+
+dependentSchemaFiles :: IO [FilePath]
+dependentSchemaFiles = do
+    appSchema <- findAppSchema
+    ihpSchema <- findIhpSchema
+    pure (catMaybes [appSchema, ihpSchema])
+
+discoverSchemaInputs :: IO SchemaInputs
+discoverSchemaInputs = do
+    appSchema <- findAppSchema >>= \case
+        Just path -> pure path
+        Nothing -> do
+            cwd <- getCurrentDirectory
+            fail
+                ( "typedSql: automatic compile-time database is enabled via "
+                    <> "IHP_TYPED_SQL_AUTO_DB, but Application/Schema.sql could "
+                    <> "not be found from " <> cwd <> ". Set "
+                    <> "IHP_TYPED_SQL_SCHEMA=/path/to/Application/Schema.sql "
+                    <> "or run GHC from the IHP project root."
+                )
+    ihpSchema <- findIhpSchema
+    hash <- schemaHash (catMaybes [ihpSchema, Just appSchema])
+    pure SchemaInputs
+        { siAppSchema = appSchema
+        , siIhpSchema = ihpSchema
+        , siHash = hash
+        }
+
+findAppSchema :: IO (Maybe FilePath)
+findAppSchema =
+    lookupEnv "IHP_TYPED_SQL_SCHEMA" >>= \case
+        Just path | not (null path) -> existing path
+        _ -> do
+            cwd <- getCurrentDirectory
+            findUpwards cwd ("Application" </> "Schema.sql")
+
+findIhpSchema :: IO (Maybe FilePath)
+findIhpSchema =
+    lookupEnv "IHP_TYPED_SQL_IHP_SCHEMA" >>= \case
+        Just path | not (null path) -> existing path
+        _ ->
+            firstExistingEnvPath
+                [ ("IHP_LIB", "IHPSchema.sql")
+                , ("IHP", "IHPSchema.sql")
+                ] >>= \case
+                    Just path -> pure (Just path)
+                    Nothing -> do
+                        cwd <- getCurrentDirectory
+                        findUpwards cwd ("ihp-schema-compiler" </> "data" </> "IHPSchema.sql")
+
+existing :: FilePath -> IO (Maybe FilePath)
+existing path = do
+    exists <- doesFileExist path
+    pure (if exists then Just path else Nothing)
+
+firstExistingEnvPath :: [(String, FilePath)] -> IO (Maybe FilePath)
+firstExistingEnvPath [] = pure Nothing
+firstExistingEnvPath ((envName, relativePath):rest) =
+    lookupEnv envName >>= \case
+        Just base | not (null base) -> do
+            let path = base </> relativePath
+            existing path >>= \case
+                Just found -> pure (Just found)
+                Nothing -> firstExistingEnvPath rest
+        _ -> firstExistingEnvPath rest
+
+findUpwards :: FilePath -> FilePath -> IO (Maybe FilePath)
+findUpwards directory relativePath = do
+    let candidate = directory </> relativePath
+    doesFileExist candidate >>= \case
+        True -> pure (Just candidate)
+        False ->
+            let parent = takeDirectory directory
+            in if parent == directory
+                then pure Nothing
+                else findUpwards parent relativePath
+
+schemaHash :: [FilePath] -> IO String
+schemaHash paths = do
+    parts <- forM paths \path -> do
+        contents <- BS.readFile path
+        pure (BSC.pack path <> "\n" <> contents)
+    pure (showHex (fnv1a64 (BS.concat parts)) "")
+
+fnv1a64 :: BS.ByteString -> Word64
+fnv1a64 =
+    BS.foldl' step 14695981039346656037
+  where
+    step hash byte = (hash `xor` fromIntegral byte) * 1099511628211
+
+startAutoDatabase :: SchemaInputs -> IO AutoDatabase
+startAutoDatabase schemaInputs = do
+    ensureRequiredExecutables
+    tempDirectory <- getTemporaryDirectory
+    root <- createTempDirectory tempDirectory "ihp-typed-sql-"
+    let pgData = root </> "pgdata"
+    let pgHost = root </> "socket"
+    let logFile = root </> "postgresql.log"
+    let databaseUrl = "postgresql:///app?host=" <> pgHost
+    let autoDatabase = AutoDatabase
+            { adbUrl = CS.cs databaseUrl
+            , adbRoot = root
+            , adbPgData = pgData
+            , adbSchemaHash = siHash schemaInputs
+            }
+
+    (do
+        createDirectoryIfMissing True pgHost
+        runChecked "initdb" ["-D", pgData, "--no-locale", "--encoding=UTF8"]
+        appendFile (pgData </> "postgresql.conf")
+            ( "unix_socket_directories = '" <> pgHost <> "'\n"
+                <> "listen_addresses = ''\n"
+            )
+        runChecked "pg_ctl" ["-D", pgData, "-l", logFile, "-w", "start"]
+        runChecked "createdb" ["-h", pgHost, "app"]
+        forM_ (catMaybes [siIhpSchema schemaInputs, Just (siAppSchema schemaInputs)]) \schemaFile ->
+            runChecked "psql" ["-v", "ON_ERROR_STOP=1", "-h", pgHost, "app", "-f", schemaFile]
+        startCleanupMonitor root pgData
+        pure autoDatabase
+        ) `Exception.onException` cleanupAutoDatabase autoDatabase
+
+stopAutoDatabase :: AutoDatabase -> IO ()
+stopAutoDatabase autoDatabase =
+    cleanupAutoDatabase autoDatabase `Exception.catch` \(_ :: Exception.IOException) ->
+        pure ()
+
+cleanupAutoDatabase :: AutoDatabase -> IO ()
+cleanupAutoDatabase AutoDatabase { adbRoot, adbPgData } = do
+    _ <- readProcessWithExitCode "pg_ctl" ["-D", adbPgData, "-m", "fast", "-w", "stop"] ""
+        `Exception.catch` \(_ :: Exception.IOException) -> pure (ExitSuccess, "", "")
+    removePathForcibly adbRoot
+
+databaseIsReady :: AutoDatabase -> IO Bool
+databaseIsReady AutoDatabase { adbRoot } = do
+    let pgHost = adbRoot </> "socket"
+    (exitCode, _, _) <- readProcessWithExitCode "pg_isready" ["-h", pgHost, "-d", "app"] ""
+        `Exception.catch` \(_ :: Exception.IOException) -> pure (ExitFailure 1, "", "")
+    pure (exitCode == ExitSuccess)
+
+ensureRequiredExecutables :: IO ()
+ensureRequiredExecutables = do
+    let commands = ["initdb", "pg_ctl", "createdb", "psql", "pg_isready", "sh"]
+    missing <- filterM (fmap isNothing . findExecutable) commands
+    unless (null missing) do
+        fail
+            ( "typedSql: automatic compile-time database is enabled via "
+                <> "IHP_TYPED_SQL_AUTO_DB, but these PostgreSQL tools are not "
+                <> "available on PATH: " <> List.intercalate ", " missing <> ". "
+                <> "Enter the IHP nix/devenv shell or start the development "
+                <> "database with devenv up."
+            )
+
+runChecked :: String -> [String] -> IO ()
+runChecked command args = do
+    (exitCode, stdOut, stdErr) <- readProcessWithExitCode command args ""
+    case exitCode of
+        ExitSuccess -> pure ()
+        ExitFailure code ->
+            fail
+                ( "typedSql: automatic compile-time database command failed: "
+                    <> Prelude.unwords (command : args)
+                    <> "\nexit code: " <> Prelude.show code
+                    <> "\nstdout:\n" <> stdOut
+                    <> "\nstderr:\n" <> stdErr
+                )
+
+startCleanupMonitor :: FilePath -> FilePath -> IO ()
+startCleanupMonitor root pgData = do
+    let script = List.unlines
+            [ "parent=$PPID"
+            , "root=$1"
+            , "pgdata=$2"
+            , "("
+            , "  while kill -0 \"$parent\" 2>/dev/null; do sleep 1; done"
+            , "  pg_ctl -D \"$pgdata\" -m fast -w stop >/dev/null 2>&1 || true"
+            , "  rm -rf \"$root\""
+            , ") >/dev/null 2>&1 &"
+            ]
+    _ <- createProcess (proc "sh" ["-c", script, "ihp-typed-sql-monitor", root, pgData])
+    pure ()

--- a/ihp-typed-sql/IHP/TypedSql/CompileTimeDatabase.hs
+++ b/ihp-typed-sql/IHP/TypedSql/CompileTimeDatabase.hs
@@ -28,8 +28,8 @@ import           System.Exit             (ExitCode (ExitFailure, ExitSuccess))
 import           System.FilePath         (takeDirectory)
 import           System.IO               (appendFile)
 import           System.IO.Temp          (createTempDirectory)
-import           System.Process          (createProcess, proc,
-                                          readProcessWithExitCode)
+import           System.Process          (proc, readProcessWithExitCode,
+                                          withCreateProcess)
 import qualified System.IO.Unsafe        as Unsafe
 import qualified Prelude
 
@@ -253,5 +253,5 @@ startCleanupMonitor root pgData = do
             , "  rm -rf \"$root\""
             , ") >/dev/null 2>&1 &"
             ]
-    _ <- createProcess (proc "sh" ["-c", script, "ihp-typed-sql-monitor", root, pgData])
-    pure ()
+    withCreateProcess (proc "sh" ["-c", script, "ihp-typed-sql-monitor", root, pgData]) \_ _ _ _ ->
+        pure ()

--- a/ihp-typed-sql/IHP/TypedSql/CompileTimeDatabase.hs
+++ b/ihp-typed-sql/IHP/TypedSql/CompileTimeDatabase.hs
@@ -28,8 +28,8 @@ import           System.Exit             (ExitCode (ExitFailure, ExitSuccess))
 import           System.FilePath         (takeDirectory)
 import           System.IO               (appendFile)
 import           System.IO.Temp          (createTempDirectory)
-import           System.Process          (proc, readProcessWithExitCode,
-                                          withCreateProcess)
+import           System.Process          (createProcess, proc,
+                                          readProcessWithExitCode)
 import qualified System.IO.Unsafe        as Unsafe
 import qualified Prelude
 
@@ -253,5 +253,5 @@ startCleanupMonitor root pgData = do
             , "  rm -rf \"$root\""
             , ") >/dev/null 2>&1 &"
             ]
-    withCreateProcess (proc "sh" ["-c", script, "ihp-typed-sql-monitor", root, pgData]) \_ _ _ _ ->
-        pure ()
+    _ <- createProcess (proc "sh" ["-c", script, "ihp-typed-sql-monitor", root, pgData])
+    pure ()

--- a/ihp-typed-sql/IHP/TypedSql/Metadata.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Metadata.hs
@@ -13,6 +13,7 @@ module IHP.TypedSql.Metadata
     ) where
 
 import           Control.Exception             (bracket)
+import qualified Control.Exception             as Exception
 import qualified Data.ByteString               as BS
 import qualified Data.List                     as List
 import qualified Data.Map.Strict               as Map
@@ -28,6 +29,9 @@ import qualified Hasql.Session                 as HasqlSession
 import qualified Hasql.Statement               as HasqlStatement
 import           IHP.FrameworkConfig           (defaultDatabaseUrl)
 import           IHP.Prelude
+import           IHP.TypedSql.CompileTimeDatabase
+                                                (adbUrl, autoDatabaseEnabled,
+                                                 ensureAutoDatabase)
 
 -- | Result of describing a statement.
 -- High-level: this is the central metadata bundle for typedSql inference.
@@ -89,7 +93,37 @@ fromOidInt32 oid = PQ.Oid (fromIntegral oid)
 describeStatement :: BS.ByteString -> IO DescribeResult
 describeStatement sql = do
     dbUrl <- defaultDatabaseUrl
-    describeStatementWith dbUrl sql
+    describeResult <- Exception.try (describeStatementWith dbUrl sql)
+    case describeResult of
+        Right result -> pure result
+        Left (originalError :: IOException)
+            | isConnectionFailure originalError -> do
+                autoEnabled <- autoDatabaseEnabled
+                if autoEnabled
+                    then do
+                        autoResult <- Exception.try do
+                            autoDatabase <- ensureAutoDatabase
+                            describeStatementWith (adbUrl autoDatabase) sql
+                        case autoResult of
+                            Right result -> pure result
+                            Left (autoError :: IOException) ->
+                                ioError (userError
+                                    ( "typedSql: could not connect to the configured "
+                                        <> "database, and the automatic compile-time "
+                                        <> "database also failed.\n\nConfigured database "
+                                        <> "error:\n" <> displayException originalError
+                                        <> "\nAutomatic database error:\n"
+                                        <> displayException autoError
+                                    ))
+                    else ioError originalError
+        Left originalError -> ioError originalError
+
+isConnectionFailure :: IOException -> Bool
+isConnectionFailure exception =
+    let message = displayException exception
+    in "could not connect" `List.isInfixOf` message
+        || "Connection refused" `List.isInfixOf` message
+        || "No such file or directory" `List.isInfixOf` message
 
 -- | Describe a statement using an explicit database URL.
 -- This is the core path for metadata lookup in typedSql.
@@ -102,6 +136,7 @@ describeStatementWith dbUrl sql = do
             fail ("typedSql: could not connect to the database: " <> CS.cs (fromMaybe "" err)
                 <> "\nThe typedSql quasiquoter connects to PostgreSQL at compile time to infer types."
                 <> "\nEnsure your development database is running (e.g. devenv up) and DATABASE_URL is set."
+                <> "\nFor non-interactive typechecking, set IHP_TYPED_SQL_AUTO_DB=1 inside an IHP nix/devenv shell."
                 <> "\nUsing: " <> CS.cs dbUrl)
 
         let statementName = "ihp_typed_sql_stmt"
@@ -172,7 +207,8 @@ runHasqlMetadataSession dbUrl session = do
             Left connectionError ->
                 fail (CS.cs ("typedSql: could not connect to database at "
                     <> CS.cs dbUrl <> ": " <> tshow connectionError
-                    <> "\nHint: ensure your development database is running (e.g. devenv up)."))
+                    <> "\nHint: ensure your development database is running (e.g. devenv up), "
+                    <> "or set IHP_TYPED_SQL_AUTO_DB=1 inside an IHP nix/devenv shell."))
             Right connection ->
                 pure connection
         )

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -17,11 +17,13 @@ import qualified Data.String.Conversions        as CS
 import qualified Hasql.DynamicStatements.Snippet as Snippet
 import qualified Language.Haskell.TH            as TH
 import qualified Language.Haskell.TH.Quote      as TH
+import qualified Language.Haskell.TH.Syntax     as TH
 import           Text.Read                      (readMaybe)
 import qualified Prelude
 import           IHP.Prelude
 import           IHP.Hasql.Encoders              ()
 
+import           IHP.TypedSql.CompileTimeDatabase (dependentSchemaFiles)
 import           IHP.TypedSql.Decoders          (resultDecoderForColumns)
 import           IHP.TypedSql.Metadata          (DescribeColumn (..), DescribeResult (..), PgTypeInfo (..), TableMeta (..),
                                                  describeStatement)
@@ -63,6 +65,9 @@ typedSqlStar =
 -- This is the heart of typedSql: parse placeholders, describe SQL, and assemble a TypedQuery.
 typedSqlExp :: Bool -> String -> TH.ExpQ
 typedSqlExp allowStar rawSql = do
+    schemaFiles <- TH.runIO dependentSchemaFiles
+    mapM_ TH.addDependentFile schemaFiles
+
     let PlaceholderPlan { ppDescribeSql, ppRuntimeSql, ppExprs } = planPlaceholders rawSql
     parsedExprs <- mapM parseExpr ppExprs
 

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -13,7 +13,9 @@ import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullabl
                                                     extractNonNullableComputedColumnsFromAst,
                                                     detectStarSelects,
                                                     detectInsertWithoutColumns)
-import           System.Directory                  (doesFileExist,
+import           System.Directory                  (createDirectoryIfMissing,
+                                                    doesFileExist,
+                                                    findExecutable,
                                                     getCurrentDirectory)
 import           System.Environment                (getEnvironment, lookupEnv)
 import           System.FilePath                   (takeDirectory)
@@ -188,6 +190,31 @@ tests = do
             (mkTestModule "TypedQuery Text"
                 "let chunk = (\"x\" :: Text) in [typedSql| SELECT CONCAT(name, ${chunk}) FROM typed_sql_test_items LIMIT 1 |]")
             ["could not determine the type of `${chunk}`", "polymorphic-argument context", "::text"]
+
+        it "auto-starts a temporary database when DATABASE_URL is unreachable" do
+            maybeInitdb <- findExecutable "initdb"
+            when (isNothing maybeInitdb) do
+                pendingWith "requires PostgreSQL tools on PATH"
+
+            template <- encodeUtf "typed-sql-auto-db"
+            withSystemTempDirectory template \tempOsDir -> do
+                tempDir <- decodeUtf tempOsDir
+                let applicationDir = tempDir </> "Application"
+                let schemaPath = applicationDir </> "Schema.sql"
+                createDirectoryIfMissing True applicationDir
+                Text.writeFile schemaPath "CREATE TABLE typed_sql_auto_items (id UUID PRIMARY KEY, name TEXT NOT NULL);\n"
+
+                let missingSocket = tempDir </> "missing-socket"
+                let envOverrides =
+                        [ ("DATABASE_URL", "postgresql:///app?host=" <> missingSocket)
+                        , ("IHP_TYPED_SQL_AUTO_DB", "1")
+                        , ("IHP_TYPED_SQL_SCHEMA", schemaPath)
+                        ]
+                ghciOutput <- ghciLoadModuleWithEnv
+                    (mkTestModule "TypedQuery Text"
+                        "[typedSql| SELECT name FROM typed_sql_auto_items LIMIT 1 |]")
+                    envOverrides
+                assertGhciSuccess ghciOutput
 
     describe "TypedSql macro compile-time success" do
         compilePassTest "primary key inferred as Id'"
@@ -507,21 +534,29 @@ setupSchema = do
 
 ghciLoadModule :: Text -> IO Text
 ghciLoadModule source =
-    ghciRun source [":set -fno-code"] []
+    ghciLoadModuleWithEnv source []
+
+ghciLoadModuleWithEnv :: Text -> [(String, String)] -> IO Text
+ghciLoadModuleWithEnv source envOverrides =
+    ghciRunWithEnv source [":set -fno-code"] [] envOverrides
 
 ghciRunModule :: Text -> IO Text
 ghciRunModule source =
-    ghciRun source [] ["main"]
+    ghciRunWithEnv source [] ["main"] []
 
 ghciRun :: Text -> [Text] -> [Text] -> IO Text
-ghciRun source preLoadCommands postLoadCommands = do
+ghciRun source preLoadCommands postLoadCommands =
+    ghciRunWithEnv source preLoadCommands postLoadCommands []
+
+ghciRunWithEnv :: Text -> [Text] -> [Text] -> [(String, String)] -> IO Text
+ghciRunWithEnv source preLoadCommands postLoadCommands envOverrides = do
     template <- encodeUtf "typed-sql-ghci"
     withSystemTempDirectory template \tempOsDir -> do
         tempDir <- decodeUtf tempOsDir
         packageRoot <- findIhpPackageRoot
         let repoRoot = takeDirectory packageRoot
         useRepoGhci <- doesFileExist (repoRoot </> ".ghci")
-        env <- ghciEnvironment
+        env <- ghciEnvironment envOverrides
 
         let modulePath = tempDir </> "TypedSqlCase.hs"
         Text.writeFile modulePath source
@@ -587,8 +622,8 @@ findIhpPackageRoot = do
                 then pure (currentDirectory </> "ihp-typed-sql")
                 else fail "TypedSqlSpec: could not locate ihp-typed-sql package root"
 
-ghciEnvironment :: IO [(String, String)]
-ghciEnvironment = do
+ghciEnvironment :: [(String, String)] -> IO [(String, String)]
+ghciEnvironment envOverrides = do
     baseEnvironment <- getEnvironment
 
     -- Prefer an existing DATABASE_URL (e.g. set by withTestPostgres in nix)
@@ -610,10 +645,12 @@ ghciEnvironment = do
                             _ -> []
                 in Prelude.unwords parts
 
-    let overrides :: [(String, String)]
-        overrides =
+    let defaultOverrides :: [(String, String)]
+        defaultOverrides =
             [ ("DATABASE_URL", databaseUrl)
             ]
+    let overrideNames = map fst envOverrides
+    let overrides = envOverrides <> filter (\(name, _) -> name `notElem` overrideNames) defaultOverrides
 
     pure (applyEnvironmentOverrides overrides baseEnvironment)
 

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- `typedSql` can now start a temporary private PostgreSQL instance for
+  compile-time query description when `DATABASE_URL` is unreachable and
+  `IHP_TYPED_SQL_AUTO_DB=1` is set. IHP app dev shells enable this by default,
+  which makes non-interactive agent/workspace typechecking work without a
+  separate `devenv up`.
+
 - Better error message when a `${...}` placeholder appears in a polymorphic-argument
   position (e.g. `CONCAT`, `COALESCE`, `GREATEST`, `LEAST`). Instead of surfacing
   the raw Postgres `could not determine data type of parameter $N` text,

--- a/ihp-typed-sql/default.nix
+++ b/ihp-typed-sql/default.nix
@@ -2,17 +2,18 @@
 , filepath, haskell-src-meta, hasql, hasql-dynamic-statements
 , hasql-mapping, hasql-pool, hspec, ihp, fast-logger, lib
 , postgresql-libpq, postgresql-syntax, postgresql-types, process
-, scientific, string-conversions, template-haskell, temporary-ospath, text
+, scientific, string-conversions, template-haskell, temporary
+, temporary-ospath, text
 }:
 mkDerivation {
   pname = "ihp-typed-sql";
   version = "1.5.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson base bytestring containers haskell-src-meta hasql
+    aeson base bytestring containers directory filepath haskell-src-meta hasql
     hasql-dynamic-statements hasql-mapping hasql-pool ihp
-    postgresql-libpq postgresql-syntax postgresql-types scientific
-    string-conversions template-haskell text
+    postgresql-libpq postgresql-syntax postgresql-types process scientific
+    string-conversions template-haskell temporary text
   ];
   testHaskellDepends = [
     base containers directory filepath hspec ihp fast-logger process

--- a/ihp-typed-sql/ihp-typed-sql.cabal
+++ b/ihp-typed-sql/ihp-typed-sql.cabal
@@ -52,12 +52,16 @@ library
         IHP.TypedSql.TypeMapping
         IHP.TypedSql.Decoders
         IHP.TypedSql.RowType
+    other-modules:
+        IHP.TypedSql.CompileTimeDatabase
     build-depends:
             base >= 4.17.0 && < 4.23
             , ihp
             , aeson
             , bytestring
             , containers
+            , directory
+            , filepath
             , hasql
             , hasql-dynamic-statements
             , hasql-mapping
@@ -66,9 +70,11 @@ library
             , postgresql-syntax >= 0.4 && < 0.5
             , postgresql-types
             , postgresql-libpq
+            , process
             , scientific
             , string-conversions
             , template-haskell
+            , temporary
             , text
 
 source-repository head


### PR DESCRIPTION
## Summary

- add an opt-in typedSql fallback that starts a private socket-only PostgreSQL when DATABASE_URL is unreachable
- load IHPSchema.sql and Application/Schema.sql for compile-time query description, with schema files registered as Template Haskell dependencies
- enable the fallback in IHP app dev shells and document the behavior
- add a regression test for non-interactive GHCi typechecking with an unreachable DATABASE_URL

## Why

Coding agents and workspace-based typechecking often run GHCi without a separate `devenv up`. Since `typedSql` needs PostgreSQL during compilation, those sessions failed even when the schema was available locally. This keeps the existing DATABASE_URL path first, but gives non-interactive dev-shell typechecks a deterministic fallback.

## Validation

- `nix build path:/Users/marc/digitallyinduced/ihp#ihp-typed-sql --impure`
- `nix build path:/Users/marc/digitallyinduced/ihp#checks.aarch64-darwin.ihp-typed-sql --impure`
