### PR TITLE
[codex] Infer typed SQL query cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- `typedSql` now tracks conservative query cardinality in `TypedQuery`, and
+  `sqlQueryTyped` returns `[result]`, `Maybe result`, or `result` depending on
+  whether the query is inferred as many-row, at-most-one-row, or exactly-one-row.
+  For example, `SELECT COUNT(*) ...` now returns `Int64` directly, while
+  `LIMIT 1` queries return `Maybe result`.
+
 ## v1.6.0 (2026-06-20)
 
 ### Breaking Changes

--- a/Guide/database.markdown
+++ b/Guide/database.markdown
@@ -332,11 +332,11 @@ do
     -- commentsCount :: [(Id Post, Int64)]
 ```
 
-For a single value use the same quoter and pick the first row:
+For a single value use the same quoter. `sqlQueryTyped` returns the scalar directly when `typedSql` can prove the query returns exactly one row:
 
 ```haskell
 do
-    [count] <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM projects |]
+    count <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM projects |]
     -- count :: Int64
 ```
 

--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -19,7 +19,7 @@ The `typedSql` quasiquoter solves this: it connects to your development database
 Add `ihp-typed-sql` to your project's dependencies and import the module:
 
 ```haskell
-import IHP.TypedSql (typedSql, sqlQueryTyped, sqlQueryTypedScalar, sqlQueryTypedScalarOrNothing, sqlExecTyped)
+import IHP.TypedSql (typedSql, sqlQueryTyped, sqlExecTyped)
 ```
 
 The `QuasiQuotes` extension is required but already enabled by default in IHP projects.
@@ -42,31 +42,19 @@ action ItemsAction = do
     render IndexView { names }
 ```
 
-The `typedSql` quasiquoter produces a `TypedQuery result` value. Use `sqlQueryTyped` to execute it and get back a list of results.
+The `typedSql` quasiquoter produces a `TypedQuery cardinality result` value. Use `sqlQueryTyped` to execute it. The return shape follows the cardinality that can be proven from the SQL:
 
-## Single-Value Queries
-
-`sqlQueryTyped` always returns a list. For queries that return exactly one row of one value — such as `SELECT count(*)` — use `sqlQueryTypedScalar`, which returns the value directly:
+- many rows: `[result]`
+- at most one row, e.g. `LIMIT 1` or a primary-key lookup: `Maybe result`
+- exactly one row, e.g. `COUNT(*)`, `SELECT 1`, or `EXISTS(...)`: `result`
 
 ```haskell
-total <- sqlQueryTypedScalar [typedSql| SELECT count(*) FROM users |]
-
+total <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM items |]
 -- total :: Int64
-```
 
-`sqlQueryTypedScalar` throws if the query returns zero rows or more than one row. When no row is a valid outcome, use `sqlQueryTypedScalarOrNothing`, which returns `Maybe result`:
-
-```haskell
-maybeName <- sqlQueryTypedScalarOrNothing [typedSql|
-    SELECT name FROM users WHERE id = ${userId}
-|]
-
+maybeName <- sqlQueryTyped [typedSql| SELECT name FROM items ORDER BY name LIMIT 1 |]
 -- maybeName :: Maybe Text
 ```
-
-Both helpers require a single-column query. Passing a multi-column query (which `typedSql` infers as a `SqlRow`) is a compile-time error — use `sqlQueryTyped` for those.
-
-These are the typed counterparts of the deprecated `sqlQueryScalar` / `sqlQueryScalarOrNothing` from `IHP.ModelSupport`.
 
 ## Selecting Multiple Columns
 
@@ -250,19 +238,19 @@ names <- sqlQueryTyped [typedSql| SELECT name FROM items |]
 
 ### Computed Expressions
 
-Computed expressions (aggregates, CASE, arithmetic, literals, etc.) are always wrapped in `Maybe`, because PostgreSQL cannot guarantee they are non-null:
+Computed expressions (aggregates, CASE, arithmetic, literals, etc.) are wrapped in `Maybe` unless `typedSql` can prove they are non-null:
 
 ```haskell
-counts <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM items |]
--- counts :: [Maybe Int64]
+count <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM items |]
+-- count :: Int64
 
 results <- sqlQueryTyped [typedSql|
     SELECT CASE WHEN views > 5 THEN name ELSE 'low' END FROM items
 |]
 -- results :: [Maybe Text]
 
-literals <- sqlQueryTyped [typedSql| SELECT 1 |]
--- literals :: [Maybe Int]
+literal <- sqlQueryTyped [typedSql| SELECT 1 |]
+-- literal :: Int
 ```
 
 ### Primary and Foreign Keys

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -347,6 +347,43 @@ To make a minimal change without touching every signature, import the alias expl
 import IHP.ControllerSupport (ControllerContext)
 ```
 
+## `sqlQueryTyped` now returns scalars for singleton queries
+
+`typedSql` now tracks conservative query cardinality. `sqlQueryTyped` still
+returns a list for ordinary many-row queries, but returns a scalar directly when
+the query is proven to return exactly one row, and returns `Maybe result` when
+the query is proven to return at most one row.
+
+Common updates:
+
+```diff
+-[count] <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM posts |]
++count <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM posts |]
+ -- count :: Int64
+```
+
+```diff
+-names <- sqlQueryTyped [typedSql| SELECT name FROM posts ORDER BY created_at DESC LIMIT 1 |]
+-case names of
+-    [name] -> ...
+-    [] -> ...
++maybeName <- sqlQueryTyped [typedSql| SELECT name FROM posts ORDER BY created_at DESC LIMIT 1 |]
++case maybeName of
++    Just name -> ...
++    Nothing -> ...
+```
+
+Explicit `TypedQuery` signatures also need the cardinality argument:
+
+```diff
+-query :: TypedQuery Text
++query :: TypedQuery 'ManyRows Text
+ query = [typedSql| SELECT name FROM posts ORDER BY name |]
+```
+
+Use `'AtMostOneRow` for `LIMIT 1` / primary-key lookups and `'ExactlyOneRow`
+for singleton queries such as `COUNT(*)`.
+
 ## `typedSql` is stricter and uses `Int64` for `bigint`
 
 `typedSql` now rejects `SELECT *`, `SELECT table.*`, and `INSERT` statements without an explicit column list by default. This prevents compiled decoders from silently depending on development database column order.

--- a/ihp-typed-sql/IHP/TypedSql.hs
+++ b/ihp-typed-sql/IHP/TypedSql.hs
@@ -1,81 +1,60 @@
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module IHP.TypedSql
     ( typedSql
     , typedSqlStar
+    , QueryCardinality (..)
     , TypedQuery (..)
+    , TypedQueryResult
+    , DecodeTypedQuery
     , sqlQueryTyped
-    , sqlQueryTypedScalar
-    , sqlQueryTypedScalarOrNothing
     , sqlExecTyped
     ) where
 
+import           Data.Proxy                       (Proxy (..))
 import qualified Hasql.Decoders                  as HasqlDecoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
 import           IHP.ModelSupport                (sqlQueryHasql)
 import           IHP.Prelude
-import           Data.Kind                       (Constraint)
-import           GHC.TypeLits                    (TypeError, ErrorMessage (..))
 
 import           IHP.TypedSql.Quoter                 (typedSql, typedSqlStar)
-import           IHP.TypedSql.RowType                (SqlRow)
-import           IHP.TypedSql.Types                  (TypedQuery (..))
+import           IHP.TypedSql.Types                  (QueryCardinality (..), TypedQuery (..), TypedQueryResult)
 
--- | Compile-time guard for the scalar query helpers.
---
--- Multi-column typed queries are inferred as 'SqlRow', so without this guard
--- @sqlQueryTypedScalar [typedSql| SELECT name, views FROM ... |]@ would silently
--- return a single 'SqlRow' instead of a scalar. This rejects that at compile
--- time, mirroring how the deprecated @sqlQueryScalar@ only accepts single-column
--- results.
-type family ScalarResult result :: Constraint where
-    ScalarResult (SqlRow fields) =
-        TypeError
-            ( 'Text "sqlQueryTypedScalar expects a query that returns a single column,"
-            ':$$: 'Text "but this query returns multiple columns (a SqlRow)."
-            ':$$: 'Text "Use sqlQueryTyped to fetch the rows, or select a single column."
-            )
-    ScalarResult result = ()
+class DecodeTypedQuery (cardinality :: QueryCardinality) where
+    typedQueryResultDecoder :: Proxy cardinality -> HasqlDecoders.Row result -> HasqlDecoders.Result (TypedQueryResult cardinality result)
 
--- | Run a typed SELECT query and return all result rows.
+instance DecodeTypedQuery 'ManyRows where
+    typedQueryResultDecoder _ = HasqlDecoders.rowList
+
+instance DecodeTypedQuery 'AtMostOneRow where
+    typedQueryResultDecoder _ = HasqlDecoders.rowMaybe
+
+instance DecodeTypedQuery 'ExactlyOneRow where
+    typedQueryResultDecoder _ = HasqlDecoders.singleRow
+
+-- | Run a typed SELECT query.
 --
 -- Also works with INSERT\/UPDATE\/DELETE ... RETURNING statements
 -- that return rows.
 --
--- > users <- sqlQueryTyped [typedSql| SELECT name FROM users |]
--- > newIds <- sqlQueryTyped [typedSql| INSERT INTO items (name) VALUES (${name}) RETURNING id |]
-sqlQueryTyped :: (?modelContext :: ModelContext) => TypedQuery result -> IO [result]
+-- The return type is inferred from the query cardinality:
+--
+-- * many rows: @[result]@
+-- * at most one row: @Maybe result@
+-- * exactly one row: @result@
+--
+-- > users <- sqlQueryTyped [typedSql| SELECT name FROM users |] -- IO [Text]
+-- > total <- sqlQueryTyped [typedSql| SELECT count(*) FROM users |] -- IO Int64
+sqlQueryTyped :: forall cardinality result. (?modelContext :: ModelContext, DecodeTypedQuery cardinality) => TypedQuery cardinality result -> IO (TypedQueryResult cardinality result)
 sqlQueryTyped TypedQuery { tqSnippet, tqResultDecoder } =
-    runTypedSqlSession tqSnippet (HasqlDecoders.rowList tqResultDecoder)
-
--- | Run a typed query expected to return exactly one row of a single column (e.g. @count(*)@).
---
--- Throws if the query returns zero rows or more than one row. Use
--- 'sqlQueryTypedScalarOrNothing' when no row is a valid outcome, or
--- 'sqlQueryTyped' when you expect many rows.
---
--- Multi-column queries are rejected at compile time, so this always returns a
--- single scalar rather than a 'SqlRow'.
---
--- > total <- sqlQueryTypedScalar [typedSql| SELECT count(*) FROM users |]
-sqlQueryTypedScalar :: (?modelContext :: ModelContext, ScalarResult result) => TypedQuery result -> IO result
-sqlQueryTypedScalar TypedQuery { tqSnippet, tqResultDecoder } =
-    runTypedSqlSession tqSnippet (HasqlDecoders.singleRow tqResultDecoder)
-
--- | Like 'sqlQueryTypedScalar' but returns 'Nothing' when there is no row.
---
--- > maybeName <- sqlQueryTypedScalarOrNothing [typedSql| SELECT name FROM users WHERE id = ${userId} |]
-sqlQueryTypedScalarOrNothing :: (?modelContext :: ModelContext, ScalarResult result) => TypedQuery result -> IO (Maybe result)
-sqlQueryTypedScalarOrNothing TypedQuery { tqSnippet, tqResultDecoder } =
-    runTypedSqlSession tqSnippet (HasqlDecoders.rowMaybe tqResultDecoder)
+    runTypedSqlSession tqSnippet (typedQueryResultDecoder (Proxy :: Proxy cardinality) tqResultDecoder)
 
 -- | Run a typed statement (INSERT\/UPDATE\/DELETE) and return the affected row count.
 --
 -- Use 'sqlQueryTyped' instead if your statement has a RETURNING clause.
 --
 -- > rowsAffected <- sqlExecTyped [typedSql| DELETE FROM items WHERE id = ${itemId} |]
-sqlExecTyped :: (?modelContext :: ModelContext) => TypedQuery result -> IO Int64
+sqlExecTyped :: (?modelContext :: ModelContext) => TypedQuery cardinality result -> IO Int64
 sqlExecTyped TypedQuery { tqSnippet } =
     runTypedSqlSession tqSnippet HasqlDecoders.rowsAffected
 

--- a/ihp-typed-sql/IHP/TypedSql.hs
+++ b/ihp-typed-sql/IHP/TypedSql.hs
@@ -11,7 +11,6 @@ module IHP.TypedSql
     , sqlExecTyped
     ) where
 
-import           Data.Proxy                       (Proxy (..))
 import qualified Hasql.Decoders                  as HasqlDecoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
 import           IHP.ModelSupport                (sqlQueryHasql)

--- a/ihp-typed-sql/IHP/TypedSql/Cardinality.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Cardinality.hs
@@ -1,0 +1,339 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module IHP.TypedSql.Cardinality
+    ( inferCardinality
+    ) where
+
+import           Data.Foldable                    (toList)
+import qualified Data.List                        as List
+import qualified Data.Map.Strict                  as Map
+import qualified Data.Set                         as Set
+import qualified Data.Text                        as Text
+import qualified Database.PostgreSQL.LibPQ        as PQ
+import           IHP.Prelude
+import qualified PostgresqlSyntax.Ast             as Ast
+
+import           IHP.TypedSql.Metadata            (ColumnMeta (..), TableMeta (..))
+import           IHP.TypedSql.Types               (QueryCardinality (..))
+
+type SourceCardinalityMap = Map.Map Text QueryCardinality
+
+-- | Conservatively infer the maximum number of rows a parsed statement can
+-- return. Unknown cases intentionally stay at 'ManyRows'.
+inferCardinality :: Map.Map PQ.Oid TableMeta -> Ast.PreparableStmt -> QueryCardinality
+inferCardinality tables = \case
+    Ast.SelectPreparableStmt selectStmt -> inferSelectStmt tables selectStmt
+    Ast.InsertPreparableStmt insertStmt -> inferInsertStmt tables insertStmt
+    Ast.UpdatePreparableStmt _ -> ManyRows
+    Ast.DeletePreparableStmt _ -> ManyRows
+    Ast.CallPreparableStmt _ -> ManyRows
+
+inferInsertStmt :: Map.Map PQ.Oid TableMeta -> Ast.InsertStmt -> QueryCardinality
+inferInsertStmt tables (Ast.InsertStmt _with _target insertRest _onConflict maybeReturning) =
+    case maybeReturning of
+        Nothing -> ManyRows
+        Just _ ->
+            case insertRest of
+                Ast.DefaultValuesInsertRest -> ExactlyOneRow
+                Ast.SelectInsertRest _columns _override selectStmt -> inferSelectStmt tables selectStmt
+
+inferSelectStmt :: Map.Map PQ.Oid TableMeta -> Ast.SelectStmt -> QueryCardinality
+inferSelectStmt tables = \case
+    Left selectNoParens -> inferSelectNoParens tables selectNoParens
+    Right selectWithParens -> inferSelectWithParens tables selectWithParens
+
+inferSelectWithParens :: Map.Map PQ.Oid TableMeta -> Ast.SelectWithParens -> QueryCardinality
+inferSelectWithParens tables = \case
+    Ast.NoParensSelectWithParens selectNoParens -> inferSelectNoParens tables selectNoParens
+    Ast.WithParensSelectWithParens inner -> inferSelectWithParens tables inner
+
+inferSelectNoParens :: Map.Map PQ.Oid TableMeta -> Ast.SelectNoParens -> QueryCardinality
+inferSelectNoParens tables (Ast.SelectNoParens maybeWith selectClause _sort maybeLimit _lock) =
+    let cteCardinality = maybe Map.empty (cteCardinalities tables) maybeWith
+    in applyLimit maybeLimit (inferSelectClause tables cteCardinality selectClause)
+
+inferSelectClause :: Map.Map PQ.Oid TableMeta -> SourceCardinalityMap -> Ast.SelectClause -> QueryCardinality
+inferSelectClause tables sourceCardinalities = \case
+    Left simpleSelect -> inferSimpleSelect tables sourceCardinalities simpleSelect
+    Right selectWithParens -> inferSelectWithParens tables selectWithParens
+
+inferSimpleSelect :: Map.Map PQ.Oid TableMeta -> SourceCardinalityMap -> Ast.SimpleSelect -> QueryCardinality
+inferSimpleSelect tables sourceCardinalities = \case
+    Ast.NormalSimpleSelect maybeTargeting _into maybeFrom maybeWhere maybeGroup maybeHaving _window
+        | isNothing maybeGroup && isAggregateTargeting maybeTargeting ->
+            if isNothing maybeHaving then ExactlyOneRow else AtMostOneRow
+        | isNothing maybeFrom && isNothing maybeWhere && isNothing maybeGroup && isNothing maybeHaving ->
+            ExactlyOneRow
+        | isNothing maybeGroup && isNothing maybeHaving
+        , Just sourceCardinality <- singleSourceCardinality tables sourceCardinalities maybeFrom ->
+            applyWhere maybeWhere sourceCardinality
+        | provesPrimaryKeyLookup tables maybeFrom maybeWhere ->
+            AtMostOneRow
+        | otherwise ->
+            ManyRows
+    Ast.ValuesSimpleSelect values
+        | length (toList values) == 1 -> ExactlyOneRow
+        | otherwise -> ManyRows
+    Ast.TableSimpleSelect _ -> ManyRows
+    Ast.BinSimpleSelect _op _left _distinct _right -> ManyRows
+
+cteCardinalities :: Map.Map PQ.Oid TableMeta -> Ast.WithClause -> SourceCardinalityMap
+cteCardinalities tables (Ast.WithClause _recursive ctes) =
+    ctes
+        |> toList
+        |> map (\(Ast.CommonTableExpr cteName _cols _materialized stmt) -> (identToText cteName, inferCardinality tables stmt))
+        |> Map.fromList
+
+singleSourceCardinality :: Map.Map PQ.Oid TableMeta -> SourceCardinalityMap -> Maybe Ast.FromClause -> Maybe QueryCardinality
+singleSourceCardinality tables sourceCardinalities maybeFrom = do
+    fromClause <- maybeFrom
+    case toList fromClause of
+        [tableRef] -> tableRefCardinality tables sourceCardinalities tableRef
+        _ -> Nothing
+
+tableRefCardinality :: Map.Map PQ.Oid TableMeta -> SourceCardinalityMap -> Ast.TableRef -> Maybe QueryCardinality
+tableRefCardinality tables sourceCardinalities = \case
+    Ast.RelationExprTableRef relExpr _alias _sample ->
+        Map.lookup (relationExprName relExpr) sourceCardinalities
+    Ast.SelectTableRef _lateral subquery _alias ->
+        Just (inferSelectWithParens tables subquery)
+    _ ->
+        Nothing
+
+applyWhere :: Maybe Ast.WhereClause -> QueryCardinality -> QueryCardinality
+applyWhere Nothing cardinality = cardinality
+applyWhere (Just _) cardinality =
+    case cardinality of
+        ExactlyOneRow -> AtMostOneRow
+        AtMostOneRow -> AtMostOneRow
+        ManyRows -> ManyRows
+
+applyLimit :: Maybe Ast.SelectLimit -> QueryCardinality -> QueryCardinality
+applyLimit Nothing cardinality = cardinality
+applyLimit (Just selectLimit) cardinality
+    | limitSelectAtMostOne selectLimit =
+        if cardinality == ExactlyOneRow && not (selectLimitHasOffset selectLimit)
+            then ExactlyOneRow
+            else AtMostOneRow
+    | otherwise = cardinality
+
+limitSelectAtMostOne :: Ast.SelectLimit -> Bool
+limitSelectAtMostOne = \case
+    Ast.LimitOffsetSelectLimit limitClause _offset -> limitClauseAtMostOne limitClause
+    Ast.OffsetLimitSelectLimit _offset limitClause -> limitClauseAtMostOne limitClause
+    Ast.LimitSelectLimit limitClause -> limitClauseAtMostOne limitClause
+    Ast.OffsetSelectLimit _offset -> False
+
+selectLimitHasOffset :: Ast.SelectLimit -> Bool
+selectLimitHasOffset = \case
+    Ast.LimitOffsetSelectLimit _ _ -> True
+    Ast.OffsetLimitSelectLimit _ _ -> True
+    Ast.OffsetSelectLimit _ -> True
+    Ast.LimitSelectLimit _ -> False
+
+limitClauseAtMostOne :: Ast.LimitClause -> Bool
+limitClauseAtMostOne = \case
+    Ast.LimitLimitClause (Ast.ExprSelectLimitValue expr) _offset -> exprAtMostOne expr
+    Ast.LimitLimitClause Ast.AllSelectLimitValue _offset -> False
+    Ast.FetchOnlyLimitClause _withTies maybeValue _rowsOnly ->
+        case maybeValue of
+            Nothing -> True
+            Just (Ast.ExprSelectFetchFirstValue cExpr) -> cExprAtMostOne cExpr
+            Just (Ast.NumSelectFetchFirstValue _signed number) -> numericLimitAtMostOne number
+
+exprAtMostOne :: Ast.AExpr -> Bool
+exprAtMostOne = \case
+    Ast.CExprAExpr cExpr -> cExprAtMostOne cExpr
+    Ast.TypecastAExpr expr _ -> exprAtMostOne expr
+    Ast.PlusAExpr expr -> exprAtMostOne expr
+    _ -> False
+
+cExprAtMostOne :: Ast.CExpr -> Bool
+cExprAtMostOne = \case
+    Ast.AexprConstCExpr (Ast.IAexprConst value) -> value <= 1
+    _ -> False
+
+numericLimitAtMostOne :: Either Int64 Double -> Bool
+numericLimitAtMostOne = \case
+    Left value -> value <= 1
+    Right value -> value <= 1
+
+isAggregateTargeting :: Maybe Ast.Targeting -> Bool
+isAggregateTargeting = \case
+    Just (Ast.NormalTargeting targets) -> any targetContainsAggregate (toList targets)
+    Just (Ast.DistinctTargeting _ targets) -> any targetContainsAggregate (toList targets)
+    _ -> False
+
+targetContainsAggregate :: Ast.TargetEl -> Bool
+targetContainsAggregate = \case
+    Ast.AliasedExprTargetEl expr _ -> exprContainsAggregate expr
+    Ast.ImplicitlyAliasedExprTargetEl expr _ -> exprContainsAggregate expr
+    Ast.ExprTargetEl expr -> exprContainsAggregate expr
+    Ast.AsteriskTargetEl -> False
+
+exprContainsAggregate :: Ast.AExpr -> Bool
+exprContainsAggregate = \case
+    Ast.CExprAExpr cExpr -> cExprContainsAggregate cExpr
+    Ast.TypecastAExpr expr _ -> exprContainsAggregate expr
+    Ast.CollateAExpr expr _ -> exprContainsAggregate expr
+    Ast.AtTimeZoneAExpr left right -> exprContainsAggregate left || exprContainsAggregate right
+    Ast.PlusAExpr expr -> exprContainsAggregate expr
+    Ast.MinusAExpr expr -> exprContainsAggregate expr
+    Ast.SymbolicBinOpAExpr left _ right -> exprContainsAggregate left || exprContainsAggregate right
+    Ast.PrefixQualOpAExpr _ expr -> exprContainsAggregate expr
+    Ast.SuffixQualOpAExpr expr _ -> exprContainsAggregate expr
+    Ast.AndAExpr left right -> exprContainsAggregate left || exprContainsAggregate right
+    Ast.OrAExpr left right -> exprContainsAggregate left || exprContainsAggregate right
+    Ast.NotAExpr expr -> exprContainsAggregate expr
+    Ast.VerbalExprBinOpAExpr left _ _ right maybeExtra ->
+        exprContainsAggregate left || exprContainsAggregate right || maybe False exprContainsAggregate maybeExtra
+    Ast.ReversableOpAExpr expr _ op -> exprContainsAggregate expr || reversibleOpContainsAggregate op
+    Ast.IsnullAExpr expr -> exprContainsAggregate expr
+    Ast.NotnullAExpr expr -> exprContainsAggregate expr
+    Ast.OverlapsAExpr _ _ -> False
+    Ast.SubqueryAExpr expr _ _ subqueryOrExpr ->
+        exprContainsAggregate expr || either (const False) exprContainsAggregate subqueryOrExpr
+    Ast.UniqueAExpr _ -> False
+    Ast.DefaultAExpr -> False
+
+cExprContainsAggregate :: Ast.CExpr -> Bool
+cExprContainsAggregate = \case
+    Ast.FuncCExpr (Ast.ApplicationFuncExpr (Ast.FuncApplication funcName _params) _withinGroup _filter overClause) ->
+        isNothing overClause && funcNameToText funcName `Set.member` aggregateFunctions
+    Ast.FuncCExpr (Ast.SubexprFuncExpr subexpr) -> subexprContainsAggregate subexpr
+    Ast.InParensCExpr expr _ -> exprContainsAggregate expr
+    Ast.CaseCExpr _ -> False
+    Ast.ArrayCExpr (Right _) -> False
+    Ast.ExplicitRowCExpr _ -> False
+    Ast.ImplicitRowCExpr _ -> False
+    _ -> False
+
+subexprContainsAggregate :: Ast.FuncExprCommonSubexpr -> Bool
+subexprContainsAggregate = \case
+    Ast.CoalesceFuncExprCommonSubexpr args -> any exprContainsAggregate (toList args)
+    Ast.GreatestFuncExprCommonSubexpr args -> any exprContainsAggregate (toList args)
+    Ast.LeastFuncExprCommonSubexpr args -> any exprContainsAggregate (toList args)
+    Ast.NullIfFuncExprCommonSubexpr left right -> exprContainsAggregate left || exprContainsAggregate right
+    Ast.CastFuncExprCommonSubexpr expr _ -> exprContainsAggregate expr
+    Ast.CollationForFuncExprCommonSubexpr expr -> exprContainsAggregate expr
+    Ast.TreatFuncExprCommonSubexpr expr _ -> exprContainsAggregate expr
+    _ -> False
+
+reversibleOpContainsAggregate :: Ast.AExprReversableOp -> Bool
+reversibleOpContainsAggregate = \case
+    Ast.DistinctFromAExprReversableOp expr -> exprContainsAggregate expr
+    Ast.BetweenAExprReversableOp _ _ right -> exprContainsAggregate right
+    Ast.BetweenSymmetricAExprReversableOp _ right -> exprContainsAggregate right
+    Ast.InAExprReversableOp (Ast.ExprListInExpr exprs) -> any exprContainsAggregate (toList exprs)
+    Ast.InAExprReversableOp (Ast.SelectInExpr _) -> False
+    _ -> False
+
+aggregateFunctions :: Set.Set Text
+aggregateFunctions =
+    Set.fromList
+        [ "array_agg"
+        , "avg"
+        , "bit_and"
+        , "bit_or"
+        , "bool_and"
+        , "bool_or"
+        , "count"
+        , "every"
+        , "json_agg"
+        , "json_object_agg"
+        , "jsonb_agg"
+        , "jsonb_object_agg"
+        , "max"
+        , "min"
+        , "string_agg"
+        , "sum"
+        , "xmlagg"
+        ]
+
+provesPrimaryKeyLookup :: Map.Map PQ.Oid TableMeta -> Maybe Ast.FromClause -> Maybe Ast.WhereClause -> Bool
+provesPrimaryKeyLookup tables maybeFrom maybeWhere =
+    let tableByName =
+            tables
+                |> Map.elems
+                |> map (\table@TableMeta { tmName } -> (tmName, table))
+                |> Map.fromList
+    in case (singleSimpleTableRef maybeFrom, maybeWhere) of
+        (Just (tableName, tableQualifier), Just whereExpr) ->
+            case Map.lookup tableName tableByName of
+                Just tableMeta ->
+                    let primaryKeyColumns = primaryKeyColumnNames tableMeta
+                        constrainedColumns = equalityConstrainedColumns tableQualifier whereExpr
+                    in not (Set.null primaryKeyColumns) && primaryKeyColumns `Set.isSubsetOf` constrainedColumns
+                Nothing -> False
+        _ -> False
+
+primaryKeyColumnNames :: TableMeta -> Set.Set Text
+primaryKeyColumnNames TableMeta { tmColumns, tmPrimaryKeys } =
+    tmPrimaryKeys
+        |> Set.toList
+        |> mapMaybe (\attnum -> cmName <$> Map.lookup attnum tmColumns)
+        |> Set.fromList
+
+singleSimpleTableRef :: Maybe Ast.FromClause -> Maybe (Text, Text)
+singleSimpleTableRef maybeFrom = do
+    fromClause <- maybeFrom
+    case toList fromClause of
+        [Ast.RelationExprTableRef relExpr maybeAlias _sample] ->
+            let tableName = relationExprName relExpr
+                qualifier = case maybeAlias of
+                    Just (Ast.AliasClause _asKw aliasIdent _cols) -> identToText aliasIdent
+                    Nothing -> tableName
+            in Just (tableName, qualifier)
+        _ -> Nothing
+
+equalityConstrainedColumns :: Text -> Ast.AExpr -> Set.Set Text
+equalityConstrainedColumns qualifier = \case
+    Ast.AndAExpr left right ->
+        Set.union (equalityConstrainedColumns qualifier left) (equalityConstrainedColumns qualifier right)
+    Ast.CExprAExpr (Ast.InParensCExpr expr Nothing) ->
+        equalityConstrainedColumns qualifier expr
+    Ast.SymbolicBinOpAExpr left (Ast.MathSymbolicExprBinOp Ast.EqualsMathOp) right ->
+        Set.fromList (mapMaybe (columnRefForQualifier qualifier) [left, right])
+    _ -> Set.empty
+
+columnRefForQualifier :: Text -> Ast.AExpr -> Maybe Text
+columnRefForQualifier qualifier = \case
+    Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref ident maybeIndirection)) ->
+        case maybeIndirection of
+            Nothing
+                | qualifier == "" -> Just (identToText ident)
+                | otherwise -> Just (identToText ident)
+            Just indirection ->
+                case toList indirection of
+                    [Ast.AttrNameIndirectionEl columnIdent]
+                        | identToText ident == qualifier -> Just (identToText columnIdent)
+                    _ -> Nothing
+    _ -> Nothing
+
+relationExprName :: Ast.RelationExpr -> Text
+relationExprName = \case
+    Ast.SimpleRelationExpr qname _ -> qualifiedNameToText qname
+    Ast.OnlyRelationExpr qname _ -> qualifiedNameToText qname
+
+qualifiedNameToText :: Ast.QualifiedName -> Text
+qualifiedNameToText = \case
+    Ast.SimpleQualifiedName ident -> identToText ident
+    Ast.IndirectedQualifiedName schema indirection ->
+        case toList indirection of
+            [] -> identToText schema
+            els -> case List.last els of
+                Ast.AttrNameIndirectionEl ident -> identToText ident
+                _ -> identToText schema
+
+funcNameToText :: Ast.FuncName -> Text
+funcNameToText = \case
+    Ast.TypeFuncName ident -> identToText ident
+    Ast.IndirectedFuncName _ indirection ->
+        case toList indirection of
+            [Ast.AttrNameIndirectionEl ident] -> identToText ident
+            _ -> ""
+
+identToText :: Ast.Ident -> Text
+identToText = \case
+    Ast.QuotedIdent text -> text
+    Ast.UnquotedIdent text -> Text.toLower text

--- a/ihp-typed-sql/IHP/TypedSql/Pagination.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Pagination.hs
@@ -21,7 +21,7 @@ import IHP.Pagination.ControllerFunctions (defaultPaginationOptions)
 import IHP.Pagination.Internal (pageSize', page, offset')
 import IHP.ModelSupport (sqlQueryHasql)
 import IHP.Hasql.Encoders () -- For the 'DefaultParamEncoder Int' instance used by 'Snippet.param'
-import IHP.TypedSql.Types (TypedQuery(..))
+import IHP.TypedSql.Types (QueryCardinality (ManyRows), TypedQuery(..))
 import Network.Wai (Request)
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
@@ -59,7 +59,7 @@ paginatedTypedSql
     :: ( ?request :: Request
        , ?modelContext :: ModelContext
        )
-    => TypedQuery model
+    => TypedQuery 'ManyRows model
     -> IO ([model], Pagination)
 paginatedTypedSql = paginatedTypedSqlWithOptions defaultPaginationOptions
 
@@ -83,7 +83,7 @@ paginatedTypedSqlWithOptions
        , ?modelContext :: ModelContext
        )
     => Options
-    -> TypedQuery model
+    -> TypedQuery 'ManyRows model
     -> IO ([model], Pagination)
 paginatedTypedSqlWithOptions options TypedQuery { tqSnippet, tqResultDecoder } = do
     let pool = ?modelContext.hasqlPool

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -23,6 +23,7 @@ import qualified Prelude
 import           IHP.Prelude
 import           IHP.Hasql.Encoders              ()
 
+import           IHP.TypedSql.Cardinality      (inferCardinality)
 import           IHP.TypedSql.CompileTimeDatabase (dependentSchemaFiles)
 import           IHP.TypedSql.Decoders          (resultDecoderForColumns)
 import           IHP.TypedSql.Metadata          (DescribeColumn (..), DescribeResult (..), PgTypeInfo (..), TableMeta (..),
@@ -35,7 +36,7 @@ import           IHP.TypedSql.Placeholders      (PlaceholderPlan (..), parseExpr
                                                  planPlaceholders)
 import           IHP.TypedSql.RowType           (SqlRow (..), sanitizeColumnName, deduplicateNames, sqlRowType)
 import           IHP.TypedSql.TypeMapping       (hsTypeForColumns, hsTypesForColumns, hsTypeForParam, detectFullTable)
-import           IHP.TypedSql.Types             (TypedQuery (..))
+import           IHP.TypedSql.Types             (QueryCardinality (..), TypedQuery (..))
 
 -- | QuasiQuoter entry point for typed SQL.
 -- Disallows SELECT * and SELECT table.* by default to prevent production errors
@@ -128,6 +129,7 @@ typedSqlExp allowStar rawSql = do
             |> Set.fromList
 
     let nonNullableColumns = maybe Set.empty extractNonNullableComputedColumnsFromAst parsedAst
+    let queryCardinality = maybe ManyRows (inferCardinality drTables) parsedAst
 
     let isCompositeColumn =
             case drColumns of
@@ -170,7 +172,13 @@ typedSqlExp allowStar rawSql = do
                 )
                 resultDecoder
 
-    pure (TH.SigE typedQueryExpr (TH.AppT (TH.ConT ''TypedQuery) resultType))
+    pure (TH.SigE typedQueryExpr (TH.AppT (TH.AppT (TH.ConT ''TypedQuery) (cardinalityType queryCardinality)) resultType))
+
+cardinalityType :: QueryCardinality -> TH.Type
+cardinalityType = \case
+    ManyRows -> TH.PromotedT 'ManyRows
+    AtMostOneRow -> TH.PromotedT 'AtMostOneRow
+    ExactlyOneRow -> TH.PromotedT 'ExactlyOneRow
 
 -- | Rephrase a describe-step error to point at the offending ${...} placeholder.
 -- Postgres reports type-inference failures as "could not determine data type of parameter $N".

--- a/ihp-typed-sql/IHP/TypedSql/Types.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Types.hs
@@ -1,13 +1,30 @@
 module IHP.TypedSql.Types
-    ( TypedQuery (..)
+    ( QueryCardinality (..)
+    , TypedQuery (..)
+    , TypedQueryResult
     ) where
 
+import           Data.Kind                       (Type)
 import qualified Hasql.Decoders                as HasqlDecoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
+import           Prelude                         (Eq, Maybe, Show)
+
+-- | What the SQL parser can prove about how many rows a query returns.
+data QueryCardinality
+    = ManyRows
+    | AtMostOneRow
+    | ExactlyOneRow
+    deriving (Eq, Show)
+
+-- | The result shape returned by 'IHP.TypedSql.sqlQueryTyped'.
+type family TypedQueryResult (cardinality :: QueryCardinality) result :: Type where
+    TypedQueryResult 'ManyRows result = [result]
+    TypedQueryResult 'AtMostOneRow result = Maybe result
+    TypedQueryResult 'ExactlyOneRow result = result
 
 -- | Prepared query with a custom row parser.
 -- High-level: this is the runtime value produced by the typed SQL quasiquoter.
-data TypedQuery result = TypedQuery
+data TypedQuery (cardinality :: QueryCardinality) result = TypedQuery
     { tqSnippet       :: !Snippet.Snippet
     , tqResultDecoder :: !(HasqlDecoders.Row result)
     }

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -37,163 +37,159 @@ tests = do
                 assertGhciSuccess ghciOutput
 
         compileFailTest "fails when a scalar parameter has the wrong type"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views = ${(\"not an int\" :: Text)} LIMIT 1 |]")
             []
 
         compileFailTest "fails when a foreign-key parameter has the wrong type"
-            (mkTestModuleWithPK ["typed_sql_test_items", "typed_sql_test_authors"] "TypedQuery Text"
+            (mkTestModuleWithPK ["typed_sql_test_items", "typed_sql_test_authors"] "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE author_id = ${(\"not-an-id\" :: Text)} LIMIT 1 |]")
             []
 
         compileFailTest "fails when an IN parameter has the wrong element type"
-            (mkTestModuleWithPK ["typed_sql_test_items", "typed_sql_test_authors"] "TypedQuery Text"
+            (mkTestModuleWithPK ["typed_sql_test_items", "typed_sql_test_authors"] "TypedQuery 'AtMostOneRow Text"
                 "let authorIds = [\"one\" :: Text, \"two\" :: Text]\n      in [typedSql| SELECT name FROM typed_sql_test_items WHERE author_id IN (${authorIds}) LIMIT 1 |]")
             []
 
         compileFailTest "fails when a placeholder expression is invalid Haskell"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views = ${(} LIMIT 1 |]")
             ["failed to parse expression"]
 
         compileFailTest "fails when SQL parameter count does not match ${...} placeholders"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views = $1 LIMIT 1 |]")
             ["placeholder count mismatch"]
 
         compileFailTest "fails when selecting a single composite value without expansion"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT ROW(name, views)::typed_sql_test_pair FROM typed_sql_test_items LIMIT 1 |]")
             ["composite columns must be expanded"]
 
         compileFailTest "fails when using SELECT * (bare asterisk)"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT * FROM typed_sql_test_items LIMIT 1 |]")
             ["is not allowed"]
 
         compileFailTest "fails when using SELECT table.*"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT typed_sql_test_items.* FROM typed_sql_test_items LIMIT 1 |]")
             ["is not allowed"]
 
         compileFailTest "fails when INSERT VALUES has no explicit column list"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'ManyRows Text"
                 "[typedSql| INSERT INTO typed_sql_test_items VALUES ('00000000-0000-0000-0000-000000000099'::uuid, '00000000-0000-0000-0000-000000000001'::uuid, 'X', 1, 1.0, ARRAY['x']::text[]) RETURNING name |]")
             ["explicit column list"]
 
         compileFailTest "fails when SQL references an unknown column"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT no_such_column FROM typed_sql_test_items LIMIT 1 |]")
             ["does not exist"]
 
         compileFailTest "fails when primary-key result type is annotated as UUID instead of Id"
-            (mkTestModuleWithPK ["typed_sql_test_items"] "TypedQuery UUID"
+            (mkTestModuleWithPK ["typed_sql_test_items"] "TypedQuery 'AtMostOneRow UUID"
                 "[typedSql| SELECT id FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when nullable column result is annotated as non-Maybe"
-            (mkTestModule "TypedQuery Double"
+            (mkTestModule "TypedQuery 'AtMostOneRow Double"
                 "[typedSql| SELECT score FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when multi-column result is annotated as a tuple"
-            (mkTestModule "TypedQuery (Text, Text)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Text, Text)"
                 "[typedSql| SELECT i.name, a.name FROM typed_sql_test_items i LEFT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]")
             []
 
         compileFailTest "fails when multi-column result is annotated as a scalar"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT name, views FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when boolean expression result is annotated as Int"
-            (mkTestModule "TypedQuery Int"
+            (mkTestModule "TypedQuery 'AtMostOneRow Int"
                 "[typedSql| SELECT author_id IS NULL FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when boolean expression result is annotated as non-Maybe Bool"
-            (mkTestModule "TypedQuery Bool"
+            (mkTestModule "TypedQuery 'AtMostOneRow Bool"
                 "[typedSql| SELECT author_id IS NULL FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when COUNT(*) result is annotated as Maybe Int64"
-            (mkTestModule "TypedQuery (Maybe Int64)"
+            (mkTestModule "TypedQuery 'ExactlyOneRow (Maybe Int64)"
                 "[typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]")
             []
 
         compileFailTest "fails when COALESCE multi-column result is annotated as a tuple"
-            (mkTestModule "TypedQuery (Maybe Text, Text)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Text, Text)"
                 "[typedSql| SELECT COALESCE(i.name, '(no-item)'), a.name FROM typed_sql_test_items i RIGHT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]")
             []
 
         compileFailTest "fails when literal expression result is annotated as Maybe Int"
-            (mkTestModule "TypedQuery (Maybe Int)"
+            (mkTestModule "TypedQuery 'ExactlyOneRow (Maybe Int)"
                 "[typedSql| SELECT 1 |]")
             []
 
         compileFailTest "fails when arithmetic expression result is annotated as non-Maybe Int"
-            (mkTestModule "TypedQuery Int"
+            (mkTestModule "TypedQuery 'AtMostOneRow Int"
                 "[typedSql| SELECT views + 1 FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when CASE expression result is annotated as non-Maybe Text"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT CASE WHEN views > 5 THEN name ELSE 'low' END FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when EXISTS expression result is annotated as Maybe Bool"
-            (mkTestModule "TypedQuery (Maybe Bool)"
+            (mkTestModule "TypedQuery 'ExactlyOneRow (Maybe Bool)"
                 "[typedSql| SELECT EXISTS(SELECT 1 FROM typed_sql_test_items WHERE views > 7) |]")
             []
 
         compileFailTest "fails when NULL literal result is annotated as non-Maybe Text"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'ExactlyOneRow Text"
                 "[typedSql| SELECT NULL::text |]")
             []
 
         compileFailTest "fails when CTE result is annotated as Maybe Text"
-            (mkTestModule "TypedQuery (Maybe Text)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Text)"
                 "[typedSql| WITH item_names AS (SELECT name FROM typed_sql_test_items WHERE views > 6) SELECT name FROM item_names LIMIT 1 |]")
             []
 
         compileFailTest "fails when subquery result is annotated as Maybe Text"
-            (mkTestModule "TypedQuery (Maybe Text)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Text)"
                 "[typedSql| SELECT name FROM (SELECT name FROM typed_sql_test_items WHERE views < 6) sub LIMIT 1 |]")
             []
 
         compileFailTest "fails when UNION result is annotated as non-Maybe Text"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'ManyRows Text"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views > 6 UNION ALL SELECT name FROM typed_sql_test_items WHERE views < 6 |]")
             []
 
         compileFailTest "fails when window function result is annotated as Maybe Int64"
-            (mkTestModule "TypedQuery (Maybe Int64)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Int64)"
                 "[typedSql| SELECT row_number() OVER (ORDER BY name) FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "fails when grouped COUNT(*) result is annotated as a tuple"
-            (mkTestModule "TypedQuery (Text, Maybe Int64)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Text, Maybe Int64)"
                 "[typedSql| SELECT name, COUNT(*) FROM typed_sql_test_items GROUP BY name ORDER BY name LIMIT 1 |]")
             []
 
         compileFailTest "fails when array literal result is annotated as non-Maybe [Text]"
-            (mkTestModule "TypedQuery [Text]"
+            (mkTestModule "TypedQuery 'ExactlyOneRow [Text]"
                 "[typedSql| SELECT ARRAY['x','y']::text[] |]")
             []
 
         compileFailTest "fails when NULLIF expression result is annotated as non-Maybe Text"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT NULLIF(name, 'First') FROM typed_sql_test_items LIMIT 1 |]")
             []
 
         compileFailTest "explains polymorphic-argument inference failure with placeholder context"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "let chunk = (\"x\" :: Text) in [typedSql| SELECT CONCAT(name, ${chunk}) FROM typed_sql_test_items LIMIT 1 |]")
             ["could not determine the type of `${chunk}`", "polymorphic-argument context", "::text"]
-
-        compileFailTest "rejects a multi-column query passed to sqlQueryTypedScalar"
-            scalarMultiColumnRejectionModule
-            ["single column"]
 
         it "auto-starts a temporary database when DATABASE_URL is unreachable" do
             maybeInitdb <- findExecutable "initdb"
@@ -215,114 +211,114 @@ tests = do
                         , ("IHP_TYPED_SQL_SCHEMA", schemaPath)
                         ]
                 ghciOutput <- ghciLoadModuleWithEnv
-                    (mkTestModule "TypedQuery Text"
+                    (mkTestModule "TypedQuery 'AtMostOneRow Text"
                         "[typedSql| SELECT name FROM typed_sql_auto_items LIMIT 1 |]")
                     envOverrides
                 assertGhciSuccess ghciOutput
 
     describe "TypedSql macro compile-time success" do
         compilePassTest "primary key inferred as Id'"
-            (mkTestModuleWithPK ["typed_sql_test_items"] "TypedQuery (Id' \"typed_sql_test_items\")"
+            (mkTestModuleWithPK ["typed_sql_test_items"] "TypedQuery 'AtMostOneRow (Id' \"typed_sql_test_items\")"
                 "[typedSql| SELECT id FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "nullable column inferred as Maybe"
-            (mkTestModule "TypedQuery (Maybe Double)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Double)"
                 "[typedSql| SELECT score FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "LEFT JOIN right side inferred as Maybe"
-            (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Text), '(\"name_1\", Maybe Text) ])"
+            (mkTestModule "TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Text), '(\"name_1\", Maybe Text) ])"
                 "[typedSql| SELECT i.name, a.name FROM typed_sql_test_items i LEFT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]")
 
         compilePassTest "RIGHT JOIN left side inferred as Maybe"
-            (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Maybe Text), '(\"name_1\", Text) ])"
+            (mkTestModule "TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Maybe Text), '(\"name_1\", Text) ])"
                 "[typedSql| SELECT i.name, a.name FROM typed_sql_test_items i RIGHT JOIN typed_sql_test_authors a ON a.id = i.author_id ORDER BY a.name LIMIT 1 |]")
 
         compilePassTest "multi-column ad-hoc returns SqlRow"
-            (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Text), '(\"views\", Int) ])"
+            (mkTestModule "TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Text), '(\"views\", Int) ])"
                 "[typedSql| SELECT name, views FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "boolean expression inferred as Maybe Bool"
-            (mkTestModule "TypedQuery (Maybe Bool)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Bool)"
                 "[typedSql| SELECT author_id IS NULL FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "COUNT(*) inferred as Int64"
-            (mkTestModule "TypedQuery Int64"
+            (mkTestModule "TypedQuery 'ExactlyOneRow Int64"
                 "[typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]")
 
         compilePassTest "COALESCE with non-null fallback inferred as non-Maybe"
-            (mkTestModule "TypedQuery (SqlRow '[ '(\"coalesce\", Text), '(\"name\", Text) ])"
+            (mkTestModule "TypedQuery 'AtMostOneRow (SqlRow '[ '(\"coalesce\", Text), '(\"name\", Text) ])"
                 "[typedSql| SELECT COALESCE(i.name, '(no-item)'), a.name FROM typed_sql_test_items i RIGHT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]")
 
         compilePassTest "literal expression inferred as Int"
-            (mkTestModule "TypedQuery Int"
+            (mkTestModule "TypedQuery 'ExactlyOneRow Int"
                 "[typedSql| SELECT 1 |]")
 
         compilePassTest "arithmetic expression inferred as Maybe Int"
-            (mkTestModule "TypedQuery (Maybe Int)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Int)"
                 "[typedSql| SELECT views + 1 FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "CASE expression inferred as Maybe Text"
-            (mkTestModule "TypedQuery (Maybe Text)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Text)"
                 "[typedSql| SELECT CASE WHEN views > 5 THEN name ELSE 'low' END FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "EXISTS expression inferred as Bool"
-            (mkTestModule "TypedQuery Bool"
+            (mkTestModule "TypedQuery 'ExactlyOneRow Bool"
                 "[typedSql| SELECT EXISTS(SELECT 1 FROM typed_sql_test_items WHERE views > 7) |]")
 
         compilePassTest "NULL literal inferred as Maybe Text"
-            (mkTestModule "TypedQuery (Maybe Text)"
+            (mkTestModule "TypedQuery 'ExactlyOneRow (Maybe Text)"
                 "[typedSql| SELECT NULL::text |]")
 
         compilePassTest "CTE preserves column type"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| WITH item_names AS (SELECT name FROM typed_sql_test_items WHERE views > 6) SELECT name FROM item_names LIMIT 1 |]")
 
         compilePassTest "subquery preserves column type"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT name FROM (SELECT name FROM typed_sql_test_items WHERE views < 6) sub LIMIT 1 |]")
 
         compilePassTest "UNION inferred as Maybe"
-            (mkTestModule "TypedQuery (Maybe Text)"
+            (mkTestModule "TypedQuery 'ManyRows (Maybe Text)"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views > 6 UNION ALL SELECT name FROM typed_sql_test_items WHERE views < 6 |]")
 
         compilePassTest "window function inferred as Int64"
-            (mkTestModule "TypedQuery Int64"
+            (mkTestModule "TypedQuery 'AtMostOneRow Int64"
                 "[typedSql| SELECT row_number() OVER (ORDER BY name) FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "grouped COUNT(*) returns SqlRow"
-            (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Text), '(\"count\", Int64) ])"
+            (mkTestModule "TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Text), '(\"count\", Int64) ])"
                 "[typedSql| SELECT name, COUNT(*) FROM typed_sql_test_items GROUP BY name ORDER BY name LIMIT 1 |]")
 
         compilePassTest "array literal inferred as Maybe [Text]"
-            (mkTestModule "TypedQuery (Maybe [Text])"
+            (mkTestModule "TypedQuery 'ExactlyOneRow (Maybe [Text])"
                 "[typedSql| SELECT ARRAY['x','y']::text[] |]")
 
         compilePassTest "NULLIF inferred as Maybe Text"
-            (mkTestModule "TypedQuery (Maybe Text)"
+            (mkTestModule "TypedQuery 'AtMostOneRow (Maybe Text)"
                 "[typedSql| SELECT NULLIF(name, 'First') FROM typed_sql_test_items LIMIT 1 |]")
 
         compilePassTest "scalar parameter accepts correct type"
-            (mkTestModule "TypedQuery Text"
+            (mkTestModule "TypedQuery 'AtMostOneRow Text"
                 "[typedSql| SELECT name FROM typed_sql_test_items WHERE views = ${(5 :: Int)} LIMIT 1 |]")
 
         compilePassTest "foreign-key parameter accepts Id' type"
-            (mkTestModuleWithPK ["typed_sql_test_items", "typed_sql_test_authors"] "TypedQuery Text"
+            (mkTestModuleWithPK ["typed_sql_test_items", "typed_sql_test_authors"] "TypedQuery 'AtMostOneRow Text"
                 "let authorId = (\"00000000-0000-0000-0000-000000000001\" :: Id' \"typed_sql_test_authors\")\n      in [typedSql| SELECT name FROM typed_sql_test_items WHERE author_id = ${authorId} LIMIT 1 |]")
 
         compilePassTest "INNER JOIN columns are non-Maybe"
-            (mkTestModule "TypedQuery (SqlRow '[ '(\"name\", Text), '(\"name_1\", Text) ])"
+            (mkTestModule "TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Text), '(\"name_1\", Text) ])"
                 "[typedSql| SELECT i.name, a.name FROM typed_sql_test_items i INNER JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]")
 
         compilePassTest "COUNT through subquery alias inferred as Int64"
-            (mkTestModule "TypedQuery Int64"
+            (mkTestModule "TypedQuery 'ExactlyOneRow Int64"
                 "[typedSql| SELECT p.c FROM (SELECT count(*) AS c FROM typed_sql_test_items) AS p |]")
 
         compilePassTest "SUM through subquery alias remains Maybe"
-            (mkTestModule "TypedQuery (Maybe Int64)"
+            (mkTestModule "TypedQuery 'ExactlyOneRow (Maybe Int64)"
                 "[typedSql| SELECT p.s FROM (SELECT sum(views) AS s FROM typed_sql_test_items) AS p |]")
 
         compilePassTest "COUNT through CTE inferred as Int64"
-            (mkTestModule "TypedQuery Int64"
+            (mkTestModule "TypedQuery 'ExactlyOneRow Int64"
                 "[typedSql| WITH item_counts AS (SELECT count(*) AS c FROM typed_sql_test_items) SELECT c FROM item_counts |]")
 
     describe "TypedSql macro runtime execution" do
@@ -331,7 +327,6 @@ tests = do
         runtimeTest "empty results and edge cases" runtimeEdgeCasesModule
         runtimeTest "additional column types (smallint, bigint, numeric, bytea, bool, timestamptz, date, jsonb)" runtimeExtraTypesModule
         runtimeTest "paginatedTypedSql / paginatedTypedSqlWithOptions" runtimePaginationModule
-        runtimeTest "scalar helpers (sqlQueryTypedScalar / sqlQueryTypedScalarOrNothing)" runtimeScalarModule
 
     describe "TypedSql SQL parser (pure, no postgres)" do
         it "parseSql succeeds on simple SELECT" do
@@ -746,7 +741,7 @@ mkTestModule typeSig body = Text.unlines
     , "module TypedSqlCase where"
     , ""
     , "import IHP.Prelude"
-    , "import IHP.TypedSql (TypedQuery, typedSql)"
+    , "import IHP.TypedSql (QueryCardinality (..), TypedQuery, typedSql)"
     , "import IHP.TypedSql.RowType (SqlRow)"
     , ""
     , "query :: " <> typeSig
@@ -766,7 +761,7 @@ mkTestModuleWithPK pkTables typeSig body = Text.unlines $
     , ""
     , "import IHP.Prelude"
     , "import IHP.ModelSupport (Id'(..), PrimaryKey)"
-    , "import IHP.TypedSql (TypedQuery, typedSql)"
+    , "import IHP.TypedSql (QueryCardinality (..), TypedQuery, typedSql)"
     , "import IHP.TypedSql.RowType (SqlRow)"
     , ""
     ]
@@ -775,31 +770,6 @@ mkTestModuleWithPK pkTables typeSig body = Text.unlines $
     [ ""
     , "query :: " <> typeSig
     , "query = " <> body
-    ]
-
--- | Module that calls 'sqlQueryTypedScalar' on a multi-column query, which must
--- be rejected by the 'ScalarResult' compile-time guard.
-scalarMultiColumnRejectionModule :: Text
-scalarMultiColumnRejectionModule = Text.unlines
-    [ "{-# LANGUAGE DataKinds #-}"
-    , "{-# LANGUAGE ImplicitParams #-}"
-    , "{-# LANGUAGE NoImplicitPrelude #-}"
-    , "{-# LANGUAGE NoFieldSelectors #-}"
-    , "{-# LANGUAGE OverloadedStrings #-}"
-    , "{-# LANGUAGE QuasiQuotes #-}"
-    , "{-# LANGUAGE TypeFamilies #-}"
-    , "module TypedSqlCase where"
-    , ""
-    , "import IHP.Prelude"
-    , "import IHP.ModelSupport (ModelContext, PrimaryKey)"
-    , "import IHP.TypedSql (sqlQueryTypedScalar, typedSql)"
-    , "import IHP.TypedSql.RowType (SqlRow)"
-    , ""
-    , "type instance PrimaryKey \"typed_sql_test_items\" = UUID"
-    , "type instance PrimaryKey \"typed_sql_test_authors\" = UUID"
-    , ""
-    , "badScalar :: (?modelContext :: ModelContext) => IO (SqlRow '[ '(\"name\", Text), '(\"views\", Int) ])"
-    , "badScalar = sqlQueryTypedScalar [typedSql| SELECT name, views FROM typed_sql_test_items LIMIT 1 |]"
     ]
 
 -- Test modules ---------------------------------------------------------------
@@ -820,7 +790,7 @@ compilePassModule = Text.unlines
     , "import GHC.Records (HasField)"
     , "import IHP.ModelSupport (Id'(..), PrimaryKey)"
     , "import IHP.Hasql.FromRow (FromRowHasql (..))"
-    , "import IHP.TypedSql (TypedQuery, typedSql, typedSqlStar)"
+    , "import IHP.TypedSql (QueryCardinality (..), TypedQuery, typedSql, typedSqlStar)"
     , "import IHP.TypedSql.RowType (SqlRow)"
     , "import qualified Hasql.Decoders as HasqlDecoders"
     , ""
@@ -846,48 +816,48 @@ compilePassModule = Text.unlines
     , "            <*> HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.float8)"
     , "            <*> HasqlDecoders.column (HasqlDecoders.nonNullable (HasqlDecoders.listArray (HasqlDecoders.nonNullable HasqlDecoders.text)))"
     , ""
-    , "qName :: TypedQuery Text"
+    , "qName :: TypedQuery 'AtMostOneRow Text"
     , "qName = [typedSql| SELECT name FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qAllFields :: TypedQuery TypedSqlTestItem"
+    , "qAllFields :: TypedQuery 'AtMostOneRow TypedSqlTestItem"
     , "qAllFields = [typedSqlStar| SELECT typed_sql_test_items.* FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qAllFieldsAlias :: TypedQuery TypedSqlTestItem"
+    , "qAllFieldsAlias :: TypedQuery 'AtMostOneRow TypedSqlTestItem"
     , "qAllFieldsAlias = [typedSqlStar| SELECT i.* FROM typed_sql_test_items i JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     , ""
-    , "qPrimaryKey :: TypedQuery (Id' \"typed_sql_test_items\")"
+    , "qPrimaryKey :: TypedQuery 'AtMostOneRow (Id' \"typed_sql_test_items\")"
     , "qPrimaryKey = [typedSql| SELECT id FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qForeignKey :: TypedQuery (Maybe (Id' \"typed_sql_test_authors\"))"
+    , "qForeignKey :: TypedQuery 'AtMostOneRow (Maybe (Id' \"typed_sql_test_authors\"))"
     , "qForeignKey = [typedSql| SELECT author_id FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qNullable :: TypedQuery (Maybe Double)"
+    , "qNullable :: TypedQuery 'AtMostOneRow (Maybe Double)"
     , "qNullable = [typedSql| SELECT score FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qArray :: TypedQuery [Text]"
+    , "qArray :: TypedQuery 'AtMostOneRow [Text]"
     , "qArray = [typedSql| SELECT tags FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qRecord :: TypedQuery (SqlRow '[ '(\"id\", Id' \"typed_sql_test_items\"), '(\"name\", Text), '(\"views\", Int) ])"
+    , "qRecord :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"id\", Id' \"typed_sql_test_items\"), '(\"name\", Text), '(\"views\", Int) ])"
     , "qRecord = [typedSql| SELECT id, name, views FROM typed_sql_test_items LIMIT 1 |]"
     , ""
     , "-- Verify .field access works on the generated record type"
     , "qRecordAccess :: (HasField \"id\" row (Id' \"typed_sql_test_items\"), HasField \"name\" row Text, HasField \"views\" row Int) => row -> (Id' \"typed_sql_test_items\", Text, Int)"
     , "qRecordAccess row = (row.id, row.name, row.views)"
     , ""
-    , "qEqParam :: TypedQuery Text"
+    , "qEqParam :: TypedQuery 'AtMostOneRow Text"
     , "qEqParam = [typedSql| SELECT name FROM typed_sql_test_items WHERE views = ${5 :: Int} LIMIT 1 |]"
     , ""
-    , "qForeignKeyParamHint :: TypedQuery Text"
+    , "qForeignKeyParamHint :: TypedQuery 'AtMostOneRow Text"
     , "qForeignKeyParamHint ="
     , "    let authorId = (\"00000000-0000-0000-0000-000000000001\" :: Id' \"typed_sql_test_authors\")"
     , "    in [typedSql| SELECT name FROM typed_sql_test_items WHERE author_id = ${authorId} LIMIT 1 |]"
     , ""
-    , "qInParamHint :: TypedQuery Text"
+    , "qInParamHint :: TypedQuery 'AtMostOneRow Text"
     , "qInParamHint ="
     , "    let authorIds = [ (\"00000000-0000-0000-0000-000000000001\" :: Id' \"typed_sql_test_authors\") ]"
     , "    in [typedSql| SELECT name FROM typed_sql_test_items WHERE author_id IN (${authorIds}) LIMIT 1 |]"
     , ""
-    , "qAnyParamHint :: TypedQuery Text"
+    , "qAnyParamHint :: TypedQuery 'AtMostOneRow Text"
     , "qAnyParamHint ="
     , "    let itemIds ="
     , "            [ (\"10000000-0000-0000-0000-000000000001\" :: Id' \"typed_sql_test_items\")"
@@ -895,67 +865,67 @@ compilePassModule = Text.unlines
     , "            ]"
     , "    in [typedSql| SELECT name FROM typed_sql_test_items WHERE id = ANY(${itemIds}) ORDER BY name LIMIT 1 |]"
     , ""
-    , "qCompositeExpanded :: TypedQuery (SqlRow '[ '(\"name\", Maybe Text), '(\"views\", Maybe Int) ])"
+    , "qCompositeExpanded :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Maybe Text), '(\"views\", Maybe Int) ])"
     , "qCompositeExpanded = [typedSql| SELECT (ROW(name, views)::typed_sql_test_pair).* FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qBoolExpr :: TypedQuery (Maybe Bool)"
+    , "qBoolExpr :: TypedQuery 'AtMostOneRow (Maybe Bool)"
     , "qBoolExpr = [typedSql| SELECT author_id IS NULL FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qCountExpr :: TypedQuery Int64"
+    , "qCountExpr :: TypedQuery 'ExactlyOneRow Int64"
     , "qCountExpr = [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
     , ""
-    , "qLiteralInt :: TypedQuery Int"
+    , "qLiteralInt :: TypedQuery 'ExactlyOneRow Int"
     , "qLiteralInt = [typedSql| SELECT 1 |]"
     , ""
-    , "qArithmeticExpr :: TypedQuery (Maybe Int)"
+    , "qArithmeticExpr :: TypedQuery 'AtMostOneRow (Maybe Int)"
     , "qArithmeticExpr = [typedSql| SELECT views + 1 FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qCaseExpr :: TypedQuery (Maybe Text)"
+    , "qCaseExpr :: TypedQuery 'AtMostOneRow (Maybe Text)"
     , "qCaseExpr = [typedSql| SELECT CASE WHEN views > 5 THEN name ELSE 'low' END FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qExistsExpr :: TypedQuery Bool"
+    , "qExistsExpr :: TypedQuery 'ExactlyOneRow Bool"
     , "qExistsExpr = [typedSql| SELECT EXISTS(SELECT 1 FROM typed_sql_test_items WHERE views > 7) |]"
     , ""
-    , "qNullLiteral :: TypedQuery (Maybe Text)"
+    , "qNullLiteral :: TypedQuery 'ExactlyOneRow (Maybe Text)"
     , "qNullLiteral = [typedSql| SELECT NULL::text |]"
     , ""
-    , "qCte :: TypedQuery Text"
+    , "qCte :: TypedQuery 'AtMostOneRow Text"
     , "qCte = [typedSql| WITH item_names AS (SELECT name FROM typed_sql_test_items WHERE views > 6) SELECT name FROM item_names LIMIT 1 |]"
     , ""
-    , "qSubquery :: TypedQuery Text"
+    , "qSubquery :: TypedQuery 'AtMostOneRow Text"
     , "qSubquery = [typedSql| SELECT name FROM (SELECT name FROM typed_sql_test_items WHERE views < 6) sub LIMIT 1 |]"
     , ""
-    , "qUnion :: TypedQuery (Maybe Text)"
+    , "qUnion :: TypedQuery 'ManyRows (Maybe Text)"
     , "qUnion = [typedSql| SELECT name FROM typed_sql_test_items WHERE views > 6 UNION ALL SELECT name FROM typed_sql_test_items WHERE views < 6 |]"
     , ""
-    , "qWindow :: TypedQuery Int64"
+    , "qWindow :: TypedQuery 'AtMostOneRow Int64"
     , "qWindow = [typedSql| SELECT row_number() OVER (ORDER BY name) FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qGroupedCount :: TypedQuery (SqlRow '[ '(\"name\", Text), '(\"count\", Int64) ])"
+    , "qGroupedCount :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Text), '(\"count\", Int64) ])"
     , "qGroupedCount = [typedSql| SELECT name, COUNT(*) FROM typed_sql_test_items GROUP BY name ORDER BY name LIMIT 1 |]"
     , ""
-    , "qArrayLiteral :: TypedQuery (Maybe [Text])"
+    , "qArrayLiteral :: TypedQuery 'ExactlyOneRow (Maybe [Text])"
     , "qArrayLiteral = [typedSql| SELECT ARRAY['x','y']::text[] |]"
     , ""
-    , "qNullIfExpr :: TypedQuery (Maybe Text)"
+    , "qNullIfExpr :: TypedQuery 'AtMostOneRow (Maybe Text)"
     , "qNullIfExpr = [typedSql| SELECT NULLIF(name, 'First') FROM typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qSchemaQualified :: TypedQuery Text"
+    , "qSchemaQualified :: TypedQuery 'AtMostOneRow Text"
     , "qSchemaQualified = [typedSql| SELECT name FROM public.typed_sql_test_items LIMIT 1 |]"
     , ""
-    , "qQuotedIdentifiers :: TypedQuery Text"
+    , "qQuotedIdentifiers :: TypedQuery 'AtMostOneRow Text"
     , "qQuotedIdentifiers = [typedSql| SELECT \"name\" FROM \"typed_sql_test_items\" LIMIT 1 |]"
     , ""
-    , "qInnerJoin :: TypedQuery (SqlRow '[ '(\"name\", Text), '(\"name_1\", Text) ])"
+    , "qInnerJoin :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Text), '(\"name_1\", Text) ])"
     , "qInnerJoin = [typedSql| SELECT i.name, a.name FROM typed_sql_test_items i INNER JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     , ""
-    , "qLeftJoin :: TypedQuery (SqlRow '[ '(\"name\", Text), '(\"name_1\", Maybe Text) ])"
+    , "qLeftJoin :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Text), '(\"name_1\", Maybe Text) ])"
     , "qLeftJoin = [typedSql| SELECT i.name, a.name FROM typed_sql_test_items i LEFT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     , ""
-    , "qRightJoin :: TypedQuery (SqlRow '[ '(\"name\", Maybe Text), '(\"name_1\", Text) ])"
+    , "qRightJoin :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"name\", Maybe Text), '(\"name_1\", Text) ])"
     , "qRightJoin = [typedSql| SELECT i.name, a.name FROM typed_sql_test_items i RIGHT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     , ""
-    , "qRightJoinCoalesced :: TypedQuery (SqlRow '[ '(\"coalesce\", Text), '(\"name\", Text) ])"
+    , "qRightJoinCoalesced :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"coalesce\", Text), '(\"name\", Text) ])"
     , "qRightJoinCoalesced = [typedSql| SELECT COALESCE(i.name, '(no-item)'), a.name FROM typed_sql_test_items i RIGHT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     ]
 
@@ -1064,15 +1034,15 @@ runtimeModule = Text.unlines
     , "        when ((boolExprRows :: [Maybe Bool]) /= [Just False, Just False]) do"
     , "            error (\"unexpected rows from bool expression query: \" <> show boolExprRows)"
     , ""
-    , "        countRows <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
+    , "        count <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
     , ""
-    , "        when ((countRows :: [Int64]) /= [2]) do"
-    , "            error (\"unexpected rows from count query: \" <> show countRows)"
+    , "        when ((count :: Int64) /= 2) do"
+    , "            error (\"unexpected count query result: \" <> show count)"
     , ""
-    , "        literalRows <- sqlQueryTyped [typedSql| SELECT 1 |]"
+    , "        literal <- sqlQueryTyped [typedSql| SELECT 1 |]"
     , ""
-    , "        when ((literalRows :: [Int]) /= [1]) do"
-    , "            error (\"unexpected rows from literal query: \" <> show literalRows)"
+    , "        when ((literal :: Int) /= 1) do"
+    , "            error (\"unexpected literal query result: \" <> show literal)"
     , ""
     , "        arithmeticRows <- sqlQueryTyped [typedSql|"
     , "            SELECT views + 1 FROM typed_sql_test_items"
@@ -1091,15 +1061,15 @@ runtimeModule = Text.unlines
     , "        when ((caseRows :: [Maybe Text]) /= [Just \"low\", Just \"Second\"]) do"
     , "            error (\"unexpected rows from CASE query: \" <> show caseRows)"
     , ""
-    , "        existsRows <- sqlQueryTyped [typedSql| SELECT EXISTS(SELECT 1 FROM typed_sql_test_items WHERE views > 7) |]"
+    , "        exists <- sqlQueryTyped [typedSql| SELECT EXISTS(SELECT 1 FROM typed_sql_test_items WHERE views > 7) |]"
     , ""
-    , "        when ((existsRows :: [Bool]) /= [True]) do"
-    , "            error (\"unexpected rows from EXISTS query: \" <> show existsRows)"
+    , "        when ((exists :: Bool) /= True) do"
+    , "            error (\"unexpected EXISTS query result: \" <> show exists)"
     , ""
-    , "        nullLiteralRows <- sqlQueryTyped [typedSql| SELECT NULL::text |]"
+    , "        nullLiteral <- sqlQueryTyped [typedSql| SELECT NULL::text |]"
     , ""
-    , "        when ((nullLiteralRows :: [Maybe Text]) /= [Nothing]) do"
-    , "            error (\"unexpected rows from NULL literal query: \" <> show nullLiteralRows)"
+    , "        when ((nullLiteral :: Maybe Text) /= Nothing) do"
+    , "            error (\"unexpected NULL literal query result: \" <> show nullLiteral)"
     , ""
     , "        cteRows <- sqlQueryTyped [typedSql|"
     , "            WITH item_names AS (SELECT name FROM typed_sql_test_items WHERE views > 6)"
@@ -1147,10 +1117,10 @@ runtimeModule = Text.unlines
     , "        when (groupedCountValues /= [(\"First\", 1 :: Int64), (\"Second\", 1)]) do"
     , "            error (\"unexpected rows from grouped count: \" <> show groupedCountRows)"
     , ""
-    , "        arrayLiteralRows <- sqlQueryTyped [typedSql| SELECT ARRAY['x','y']::text[] |]"
+    , "        arrayLiteral <- sqlQueryTyped [typedSql| SELECT ARRAY['x','y']::text[] |]"
     , ""
-    , "        when ((arrayLiteralRows :: [Maybe [Text]]) /= [Just [\"x\", \"y\"]]) do"
-    , "            error (\"unexpected rows from array literal: \" <> show arrayLiteralRows)"
+    , "        when ((arrayLiteral :: Maybe [Text]) /= Just [\"x\", \"y\"]) do"
+    , "            error (\"unexpected array literal result: \" <> show arrayLiteral)"
     , ""
     , "        nullIfRows <- sqlQueryTyped [typedSql|"
     , "            SELECT NULLIF(name, 'First')"
@@ -1265,7 +1235,7 @@ runtimeUpdateDeleteModule = Text.unlines
     , "        assertTest \"UPDATE single column rows affected\" (rowsUpdated == 1)"
     , ""
     , "        viewsAfter <- sqlQueryTyped [typedSql| SELECT views FROM typed_sql_test_items WHERE id = ${itemId1} |]"
-    , "        assertTest \"UPDATE single column value\" ((viewsAfter :: [Int]) == [10])"
+    , "        assertTest \"UPDATE single column value\" ((viewsAfter :: Maybe Int) == Just 10)"
     , ""
     , "        -- UPDATE multiple columns"
     , "        rowsUpdated2 <- sqlExecTyped [typedSql|"
@@ -1274,8 +1244,8 @@ runtimeUpdateDeleteModule = Text.unlines
     , "        assertTest \"UPDATE multiple columns rows affected\" (rowsUpdated2 == 1)"
     , ""
     , "        updated <- sqlQueryTyped [typedSql| SELECT name, views FROM typed_sql_test_items WHERE id = ${itemId2} |]"
-    , "        let updatedValues = map (\\r -> (r.name, r.views)) updated"
-    , "        assertTest \"UPDATE multiple columns values\" (updatedValues == [(\"Updated\" :: Text, 99 :: Int)])"
+    , "        let updatedValues = fmap (\\r -> (r.name, r.views)) updated"
+    , "        assertTest \"UPDATE multiple columns values\" (updatedValues == Just ((\"Updated\" :: Text), 99 :: Int))"
     , ""
     , "        -- UPDATE with no matching rows"
     , "        noMatch <- sqlExecTyped [typedSql|"
@@ -1343,7 +1313,7 @@ runtimeEdgeCasesModule = Text.unlines
     , ""
     , "        -- COUNT on empty table"
     , "        countEmpty <- sqlQueryTyped [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
-    , "        assertTest \"COUNT on empty table\" ((countEmpty :: [Int64]) == [0])"
+    , "        assertTest \"COUNT on empty table\" ((countEmpty :: Int64) == 0)"
     , ""
     , "        -- Re-insert rows for further tests"
     , "        _ <- sqlExecTyped [typedSql|"
@@ -1361,8 +1331,8 @@ runtimeEdgeCasesModule = Text.unlines
     , "            FROM typed_sql_test_items"
     , "            WHERE id = ${itemId1}"
     , "        |]"
-    , "        let fiveColValues = map (\\r -> (r.name, r.views, r.score, r.is_orphan, r.tags)) fiveColRows"
-    , "        assertTest \"5-column record select\" (fiveColValues == [(\"First\" :: Text, 5 :: Int, Just (1.5 :: Double), Just False, [\"red\", \"blue\"] :: [Text])])"
+    , "        let fiveColValues = fmap (\\r -> (r.name, r.views, r.score, r.is_orphan, r.tags)) fiveColRows"
+    , "        assertTest \"5-column record select\" (fiveColValues == Just (\"First\" :: Text, 5 :: Int, Just (1.5 :: Double), Just False, [\"red\", \"blue\"] :: [Text]))"
     , ""
     , "        -- Multi-param WHERE with AND"
     , "        andRows <- sqlQueryTyped [typedSql|"
@@ -1421,46 +1391,46 @@ runtimeExtraTypesModule = Text.unlines
     , ""
     , "        -- smallint -> Int"
     , "        smallRows <- sqlQueryTyped [typedSql| SELECT small_count FROM typed_sql_test_extras LIMIT 1 |]"
-    , "        assertTest \"smallint -> Int\" ((smallRows :: [Int]) == [7])"
+    , "        assertTest \"smallint -> Int\" ((smallRows :: Maybe Int) == Just 7)"
     , ""
     , "        -- bigint -> Int64"
     , "        bigRows <- sqlQueryTyped [typedSql| SELECT big_count FROM typed_sql_test_extras LIMIT 1 |]"
-    , "        assertTest \"bigint -> Int64\" ((bigRows :: [Int64]) == [1000000000])"
+    , "        assertTest \"bigint -> Int64\" ((bigRows :: Maybe Int64) == Just 1000000000)"
     , ""
     , "        -- numeric -> Scientific"
     , "        numericRows <- sqlQueryTyped [typedSql| SELECT amount FROM typed_sql_test_extras LIMIT 1 |]"
-    , "        assertTest \"numeric -> Scientific\" ((numericRows :: [Maybe Scientific]) == [Just 99.95])"
+    , "        assertTest \"numeric -> Scientific\" ((numericRows :: Maybe (Maybe Scientific)) == Just (Just 99.95))"
     , ""
     , "        -- bytea -> ByteString"
     , "        byteaRows <- sqlQueryTyped [typedSql| SELECT payload FROM typed_sql_test_extras LIMIT 1 |]"
-    , "        assertTest \"bytea -> ByteString\" ((byteaRows :: [Maybe BS.ByteString]) == [Just (BS.pack [0xDE, 0xAD, 0xBE, 0xEF])])"
+    , "        assertTest \"bytea -> ByteString\" ((byteaRows :: Maybe (Maybe BS.ByteString)) == Just (Just (BS.pack [0xDE, 0xAD, 0xBE, 0xEF])))"
     , ""
     , "        -- bool -> Bool"
     , "        boolRows <- sqlQueryTyped [typedSql| SELECT active FROM typed_sql_test_extras LIMIT 1 |]"
-    , "        assertTest \"bool -> Bool\" ((boolRows :: [Bool]) == [True])"
+    , "        assertTest \"bool -> Bool\" ((boolRows :: Maybe Bool) == Just True)"
     , ""
     , "        -- timestamptz -> UTCTime"
     , "        tsRows <- sqlQueryTyped [typedSql| SELECT created_at FROM typed_sql_test_extras LIMIT 1 |]"
     , "        let Just expectedTime = parseTimeM True defaultTimeLocale \"%Y-%m-%d %H:%M:%S%Z\" \"2025-06-15 12:00:00UTC\" :: Maybe UTCTime"
-    , "        assertTest \"timestamptz -> UTCTime\" ((tsRows :: [UTCTime]) == [expectedTime])"
+    , "        assertTest \"timestamptz -> UTCTime\" ((tsRows :: Maybe UTCTime) == Just expectedTime)"
     , ""
     , "        -- date -> Day"
     , "        dateRows <- sqlQueryTyped [typedSql| SELECT due_date FROM typed_sql_test_extras LIMIT 1 |]"
     , "        let Just expectedDate = parseTimeM True defaultTimeLocale \"%Y-%m-%d\" \"2025-06-15\" :: Maybe Day"
-    , "        assertTest \"date -> Day\" ((dateRows :: [Maybe Day]) == [Just expectedDate])"
+    , "        assertTest \"date -> Day\" ((dateRows :: Maybe (Maybe Day)) == Just (Just expectedDate))"
     , ""
     , "        -- jsonb -> Aeson.Value"
     , "        jsonRows <- sqlQueryTyped [typedSql| SELECT metadata FROM typed_sql_test_extras LIMIT 1 |]"
     , "        let expectedJson = Aeson.object [(\"key\", Aeson.String \"value\")]"
-    , "        assertTest \"jsonb -> Aeson.Value\" ((jsonRows :: [Maybe Aeson.Value]) == [Just expectedJson])"
+    , "        assertTest \"jsonb -> Aeson.Value\" ((jsonRows :: Maybe (Maybe Aeson.Value)) == Just (Just expectedJson))"
     , ""
     , "        -- multi-type record"
     , "        multiTypeRows <- sqlQueryTyped [typedSql|"
     , "            SELECT small_count, big_count, active"
     , "            FROM typed_sql_test_extras LIMIT 1"
     , "        |]"
-    , "        let multiTypeValues = map (\\r -> (r.small_count, r.big_count, r.active)) multiTypeRows"
-    , "        assertTest \"multi-type record\" (multiTypeValues == [(7 :: Int, 1000000000 :: Int64, True)])"
+    , "        let multiTypeValues = fmap (\\r -> (r.small_count, r.big_count, r.active)) multiTypeRows"
+    , "        assertTest \"multi-type record\" (multiTypeValues == Just (7 :: Int, 1000000000 :: Int64, True))"
     , ""
     , "        putStrLn \"RUNTIME_OK\""
     ]
@@ -1485,7 +1455,7 @@ runtimePaginationModule = Text.unlines
     , "import qualified Control.Exception as Exception"
     , "import IHP.Prelude"
     , "import IHP.ModelSupport (ModelContext, createModelContext, releaseModelContext, noopLogger, unsafeSqlExecDiscardResult)"
-    , "import IHP.TypedSql (TypedQuery, typedSql)"
+    , "import IHP.TypedSql (QueryCardinality (..), TypedQuery, typedSql)"
     , "import IHP.TypedSql.Pagination (paginatedTypedSql, paginatedTypedSqlWithOptions)"
     , "import IHP.Pagination.ControllerFunctions (defaultPaginationOptions)"
     , "import IHP.Pagination.Types (Options (..), Pagination (..))"
@@ -1521,7 +1491,7 @@ runtimePaginationModule = Text.unlines
     , "            \"INSERT INTO typed_sql_test_items (id, author_id, name, views, score, tags) SELECT ('10000000-0000-0000-0000-' || lpad(g::text, 12, '0'))::uuid, '00000000-0000-0000-0000-000000000001'::uuid, 'item-' || lpad(g::text, 3, '0'), g, NULL, '{}'::text[] FROM generate_series(1, 100) g\""
     , "            ()"
     , ""
-    , "        let pageQuery = [typedSql| SELECT name FROM typed_sql_test_items ORDER BY name |] :: TypedQuery Text"
+    , "        let pageQuery = [typedSql| SELECT name FROM typed_sql_test_items ORDER BY name |] :: TypedQuery 'ManyRows Text"
     , ""
     , "        -- First page, default options (maxItems 50)."
     , "        do"
@@ -1566,78 +1536,6 @@ runtimePaginationModule = Text.unlines
     , "            assertTest \"custom maxItems=25 length\" (length results == 25)"
     , "            assertTest \"custom maxItems=25 pageSize\" (pagination.pageSize == 25)"
     , "            assertTest \"custom maxItems=25 window\" (pagination.window == 3)"
-    , ""
-    , "        putStrLn \"RUNTIME_OK\""
-    ]
-
-runtimeScalarModule :: Text
-runtimeScalarModule = Text.unlines
-    [ "{-# LANGUAGE DataKinds #-}"
-    , "{-# LANGUAGE ImplicitParams #-}"
-    , "{-# LANGUAGE NoImplicitPrelude #-}"
-    , "{-# LANGUAGE NoFieldSelectors #-}"
-    , "{-# LANGUAGE OverloadedRecordDot #-}"
-    , "{-# LANGUAGE OverloadedStrings #-}"
-    , "{-# LANGUAGE QuasiQuotes #-}"
-    , "{-# LANGUAGE TypeFamilies #-}"
-    , "module Main where"
-    , ""
-    , "import qualified Control.Exception as Exception"
-    , "import IHP.Prelude"
-    , "import IHP.ModelSupport (Id'(..), ModelContext, PrimaryKey, createModelContext, releaseModelContext, noopLogger)"
-    , "import IHP.TypedSql (sqlExecTyped, sqlQueryTypedScalar, sqlQueryTypedScalarOrNothing, typedSql)"
-    , "import System.Environment (lookupEnv)"
-    , ""
-    , "type instance PrimaryKey \"typed_sql_test_items\" = UUID"
-    , "type instance PrimaryKey \"typed_sql_test_authors\" = UUID"
-    , ""
-    , "assertTest :: Text -> Bool -> IO ()"
-    , "assertTest name True  = putStrLn (\"PASS: \" <> name)"
-    , "assertTest name False = error (\"FAIL: \" <> name)"
-    , ""
-    , "main :: IO ()"
-    , "main = do"
-    , "    let logger = noopLogger"
-    , "    databaseUrl <- cs . fromMaybe \"\" <$> lookupEnv \"DATABASE_URL\""
-    , "    modelContext <- createModelContext databaseUrl logger"
-    , "    let ?modelContext = modelContext"
-    , "    flip Exception.finally (releaseModelContext modelContext) do"
-    , "        let authorId = (\"00000000-0000-0000-0000-000000000001\" :: UUID)"
-    , "        let itemId1 = (\"10000000-0000-0000-0000-000000000001\" :: UUID)"
-    , "        let itemId2 = (\"10000000-0000-0000-0000-000000000002\" :: UUID)"
-    , ""
-    , "        -- Clean slate"
-    , "        _ <- sqlExecTyped [typedSql| DELETE FROM typed_sql_test_items |]"
-    , ""
-    , "        -- sqlQueryTypedScalar on an empty table still returns the single count row"
-    , "        countEmpty <- sqlQueryTypedScalar [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
-    , "        assertTest \"sqlQueryTypedScalar COUNT(*) on empty table\" ((countEmpty :: Int64) == 0)"
-    , ""
-    , "        -- sqlQueryTypedScalarOrNothing returns Nothing when there is no matching row"
-    , "        missingName <- sqlQueryTypedScalarOrNothing [typedSql| SELECT name FROM typed_sql_test_items WHERE id = ${itemId1} |]"
-    , "        assertTest \"sqlQueryTypedScalarOrNothing with no row\" ((missingName :: Maybe Text) == Nothing)"
-    , ""
-    , "        -- Insert two rows"
-    , "        _ <- sqlExecTyped [typedSql|"
-    , "            INSERT INTO typed_sql_test_items (id, author_id, name, views, score, tags)"
-    , "            VALUES (${itemId1}, ${authorId}, ${(\"First\" :: Text)}, ${5 :: Int}, ${(1.5 :: Double)}, ${([\"red\", \"blue\"] :: [Text])})"
-    , "        |]"
-    , "        _ <- sqlExecTyped [typedSql|"
-    , "            INSERT INTO typed_sql_test_items (id, author_id, name, views, score, tags)"
-    , "            VALUES (${itemId2}, ${authorId}, ${(\"Second\" :: Text)}, ${8 :: Int}, ${(2.0 :: Double)}, ${([\"green\"] :: [Text])})"
-    , "        |]"
-    , ""
-    , "        -- sqlQueryTypedScalar returns the single count value directly"
-    , "        total <- sqlQueryTypedScalar [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
-    , "        assertTest \"sqlQueryTypedScalar COUNT(*)\" ((total :: Int64) == 2)"
-    , ""
-    , "        -- sqlQueryTypedScalar on a non-aggregate single column returning exactly one row"
-    , "        name <- sqlQueryTypedScalar [typedSql| SELECT name FROM typed_sql_test_items WHERE id = ${itemId1} |]"
-    , "        assertTest \"sqlQueryTypedScalar single column\" ((name :: Text) == \"First\")"
-    , ""
-    , "        -- sqlQueryTypedScalarOrNothing returns Just for an existing row"
-    , "        existingName <- sqlQueryTypedScalarOrNothing [typedSql| SELECT name FROM typed_sql_test_items WHERE id = ${itemId1} |]"
-    , "        assertTest \"sqlQueryTypedScalarOrNothing with a row\" ((existingName :: Maybe Text) == Just \"First\")"
     , ""
     , "        putStrLn \"RUNTIME_OK\""
     ]

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -2,18 +2,21 @@
 
 ## v1.7.0
 
+- **Breaking:** `TypedQuery` now carries a type-level cardinality marker and
+  `sqlQueryTyped` returns a shape derived from it. Many-row queries still return
+  `[result]`; queries proven to return at most one row return `Maybe result`;
+  queries proven to return exactly one row return `result` directly. The
+  quasiquoter currently detects conservative cases such as `LIMIT 1`, primary
+  key lookups, singleton `VALUES`, aggregate queries without `GROUP BY`,
+  no-`FROM` singleton selects, and simple singleton CTE/subquery projections.
+
 - Added `paginatedTypedSql` and `paginatedTypedSqlWithOptions` (in the new
   `IHP.TypedSql.Pagination` module). These are the `typedSql` analogue of IHP's
-  `paginatedSqlQuery` / `paginatedSqlQueryWithOptions`: pass a `TypedQuery` and
-  get back `([model], Pagination)`, with the same `page` / `maxItems` request
-  params, the same 200-item cap, and the same `Pagination` shape. Put any
-  `ORDER BY` inside the query you pass in — the query is wrapped in a subquery
-  before `LIMIT` / `OFFSET` are applied.
-
-- Added `sqlQueryTypedScalar` and `sqlQueryTypedScalarOrNothing` for single-column
-  queries such as `SELECT count(*)`. These are the typed counterparts of the now
-  deprecated `sqlQueryScalar` / `sqlQueryScalarOrNothing` from `IHP.ModelSupport`.
-  Passing a multi-column query is rejected at compile time.
+  `paginatedSqlQuery` / `paginatedSqlQueryWithOptions`: pass a many-row
+  `TypedQuery` and get back `([model], Pagination)`, with the same `page` /
+  `maxItems` request params, the same 200-item cap, and the same `Pagination`
+  shape. Put any `ORDER BY` inside the query you pass in — the query is wrapped
+  in a subquery before `LIMIT` / `OFFSET` are applied.
 
 ## v1.6.0
 

--- a/ihp-typed-sql/ihp-typed-sql.cabal
+++ b/ihp-typed-sql/ihp-typed-sql.cabal
@@ -54,6 +54,7 @@ library
         IHP.TypedSql.Decoders
         IHP.TypedSql.RowType
     other-modules:
+        IHP.TypedSql.Cardinality
         IHP.TypedSql.CompileTimeDatabase
     build-depends:
             base >= 4.17.0 && < 4.23

--- a/integration-test/Test/TypedSqlSpec.hs
+++ b/integration-test/Test/TypedSqlSpec.hs
@@ -68,7 +68,9 @@ tests = around (withIHPApp WebApplication testConfig) do
             |]
             rowsAffected `shouldBe` 1
 
-            titles <- sqlQueryTyped [typedSql|
+            -- Cardinality is inferred: filtering on the primary key yields
+            -- at most one row, so the result is @Maybe Text@ rather than a list.
+            title <- sqlQueryTyped [typedSql|
                 SELECT title FROM posts WHERE id = ${thePostId}
             |]
-            titles `shouldBe` ["After"]
+            title `shouldBe` Just "After"


### PR DESCRIPTION
## Summary

This changes `typedSql` so the generated `TypedQuery` carries a type-level cardinality marker. `sqlQueryTyped` now returns a result shape derived from that cardinality: many-row queries return `[result]`, at-most-one-row queries return `Maybe result`, and exactly-one-row queries return `result` directly.

The quasiquoter now conservatively detects common singleton cases such as `LIMIT 1`, primary-key lookups, singleton `VALUES`, aggregate queries without `GROUP BY`, no-`FROM` singleton selects, and simple singleton CTE/subquery projections. This makes `SELECT COUNT(*)` and similar queries work through `sqlQueryTyped` without a separate scalar helper.

## Impact

This is a breaking API change for explicit `TypedQuery` signatures and for code that expected singleton queries from `sqlQueryTyped` to be wrapped in one-element lists. Documentation, upgrade notes, changelogs, typed SQL tests, and pagination signatures were updated accordingly.

## Validation

- `nix develop --override-input devenv-root "file+file://$PWD/.devenv/root" --command sh -c "echo ':l ihp-typed-sql/IHP/TypedSql.hs\n:quit' | ghci"`
- `nix develop --override-input devenv-root "file+file://$PWD/.devenv/root" --command sh -c "echo ':l ihp-typed-sql/IHP/TypedSql/Pagination.hs\n:quit' | ghci"`
- `nix develop --override-input devenv-root "file+file://$PWD/.devenv/root" --command sh -c "echo ':l ihp-typed-sql/Test/Test/Main.hs\nmain\n:quit' | ghci"` (DB-backed cases pending because `PGHOST` is not set; pure parser tests pass)
- `git diff --check`