### PR TITLE
[codex] Fail on duplicate migration timestamps

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -19,6 +19,7 @@
 , buildWithPostgres ? false  # Start a temporary PostgreSQL during build (e.g. for typedSql TH)
 , appSchemaSql ? null       # Path to Application/Schema.sql (required when buildWithPostgres = true)
 , ihpSchemaSql ? null       # Path to IHPSchema.sql (required when buildWithPostgres = true)
+, migrationCheck ? null     # Optional derivation that validates Application/Migration before building the app
 }:
 
 let
@@ -29,6 +30,42 @@ let
         export IHP_LIB=${ihp-env-var-backwards-compat}
         export IHP=${ihp-env-var-backwards-compat}
     '';
+
+    migrationDir = projectPath + "/Application/Migration";
+
+    defaultMigrationCheck = pkgs.runCommand "${appName}-migration-check" {} (''
+        set -euo pipefail
+    '' + pkgs.lib.optionalString (builtins.pathExists migrationDir) ''
+        cd ${migrationDir}
+
+        revisions="$(
+            for file in *.sql; do
+                [ -e "$file" ] || continue
+                printf '%s\n' "$file" | sed -n 's/^\([0-9][0-9]*\).*/\1/p'
+            done | sort
+        )"
+        duplicates="$(printf '%s\n' "$revisions" | uniq -d)"
+
+        if [ -n "$duplicates" ]; then
+            echo "error: multiple migrations use the same timestamp. Each migration filename needs a unique numeric prefix:" >&2
+            for revision in $duplicates; do
+                echo "  $revision:" >&2
+                for file in "$revision"*.sql; do
+                    [ -e "$file" ] || continue
+                    echo "    Application/Migration/$file" >&2
+                done
+            done
+            exit 1
+        fi
+    '' + ''
+        mkdir -p $out
+        touch $out/ok
+    '');
+
+    effectiveMigrationCheck =
+        if migrationCheck == null
+        then defaultMigrationCheck
+        else migrationCheck;
 
     # Generate the models package source from Schema.sql
     modelsPackageSrc = pkgs.stdenv.mkDerivation {
@@ -535,8 +572,10 @@ in
     pkgs.runCommand appName {
         inherit static binaries;
         nativeBuildInputs = [ pkgs.makeWrapper ];
-        passthru = { inherit scriptBinaries; };
+        passthru = { inherit scriptBinaries; migrationCheck = effectiveMigrationCheck; };
     } ''
+            test -e ${effectiveMigrationCheck}
+
             # Hash that changes only when `static` changes:
             INPUT_HASH="$(basename ${static} | cut -d- -f1)"
             makeWrapper ${binaries}/bin/RunProdServer $out/bin/RunProdServer \

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -277,6 +277,8 @@ ihpFlake:
 
                 migrate = ghcCompiler.ihp-migrate;
 
+                migration-check = unoptimizedProdServer.passthru.migrationCheck;
+
                 ihp-schema = pkgs.stdenv.mkDerivation {
                     name = "ihp-schema";
                     src = ihp;

--- a/ihp-migrate/IHP/SchemaMigration.hs
+++ b/ihp-migrate/IHP/SchemaMigration.hs
@@ -11,9 +11,9 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.String.Conversions (cs)
 import Data.Maybe (fromMaybe, mapMaybe, isJust, listToMaybe)
-import Data.List (sortBy)
+import Data.List (groupBy, sortBy)
 import Data.Ord (comparing)
-import Data.Function ((&))
+import Data.Function ((&), on)
 import Control.Monad (unless, forM, join)
 import Data.Int (Int64)
 import System.Environment (lookupEnv)
@@ -141,11 +141,42 @@ findAllMigrations = do
     directoryFiles <- Directory.listDirectory migrationDirOsPath
     fileNames <- mapM decodeUtf directoryFiles
     let textNames = map (cs :: FilePath -> Text) fileNames
-    textNames
-        & filter (\path -> ".sql" `Text.isSuffixOf` path)
-        & mapMaybe pathToMigration
+    let migrations = textNames
+            & filter (\path -> ".sql" `Text.isSuffixOf` path)
+            & mapMaybe pathToMigration
+    validateUniqueMigrationRevisions migrations
+    migrations
         & sortBy (comparing revision)
         & pure
+
+validateUniqueMigrationRevisions :: [Migration] -> IO ()
+validateUniqueMigrationRevisions migrations =
+    case duplicateMigrationRevisions migrations of
+        [] -> pure ()
+        duplicates -> ioError (userError (cs (formatDuplicateMigrationRevisions duplicates)))
+
+duplicateMigrationRevisions :: [Migration] -> [(Int, [Text])]
+duplicateMigrationRevisions migrations =
+    migrations
+        & sortBy (comparing revision)
+        & groupBy ((==) `on` revision)
+        & mapMaybe toDuplicate
+    where
+        toDuplicate [] = Nothing
+        toDuplicate group@(migration : _)
+            | length group > 1 = Just (migration.revision, map migrationFile group)
+            | otherwise = Nothing
+
+formatDuplicateMigrationRevisions :: [(Int, [Text])] -> Text
+formatDuplicateMigrationRevisions duplicates =
+    "Multiple migrations use the same timestamp. Each migration filename needs a unique numeric prefix:\n"
+    <> Text.unlines (map formatDuplicate duplicates)
+    where
+        formatDuplicate (duplicateRevision, migrationFiles) =
+            "  "
+            <> cs (show duplicateRevision)
+            <> ": "
+            <> Text.intercalate ", " migrationFiles
 
 -- | Given a path such as Application/Migrate/00-initial-migration.sql it returns a Migration
 --

--- a/ihp-migrate/Test/SchemaMigrationSpec.hs
+++ b/ihp-migrate/Test/SchemaMigrationSpec.hs
@@ -7,9 +7,12 @@ module Main where
 import Test.Hspec
 import Prelude
 import IHP.SchemaMigration
+import Control.Monad (forM_)
+import Data.List (isInfixOf)
 import qualified System.Directory as Directory
 import System.FilePath ((</>))
 import System.IO.Temp.OsPath (withSystemTempDirectory)
+import System.IO.Error (ioeGetErrorString, isUserError)
 import System.OsPath (encodeUtf, decodeUtf)
 
 main :: IO ()
@@ -28,9 +31,25 @@ tests = do
                             , Migration { revision = 1605721940, migrationFile = "1605721940-create-users.sql" }
                             ]
 
+            it "should fail when multiple migrations use the same timestamp" do
+                withTempMigrationFiles ["1605721927.sql", "1605721927-create-users.sql"] do
+                    findAllMigrations `shouldThrow` \exception ->
+                        let message = ioeGetErrorString exception
+                        in isUserError exception
+                            && "Multiple migrations use the same timestamp" `isInfixOf` message
+                            && "1605721927.sql" `isInfixOf` message
+                            && "1605721927-create-users.sql" `isInfixOf` message
+
 
 withTempApp :: IO a -> IO a
-withTempApp action = do
+withTempApp =
+    withTempMigrationFiles
+        [ "1605721927.sql"
+        , "1605721940-create-users.sql"
+        ]
+
+withTempMigrationFiles :: [FilePath] -> IO a -> IO a
+withTempMigrationFiles migrationFiles action = do
     template <- encodeUtf "ihp-migrate-test"
     withSystemTempDirectory template \tmpOsPath -> do
         tmp <- decodeUtf tmpOsPath
@@ -40,9 +59,9 @@ withTempApp action = do
         -- Create the directory structure
         Directory.createDirectoryIfMissing True migrationDir
 
-        -- Create two migration files and one non-migration file
-        writeFile (migrationDir </> "1605721927.sql") ""
-        writeFile (migrationDir </> "1605721940-create-users.sql") ""
+        -- Create migration files and one non-migration file
+        forM_ migrationFiles \migrationFile -> do
+            writeFile (migrationDir </> migrationFile) ""
         writeFile (migrationDir </> "not_a_migration") ""
 
         -- Now run findAllMigrations as if this were an IHP app root


### PR DESCRIPTION
## Summary

This changes migration discovery and app builds so duplicate migration timestamp prefixes fail fast instead of allowing one migration to be skipped after the shared revision is recorded.

## What changed

- `IHP.SchemaMigration.findAllMigrations` now validates that every parsed migration revision is unique and reports the colliding filenames.
- The app Nix build path now depends on a lightweight `Application/Migration` filename check, exposed as `packages.migration-check` from the flake module.
- Added an `ihp-migrate` regression test for duplicate timestamp detection.

## Why

IHP records applied migrations by revision in `schema_migrations`. If two migration files share the same numeric timestamp prefix, the first applied migration records that revision and the second can be filtered out as already applied.

## Validation

- `nix develop --impure -c sh -c 'tmp=$(mktemp); printf "packages: %s/ihp-migrate\n" "$PWD" > "$tmp"; cabal test --project-file="$tmp" ihp-migrate:test:tests'`
- `nix-instantiate --parse flake-module.nix`
- `nix-instantiate --parse NixSupport/default.nix`
