### PR TITLE
Surface app startup crashes on the dev server error page

### DIFF
--- a/ihp-ide/IHP/IDE/Types.hs
+++ b/ihp-ide/IHP/IDE/Types.hs
@@ -31,6 +31,27 @@ sendGhciCommands handle commands = forM_ commands (sendGhciCommand handle)
 
 data OutputLine = StandardOutput !ByteString | ErrorOutput !ByteString deriving (Show, Eq)
 
+-- | Extract the runtime crash message from the accumulated app/GHCi output.
+--
+-- When running the app, the dev server wraps its @main@ in a handler that, on an
+-- uncaught exception, prints the exception text between two marker lines:
+--
+-- > [[IHP_APP_CRASHED_BEGIN]]
+-- > <exception text, possibly spanning multiple lines>
+-- > [[IHP_APP_CRASHED]]
+--
+-- This returns just the exception lines (without the markers), so a startup crash
+-- (e.g. a missing env var) can be surfaced as the prominent error on the status
+-- page instead of being buried at the bottom of the build log. Returns @[]@ when
+-- no crash message is present.
+extractCrashMessage :: ByteString -> [ByteString]
+extractCrashMessage accumulatedOutput =
+    let
+        allLines = ByteString.lines accumulatedOutput
+        afterBeginMarker = drop 1 (dropWhile (not . isInfixOf "[[IHP_APP_CRASHED_BEGIN]]") allLines)
+    in
+        takeWhile (not . isInfixOf "[[IHP_APP_CRASHED]]") afterBeginMarker
+
 
 data Context = Context
     { portConfig :: !PortConfig

--- a/ihp-ide/Test/IDE/DevServerSpec.hs
+++ b/ihp-ide/Test/IDE/DevServerSpec.hs
@@ -1,0 +1,59 @@
+module IDE.DevServerSpec where
+
+import IHP.Prelude
+import Test.Hspec
+import qualified Data.ByteString.Char8 as ByteString
+import IHP.IDE.Types (extractCrashMessage)
+
+tests :: Spec
+tests = describe "IHP.IDE.Types.extractCrashMessage" $ do
+    -- Joins lines the way the GHCi output is accumulated by the dev server.
+    let output = ByteString.intercalate "\n"
+
+    it "extracts a single-line crash message between the markers" $ do
+        let input = output
+                [ "[[IHP_APP_CRASHED_BEGIN]]"
+                , "Environment variable TELEGRAM_OWNER_USER_ID is required"
+                , "[[IHP_APP_CRASHED]]"
+                ]
+        extractCrashMessage input `shouldBe` ["Environment variable TELEGRAM_OWNER_USER_ID is required"]
+
+    it "extracts a multi-line crash message including the call stack" $ do
+        let input = output
+                [ "[[IHP_APP_CRASHED_BEGIN]]"
+                , "Environment variable TELEGRAM_OWNER_USER_ID is required"
+                , "CallStack (from HasCallStack):"
+                , "  error, called at ./IHP/Prelude.hs:106:17 in ihp:IHP.Prelude"
+                , "[[IHP_APP_CRASHED]]"
+                ]
+        extractCrashMessage input `shouldBe`
+                [ "Environment variable TELEGRAM_OWNER_USER_ID is required"
+                , "CallStack (from HasCallStack):"
+                , "  error, called at ./IHP/Prelude.hs:106:17 in ihp:IHP.Prelude"
+                ]
+
+    it "ignores build-log output printed before the crash" $ do
+        let input = output
+                [ "[131 of 132] Compiling Main"
+                , "Ok, 131 modules loaded."
+                , "[[IHP_APP_CRASHED_BEGIN]]"
+                , "Prelude.read: no parse"
+                , "[[IHP_APP_CRASHED]]"
+                ]
+        extractCrashMessage input `shouldBe` ["Prelude.read: no parse"]
+
+    it "matches the markers even when prefixed (e.g. by the GHCi prompt)" $ do
+        let input = output
+                [ "IHP> [[IHP_APP_CRASHED_BEGIN]]"
+                , "Environment variable API_KEY is required"
+                , "[[IHP_APP_CRASHED]]"
+                ]
+        extractCrashMessage input `shouldBe` ["Environment variable API_KEY is required"]
+
+    it "returns an empty list when there is no crash" $ do
+        let input = output
+                [ "[131 of 132] Compiling Main"
+                , "Ok, 131 modules loaded."
+                , "Server started"
+                ]
+        extractCrashMessage input `shouldBe` []

--- a/ihp-ide/Test/Main.hs
+++ b/ihp-ide/Test/Main.hs
@@ -20,6 +20,7 @@ import qualified IDE.PortConfigSpec
 import qualified SchemaCompilerSpec
 import qualified IDE.ToolServer.MiddlewareSpec
 import qualified IDE.Logs.ControllerSpec
+import qualified IDE.DevServerSpec
 import qualified ServerSpec
 
 main :: IO ()
@@ -41,4 +42,5 @@ main = hspec do
     SchemaCompilerSpec.tests
     IDE.ToolServer.MiddlewareSpec.tests
     IDE.Logs.ControllerSpec.tests
+    IDE.DevServerSpec.tests
     ServerSpec.tests

--- a/ihp-ide/exe/IHP/IDE/DevServer.hs
+++ b/ihp-ide/exe/IHP/IDE/DevServer.hs
@@ -360,7 +360,12 @@ withRunningApp appPort inputHandle outputHandle errorHandle processHandle logLin
             -- If the app crashes during startup (e.g. a missing env var), react to the
             -- crash right away instead of waiting out the full timeout — and surface the
             -- crash message as the prominent error rather than the misleading timeout.
-            outcome <- timeout (60 * 1000000) (race (takeMVar serverStarted) (takeMVar appCrashed))
+            --
+            -- Use readMVar (not takeMVar) so the losing branch of the race never drains
+            -- the signal: if "Server started" and a crash land near-simultaneously and the
+            -- race reports the start, appCrashed stays full so the callback below still
+            -- observes the crash instead of blocking forever on an emptied MVar.
+            outcome <- timeout (60 * 1000000) (race (readMVar serverStarted) (readMVar appCrashed))
             case outcome of
                 Just (Left ()) -> callback appCrashed
                 Just (Right crashMessage) -> do

--- a/ihp-ide/exe/IHP/IDE/DevServer.hs
+++ b/ihp-ide/exe/IHP/IDE/DevServer.hs
@@ -318,15 +318,23 @@ withLoadedApp inputHandle outputHandle errorHandle logLine callback = do
 
     pure result
 
-withRunningApp :: (?context :: Context) => Socket.PortNumber -> Handle -> Handle -> Handle -> Process.ProcessHandle -> (OutputLine -> IO ()) -> (MVar () -> IO a) -> IO a
+withRunningApp :: (?context :: Context) => Socket.PortNumber -> Handle -> Handle -> Handle -> Process.ProcessHandle -> (OutputLine -> IO ()) -> (MVar [ByteString] -> IO a) -> IO a
 withRunningApp appPort inputHandle outputHandle errorHandle processHandle logLine callback = do
     outputVar :: MVar ByteString.Builder <- newMVar ""
     serverStarted :: MVar () <- newEmptyMVar
     serverStopped :: MVar () <- newEmptyMVar
-    appCrashed :: MVar () <- newEmptyMVar
+    -- Carries the captured crash message (the exception lines), so a startup
+    -- crash can be surfaced as the prominent error instead of being buried in
+    -- the build log.
+    appCrashed :: MVar [ByteString] <- newEmptyMVar
     let onMatch line = case line of
             line | "Server started" `isInfixOf` line -> putMVar serverStarted ()
-            line | "[[IHP_APP_CRASHED]]" `isInfixOf` line -> void $ tryPutMVar appCrashed ()
+            line | "[[IHP_APP_CRASHED]]" `isInfixOf` line -> do
+                -- The handler wrapped around the app's `main` (see startApp) prints
+                -- the exception between [[IHP_APP_CRASHED_BEGIN]] and [[IHP_APP_CRASHED]].
+                -- Pull those lines out of the accumulated output so we can show them.
+                accumulatedOutput <- readMVar outputVar
+                void $ tryPutMVar appCrashed (extractCrashMessage (cs (ByteString.toLazyByteString accumulatedOutput)))
             _ -> pure ()
 
     let startApp = do
@@ -337,7 +345,7 @@ withRunningApp appPort inputHandle outputHandle errorHandle processHandle logLin
             socketFd <- Socket.unsafeFdSocket ?context.appSocket
             sendGhciCommand inputHandle $ "System.Environment.setEnv \"IHP_SOCKET_FD\" \"" <> cs (show socketFd) <> "\""
             sendGhciCommand inputHandle "stopVar :: ClassyPrelude.MVar () <- ClassyPrelude.newEmptyMVar"
-            sendGhciCommand inputHandle "app <- ClassyPrelude.async (ClassyPrelude.race_ (ClassyPrelude.takeMVar stopVar) (main `ClassyPrelude.catch` \\(e :: SomeException) -> IHP.Prelude.putStrLn (tshow e) >> IHP.Prelude.putStrLn \"[[IHP_APP_CRASHED]]\"))"
+            sendGhciCommand inputHandle "app <- ClassyPrelude.async (ClassyPrelude.race_ (ClassyPrelude.takeMVar stopVar) (main `ClassyPrelude.catch` \\(e :: SomeException) -> IHP.Prelude.putStrLn \"[[IHP_APP_CRASHED_BEGIN]]\" >> IHP.Prelude.putStrLn (tshow e) >> IHP.Prelude.putStrLn \"[[IHP_APP_CRASHED]]\"))"
     let stopApp = do
             sendGhciCommand inputHandle "ClassyPrelude.putMVar stopVar ()"
             sendGhciCommand inputHandle "ClassyPrelude.cancel app"
@@ -348,11 +356,20 @@ withRunningApp appPort inputHandle outputHandle errorHandle processHandle logLin
             putMVar serverStopped ()
 
     let waitForServerStart = do
-            -- Wait up to 60 seconds for "Server started" message
-            -- If the app crashes during startup, "Server started" will never be printed
-            maybeStarted <- timeout (60 * 1000000) (takeMVar serverStarted)
-            case maybeStarted of
-                Just () -> callback appCrashed
+            -- Wait up to 60 seconds for the "Server started" message.
+            -- If the app crashes during startup (e.g. a missing env var), react to the
+            -- crash right away instead of waiting out the full timeout — and surface the
+            -- crash message as the prominent error rather than the misleading timeout.
+            outcome <- timeout (60 * 1000000) (race (takeMVar serverStarted) (takeMVar appCrashed))
+            case outcome of
+                Just (Left ()) -> callback appCrashed
+                Just (Right crashMessage) -> do
+                    let reportedMessage = if null crashMessage
+                            then ["App crashed during startup. Check the output below for details."]
+                            else crashMessage
+                    forM_ reportedMessage (logLine . ErrorOutput)
+                    -- Throw exception to trigger bracket cleanup and return to status server
+                    Exception.throwString "App crashed during startup"
                 Nothing -> do
                     logLine (ErrorOutput "App startup timed out after 60 seconds. Check for runtime errors above.")
                     -- Throw exception to trigger bracket cleanup and return to status server
@@ -397,10 +414,14 @@ refresh inputHandle outputHandle errorHandle logOutput = do
 
 receiveAppOutput :: (?context :: Context) => OutputLine -> IO ()
 receiveAppOutput line = do
-    case line of
-        StandardOutput output -> ByteString.putStrLn output
-        ErrorOutput output -> ByteString.putStrLn output
-    Queue.writeChan ?context.ghciInChan line
+    let output = case line of
+            StandardOutput output -> output
+            ErrorOutput output -> output
+    -- The crash markers are an internal detail used to detect and capture runtime
+    -- crashes — don't echo them to the console or the browser status page.
+    unless ("[[IHP_APP_CRASHED" `isInfixOf` output) do
+        ByteString.putStrLn output
+        Queue.writeChan ?context.ghciInChan line
 
 checkDatabaseIsOutdated :: IO Bool
 checkDatabaseIsOutdated = do

--- a/ihp-ide/ihp-ide.cabal
+++ b/ihp-ide/ihp-ide.cabal
@@ -380,4 +380,5 @@ test-suite tests
         SchemaCompilerSpec
         IDE.ToolServer.MiddlewareSpec
         IDE.Logs.ControllerSpec
+        IDE.DevServerSpec
         ServerSpec


### PR DESCRIPTION
## Problem

When a dev-mode app crashes during startup because of a runtime error — most commonly a missing env var — the browser status page is unhelpful:

- It shows **"App startup timed out after 60 seconds. Check for runtime errors above."**, and only *after* a full 60-second wait.
- The actual exception (e.g. `Environment variable TELEGRAM_OWNER_USER_ID is required`) is printed to stdout and rendered in 10px text at the very bottom of the page, under the entire build log.
- The internal `[[IHP_APP_CRASHED]]` marker leaks into the UI.

The crash was in fact already detected (it fills the `appCrashed` MVar), but `waitForServerStart` only waited on the `Server started` message and ignored the crash signal — so it always fell through to the timeout.

## Changes

- **React immediately.** `waitForServerStart` now races `Server started` against the crash signal, so a startup crash is reported at once. The 60s timeout is kept for genuine hangs.
- **Surface the real error.** The crash handler wrapped around the app's `main` now brackets the exception with `[[IHP_APP_CRASHED_BEGIN]]` … `[[IHP_APP_CRASHED]]`. `extractCrashMessage` pulls those lines out and re-emits them as error output, so they render prominently (the slot previously used by the timeout message) instead of being buried in the stdout log.
- **Hide the markers.** `receiveAppOutput` no longer echoes the internal `[[IHP_APP_CRASHED…]]` markers to the console or the status page.

Result: the page now shows **"Environment variable TELEGRAM_OWNER_USER_ID is required"** prominently and instantly, instead of a 60s "timed out" with the cause hidden at the bottom.

## Tests

`extractCrashMessage` was moved to `IHP.IDE.Types` (so it's reachable from the test-suite, which depends on the library rather than the executable) and is covered by a new `IDE.DevServerSpec` — single-line, multi-line + CallStack, build-log noise before the crash, prompt-prefixed markers, and the no-crash → `[]` case.

Verified locally via the project ghci dev shell:
- `DevServer.hs` compiles — `Ok, 204 modules loaded`
- full test-suite compiles — `Ok, 219 modules loaded`
- new spec passes — `5 examples, 0 failures`

## Note / not included

The page header still reads *"Problems found while compiling"* even for a runtime startup crash (it compiled fine, then crashed). Making that read e.g. *"App crashed during startup"* would mean threading a crash flag into `renderErrorView`; left out to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)