### PR TITLE
Don't take AccessExclusiveLock on job tables when triggers already exist

### DIFF
--- a/ihp/IHP/Job/Queue/Watch.hs
+++ b/ihp/IHP/Job/Queue/Watch.hs
@@ -54,7 +54,10 @@ watchForJobWithPollerTriggerRepair :: (?context :: context, HasField "logger" co
 watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener tableName pollInterval onNewJob = do
     let tableNameBS = cs tableName
     liftIO do
-        runPool pool (HasqlSession.script (createNotificationTriggerSQL tableNameBS))
+        result <- Exception.tryAny (runPool pool (HasqlSession.script (createNotificationTriggerSQL tableNameBS)))
+        case result of
+            Left err -> ?context.logger (toLogStr ("Failed to install notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller."))
+            Right _ -> pure ()
 
         -- Recreate notification triggers when PGListener reconnects (e.g. after `make db` drops the database)
         PGListener.onReconnect (\connection -> do
@@ -143,25 +146,52 @@ ensureNotificationTriggers pool tableName = do
 
 -- | Returns a SQL script to create the notification trigger.
 --
--- Wrapped in a DO $$ block with EXCEPTION handler because concurrent requests
--- can race to CREATE OR REPLACE the same function, causing PostgreSQL to throw
--- 'tuple concurrently updated' (SQLSTATE XX000). This is safe to ignore: the
--- other connection's CREATE OR REPLACE will have succeeded.
+-- The function body is always updated via @CREATE OR REPLACE FUNCTION@, which only
+-- locks the function's row in @pg_proc@, not the job table.
+--
+-- The trigger DDL is only executed when the triggers don't exist yet:
+-- @DROP TRIGGER@ takes an @AccessExclusiveLock@ on the job table, which conflicts with
+-- every other lock — even the @AccessShareLock@s held by a running @pg_dump@. Running
+-- DROP + CREATE TRIGGER unconditionally on every start meant a job worker (re)started
+-- while a backup was in flight would block on the trigger DDL, and all subsequent
+-- INSERTs/UPDATEs on the job table would queue up behind that pending lock request,
+-- stalling job processing until the backup finished.
+--
+-- When the triggers are actually missing (first install, or after @make db@), a short
+-- @lock_timeout@ makes the DDL fail fast instead of blocking; the caller falls back to
+-- the poller and the trigger installation is retried on the next reconnect.
+--
+-- The @pg_advisory_xact_lock@ serializes concurrent installation attempts, which would
+-- otherwise cause 'tuple concurrently updated' (XX000) errors from concurrent
+-- @CREATE OR REPLACE FUNCTION@ calls.
+--
+-- Note: because existing triggers are left untouched, a change to the trigger
+-- definition itself requires dropping the old triggers once (e.g. in a migration)
+-- so they get recreated with the new definition.
 createNotificationTriggerSQL :: ByteString -> Text
 createNotificationTriggerSQL tableName =
         cs $
         "DO $$\n"
         <> "BEGIN\n"
+        <> "    PERFORM pg_advisory_xact_lock(hashtext('" <> functionName <> "'));\n"
         <> "    CREATE OR REPLACE FUNCTION " <> functionName <> "() RETURNS TRIGGER AS $BODY$"
             <> "BEGIN\n"
             <> "    PERFORM pg_notify('" <> channelName tableName <> "', '');\n"
             <> "    RETURN new;"
             <> "\nEND;\n"
             <> "$BODY$ language plpgsql;\n"
-        <> "    DROP TRIGGER IF EXISTS " <> insertTriggerName <> " ON " <> tableName <> ";\n"
-        <> "    CREATE TRIGGER " <> insertTriggerName <> " AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
-        <> "    DROP TRIGGER IF EXISTS " <> updateTriggerName <> " ON " <> tableName <> ";\n"
-        <> "    CREATE TRIGGER " <> updateTriggerName <> " AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> insertTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass)\n"
+        <> "       OR NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> updateTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass) THEN\n"
+        <> "        SET LOCAL lock_timeout = '5s';\n"
+        <> "        BEGIN\n"
+        <> "            DROP TRIGGER IF EXISTS " <> insertTriggerName <> " ON \"" <> tableName <> "\";\n"
+        <> "            CREATE TRIGGER " <> insertTriggerName <> " AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "            DROP TRIGGER IF EXISTS " <> updateTriggerName <> " ON \"" <> tableName <> "\";\n"
+        <> "            CREATE TRIGGER " <> updateTriggerName <> " AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "        EXCEPTION\n"
+        <> "            WHEN duplicate_object THEN null; -- another connection installed the triggers first\n"
+        <> "        END;\n"
+        <> "    END IF;\n"
         <> "EXCEPTION\n"
         <> "    WHEN SQLSTATE 'XX000' THEN null; -- 'tuple concurrently updated': another connection installed it first\n"
         <> "END; $$"


### PR DESCRIPTION
Fixes #2754

## Problem

The job watcher ran `DROP TRIGGER` + `CREATE TRIGGER` unconditionally on every worker start. `DROP TRIGGER` takes an `AccessExclusiveLock` on the job table, which conflicts with every other lock — including the `AccessShareLock`s a running `pg_dump` holds. A worker (re)started during a backup blocked on the trigger DDL, and all subsequent INSERTs/UPDATEs on the job table queued behind the pending lock request, stalling **all** job processing until the backup finished (hours, in production).

## Fix

Ports the approach already used by DataSync's `ChangeNotifications.createNotificationFunction` to the job queue watcher:

- The trigger function is still updated unconditionally via `CREATE OR REPLACE FUNCTION` — that only locks the function's `pg_proc` row, not the table, so it can't block behind `pg_dump`.
- The trigger DDL only runs when one of the triggers is actually missing (checked against `pg_trigger`; `::name` casts so >63-char identifiers compare truncated, matching what `CREATE TRIGGER` stores). Steady-state restarts take no table lock at all.
- When triggers are missing (first install, after `make db`), `SET LOCAL lock_timeout = '5s'` makes the DDL fail fast instead of blocking. Worker startup now catches that error, logs it, and falls back to the poller (`ensureNotificationTriggers` / reconnect retries later) instead of hanging.
- `pg_advisory_xact_lock` serializes concurrent installs across processes.

## Verification

- `ghci` type check of `IHP.Job.Queue.Watch` passes.
- Behavior verified against a scratch PostgreSQL 17.9:
  - fresh install creates both triggers, `pg_notify` fires on INSERT;
  - re-run is a no-op (no trigger DDL executed);
  - **re-run while another session holds `ACCESS SHARE` (what `pg_dump` holds) completes instantly — the old SQL blocks on `DROP TRIGGER` until cancelled** (reproduces the production hang);
  - long table names (identifier truncation at 63 chars) stay idempotent: re-run under a held lock does not attempt DDL.

Note: since existing triggers are left untouched, a future change to the trigger definition itself needs the old triggers dropped once (e.g. in a migration) to be recreated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)