### PR TITLE
Honor the PORT env var in the IHP dev server

### DIFF
--- a/Guide/config.markdown
+++ b/Guide/config.markdown
@@ -310,6 +310,22 @@ config = do
     option (AppPort 3000)
 ```
 
+> **Development server port**
+>
+> The `AppPort` option above configures the production server. The development
+> server started with `devenv up` selects its port at startup: it honors the
+> `PORT` environment variable when set, otherwise it picks the first free port
+> starting at `8000`.
+>
+> ```bash
+> # Start the dev server on port 9000 (the IHP IDE tool server then uses 9001)
+> PORT=9000 devenv up
+> ```
+>
+> This is useful behind a fixed reverse proxy, when running several apps at
+> once, or for tools that assign a port and pass it via `PORT` (such as the
+> Claude Code preview server).
+
 #### App Hostname
 
 The hostname used when constructing the base URL.

--- a/ihp-ide/IHP/IDE/PortConfig.hs
+++ b/ihp-ide/IHP/IDE/PortConfig.hs
@@ -2,6 +2,7 @@ module IHP.IDE.PortConfig
 ( PortConfig (..)
 , defaultAppPort
 , findAvailablePortConfig
+, portConfigFromEnvironment
 , isPortAvailable
 , createListeningSocket
 )
@@ -13,6 +14,7 @@ import qualified UnliftIO.Exception as Exception
 import Foreign.C.Error (Errno (..), eCONNREFUSED)
 import GHC.IO.Exception (ioe_errno)
 import IHP.FrameworkConfig (defaultPort)
+import qualified IHP.EnvVar as EnvVar
 import qualified System.Posix.IO as Posix
 import System.Posix.Types (Fd(..))
 
@@ -78,6 +80,30 @@ findAvailablePortConfig = do
                 then pure portConfig
                 else go rest
         go [] = error "findAvailablePortConfig: No port configuration found"
+
+-- | Builds a 'PortConfig', honoring the @PORT@ environment variable when it is set.
+--
+-- When @PORT@ is set, the dev server binds exactly that port for the app and
+-- @PORT + 1@ for the tool server, without scanning for a free port. This lets
+-- external tooling control the port deterministically — e.g. Claude Code's
+-- preview server (which picks a free port and passes it via @PORT@), a reverse
+-- proxy, or running multiple apps on fixed ports. If the requested port is
+-- already in use, binding fails loudly rather than silently moving elsewhere,
+-- so the caller that chose the port stays in sync with the dev server.
+--
+-- When @PORT@ is not set, this falls back to 'findAvailablePortConfig', keeping
+-- the default behavior of scanning upwards from 'defaultAppPort' (8000). This is
+-- the common case and is unchanged from before, so existing setups are unaffected.
+--
+-- Note: @PORT@ is the same variable IHP reads in production
+-- ('IHP.FrameworkConfig.defaultPort' fallback), so the dev and production port
+-- conventions now match.
+portConfigFromEnvironment :: IO PortConfig
+portConfigFromEnvironment = do
+    envAppPort :: Maybe Socket.PortNumber <- EnvVar.envOrNothing "PORT"
+    case envAppPort of
+        Just appPort -> pure PortConfig { appPort = appPort, toolServerPort = appPort + 1 }
+        Nothing -> findAvailablePortConfig
 
 -- | Creates a listening socket bound to the given port on localhost.
 -- The socket is set up with SO_REUSEADDR and a listen backlog of 1024.

--- a/ihp-ide/Test/IDE/PortConfigSpec.hs
+++ b/ihp-ide/Test/IDE/PortConfigSpec.hs
@@ -1,0 +1,31 @@
+{-|
+Module: IDE.PortConfigSpec
+-}
+module IDE.PortConfigSpec where
+
+import Test.Hspec
+import IHP.Prelude
+import IHP.IDE.PortConfig
+import Control.Exception (bracket_)
+import qualified System.Environment as Env
+
+tests :: Spec
+tests = do
+    describe "IHP.IDE.PortConfig.portConfigFromEnvironment" do
+        it "binds the PORT env var as the app port and PORT + 1 as the tool server port" do
+            portConfig <- withPortEnv "9000" portConfigFromEnvironment
+            portConfig.appPort `shouldBe` 9000
+            portConfig.toolServerPort `shouldBe` 9001
+
+        it "falls back to scanning from the default port when PORT is unset" do
+            portConfig <- withoutPortEnv portConfigFromEnvironment
+            portConfig.appPort `shouldSatisfy` (>= defaultAppPort)
+            portConfig.toolServerPort `shouldBe` (portConfig.appPort + 1)
+
+-- | Runs the action with the @PORT@ env var set, restoring the previous state afterwards.
+withPortEnv :: String -> IO a -> IO a
+withPortEnv value action = bracket_ (Env.setEnv "PORT" value) (Env.unsetEnv "PORT") action
+
+-- | Runs the action with the @PORT@ env var guaranteed unset.
+withoutPortEnv :: IO a -> IO a
+withoutPortEnv action = Env.unsetEnv "PORT" >> action

--- a/ihp-ide/Test/Main.hs
+++ b/ihp-ide/Test/Main.hs
@@ -16,6 +16,7 @@ import qualified IDE.CodeGeneration.JobGenerator
 import qualified IDE.CodeGeneration.MigrationGenerator
 import qualified IDE.SplitModeSpec
 import qualified IDE.WorkerSignalSpec
+import qualified IDE.PortConfigSpec
 import qualified SchemaCompilerSpec
 import qualified IDE.ToolServer.MiddlewareSpec
 import qualified IDE.Logs.ControllerSpec
@@ -36,6 +37,7 @@ main = hspec do
     IDE.CodeGeneration.MigrationGenerator.tests
     IDE.SplitModeSpec.tests
     IDE.WorkerSignalSpec.tests
+    IDE.PortConfigSpec.tests
     SchemaCompilerSpec.tests
     IDE.ToolServer.MiddlewareSpec.tests
     IDE.Logs.ControllerSpec.tests

--- a/ihp-ide/exe/IHP/IDE/DevServer.hs
+++ b/ihp-ide/exe/IHP/IDE/DevServer.hs
@@ -79,7 +79,9 @@ mainWithOptions wrapWithDirenv = withUtf8 do
         IO.hSetBuffering IO.stderr IO.LineBuffering
 
         databaseNeedsMigration <- newIORef False
-        portConfig <- findAvailablePortConfig
+        -- Honors the PORT env var when set (e.g. Claude Code preview, reverse
+        -- proxies, fixed-port multi-app setups); otherwise scans from port 8000.
+        portConfig <- portConfigFromEnvironment
 
         -- Start the dev server in Debug mode by setting the env var DEBUG=1
         -- Like: $ DEBUG=1 devenv up

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -376,6 +376,7 @@ test-suite tests
         IDE.CodeGeneration.MigrationGenerator
         IDE.SplitModeSpec
         IDE.WorkerSignalSpec
+        IDE.PortConfigSpec
         SchemaCompilerSpec
         IDE.ToolServer.MiddlewareSpec
         IDE.Logs.ControllerSpec


### PR DESCRIPTION
## What

Makes the IHP development server (`devenv up`) honor the `PORT` environment variable when choosing its app port:

- `PORT` set → bind exactly `PORT` for the app and `PORT + 1` for the IHP IDE tool server (no scanning).
- `PORT` unset → unchanged: scan upwards from `8000` (`findAvailablePortConfig`), so existing setups are unaffected.

`PORT` is the same variable IHP already reads in production (the `FrameworkConfig.defaultPort` fallback), so the dev and production port conventions now match.

## Why

Today the dev server always grabs the first free port starting at 8000 and ignores any inherited `PORT`, so there's no way to pin it. This blocks tools that assign a port and expect the server to use it — in particular Claude Code's desktop **preview**, which picks a free port and passes it via `PORT` (its `autoPort` feature). With this change the preview and the running app stay in sync even when 8000 is busy. It's also useful behind a fixed reverse proxy or when running several IHP apps at once.

Companion change in the boilerplate: digitallyinduced/ihp-boilerplate#67 (adds `.claude/launch.json` with `autoPort`).

## Implementation

- `IHP.IDE.PortConfig.portConfigFromEnvironment` — new; reads `PORT` via `IHP.EnvVar.envOrNothing` (there is already an `EnvVarReader PortNumber` instance), falling back to `findAvailablePortConfig`.
- `DevServer.hs` — calls it instead of `findAvailablePortConfig`.
- `Guide/config.markdown` — documents the dev-server `PORT` behavior.

## Testing

New `IDE.PortConfigSpec` (wired into the ihp-ide test suite):
- `PORT=9000` → app port 9000, tool server 9001.
- `PORT` unset → falls back to scanning from the default port.

Both pass locally (`hspec`: 2 examples, 0 failures); the module graph compiles clean with `-Wunused-imports`.

End-to-end: the `start` script runs `env IHP_STATIC=… RunDevServer` and process-compose forwards the ambient environment, so `PORT=9000 devenv up` brings the app up on 9000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)