### PR TITLE
Add New<Model> attributes records for type-safe record creation

### DIFF
--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -1453,6 +1453,44 @@ tests = do
                         newRecord = Generated.ActualTypes.PostRevision def def def def  def
                     |]
 
+        describe "compileNewType / compileNewConstructor" do
+            let statements = parseSqlStatements [trimming|
+                CREATE TABLE posts (
+                    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
+                    title TEXT NOT NULL
+                );
+                CREATE TABLE comments (
+                    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
+                    post_id UUID NOT NULL,
+                    body TEXT NOT NULL,
+                    author TEXT,
+                    likes_count INT DEFAULT 0 NOT NULL
+                );
+                ALTER TABLE comments ADD CONSTRAINT comments_ref_post_id FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE NO ACTION;
+            |]
+            let
+                isComments :: Statement -> Bool
+                isComments (StatementCreateTable CreateTable { name }) = name == "comments"
+                isComments _ = False
+            let (Just (StatementCreateTable commentsTable)) = find isComments statements
+
+            it "should generate a New<Model> record holding only the required columns (NOT NULL, no default, not PK)" do
+                let ?schema = Schema statements
+                    ?compilerOptions = fullCompileOptions
+                (compileNewType commentsTable |> Text.strip) `shouldBe` [trimming|
+                    data NewComment = NewComment {postId :: (Id' "posts"), body :: Text} deriving (Eq, Show)
+                |]
+
+            it "should generate a new<Model> smart constructor that sets the required columns via 'set'" do
+                let ?schema = Schema statements
+                    ?compilerOptions = fullCompileOptions
+                (compileNewConstructor commentsTable |> Text.strip) `shouldBe` [trimming|
+                    newComment :: NewComment -> Comment
+                    newComment attributes = newRecord @Comment
+                        |> set #postId attributes.postId
+                        |> set #body attributes.body
+                |]
+
 -- | Extract the body of a statement module (everything after the import block)
 getStatementBody :: Text -> Text
 getStatementBody full =

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -10,6 +10,9 @@ module IHP.SchemaCompiler
 , compileFetchByIdStatement
 , compileCreateManyStatement
 , compileRowDecoderModule
+, compileNewType
+, compileNewConstructor
+, requiredColumns
 , Schema(..)
 ) where
 
@@ -18,7 +21,7 @@ import Data.Bits (bit)
 import Data.Maybe (fromJust)
 import Data.String.Conversions (cs)
 import "interpolate" Data.String.Interpolate (i)
-import IHP.NameSupport (tableNameToModelName, columnNameToFieldName, enumValueToControllerName)
+import IHP.NameSupport (tableNameToModelName, columnNameToFieldName, enumValueToControllerName, lcfirst)
 import qualified Data.Text as Text
 import qualified System.Directory.OsPath as Directory
 import IHP.HaskellSupport
@@ -165,6 +168,11 @@ tableModuleBody options table = Text.unlines $ filter (not . Text.null)
     , if options.compileGetAndSetFieldInstances
             then compileSetFieldInstances table <> compileUpdateFieldInstances table
             else ""
+    -- The @new<Model>@ smart constructor uses 'set', so it is only emitted when the
+    -- SetField instances are (i.e. not in the schema-designer preview).
+    , if options.compileGetAndSetFieldInstances
+            then compileNewConstructor table
+            else ""
     , compileFieldBitInstances table
     ]
 
@@ -281,6 +289,7 @@ compileActualTypesForTable :: (?schema :: Schema, ?compilerOptions :: CompilerOp
 compileActualTypesForTable table = Text.unlines
     [ compileData table
     , compileTypeAlias table
+    , compileNewType table
     , compileHasTableNameInstance table
     , compileTableInstance table
     ]
@@ -975,6 +984,68 @@ compileBuild table@(CreateTable { name }) =
         "instance Record " <> constructor <> " where\n"
         <> "    {-# INLINE newRecord #-}\n"
         <> "    newRecord = " <> constructor <> " " <> unwords (map toDefaultValueExpr columns) <> " " <> qbDefaults <> " def\n"
+
+-- | The columns a user must provide to create a valid record: writable (no generator),
+-- @NOT NULL@, without a database default, and not the primary key.
+--
+-- These are exactly the columns 'newRecord' fills with a sentinel default — e.g. the null
+-- UUID @00000000-0000-0000-0000-000000000000@ for a @NOT NULL@ foreign key — which then
+-- fails the constraint at runtime. The generated @New<Model>@ record (see 'compileNewType')
+-- makes them mandatory at compile time instead.
+--
+-- A nullable column is omitted (it safely defaults to @Nothing@); a column with a @DEFAULT@
+-- or @SERIAL@ is omitted (the database fills it when the touched-fields bit stays unset).
+requiredColumns :: (?schema :: Schema) => CreateTable -> [Column]
+requiredColumns table = filter (isRequiredColumn table) (allColumnsIncludingInherited table)
+
+isRequiredColumn :: (?schema :: Schema) => CreateTable -> Column -> Bool
+isRequiredColumn table column@Column { name, notNull, generator } =
+       isNothing generator                                          -- writable, not a generated column
+    && notNull                                                      -- a NULL would not be accepted
+    && not (hasExplicitOrImplicitDefault column)                    -- no DEFAULT / SERIAL to fall back on
+    && [name] /= primaryKeyColumnNames table.primaryKeyConstraint   -- the primary key is filled by the DB
+
+-- | Generates the @New<Model>@ attributes record carrying only the required columns:
+--
+-- > data NewComment = NewComment { postId :: (Id' "posts"), body :: Text } deriving (Eq, Show)
+--
+-- Because it is built with record-construction syntax, a forgotten field is a
+-- @-Wmissing-fields@ warning — a hard compile error under @-Werror=missing-fields@. Unlike
+-- the full model it carries no @meta@, @id@, timestamps or defaultable columns, so there is
+-- no boilerplate and no leaking of the internal 'MetaBag'.
+compileNewType :: (?schema :: Schema, ?compilerOptions :: CompilerOptions) => CreateTable -> Text
+compileNewType table@(CreateTable { name }) =
+        "data " <> newModelName <> " = " <> newModelName <> " {"
+        <> commaSep (map field (requiredColumns table))
+        <> "} deriving (Eq, Show)\n"
+    where
+        newModelName = "New" <> tableNameToModelName name
+        field column = columnNameToFieldName column.name <> " :: " <> haskellType table column
+
+-- | Generates the smart constructor turning a @New<Model>@ into a fully-defaulted model:
+--
+-- > newComment :: NewComment -> Comment
+-- > newComment attributes = newRecord @Comment
+-- >     |> set #postId attributes.postId
+-- >     |> set #body attributes.body
+--
+-- The result is an ordinary model, so it composes unchanged with 'set' (for optional
+-- columns), validation, forms and 'createRecord'. Required columns are always written to
+-- the INSERT regardless of the touched-fields bitmask, so the provided values reach the
+-- database; using 'set' additionally marks them touched, keeping dirty-tracking consistent.
+compileNewConstructor :: (?schema :: Schema, ?compilerOptions :: CompilerOptions) => CreateTable -> Text
+compileNewConstructor table@(CreateTable { name }) =
+        funcName <> " :: " <> newModelName <> " -> " <> modelName <> "\n"
+        <> funcName <> " attributes = newRecord @" <> modelName
+        <> concatMap setField (requiredColumns table)
+        <> "\n"
+    where
+        modelName = tableNameToModelName name
+        newModelName = "New" <> modelName
+        funcName = lcfirst newModelName
+        setField column =
+            let fieldName = columnNameToFieldName column.name
+            in "\n    |> set #" <> fieldName <> " attributes." <> fieldName
 
 
 compileDefaultIdInstance :: CreateTable -> Text


### PR DESCRIPTION
## Motivation

`newRecord` fills every field via its `Default` instance, so a `NOT NULL` foreign key without a database default becomes the null UUID `00000000-0000-0000-0000-000000000000`. That means:

```haskell
newRecord @Comment |> createRecord
```

…type-checks but fails the foreign key constraint **at runtime** — there is no compile-time signal that `postId` was never set, and the eventual error is a cryptic Postgres FK violation rather than "you forgot `postId`". This is a common footgun, and especially bad for AI coding agents, which is where this idea came from.

## What this generates

Per table, a `New<Model>` attributes record holding only the **required** columns — writable (no generator), `NOT NULL`, no database default, and not the primary key — plus a `new<Model>` smart constructor:

```haskell
data NewComment = NewComment { postId :: Id Post, body :: Text }

newComment :: NewComment -> Comment
newComment attributes = newRecord @Comment
    |> set #postId attributes.postId
    |> set #body attributes.body
```

Nullable columns, columns with a `DEFAULT`/`SERIAL`, and the primary key are intentionally excluded (they are safe to omit).

## Usage

```haskell
-- required fields enforced, no meta/default boilerplate:
newComment NewComment { postId = post.id, body = "Hi" } |> createRecord

-- optional fields via the familiar `set`:
newComment NewComment { postId = post.id, body = "Hi" }
    |> set #author (Just "Marc")
    |> createRecord

-- forgetting postId is now a compile-time signal:
newComment NewComment { body = "Hi" }
-- warning: [-Wmissing-fields] Fields of 'NewComment' not initialised: postId
```

Because `New<Model>` is built with record-**construction** syntax, a forgotten required field is a `-Wmissing-fields` warning — a hard compile error under `-Werror=missing-fields`. Unlike the full model it carries no `meta`, `id`, timestamps or defaultable columns, so there is no boilerplate and no leaking of the internal `MetaBag`.

## Design notes

- The constructor returns an ordinary model, so it composes unchanged with `set` (optional columns), validation, forms and `createRecord`. **`newRecord` stays** — it is still the right tool for the form workflow (empty record → fill from params → validate).
- Required columns are always written to the INSERT regardless of the touched-fields bitmask (`compileSqlEntry`), so the provided values reach the DB; using `set` additionally marks them touched, keeping dirty-tracking consistent.
- The `New<Model>` **type** lives in `Generated.ActualTypes.<Model>`; the **constructor** lives in `Generated.<Model>` (next to `newRecord`/`set`).
- The type is omitted from the schema-designer **preview** (like the SetField instances), and the constructor is only emitted when the SetField instances are. This keeps the existing golden-output tests unchanged.
- `requiredColumns` treats composite-PK member columns as required (correct for join tables, where the user must supply both FKs).

## Tests

- All 47 existing `SchemaCompilerSpec` examples still pass.
- 2 new examples assert the generated `New<Model>` type and `new<Model>` constructor for a `posts`/`comments` schema.

## Verification status / open questions

This is a **draft / RFC** to discuss the approach:

- ✅ The generator compiles and `SchemaCompilerSpec` (49 examples) passes; the generated string is verified to be exactly the snippet above.
- ⚠️ I have **not** yet regenerated a real app and compiled its `build/Generated` end-to-end. The generated code uses only constructs IHP already emits (`newRecord @M`, `set #f`, `record.field`), so it should compile, but this needs confirming — note IHP's own CI may not exercise generated code unless a fixture app does.
- ❓ Should generated apps enable `-Werror=missing-fields` so the guarantee actually bites?
- ❓ Should the scaffolded `new`/`create` actions use `new<Model> New<Model>{…}` instead of `newRecord`?
- ❓ Should the `New<Model>` type also appear in the schema-designer preview?

🤖 Generated with [Claude Code](https://claude.com/claude-code)