### PR TITLE
Switch dev-server GHCi to the copying GC so it returns memory to the OS

### DIFF
--- a/Guide/troubleshooting.markdown
+++ b/Guide/troubleshooting.markdown
@@ -215,7 +215,7 @@ export GHCRTS="-M8G"
 
 A reasonable default is **roughly half of system RAM**: `-M8G` on a 16 GB box, `-M4G` on an 8 GB box, `-M16G` on a 32 GB workstation. The cap should be generous, not tight — it exists to protect the desktop from a leak, not to shrink the dev-server footprint.
 
-**Setting the cap too low.** IHP runs the dev server with the non-moving garbage collector, which is great for latency but lets the heap grow freely between collection cycles. A tight cap will trip on legitimate workloads (large fixture loads, schema reload after a big migration, code generation passes). If `-M4G` keeps firing on a box with plenty of free RAM, raise the cap rather than fight the GC.
+**Setting the cap too low.** The dev server's GHCi can spike to a multi-GB transient heap on legitimate workloads (large fixture loads, schema reload after a big migration, code generation passes), even though it returns most of that memory to the OS afterwards. A tight cap will trip on those spikes. If `-M4G` keeps firing on a box with plenty of free RAM, raise the cap rather than fight the GC.
 
 **What happens when the cap is hit.** The dev server panics with:
 

--- a/ihp-ide/IHP/IDE/GhciSupport.hs
+++ b/ihp-ide/IHP/IDE/GhciSupport.hs
@@ -32,6 +32,16 @@ import qualified System.Posix.Signals as Signals
 import qualified System.Process as Process
 
 -- | Default GHCi argv used by every IHP dev-mode GHCi child.
+--
+-- RTS notes: the dev-mode GHCi both /compiles/ the app (large transient heap
+-- spikes on every reload) and /runs/ it (serving requests). We use the copying
+-- collector with aggressive idle return (@-Fd1@) rather than @--nonmoving-gc@:
+-- the non-moving collector has lower GC pauses but never returns freed memory to
+-- the OS, so its heap only grows across reloads and reaches several GB over a
+-- session (most of which ends up swapped out while the server is idle — painful
+-- when running many dev servers at once). The copying collector compacts and
+-- hands accumulated heap back to the OS between reloads, keeping the footprint
+-- close to a fresh load.
 ghciArguments :: [String]
 ghciArguments =
     [ "-threaded"
@@ -41,7 +51,7 @@ ghciArguments =
     , "-package-env -" -- Don't load global package environments — they conflict with our pinned set
     , "-ignore-dot-ghci" -- Skip the global ~/.ghc/ghci.conf which sometimes sets `+c +s`
     , "-ghci-script", ".ghci" -- Manually point at the project's .ghci since we just disabled defaults
-    , "+RTS", "-A64m", "-n4m", "-H256m", "--nonmoving-gc", "-Iw60", "-N4"
+    , "+RTS", "-A32m", "-n4m", "-H64m", "-Iw60", "-N4", "-Fd1"
     ]
 
 -- | Build a 'Process.CreateProcess' that launches GHCi, optionally wrapped in

--- a/ihp-ide/exe/IHP/IDE/DevServer.hs
+++ b/ihp-ide/exe/IHP/IDE/DevServer.hs
@@ -25,6 +25,7 @@ import Main.Utf8 (withUtf8)
 import qualified IHP.FrameworkConfig as FrameworkConfig
 import qualified Control.Concurrent.Chan.Unagi as Queue
 import IHP.IDE.FileWatcher
+import IHP.IDE.GhciSupport (ghciArguments)
 import qualified IHP.IDE.SplitMode as SplitMode
 import qualified IHP.IDE.WorkerSignal as WorkerSignal
 import qualified System.Environment as Env
@@ -184,17 +185,7 @@ fileWatcherParams liveReloadClients databaseNeedsMigration reloadGhciVar startSt
                 SplitMode.generateRunJobsModule
                 WorkerSignal.sendReload SplitMode.workerSocketPath
 
-ghciArguments :: [String]
-ghciArguments =
-    [ "-threaded"
-    , "-fomit-interface-pragmas"
-    , "-j"
-    , "-O0"
-    , "-package-env -" -- Do not load `~/.ghc/arch-os-version/environments/name file`, global packages interfere with our packages
-    , "-ignore-dot-ghci" -- Ignore the global ~/.ghc/ghci.conf That file sometimes causes trouble (specifically `:set +c +s`)
-    , "-ghci-script", ".ghci" -- Because the previous line ignored default ghci config file locations, we have to manual load our .ghci
-    , "+RTS", "-A64m", "-n4m", "-H256m", "--nonmoving-gc", "-Iw60", "-N4"
-    ]
+-- 'ghciArguments' is shared with the dev worker — see 'IHP.IDE.GhciSupport'.
 
 withGHCI :: (?context :: Context) => Concurrent.ThreadId -> (Handle -> Handle -> Handle -> Process.ProcessHandle -> IO a) -> IO a
 withGHCI mainThreadId callback = do


### PR DESCRIPTION
## Problem

The dev-mode GHCi ran with the non-moving collector (`--nonmoving-gc`), chosen in #2323 for low GC pause times while the app serves requests. The catch: **the non-moving collector never returns freed memory to the OS**, so the GHCi heap only grows across reloads.

Measured on a real ~800-module IHP app:

- **Fresh load:** ~1.5 GB (genuinely-live working set — loaded modules + type/instance env; *not* reducible by GC tuning, object-code, or `-fignore-interface-pragmas`, all of which I tested and ruled out).
- **Per reload:** ~50 MB of dead heap is retained and never given back. A forced major GC does **not** reclaim it.
- **Over a session:** climbs to 6+ GB, almost all swapped out (`vmmap` on a live idle server: 6.3 GB footprint = ~390 MB resident + 6.2 GB swapped). One dev server per worktree multiplies this and fills swap.

## Change

Switch the dev GHCi from `--nonmoving-gc` to the copying/generational collector with aggressive idle return (`-Fd1`):

```
-A64m -n4m -H256m --nonmoving-gc -Iw60 -N4   →   -A32m -n4m -H64m -Iw60 -N4 -Fd1
```

The copying collector compacts and hands accumulated heap back to the OS over idle GCs; the non-moving collector structurally cannot.

## Measured effect

Same ~800-module app (`phys_footprint`):

| | Fresh | After 8 reloads (idle-settled) | Running server |
|---|---|---|---|
| non-moving (old) | 750 MB | **1154 MB (stuck, keeps growing)** | ~1536 MB |
| copying + `-Fd1` (new) | 652 MB | **802 MB (returned to OS)** | **~660 MB** |

The gap widens with every reload — extrapolated, it's the 1.5 GB → 6.3 GB divergence seen on a live server.

**Latency** (the reason #2323 picked non-moving) was verified, not assumed: under the new flags the app boots (`Ok, 802 modules`), serves HTTP 200, a 20-request burst averages **1 ms** (max 2 ms), and the first request after an idle period returns in **1.6 ms with no GC-pause spike**. For a single-developer dev server the copying collector's pauses are invisible, while the memory saving is large.

## Also

Dedupes the two copies of `ghciArguments` (`DevServer` + `GhciSupport`) into the shared `GhciSupport` module so the flag list can't drift.

## Verification

- Type-checks: `GhciSupport` loads clean; `DevServer` loads `Ok, 204 modules`.
- Booted the real app under the new flags against an isolated full-schema DB: serves HTTP 200, footprint ~660 MB, latency as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)