### PR TITLE
Fix datasync yarn offline hash

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -582,7 +582,7 @@ that is defined in flake-module.nix
 
                 yarnOfflineCache = pkgs.fetchYarnDeps {
                     yarnLock = ./ihp-datasync/data/DataSync/yarn.lock;
-                    hash = "sha256-Jy1GtEUMemtPmfIPBYMKOl1W8kWfGM51vzkY481qV+8=";
+                    hash = "sha256-D9pLOT4afe8M29nKgJyNZhCj0KlF6X8ZQ0e8RZZsVsY=";
                 };
 
                 nativeBuildInputs = [ pkgs.nodejs pkgs.yarn pkgs.yarnConfigHook ];


### PR DESCRIPTION
## What changed

- Updated the `datasync-js` `fetchYarnDeps` hash in `devenv-module.nix` to match the current `ihp-datasync/data/DataSync/yarn.lock`.

## Why

`master` now has `js-yaml` 3.15.0 in the DataSync yarn lockfile, but the Nix offline Yarn cache hash still pointed at the previous lockfile contents. This made `checks.aarch64-darwin.datasync-js` fail during `yarnConfigHook` consistency validation.

## Validation

- `nix build --impure .#checks.aarch64-darwin.datasync-js`