### PR TITLE
Improve typed SQL ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `typedSql` `${...}` parameters now accept `Maybe` and `[Maybe]` values, not just bare values and lists. Alongside `${x}` and `${[x]}` you can now write `${Just x}`, `${Nothing}` (binds SQL `NULL`), and `${[Just x]}` — so enum-filtered joins like `WHERE status = ANY(${[Just Active, Just Pending]})` work without fetch-ids-then-`filterWhereIn` or text casts. Bare values still work for every column, and wrong-typed parameters are still rejected at compile time.
 - The schema compiler now also generates a `DefaultParamEncoder [Maybe <Enum>]` instance for each enum type, alongside the existing `<Enum>`, `Maybe <Enum>`, and `[<Enum>]` instances, so `[Maybe <Enum>]` arrays bind as parameters.
+- `IHP.TypedSql` now exposes `sqlQueryTypedPipelined`, explicit cardinality helpers (`sqlQueryTypedRows`, `sqlQueryTypedOneOrNothing`, `sqlQueryTypedSingle`), and `sqlQueryTypedMaybeColumn`. `typedSql` also infers `json[b]_build_object` and `json[b]_build_array` as non-null computed JSON expressions.
 
 ### Breaking Changes
 

--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -56,6 +56,35 @@ maybeName <- sqlQueryTyped [typedSql| SELECT name FROM items ORDER BY name LIMIT
 -- maybeName :: Maybe Text
 ```
 
+If you want the expected shape in the function name, use
+`sqlQueryTypedRows`, `sqlQueryTypedOneOrNothing`, and
+`sqlQueryTypedSingle`:
+
+```haskell
+names <- sqlQueryTypedRows [typedSql| SELECT name FROM items ORDER BY name |]
+-- names :: [Text]
+
+maybeName <- sqlQueryTypedOneOrNothing [typedSql|
+    SELECT name FROM items ORDER BY name LIMIT 1
+|]
+-- maybeName :: Maybe Text
+
+total <- sqlQueryTypedSingle [typedSql| SELECT COUNT(*) FROM items |]
+-- total :: Int64
+```
+
+For nullable single-column queries that return at most one row, the precise
+result shape is `Maybe (Maybe a)`: the outer `Maybe` is "no row", the inner
+`Maybe` is "the SQL value was NULL". Use `sqlQueryTypedMaybeColumn` when you
+want both cases collapsed into `Nothing`:
+
+```haskell
+score <- sqlQueryTypedMaybeColumn [typedSql|
+    SELECT score FROM items WHERE id = ${itemId}
+|]
+-- score :: Maybe Double
+```
+
 ## Selecting Multiple Columns
 
 When selecting multiple columns, the result is a tuple:
@@ -218,6 +247,33 @@ Pass the `pagination` value to your view and call `renderPagination` there, exac
 
 Because the query is wrapped in a subquery before `LIMIT`/`OFFSET` are applied, any `ORDER BY` must live **inside** the query you pass in. See the [Pagination guide](pagination.html#typed-sql-pagination) for the full details.
 
+## Pipeline Mode
+
+Use `sqlQueryTypedPipelined` together with `IHP.FetchPipelined.pipeline` to run
+independent typed SQL queries in a single PostgreSQL pipeline batch:
+
+```haskell
+import IHP.FetchPipelined (pipeline)
+import IHP.TypedSql (sqlQueryTypedPipelined, typedSql)
+
+action DashboardAction = do
+    (names, total) <- pipeline do
+        names <- sqlQueryTypedPipelined [typedSql|
+            SELECT name FROM items ORDER BY name LIMIT 10
+        |]
+        total <- sqlQueryTypedPipelined [typedSql|
+            SELECT COUNT(*) FROM items
+        |]
+        pure (names, total)
+
+    -- names :: [Text]
+    -- total :: Int64
+    render DashboardView { names, total }
+```
+
+For nullable single-column queries in a pipeline, use
+`sqlQueryTypedMaybeColumnPipelined`.
+
 ## Nullability
 
 Typed SQL automatically determines whether result columns should be wrapped in `Maybe`:
@@ -252,6 +308,13 @@ results <- sqlQueryTyped [typedSql|
 literal <- sqlQueryTyped [typedSql| SELECT 1 |]
 -- literal :: Int
 ```
+
+IHP also corrects conservative cases where PostgreSQL reports computed
+expressions as nullable even though a value is guaranteed, including
+`COUNT(*)`, `EXISTS`, non-null literals, window ranking functions, `COALESCE`
+with a known non-null argument, and JSON constructors like
+`json_build_object`, `jsonb_build_object`, `json_build_array`, and
+`jsonb_build_array`.
 
 ### Primary and Foreign Keys
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -384,6 +384,24 @@ Explicit `TypedQuery` signatures also need the cardinality argument:
 Use `'AtMostOneRow` for `LIMIT 1` / primary-key lookups and `'ExactlyOneRow`
 for singleton queries such as `COUNT(*)`.
 
+You can also use cardinality-specific helper names when that makes migrations
+easier to read:
+
+```haskell
+names <- sqlQueryTypedRows [typedSql| SELECT name FROM posts ORDER BY name |]
+maybeName <- sqlQueryTypedOneOrNothing [typedSql| SELECT name FROM posts LIMIT 1 |]
+count <- sqlQueryTypedSingle [typedSql| SELECT COUNT(*) FROM posts |]
+```
+
+Nullable single-column queries with `LIMIT 1` have the precise shape
+`Maybe (Maybe a)` because "no row" and "row with SQL NULL" are independent.
+Use `sqlQueryTypedMaybeColumn` when you want both to become `Nothing`:
+
+```diff
+-maybeScore <- sqlQueryTyped [typedSql| SELECT score FROM posts WHERE id = ${postId} LIMIT 1 |]
++maybeScore <- sqlQueryTypedMaybeColumn [typedSql| SELECT score FROM posts WHERE id = ${postId} LIMIT 1 |]
+```
+
 ## `typedSql` is stricter and uses `Int64` for `bigint`
 
 `typedSql` now rejects `SELECT *`, `SELECT table.*`, and `INSERT` statements without an explicit column list by default. This prevents compiled decoders from silently depending on development database column order.

--- a/ihp-typed-sql/IHP/TypedSql.hs
+++ b/ihp-typed-sql/IHP/TypedSql.hs
@@ -8,11 +8,18 @@ module IHP.TypedSql
     , TypedQueryResult
     , DecodeTypedQuery
     , sqlQueryTyped
+    , sqlQueryTypedRows
+    , sqlQueryTypedOneOrNothing
+    , sqlQueryTypedSingle
+    , sqlQueryTypedMaybeColumn
+    , sqlQueryTypedPipelined
+    , sqlQueryTypedMaybeColumnPipelined
     , sqlExecTyped
     ) where
 
 import qualified Hasql.Decoders                  as HasqlDecoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
+import qualified Hasql.Pipeline                  as HasqlPipeline
 import           IHP.ModelSupport                (sqlQueryHasql)
 import           IHP.Prelude
 
@@ -47,6 +54,65 @@ instance DecodeTypedQuery 'ExactlyOneRow where
 sqlQueryTyped :: forall cardinality result. (?modelContext :: ModelContext, DecodeTypedQuery cardinality) => TypedQuery cardinality result -> IO (TypedQueryResult cardinality result)
 sqlQueryTyped TypedQuery { tqSnippet, tqResultDecoder } =
     runTypedSqlSession tqSnippet (typedQueryResultDecoder (Proxy :: Proxy cardinality) tqResultDecoder)
+
+-- | Run a typed query that can return many rows.
+--
+-- This is equivalent to 'sqlQueryTyped', but fixes the expected cardinality in
+-- the function name. It can make type errors easier to read when migrating code
+-- from the old list-shaped 'sqlQueryTyped' result.
+sqlQueryTypedRows :: (?modelContext :: ModelContext) => TypedQuery 'ManyRows result -> IO [result]
+sqlQueryTypedRows = sqlQueryTyped
+
+-- | Run a typed query that can return at most one row.
+--
+-- This is equivalent to 'sqlQueryTyped', but fixes the expected cardinality in
+-- the function name.
+sqlQueryTypedOneOrNothing :: (?modelContext :: ModelContext) => TypedQuery 'AtMostOneRow result -> IO (Maybe result)
+sqlQueryTypedOneOrNothing = sqlQueryTyped
+
+-- | Run a typed query that must return exactly one row.
+--
+-- This is equivalent to 'sqlQueryTyped', but fixes the expected cardinality in
+-- the function name.
+sqlQueryTypedSingle :: (?modelContext :: ModelContext) => TypedQuery 'ExactlyOneRow result -> IO result
+sqlQueryTypedSingle = sqlQueryTyped
+
+-- | Run an at-most-one-row query selecting a nullable single column and flatten
+-- the two independent failure modes into one 'Maybe'.
+--
+-- Useful for queries like:
+--
+-- > email <- sqlQueryTypedMaybeColumn [typedSql|
+-- >     SELECT optional_email FROM users WHERE id = ${userId}
+-- > |]
+--
+-- Without this helper, the precise 'sqlQueryTyped' result is
+-- @Maybe (Maybe Text)@: the outer 'Maybe' is "no row", the inner 'Maybe' is
+-- "the selected column was NULL".
+sqlQueryTypedMaybeColumn :: (?modelContext :: ModelContext) => TypedQuery 'AtMostOneRow (Maybe result) -> IO (Maybe result)
+sqlQueryTypedMaybeColumn query = do
+    value <- sqlQueryTyped query
+    pure case value of
+        Nothing -> Nothing
+        Just inner -> inner
+
+-- | Pipeline variant of 'sqlQueryTyped'.
+--
+-- Compose this with 'IHP.FetchPipelined.pipeline' to run independent typed SQL
+-- queries in one PostgreSQL pipeline batch.
+sqlQueryTypedPipelined :: forall cardinality result. DecodeTypedQuery cardinality => TypedQuery cardinality result -> HasqlPipeline.Pipeline (TypedQueryResult cardinality result)
+sqlQueryTypedPipelined TypedQuery { tqSnippet, tqResultDecoder } =
+    HasqlPipeline.statement () $
+        Snippet.toPreparableStatement tqSnippet (typedQueryResultDecoder (Proxy :: Proxy cardinality) tqResultDecoder)
+
+-- | Pipeline variant of 'sqlQueryTypedMaybeColumn'.
+sqlQueryTypedMaybeColumnPipelined :: TypedQuery 'AtMostOneRow (Maybe result) -> HasqlPipeline.Pipeline (Maybe result)
+sqlQueryTypedMaybeColumnPipelined query =
+    flatten <$> sqlQueryTypedPipelined query
+  where
+    flatten = \case
+        Nothing -> Nothing
+        Just inner -> inner
 
 -- | Run a typed statement (INSERT\/UPDATE\/DELETE) and return the affected row count.
 --

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -501,9 +501,20 @@ isExprNonNullable sqMap = \case
 -- | Functions that are guaranteed to return a non-null value.
 -- count() always returns 0 for empty groups.
 -- row_number(), rank(), dense_rank() are window functions that never return NULL.
+-- json[b]_build_object and json[b]_build_array return JSON null/object/array
+-- values rather than SQL NULL when their arguments are NULL.
 isNonNullableFunction :: Ast.FuncName -> Bool
 isNonNullableFunction funcName =
-    funcNameToText funcName `elem` ["count", "row_number", "rank", "dense_rank"]
+    funcNameToText funcName `elem`
+        [ "count"
+        , "row_number"
+        , "rank"
+        , "dense_rank"
+        , "json_build_object"
+        , "jsonb_build_object"
+        , "json_build_array"
+        , "jsonb_build_array"
+        ]
 
 -- | Special syntax expressions that are non-nullable.
 isSubexprNonNullable :: SubqueryTargetMap -> Ast.FuncExprCommonSubexpr -> Bool

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -345,6 +345,14 @@ tests = do
             (mkTestModule "TypedQuery 'ExactlyOneRow Int64"
                 "[typedSql| WITH item_counts AS (SELECT count(*) AS c FROM typed_sql_test_items) SELECT c FROM item_counts |]")
 
+        compilePassTest "jsonb_build_object inferred as non-Maybe JSON"
+            (mkTestModuleWithAeson "TypedQuery 'ExactlyOneRow Aeson.Value"
+                "[typedSql| SELECT jsonb_build_object('name', NULL::text) |]")
+
+        compilePassTest "json_build_array inferred as non-Maybe JSON"
+            (mkTestModuleWithAeson "TypedQuery 'ExactlyOneRow Aeson.Value"
+                "[typedSql| SELECT json_build_array(NULL::text) |]")
+
     describe "TypedSql macro runtime execution" do
         runtimeTest "executes typedSql queries end-to-end via ghci" runtimeModule
         runtimeTest "UPDATE and DELETE with parameters" runtimeUpdateDeleteModule
@@ -447,6 +455,10 @@ tests = do
         it "extractNonNullableComputedColumns does not mark NULL::text" do
             let Just ast = parseSql "SELECT NULL::text"
             extractNonNullableComputedColumnsFromAst ast `shouldBe` Set.empty
+
+        it "extractNonNullableComputedColumns detects JSON build constructors" do
+            let Just ast = parseSql "SELECT jsonb_build_object('x', NULL::text), json_build_array(NULL::text)"
+            extractNonNullableComputedColumnsFromAst ast `shouldBe` Set.fromList [0, 1]
 
         it "detectStarSelects detects bare SELECT *" do
             let Just ast = parseSql "SELECT * FROM items"
@@ -790,6 +802,23 @@ mkTestModule typeSig body = Text.unlines
     , "query = " <> body
     ]
 
+mkTestModuleWithAeson :: Text -> Text -> Text
+mkTestModuleWithAeson typeSig body = Text.unlines
+    [ "{-# LANGUAGE DataKinds #-}"
+    , "{-# LANGUAGE NoImplicitPrelude #-}"
+    , "{-# LANGUAGE NoFieldSelectors #-}"
+    , "{-# LANGUAGE OverloadedStrings #-}"
+    , "{-# LANGUAGE QuasiQuotes #-}"
+    , "module TypedSqlCase where"
+    , ""
+    , "import IHP.Prelude"
+    , "import IHP.TypedSql (QueryCardinality (..), TypedQuery, typedSql)"
+    , "import qualified Data.Aeson as Aeson"
+    , ""
+    , "query :: " <> typeSig
+    , "query = " <> body
+    ]
+
 -- | Build a test module that also needs PrimaryKey type instances.
 mkTestModuleWithPK :: [Text] -> Text -> Text -> Text
 mkTestModuleWithPK pkTables typeSig body = Text.unlines $
@@ -834,6 +863,7 @@ compilePassModule = Text.unlines
     , "import IHP.Hasql.FromRow (FromRowHasql (..))"
     , "import IHP.TypedSql (QueryCardinality (..), TypedQuery, typedSql, typedSqlStar)"
     , "import IHP.TypedSql.RowType (SqlRow)"
+    , "import qualified Data.Aeson as Aeson"
     , "import qualified Hasql.Decoders as HasqlDecoders"
     , ""
     , "type instance PrimaryKey \"typed_sql_test_items\" = UUID"
@@ -969,11 +999,18 @@ compilePassModule = Text.unlines
     , ""
     , "qRightJoinCoalesced :: TypedQuery 'AtMostOneRow (SqlRow '[ '(\"coalesce\", Text), '(\"name\", Text) ])"
     , "qRightJoinCoalesced = [typedSql| SELECT COALESCE(i.name, '(no-item)'), a.name FROM typed_sql_test_items i RIGHT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , ""
+    , "qJsonBuildObject :: TypedQuery 'ExactlyOneRow Aeson.Value"
+    , "qJsonBuildObject = [typedSql| SELECT jsonb_build_object('name', NULL::text) |]"
+    , ""
+    , "qJsonBuildArray :: TypedQuery 'ExactlyOneRow Aeson.Value"
+    , "qJsonBuildArray = [typedSql| SELECT json_build_array(NULL::text) |]"
     ]
 
 runtimeModule :: Text
 runtimeModule = Text.unlines
     [ "{-# LANGUAGE DataKinds #-}"
+    , "{-# LANGUAGE ApplicativeDo #-}"
     , "{-# LANGUAGE ImplicitParams #-}"
     , "{-# LANGUAGE NoImplicitPrelude #-}"
     , "{-# LANGUAGE NoFieldSelectors #-}"
@@ -987,7 +1024,8 @@ runtimeModule = Text.unlines
     , "import IHP.Prelude"
     , "import IHP.ModelSupport (Id'(..), ModelContext, PrimaryKey, createModelContext, releaseModelContext, noopLogger)"
     , "import IHP.Hasql.FromRow (FromRowHasql (..))"
-    , "import IHP.TypedSql (sqlExecTyped, sqlQueryTyped, typedSql, typedSqlStar)"
+    , "import IHP.FetchPipelined (pipeline)"
+    , "import IHP.TypedSql (sqlExecTyped, sqlQueryTyped, sqlQueryTypedRows, sqlQueryTypedOneOrNothing, sqlQueryTypedSingle, sqlQueryTypedMaybeColumn, sqlQueryTypedPipelined, sqlQueryTypedMaybeColumnPipelined, typedSql, typedSqlStar)"
     , "import qualified Hasql.Decoders as HasqlDecoders"
     , "import System.Environment (lookupEnv)"
     , ""
@@ -1053,6 +1091,58 @@ runtimeModule = Text.unlines
     , ""
     , "        when ((namesViaTypedSql :: [Text]) /= [\"First\", \"Second\"]) do"
     , "            error (\"unexpected names from typedSql second query: \" <> show namesViaTypedSql)"
+    , ""
+    , "        namesViaRows <- sqlQueryTypedRows [typedSql|"
+    , "            SELECT name FROM typed_sql_test_items"
+    , "            ORDER BY name"
+    , "        |]"
+    , ""
+    , "        when ((namesViaRows :: [Text]) /= [\"First\", \"Second\"]) do"
+    , "            error (\"unexpected names from sqlQueryTypedRows: \" <> show namesViaRows)"
+    , ""
+    , "        maybeFirst <- sqlQueryTypedOneOrNothing [typedSql|"
+    , "            SELECT name FROM typed_sql_test_items"
+    , "            WHERE id = ${itemId1}"
+    , "        |]"
+    , ""
+    , "        when ((maybeFirst :: Maybe Text) /= Just \"First\") do"
+    , "            error (\"unexpected row from sqlQueryTypedOneOrNothing: \" <> show maybeFirst)"
+    , ""
+    , "        countViaSingle <- sqlQueryTypedSingle [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
+    , ""
+    , "        when ((countViaSingle :: Int64) /= 2) do"
+    , "            error (\"unexpected count from sqlQueryTypedSingle: \" <> show countViaSingle)"
+    , ""
+    , "        maybeScore <- sqlQueryTypedMaybeColumn [typedSql|"
+    , "            SELECT score FROM typed_sql_test_items"
+    , "            WHERE id = ${itemId1}"
+    , "        |]"
+    , ""
+    , "        when ((maybeScore :: Maybe Double) /= Just 1.5) do"
+    , "            error (\"unexpected value from sqlQueryTypedMaybeColumn: \" <> show maybeScore)"
+    , ""
+    , "        missingScore <- sqlQueryTypedMaybeColumn [typedSql|"
+    , "            SELECT score FROM typed_sql_test_items"
+    , "            WHERE id = ${(\"10000000-0000-0000-0000-000000000099\" :: UUID)}"
+    , "        |]"
+    , ""
+    , "        when ((missingScore :: Maybe Double) /= Nothing) do"
+    , "            error (\"unexpected missing value from sqlQueryTypedMaybeColumn: \" <> show missingScore)"
+    , ""
+    , "        (pipelinedNames, pipelinedCount, pipelinedMissingScore) <- pipeline do"
+    , "            pipelinedNames <- sqlQueryTypedPipelined [typedSql|"
+    , "                SELECT name FROM typed_sql_test_items"
+    , "                ORDER BY name"
+    , "            |]"
+    , "            pipelinedCount <- sqlQueryTypedPipelined [typedSql| SELECT COUNT(*) FROM typed_sql_test_items |]"
+    , "            pipelinedMissingScore <- sqlQueryTypedMaybeColumnPipelined [typedSql|"
+    , "                SELECT score FROM typed_sql_test_items"
+    , "                WHERE id = ${(\"10000000-0000-0000-0000-000000000099\" :: UUID)}"
+    , "            |]"
+    , "            pure (pipelinedNames, pipelinedCount, pipelinedMissingScore)"
+    , ""
+    , "        when ((pipelinedNames :: [Text]) /= [\"First\", \"Second\"] || (pipelinedCount :: Int64) /= 2 || (pipelinedMissingScore :: Maybe Double) /= Nothing) do"
+    , "            error (\"unexpected typedSql pipeline result: \" <> show (pipelinedNames, pipelinedCount, pipelinedMissingScore))"
     , ""
     , "        allItems <- sqlQueryTyped [typedSqlStar|"
     , "            SELECT typed_sql_test_items.*"

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -1,5 +1,21 @@
 # Changelog for `ihp-typed-sql`
 
+## Unreleased
+
+- Added `sqlQueryTypedPipelined` for running typed SQL queries through
+  `IHP.FetchPipelined.pipeline`.
+
+- Added explicit cardinality helpers: `sqlQueryTypedRows`,
+  `sqlQueryTypedOneOrNothing`, and `sqlQueryTypedSingle`.
+
+- Added `sqlQueryTypedMaybeColumn` and `sqlQueryTypedMaybeColumnPipelined` for
+  nullable single-column `LIMIT 1` queries where callers want both "no row" and
+  "SQL NULL" represented as `Nothing`.
+
+- `typedSql` now infers `json_build_object`, `jsonb_build_object`,
+  `json_build_array`, and `jsonb_build_array` as non-null computed JSON
+  expressions.
+
 ## v1.7.0
 
 - **Breaking:** `TypedQuery` now carries a type-level cardinality marker and


### PR DESCRIPTION
## Summary

- add `sqlQueryTypedPipelined` plus `sqlQueryTypedMaybeColumnPipelined` for typed SQL pipeline batches
- add explicit cardinality helpers: `sqlQueryTypedRows`, `sqlQueryTypedOneOrNothing`, and `sqlQueryTypedSingle`
- add `sqlQueryTypedMaybeColumn` for nullable single-column `LIMIT 1` queries that should flatten `Maybe (Maybe a)` to `Maybe a`
- infer JSON build constructors (`json[b]_build_object`, `json[b]_build_array`) as non-null computed JSON expressions
- document the new helper choices in the guide, upgrade notes, and changelogs

## Notes

This keeps JSON nullability inference conservative. It does not globally mark `to_jsonb(...)` as non-null because `to_jsonb(NULL::...)` can be SQL NULL.

## Validation

- `git diff --check`
- `nix build .#checks.aarch64-darwin.ihp-typed-sql -L` (110 examples, 0 failures)
