### PR TITLE
Bump nixpkgs inputs (freshness)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1592,11 +1592,11 @@
     },
     "nixpkgs-nixos": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
+        "lastModified": 1781509190,
+        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
         "type": "github"
       },
       "original": {
@@ -1815,11 +1815,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Routine freshness refresh of both `nixpkgs` inputs in `flake.lock`:

- **nixpkgs** (Haskell package set): `3d8f0f3f` (2026-05-23) → `3e41b24` (2026-06-16), `nixpkgs-unstable`
- **nixpkgs-nixos** (deployment modules): `4590696c` (2026-03-23) → `d6df3513` (2026-06-15), `nixos-25.11`

Default GHC stays **9.10.3**; `ihp` builds green on the new pin.

## No overrides dropped here (all still required at this rev)

- hasql default is still **1.9.3.1** (<1.10) and `postgresql-simple-postgresql-types` / `hasql-mapping` are still marked broken → the hasql 1.10 pins + `markUnbroken` stay.
- `hasql-interpolate` is still **1.0.1.0** (caps hasql <1.10) → fork stays.
- `HsOpenSSL`: nixpkgs still passes only `-Wno-error=incompatible-pointer-types` (openssl 3.6.2) → pointer-sign flag stays.
- GHC 9.14 overrides are owned by the `upgrade-ghc-9.14-sync` branch.

The actual override removal is gated on nixpkgs [PR #521260](https://github.com/NixOS/nixpkgs/pull/521260) (hasql 1.10 default, GHC 9.12) reaching `nixpkgs-unstable` — prepared in the companion draft PR #2729.

## Verification

- `nix build .#default` (9.10 `ihp`): ✅ green.
- `nix flake check`: 57 checks green (nixosModules, overlays, templates, all cached package builds), **0 code regressions**. The from-source GHC 9.12/9.14 check matrices couldn't finish on the build box (disk-bound) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
