### PR TITLE
Fix renderFilter accumulating duplicate query params (#2156)

### DIFF
--- a/ihp/data/static/helpers.js
+++ b/ihp/data/static/helpers.js
@@ -195,8 +195,16 @@ window.submitForm = function (form, possibleClickedButton) {
         // Otherwise the displayed URL in the browser address bar is not updated correctly.
         if (formMethod.toUpperCase() === 'GET') {
             var formData = new FormData(form);
+            // Mirror the request-URL builder below: delete each submitted field's existing
+            // values once before appending, so this matches what is actually sent (no
+            // accumulated duplicates, and multi-value fields like checkbox groups are kept).
+            var clearedParams = new Set();
             for (var pair of formData.entries()) {
-                url.searchParams.set(pair[0], pair[1]);
+                if (!clearedParams.has(pair[0])) {
+                    url.searchParams.delete(pair[0]);
+                    clearedParams.add(pair[0]);
+                }
+                url.searchParams.append(pair[0], pair[1]);
             }
         }
         urlPathnameWithQuery += url.search; // Append the query parameters submitted via the form

--- a/ihp/data/static/helpers.js
+++ b/ihp/data/static/helpers.js
@@ -277,7 +277,18 @@ window.submitForm = function (form, possibleClickedButton) {
             // Using document.baseURI here allows this to work with relative paths like `/Projects` instead
             // of full urls like `http://example.com/Projects`
             var url = new URL(formAction, document.baseURI);
+
+            // When the action is empty/relative, `new URL` keeps the current page's query string.
+            // Delete each submitted field's existing values once before appending, so resubmitting a
+            // GET form (e.g. renderFilter) overwrites instead of accumulating `?filter=a&filter=b` (#2156),
+            // while unrelated params (e.g. maxItems) are preserved and multi-value fields like checkbox
+            // groups keep all of their values (the reason .set was replaced by .append in the first place).
+            var clearedParams = new Set();
             for (var pair of formData.entries()) {
+                if (!clearedParams.has(pair[0])) {
+                    url.searchParams.delete(pair[0]);
+                    clearedParams.add(pair[0]);
+                }
                 url.searchParams.append(pair[0], pair[1]);
             }
 

--- a/ihp/data/static/helpers.js
+++ b/ihp/data/static/helpers.js
@@ -280,7 +280,7 @@ window.submitForm = function (form, possibleClickedButton) {
 
             // When the action is empty/relative, `new URL` keeps the current page's query string.
             // Delete each submitted field's existing values once before appending, so resubmitting a
-            // GET form (e.g. renderFilter) overwrites instead of accumulating `?filter=a&filter=b` (#2156),
+            // GET form (e.g. renderFilter) overwrites instead of accumulating `?filter=a&filter=b`,
             // while unrelated params (e.g. maxItems) are preserved and multi-value fields like checkbox
             // groups keep all of their values (the reason .set was replaced by .append in the first place).
             var clearedParams = new Set();


### PR DESCRIPTION
## Problem

Fixes #2156. Since v1.4.x, repeatedly submitting the `renderFilter` box appends `filter=` (and `page=`) to the URL — `?filter=a&filter=b&filter=c…` — instead of overwriting, breaking filtering. This worked in v1.3.0.

## Root cause

`renderFilter` renders `<form method="GET" action="">` and has **not** changed. The regression is in the client-side form interceptor `window.submitForm` in `ihp/data/static/helpers.js`.

Commit 2663002a ("Fix multiple checkboxes submit") changed the GET request-URL builder from `searchParams.set` to `searchParams.append`:

```js
var url = new URL(formAction, document.baseURI);
for (var pair of formData.entries()) {
    url.searchParams.append(pair[0], pair[1]); // <-- the bug
}
```

Because `formAction` is `""`, `new URL("", document.baseURI)` resolves to the current page **including its existing query string**. `.append` then stacks the form's `page`/`filter` values on top of the ones already present, so every submit grows the URL. The address bar is set from `request.responseURL` (the duplicated URL), so the next submit compounds it.

`.set` (v1.3.0 behavior) avoided the duplication but collapsed multi-valued fields to their last value — exactly what 2663002a was fixing for checkbox groups. So the fix must do **both**.

## Fix

Delete each submitted field's existing values **once** (the first time the name is seen) before appending:

```js
var clearedParams = new Set();
for (var pair of formData.entries()) {
    if (!clearedParams.has(pair[0])) {
        url.searchParams.delete(pair[0]);
        clearedParams.add(pair[0]);
    }
    url.searchParams.append(pair[0], pair[1]);
}
```

- **Resolves #2156**: `filter`/`page` existing values are deleted before the new ones are appended → no accumulation, matching pre-1.4 behavior.
- **Keeps the 2663002a checkbox fix**: a name is deleted only on first sight, so `tags=a&tags=b&tags=c` from a checkbox group is preserved.
- **Preserves merge semantics**: params not in the form (e.g. `maxItems` from `renderPagination`) are left untouched.
- **Address bar follows for free**: it is set to `request.responseURL`; once the request URL is clean, the displayed URL is clean too.

## Verification

No JS test harness exists for `helpers.js`, so verified by replaying the patched GET URL-building logic in Node across these scenarios (all pass):

| Scenario | Base URL | Form fields | Result |
|---|---|---|---|
| Filter resubmit | `?maxItems=50&page=2&filter=foo` | `page=1, filter=bar` | `?maxItems=50&page=1&filter=bar` |
| Resubmit again | result above | `page=1, filter=bar` | unchanged (no growth) |
| Change filter | filtered URL | `page=1, filter=baz` | single `filter=baz` |
| Checkbox group | `/Tags` | `tags=a,b,c` | `?tags=a&tags=b&tags=c` |
| Checkbox overwrite | `?tags=old1&tags=old2&keep=1` | `tags=a,b` | `?keep=1&tags=a&tags=b` |

Manual check recommended: in an app whose index uses `renderFilter`, submit the filter repeatedly and confirm the URL stays `?page=1&filter=...` without accumulating, that `maxItems` survives, and that multi-checkbox GET forms still submit all values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)