### PR TITLE
[codex] Retry missing prepared statements

### DIFF
--- a/ihp/IHP/Hasql/Pool.hs
+++ b/ihp/IHP/Hasql/Pool.hs
@@ -40,6 +40,10 @@ isCachedPlanError _ = False
 
 isCachedPlanSessionError :: HasqlErrors.SessionError -> Bool
 isCachedPlanSessionError (HasqlErrors.StatementSessionError _ _ _ _ _ (HasqlErrors.ServerStatementError (HasqlErrors.ServerError "0A000" _ _ _ _))) = True
+-- 26000 = invalid_sql_statement_name. This can happen when hasql's
+-- client-side prepared-statement cache outlives the corresponding
+-- server-side prepared statement.
+isCachedPlanSessionError (HasqlErrors.StatementSessionError _ _ _ _ True (HasqlErrors.ServerStatementError (HasqlErrors.ServerError "26000" _ _ _ _))) = True
 isCachedPlanSessionError (HasqlErrors.StatementSessionError _ _ _ _ _ (HasqlErrors.ServerStatementError (HasqlErrors.ServerError "XX000" _ _ _ _))) = True
 isCachedPlanSessionError (HasqlErrors.ScriptSessionError _ (HasqlErrors.ServerError "0A000" _ _ _ _)) = True
 isCachedPlanSessionError (HasqlErrors.ScriptSessionError _ (HasqlErrors.ServerError "XX000" _ _ _ _)) = True


### PR DESCRIPTION
## Summary

Treat PostgreSQL SQLSTATE `26000` (`invalid_sql_statement_name`) as a retryable stale prepared-statement cache error in `IHP.Hasql.Pool.usePoolWithRetry`.

## Why

`hasql` keeps a client-side prepared-statement cache. If that cache outlives the corresponding server-side prepared statement, PostgreSQL can return errors like:

```text
prepared statement "7" does not exist
SQLSTATE 26000
```

This is transient for cached/prepared statements and should be handled the same way as the existing stale cached-plan retry cases: let `hasql-pool` discard the bad connection and retry on a fresh one.

## Validation

- `git diff --check`
- `nix develop --impure --command bash -lc 'printf ":l ihp/IHP/Hasql/Pool.hs\n:q\n" | ghci'`

The focused GHCi load compiled `IHP.ModelSupport.Types` and `IHP.Hasql.Pool` successfully.