### PR TITLE
devenv-module: fix datasync-js fetchYarnDeps hash (unbreaks master CI)

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -573,7 +573,7 @@ that is defined in flake-module.nix
 
                 yarnOfflineCache = pkgs.fetchYarnDeps {
                     yarnLock = ./ihp-datasync/data/DataSync/yarn.lock;
-                    hash = "sha256-vu7gXhPlgnm76GAQiD7DqROCC80uwAhMrh24mXqdfG0=";
+                    hash = "sha256-Jy1GtEUMemtPmfIPBYMKOl1W8kWfGM51vzkY481qV+8=";
                 };
 
                 nativeBuildInputs = [ pkgs.nodejs pkgs.yarn pkgs.yarnConfigHook ];


### PR DESCRIPTION
## Problem

`master` CI (`nix flake check --impure`) is red. The dependabot bump #2734 (`@babel/core` 7.29.0 → 7.29.7) updated `ihp-datasync/data/DataSync/yarn.lock` but left the `fetchYarnDeps` hash in `devenv-module.nix` stale, so `checks.<system>.datasync-js` fails:

```
ERROR: fetchYarnDeps hash is out of date
The yarn.lock in src is not the same as the in /nix/store/…-offline.
```

Because `nix flake check` aborts on the first failed check, this also cancels every other check (and turns every open PR's CI red).

## Fix

Recompute the `fetchYarnDeps` hash from the updated lock (`prefetch-yarn-deps`):

```
- hash = "sha256-vu7gXhPlgnm76GAQiD7DqROCC80uwAhMrh24mXqdfG0=";
+ hash = "sha256-Jy1GtEUMemtPmfIPBYMKOl1W8kWfGM51vzkY481qV+8=";
```

## Verification

`nix build .#checks.x86_64-linux.datasync-js` (previously failing) now builds: deps resolve offline with no hash mismatch, `tsc` passes, and jest reports **2 suites / 135 tests passed**.
