### PR TITLE
[codex] Fix router exception wrapping

### DIFF
--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -664,16 +664,18 @@ instance {-# OVERLAPPABLE #-} (AutoRoute controller, Controller controller) => C
         pure (toApp action)
       ) <|> (do
         (constr, allowedMethods) <- routeMatchParser @controller
-        pure $ \waiRequest waiRespond -> wrapRouterException do
-            case applyAction @controller constr (queryString waiRequest) of
-                Left e -> Exception.throw e
-                Right action -> do
-                    case parseMethod (requestMethod waiRequest) of
-                        Right method -> do
-                            unless (allowedMethods |> includes method)
-                                (throwIO UnexpectedMethodException { allowedMethods, method })
-                            toApp action waiRequest waiRespond
-                        Left err -> throwIO BadHttpMethodException { method = err }
+        pure $ \waiRequest waiRespond -> do
+            action <- wrapRouterException do
+                case applyAction @controller constr (queryString waiRequest) of
+                    Left e -> Exception.throw e
+                    Right action -> do
+                        case parseMethod (requestMethod waiRequest) of
+                            Right method -> do
+                                unless (allowedMethods |> includes method)
+                                    (throwIO UnexpectedMethodException { allowedMethods, method })
+                                pure action
+                            Left err -> throwIO BadHttpMethodException { method = err }
+            toApp action waiRequest waiRespond
       )
     {-# INLINABLE parseRouteWithAction #-}
 
@@ -803,12 +805,14 @@ get :: (Controller action
     ) => ByteString -> action -> ControllerRoute application
 get path action = ControllerRouteParser $ do
     string path
-    pure $ \waiRequest waiRespond -> wrapRouterException do
-        case parseMethod (requestMethod waiRequest) of
-            Right GET -> runAction' action waiRequest waiRespond
-            Right HEAD -> runAction' action waiRequest waiRespond
-            Right method -> throwIO UnexpectedMethodException { allowedMethods = [GET, HEAD], method }
-            Left err -> throwIO BadHttpMethodException { method = err }
+    pure $ \waiRequest waiRespond -> do
+        wrapRouterException do
+            case parseMethod (requestMethod waiRequest) of
+                Right GET -> pure ()
+                Right HEAD -> pure ()
+                Right method -> throwIO UnexpectedMethodException { allowedMethods = [GET, HEAD], method }
+                Left err -> throwIO BadHttpMethodException { method = err }
+        runAction' action waiRequest waiRespond
 {-# INLINABLE get #-}
 
 -- | Routes a given path to an action when requested via POST.
@@ -831,11 +835,13 @@ post :: (Controller action
     ) => ByteString -> action -> ControllerRoute application
 post path action = ControllerRouteParser $ do
     string path
-    pure $ \waiRequest waiRespond -> wrapRouterException do
-        case parseMethod (requestMethod waiRequest) of
-            Right POST -> runAction' action waiRequest waiRespond
-            Right method -> throwIO UnexpectedMethodException { allowedMethods = [POST], method }
-            Left err -> throwIO BadHttpMethodException { method = err }
+    pure $ \waiRequest waiRespond -> do
+        wrapRouterException do
+            case parseMethod (requestMethod waiRequest) of
+                Right POST -> pure ()
+                Right method -> throwIO UnexpectedMethodException { allowedMethods = [POST], method }
+                Left err -> throwIO BadHttpMethodException { method = err }
+        runAction' action waiRequest waiRespond
 {-# INLINABLE post #-}
 
 -- | Filter methods when writing a custom routing parser
@@ -1182,15 +1188,17 @@ buildAutoRouteMap = HashMap.fromList
           allowedMethods = allowedMethodsForAction @controller actionName
           handler app waiRequest waiRespond =
               let ?application = app
-              in wrapRouterException do
-                  case parseMethod (requestMethod waiRequest) of
-                      Left err -> throwIO BadHttpMethodException { method = err }
-                      Right method -> do
-                          unless (allowedMethods |> includes method)
-                              (throwIO UnexpectedMethodException { allowedMethods, method })
-                          case applyAction @controller constr (queryString waiRequest) of
-                              Left e -> Exception.throw e
-                              Right action -> runAction' @application action waiRequest waiRespond
+              in do
+                  action <- wrapRouterException do
+                      case parseMethod (requestMethod waiRequest) of
+                          Left err -> throwIO BadHttpMethodException { method = err }
+                          Right method -> do
+                              unless (allowedMethods |> includes method)
+                                  (throwIO UnexpectedMethodException { allowedMethods, method })
+                              case applyAction @controller constr (queryString waiRequest) of
+                                  Left e -> Exception.throw e
+                                  Right action -> pure action
+                  runAction' @application action waiRequest waiRespond
     ]
     where
         prefix :: ByteString

--- a/ihp/Test/Test/RouterSupportSpec.hs
+++ b/ihp/Test/Test/RouterSupportSpec.hs
@@ -13,12 +13,14 @@ import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
 import IHP.RouterSupport hiding (get)
+import qualified IHP.RouterSupport as RouterSupport
 import Data.Attoparsec.ByteString.Char8 (string, endOfInput)
 import IHP.ViewPrelude hiding (request)
 import IHP.ControllerPrelude hiding (get, request)
 import Network.Wai.Test
 import Network.HTTP.Types
-import Test.Util (testGet)
+import Test.Util (assertBodyNotContains, testGet)
+import qualified Control.Exception.Safe as Exception
 
 data Band' = Band {id :: (Id' "bands"), meta :: MetaBag} deriving (Eq, Show)
 type Band = Band'
@@ -56,6 +58,7 @@ data TestController
   | TestIntegerId { integerId :: Id Band }
   | TestUUIDId { uuidId :: Id Performance }
   | TestUUIDList { uuidList :: [UUID] }
+  | TestThrowsAction
   deriving (Eq, Show, Data)
 
 instance Controller TestController where
@@ -96,6 +99,8 @@ instance Controller TestController where
         renderPlain (cs $ ClassyPrelude.show uuidId)
     action TestUUIDList { .. } = do
         renderPlain $ cs $ ClassyPrelude.show uuidList
+    action TestThrowsAction = do
+        Exception.throwIO (userError "action failure")
 
 instance AutoRoute TestController where
     autoRoute = autoRouteWithIdType (parseIntegerId @(Id Band))
@@ -126,7 +131,8 @@ instance AutoRoute CustomRouteController where
 
 instance FrontController WebApplication where
   controllers =
-    [ parseRoute @TestController
+    [ RouterSupport.get "/custom-throws" TestThrowsAction
+    , parseRoute @TestController
     , parseRoute @CustomRouteController
     ]
 
@@ -292,6 +298,22 @@ tests = aroundAll (withMockContextAndApp WebApplication config) do
                 assertStatus 400 response
                 assertContentType "application/json" response
                 assertBodyContains "\"PROPFIND\"" response
+                ) application
+        it "does not classify matched action exceptions as routing failures" $ withContextAndApp \application -> do
+            runSession (do
+                response <- testGet "test/TestThrows"
+                assertStatus 500 response
+                assertBodyContains "action failure" response
+                assertBodyNotContains "Routing failed" response
+                assertBodyNotContains "js-delete" response
+                ) application
+        it "does not classify explicit get route action exceptions as routing failures" $ withContextAndApp \application -> do
+            runSession (do
+                response <- testGet "custom-throws"
+                assertStatus 500 response
+                assertBodyContains "action failure" response
+                assertBodyNotContains "Routing failed" response
+                assertBodyNotContains "js-delete" response
                 ) application
     describe "customPathTo" $ do
         it "generates custom path for overridden action" $ withContextAndApp \application -> do


### PR DESCRIPTION
## Summary

- keep RouterException wrapping limited to route, method, and parameter resolution
- let matched controller action failures flow through the normal action error handler
- add regression coverage for AutoRoute and explicit get routes throwing from actions

## Root Cause

Route handlers wrapped both route resolution and `runAction'` in `wrapRouterException`. Exceptions raised after a route had already matched, such as controller, rendering, or database errors, were therefore rendered as `Routing failed` with unrelated router guidance.

## Validation

- `direnv exec . sh -c "echo -e ':l IHP/Test/Test/RouterSupportSpec.hs\n:m + Test.Hspec Test.RouterSupportSpec\nhspec tests' | ghci"`
- `git diff --check -- ihp/IHP/RouterSupport.hs ihp/Test/Test/RouterSupportSpec.hs`