### PR TITLE
flake-module: make tests/integration-tests checks typedSql-safe

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -97,6 +97,7 @@ that is defined in flake-module.nix
                     nativeBuildInputs = [
                         (pkgs.ghc.ghc.withPackages (p: with p; [
                             ihp ihp-hsx ihp-hspec ihp-ide ihp-schema-compiler
+                            ihp-typed-sql
                             hspec
                         ]))
                         pkgs.gnumake
@@ -118,6 +119,14 @@ that is defined in flake-module.nix
                         createdb -h "$PGHOST" app
                         export DATABASE_URL="postgresql:///app?host=$PGHOST"
 
+                        # Test/TypedSqlSpec.hs uses [typedSql| … |], which describes each
+                        # query against DATABASE_URL at COMPILE time, so the schema must
+                        # exist before we compile. (withIHPApp creates its own per-test
+                        # databases at runtime; this load only serves the compile-time
+                        # describe.) Load IHP's schema first, then the app's.
+                        psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f ${self}/ihp-schema-compiler/data/IHPSchema.sql
+                        psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f Application/Schema.sql
+
                         # Generate types from Schema.sql
                         make -f $IHP_LIB/lib/IHP/Makefile.dist build/Generated/Types.hs
 
@@ -128,7 +137,7 @@ that is defined in flake-module.nix
                             -threaded \
                             -i. -ibuild -iConfig \
                             -package-env - \
-                            -package ihp -package ihp-hspec -package hspec \
+                            -package ihp -package ihp-hspec -package ihp-typed-sql -package hspec \
                             -main-is Test.Main \
                             Test/Main.hs -o test-runner
                         ./test-runner

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -341,8 +341,24 @@ ihpFlake:
                     tests = pkgs.stdenv.mkDerivation {
                             name = "${config.ihp.appName}-tests";
                             src = builtins.path { path = config.ihp.projectPath; name = "source"; };
-                            nativeBuildInputs = with pkgs; [ (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler])) ];
+                            nativeBuildInputs = with pkgs; [ (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler])) ]
+                                # typedSql's quasi-quoter boots an ephemeral PostgreSQL at
+                                # compile time to describe queries (see IHP_TYPED_SQL_AUTO_DB
+                                # below), so the postgres tools must be on PATH whenever the
+                                # app depends on ihp-typed-sql.
+                                ++ lib.optionals buildWithPostgres [ postgresql ];
                             buildPhase = ''
+                                export IHP_LIB=${ihpLib}
+
+                                # typedSql describes each [typedSql|…|] query against a live
+                                # database at COMPILE time. IHP_TYPED_SQL_AUTO_DB=1 makes the
+                                # quasi-quoter boot its own throwaway PostgreSQL and load
+                                # IHPSchema.sql (found via IHP_LIB) plus Application/Schema.sql
+                                # (found from the project root) before describing, so test
+                                # modules that use typedSql compile here without a running dev
+                                # server. The dev shell sets the same variable.
+                                export IHP_TYPED_SQL_AUTO_DB=1
+
                                 # shellcheck disable=SC2046
                                 make -f ${ihpLib}/lib/IHP/Makefile.dist build/Generated/Types.hs
 
@@ -377,6 +393,15 @@ ihpFlake:
 
                                 createdb -h "$PGHOST" app
                                 export DATABASE_URL="postgresql:///app?host=$PGHOST"
+
+                                # typedSql describes each [typedSql| … |] query against
+                                # DATABASE_URL at COMPILE time, so the schema must exist
+                                # before we compile. (The hspec harness creates its own
+                                # per-test databases at runtime; this load only serves the
+                                # compile-time describe.) Load IHP's schema first, then the
+                                # app's.
+                                psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f ${self'.packages.ihp-schema}/IHPSchema.sql
+                                psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f Application/Schema.sql
 
                                 # Generate types and run integration tests
                                 make -f $IHP_LIB/lib/IHP/Makefile.dist build/Generated/Types.hs

--- a/integration-test/Test/Main.hs
+++ b/integration-test/Test/Main.hs
@@ -3,7 +3,9 @@ module Test.Main where
 import Prelude
 import Test.Hspec
 import qualified Test.IntegrationSpec
+import qualified Test.TypedSqlSpec
 
 main :: IO ()
 main = hspec do
     Test.IntegrationSpec.tests
+    Test.TypedSqlSpec.tests

--- a/integration-test/Test/TypedSqlSpec.hs
+++ b/integration-test/Test/TypedSqlSpec.hs
@@ -1,0 +1,74 @@
+module Test.TypedSqlSpec where
+
+import Web.Controller.Prelude hiding (get, request)
+import IHP.FrameworkConfig
+import IHP.Environment
+import IHP.Test.Mocking
+import IHP.Hspec (withIHPApp)
+import IHP.TypedSql (typedSql, sqlQueryTyped, sqlExecTyped)
+import Test.Hspec
+
+import Web.FrontController ()
+
+testConfig :: ConfigBuilder
+testConfig = do
+    option Development
+    option (AppPort 8002)
+
+-- | These specs exist primarily to guard the typedSql-safety of the nix
+-- test checks (see flake-module.nix). Each [typedSql| … |] quasiquote
+-- describes its SQL against a live PostgreSQL schema at COMPILE time. That
+-- only works because the test check sets IHP_TYPED_SQL_AUTO_DB=1 (plus
+-- IHP_LIB and postgres on PATH), which makes the quasiquoter boot a
+-- throwaway database and load IHPSchema.sql + Application/Schema.sql before
+-- describing. Remove that wiring and this module fails to compile.
+tests :: Spec
+tests = around (withIHPApp WebApplication testConfig) do
+    describe "typedSql" do
+        it "describes a SELECT at compile time and runs it at runtime" $ withContext do
+            user <- newRecord @User
+                |> set #email "typed@example.com"
+                |> set #passwordHash "hash"
+                |> createRecord
+
+            newRecord @Post
+                |> set #title "Typed Post"
+                |> set #body "Body"
+                |> set #userId user.id
+                |> createRecord
+
+            -- Result type ([Text]) is inferred by describing the query against
+            -- the schema at compile time — no manual decoder.
+            titles <- sqlQueryTyped [typedSql|
+                SELECT title FROM posts ORDER BY title
+            |]
+
+            titles `shouldBe` ["Typed Post"]
+
+        it "describes a parameterised UPDATE/SELECT" $ withContext do
+            user <- newRecord @User
+                |> set #email "param@example.com"
+                |> set #passwordHash "hash"
+                |> createRecord
+
+            post <- newRecord @Post
+                |> set #title "Before"
+                |> set #body "Body"
+                |> set #userId user.id
+                |> createRecord
+
+            -- Splices must be simple identifiers/parenthesised expressions: the
+            -- quasiquoter parses `post.id` as `post . id`, so bind it first.
+            let thePostId = post.id
+
+            -- ${…} splices are typed too: a wrong-typed parameter would fail
+            -- the compile-time describe.
+            rowsAffected <- sqlExecTyped [typedSql|
+                UPDATE posts SET title = ${("After" :: Text)} WHERE id = ${thePostId}
+            |]
+            rowsAffected `shouldBe` 1
+
+            titles <- sqlQueryTyped [typedSql|
+                SELECT title FROM posts WHERE id = ${thePostId}
+            |]
+            titles `shouldBe` ["After"]


### PR DESCRIPTION
## Problem

The flake module auto-generates two checks when the matching files exist:

- `tests` — runs `Test/Main.hs`
- `integration-tests` — starts a temp Postgres and runs `Test/Integration.hs`

`typedSql` describes every `[typedSql| … |]` query against a **live database at compile time**. Neither check made one available, so the moment a test module uses `sqlQueryTyped [typedSql| … |]`, `nix flake check` fails during compilation — even though the same code compiles fine in the dev shell. With the boilerplate now defaulting to typedSql (`relationSupport = false`), the first test someone writes against a typedSql query breaks CI.

## The subtlety (why one env var isn't enough)

typedSql connects to `DATABASE_URL` **first** and only falls back to the auto compile-time database (`IHP_TYPED_SQL_AUTO_DB`) when that connection *fails* (see `ihp-typed-sql/IHP/TypedSql/Metadata.hs`). So the two checks need different fixes:

- **`tests`** sets no `DATABASE_URL`, so `defaultDatabaseUrl` resolves to an unreachable socket, the connection fails, and the auto DB takes over. Fix: set `IHP_TYPED_SQL_AUTO_DB=1`, export `IHP_LIB` (so `IHPSchema.sql` is found), and add `postgresql` to `nativeBuildInputs` — **gated on `buildWithPostgres`** so non-typedSql apps are unaffected. Mirrors the dev shell.
- **`integration-tests`** points `DATABASE_URL` at a reachable but **empty** `app` DB, so the connection succeeds and the auto DB never triggers — `prepare` then fails with `relation "…" does not exist`. Fix: load `IHPSchema.sql` + `Application/Schema.sql` into that DB before compiling. (The hspec harness creates its own per-test DBs at runtime; this load only serves the compile-time describe.)

An earlier revision of this PR naively set `IHP_TYPED_SQL_AUTO_DB=1` in both checks; the build below caught that it's a no-op for `integration-tests`.

## Regression test (`integration-test/`)

`Test/TypedSqlSpec.hs` exercises `[typedSql| … |]` (a plain SELECT and a parameterised UPDATE/SELECT) via `withIHPApp`, and the `integration-test` check now installs `ihp-typed-sql` and loads the schema into the build DB before compiling — the same wiring the generated `integration-tests` check gets.

## Verification

Built `nix build .#checks.x86_64-linux.integration-test` against this branch:

- **Before the schema load** (auto-DB only): fails at compile time —
  `typedSql: prepare failed: ERROR:  relation "posts" does not exist`.
- **After the schema load**: compiles and runs — **`7 examples, 0 failures`**.

That negative→positive transition exercises the same mechanism as the `integration-tests` fix. The `tests` auto-DB path is verified by the source logic above plus dev-shell parity (the dev shell sets `IHP_TYPED_SQL_AUTO_DB=1` and is known-working); it isn't separately built here because the only in-CI consumer of the generated `tests` check is the boilerplate, whose `Test/Main.hs` doesn't yet use typedSql.

## Why upstream

This was previously worked around per-app by redefining `packages."integration-tests"` with `lib.mkForce`. It belongs in the framework: every typedSql app needs it, and after this an app needs zero flake boilerplate to test typedSql code.
