### PR TITLE
Add "never force push" to CLAUDE.md git guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,10 @@ This is a monorepo with multiple Haskell packages:
 - The framework uses implicit parameters extensively (see `ImplicitParams` extension)
 - HSX uses quasiquotes: `[hsx|<div>content</div>|]`
 
+## Git Workflow
+
+- **Never force push.** If a push is rejected because the remote has advanced, `git fetch` and rebase (or merge) onto the updated remote, then push normally. Do not use `git push --force` or `--force-with-lease`.
+
 ## Hasql Database Patterns (Reference)
 
 Based on patterns from [hasql-tutorial1](https://github.com/nikita-volkov/hasql-tutorial1). Hasql provides type-safe PostgreSQL access with a layered architecture.


### PR DESCRIPTION
## What

Adds a **Git Workflow** section to `CLAUDE.md` instructing the coding agent to never force push, and to instead fetch + rebase/merge onto the updated remote when a push is rejected.

## Why

Force pushes can clobber work that another contributor (or another agent) pushed to a shared branch. The safe recovery from a rejected push is to integrate the remote changes first, then push a normal fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)