### PR TITLE
Repair job notification triggers after transient install failures

### DIFF
--- a/ihp/IHP/Job/Queue/Watch.hs
+++ b/ihp/IHP/Job/Queue/Watch.hs
@@ -26,14 +26,14 @@ import qualified Hasql.Connection as HasqlConnection
 import qualified Hasql.Statement as Hasql
 import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Decoders as Decoders
-import Control.Concurrent.STM (TBQueue, atomically)
+import Control.Concurrent.STM (TBQueue, TVar, atomically, newTVarIO, readTVarIO, writeTVar)
 import Data.Functor.Contravariant (contramap)
 
 -- | Calls a callback every time something is inserted, updated or deleted in a given database table.
 --
--- In the background this function creates a database trigger to notify this function about table changes
--- using pg_notify. When there are existing triggers, it will silently recreate them. So this will most likely
--- not fail.
+-- In the background this function creates and validates database triggers that notify this function about
+-- table changes using @pg_notify@. If installing the triggers fails temporarily, jobs are still found by the
+-- poller and trigger installation is retried.
 --
 -- This function returns a Async. Call 'cancel' on the async to stop watching the database.
 --
@@ -53,21 +53,28 @@ watchForJob pool pgListener tableName pollInterval onNewJob =
 watchForJobWithPollerTriggerRepair :: (?context :: context, HasField "logger" context FastLogger) => Bool -> HasqlPool.Pool -> PGListener.PGListener -> Text -> Int -> TBQueue JobWorkerProcessMessage -> ResourceT IO (PGListener.Subscription, ReleaseKey)
 watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener tableName pollInterval onNewJob = do
     let tableNameBS = cs tableName
+    triggerRepairNeeded <- liftIO (newTVarIO False)
     liftIO do
         result <- Exception.tryAny (runPool pool (HasqlSession.script (createNotificationTriggerSQL tableNameBS)))
         case result of
-            Left err -> ?context.logger (toLogStr ("Failed to install notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller."))
-            Right _ -> pure ()
+            Left err -> do
+                atomically (writeTVar triggerRepairNeeded True)
+                ?context.logger (toLogStr ("Failed to install notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller and retrying later."))
+            Right _ -> atomically (writeTVar triggerRepairNeeded False)
 
         -- Recreate notification triggers when PGListener reconnects (e.g. after `make db` drops the database)
         PGListener.onReconnect (\connection -> do
             result <- HasqlConnection.use connection (HasqlSession.script (createNotificationTriggerSQL tableNameBS))
             case result of
-                Left err -> ?context.logger (toLogStr ("Failed to recreate notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller."))
-                Right _ -> ?context.logger (toLogStr ("Recreated notification triggers for " <> tableName))
+                Left err -> do
+                    atomically (writeTVar triggerRepairNeeded True)
+                    ?context.logger (toLogStr ("Failed to recreate notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller and retrying later."))
+                Right _ -> do
+                    atomically (writeTVar triggerRepairNeeded False)
+                    ?context.logger (toLogStr ("Recreated notification triggers for " <> tableName))
             ) pgListener
 
-    poller <- pollForJob enablePollerTriggerRepair pool tableName pollInterval onNewJob
+    poller <- pollForJobWithTriggerRepairState enablePollerTriggerRepair triggerRepairNeeded pool tableName pollInterval onNewJob
     subscription <- liftIO $ pgListener |> PGListener.subscribe (channelName tableNameBS) (const (do
             didWrite <- atomically $ tryWriteTBQueue onNewJob JobAvailable
             unless didWrite (?context.logger (toLogStr ("Job queue full for " <> tableName)))
@@ -84,54 +91,73 @@ watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener tab
 -- This function returns a Async. Call 'cancel' on the async to stop polling the database.
 pollForJob :: (?context :: context, HasField "logger" context FastLogger) => Bool -> HasqlPool.Pool -> Text -> Int -> TBQueue JobWorkerProcessMessage -> ResourceT IO ReleaseKey
 pollForJob enablePollerTriggerRepair pool tableName pollInterval onNewJob = do
+    triggerRepairNeeded <- liftIO (newTVarIO False)
+    pollForJobWithTriggerRepairState enablePollerTriggerRepair triggerRepairNeeded pool tableName pollInterval onNewJob
+
+pollForJobWithTriggerRepairState :: (?context :: context, HasField "logger" context FastLogger) => Bool -> TVar Bool -> HasqlPool.Pool -> Text -> Int -> TBQueue JobWorkerProcessMessage -> ResourceT IO ReleaseKey
+pollForJobWithTriggerRepairState enablePollerTriggerRepair triggerRepairNeeded pool tableName pollInterval onNewJob = do
     let sql = "SELECT COUNT(*) FROM " <> tableName
             <> " WHERE " <> pendingJobConditionSQL
     let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
     let statement = Hasql.unpreparable sql Encoders.noParams decoder
-    let handler = do
-            forever do
-                result <- Exception.tryAny do
-                    when enablePollerTriggerRepair do
-                        ensureNotificationTriggers pool tableName
+    let handler isFirstPoll = do
+            pollResult <- Exception.tryAny do
+                count :: Int <- fromIntegral <$> runPool pool (HasqlSession.statement () statement)
 
-                    count :: Int <- fromIntegral <$> runPool pool (HasqlSession.statement () statement)
+                -- For every job we send one signal to the job workers
+                -- This way we use full concurrency when we find multiple jobs
+                -- that haven't been picked up by the PGListener
+                forEach [1..count] \_ -> do
+                    _ <- atomically $ tryWriteTBQueue onNewJob JobAvailable
+                    pure ()
+            case pollResult of
+                Left exception -> ?context.logger (toLogStr ("Job poller: " <> tshow exception))
+                Right _ -> pure ()
 
-                    -- For every job we send one signal to the job workers
-                    -- This way we use full concurrency when we find multiple jobs
-                    -- that haven't been picked up by the PGListener
-                    forEach [1..count] \_ -> do
-                        _ <- atomically $ tryWriteTBQueue onNewJob JobAvailable
-                        pure ()
-                case result of
-                    Left exception -> ?context.logger (toLogStr ("Job poller: " <> tshow exception))
-                    Right _ -> pure ()
+            repairNeeded <- readTVarIO triggerRepairNeeded
+            -- After a startup failure, first poll once before retrying so the
+            -- fallback remains useful and we don't immediately repeat a timed-out DDL request.
+            when (enablePollerTriggerRepair || (repairNeeded && not isFirstPoll)) do
+                repairResult <- Exception.tryAny (ensureNotificationTriggers pool tableName)
+                case repairResult of
+                    Left exception -> ?context.logger (toLogStr ("Job poller: Failed to repair notification triggers for " <> tableName <> ": " <> tshow exception))
+                    Right _ -> atomically (writeTVar triggerRepairNeeded False)
 
-                -- Add up to 2 seconds of jitter to avoid all job queues polling at the same time
-                jitter <- Random.randomRIO (0, 2000000)
-                let pollIntervalWithJitter = pollInterval + jitter
+            -- Add up to 2 seconds of jitter to avoid all job queues polling at the same time
+            jitter <- Random.randomRIO (0, 2000000)
+            let pollIntervalWithJitter = pollInterval + jitter
 
-                Concurrent.threadDelay pollIntervalWithJitter
+            Concurrent.threadDelay pollIntervalWithJitter
+            handler False
 
-    fst <$> allocate (Async.async handler) Async.cancel
+    fst <$> allocate (Async.async (handler True)) Async.cancel
 
 notificationTriggersHealthy :: HasqlPool.Pool -> Text -> IO Bool
 notificationTriggersHealthy pool tableName = do
     let insertTriggerName = "did_insert_job_" <> tableName
     let updateTriggerName = "did_update_job_" <> tableName
+    let functionName = "notify_job_queued_" <> tableName
     let sql = "SELECT COUNT(*) FROM pg_trigger t"
             <> " JOIN pg_class c ON t.tgrelid = c.oid"
             <> " JOIN pg_namespace n ON c.relnamespace = n.oid"
             <> " WHERE n.nspname = current_schema()"
             <> " AND c.relname = $1::name"
             <> " AND NOT t.tgisinternal"
-            <> " AND (t.tgname = $2::name OR t.tgname = $3::name)"
+            <> " AND t.tgenabled = 'O'"
+            <> " AND t.tgfoid = to_regproc($4)"
+            <> " AND t.tgqual IS NOT NULL"
+            <> " AND position('job_status_not_started' IN pg_get_triggerdef(t.oid)) > 0"
+            <> " AND position('job_status_retry' IN pg_get_triggerdef(t.oid)) > 0"
+            <> " AND ((t.tgname = $2::name AND t.tgtype = 5)"
+            <> "   OR (t.tgname = $3::name AND t.tgtype = 17))"
     let encoder =
-            contramap (\(tableNameParam, _, _) -> tableNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
-            <> contramap (\(_, insertTriggerNameParam, _) -> insertTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
-            <> contramap (\(_, _, updateTriggerNameParam) -> updateTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
+            contramap (\(tableNameParam, _, _, _) -> tableNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
+            <> contramap (\(_, insertTriggerNameParam, _, _) -> insertTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
+            <> contramap (\(_, _, updateTriggerNameParam, _) -> updateTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
+            <> contramap (\(_, _, _, functionNameParam) -> functionNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
     let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
     let statement = Hasql.unpreparable sql encoder decoder
-    count :: Int <- fromIntegral <$> runPool pool (HasqlSession.statement (tableName, insertTriggerName, updateTriggerName) statement)
+    count :: Int <- fromIntegral <$> runPool pool (HasqlSession.statement (tableName, insertTriggerName, updateTriggerName, functionName) statement)
     pure (count == 2)
 
 ensureNotificationTriggers :: (?context :: context, HasField "logger" context FastLogger) => HasqlPool.Pool -> Text -> IO ()
@@ -140,16 +166,16 @@ ensureNotificationTriggers pool tableName = do
     unless healthy do
         let insertTriggerName = "did_insert_job_" <> tableName
         let updateTriggerName = "did_update_job_" <> tableName
-        ?context.logger (toLogStr ("Job poller: Missing notification triggers for " <> tableName <> " (" <> insertTriggerName <> ", " <> updateTriggerName <> "). Recreating."))
+        ?context.logger (toLogStr ("Job poller: Missing or invalid notification triggers for " <> tableName <> " (" <> insertTriggerName <> ", " <> updateTriggerName <> "). Repairing."))
         runPool pool (HasqlSession.script (createNotificationTriggerSQL (cs tableName)))
-        ?context.logger (toLogStr ("Job poller: Recreated notification triggers for " <> tableName))
+        ?context.logger (toLogStr ("Job poller: Repaired notification triggers for " <> tableName))
 
 -- | Returns a SQL script to create the notification trigger.
 --
 -- The function body is always updated via @CREATE OR REPLACE FUNCTION@, which only
 -- locks the function's row in @pg_proc@, not the job table.
 --
--- The trigger DDL is only executed when the triggers don't exist yet:
+-- The trigger DDL is only executed when a trigger is missing or invalid:
 -- @DROP TRIGGER@ takes an @AccessExclusiveLock@ on the job table, which conflicts with
 -- every other lock — even the @AccessShareLock@s held by a running @pg_dump@. Running
 -- DROP + CREATE TRIGGER unconditionally on every start meant a job worker (re)started
@@ -157,48 +183,54 @@ ensureNotificationTriggers pool tableName = do
 -- INSERTs/UPDATEs on the job table would queue up behind that pending lock request,
 -- stalling job processing until the backup finished.
 --
--- When the triggers are actually missing (first install, or after @make db@), a short
--- @lock_timeout@ makes the DDL fail fast instead of blocking; the caller falls back to
--- the poller and the trigger installation is retried on the next reconnect.
+-- When a trigger is missing or invalid (first install, after @make db@, or after manual
+-- changes), a short @lock_timeout@ makes the DDL fail fast instead of blocking; the
+-- caller falls back to the poller and retries later. Healthy triggers are never dropped.
 --
--- The @pg_advisory_xact_lock@ serializes concurrent installation attempts, which would
--- otherwise cause 'tuple concurrently updated' (XX000) errors from concurrent
--- @CREATE OR REPLACE FUNCTION@ calls.
---
--- Note: because existing triggers are left untouched, a change to the trigger
--- definition itself requires dropping the old triggers once (e.g. in a migration)
--- so they get recreated with the new definition.
+-- The non-blocking advisory lock ensures only one process attempts installation at a
+-- time. Other processes immediately fall back to polling instead of queuing behind it.
 createNotificationTriggerSQL :: ByteString -> Text
 createNotificationTriggerSQL tableName =
         cs $
         "DO $$\n"
         <> "BEGIN\n"
-        <> "    PERFORM pg_advisory_xact_lock(hashtext('" <> functionName <> "'));\n"
+        <> "    SET LOCAL lock_timeout = '5s';\n"
+        <> "    IF NOT pg_try_advisory_xact_lock(hashtext(current_schema()), hashtext('" <> functionName <> "'::name::text)) THEN\n"
+        <> "        RAISE EXCEPTION 'Notification trigger installation already in progress' USING ERRCODE = '55P03';\n"
+        <> "    END IF;\n"
         <> "    CREATE OR REPLACE FUNCTION " <> functionName <> "() RETURNS TRIGGER AS $BODY$"
             <> "BEGIN\n"
             <> "    PERFORM pg_notify('" <> channelName tableName <> "', '');\n"
             <> "    RETURN new;"
             <> "\nEND;\n"
             <> "$BODY$ language plpgsql;\n"
-        <> "    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> insertTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass)\n"
-        <> "       OR NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> updateTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass) THEN\n"
-        <> "        SET LOCAL lock_timeout = '5s';\n"
-        <> "        BEGIN\n"
-        <> "            DROP TRIGGER IF EXISTS " <> insertTriggerName <> " ON \"" <> tableName <> "\";\n"
-        <> "            CREATE TRIGGER " <> insertTriggerName <> " AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
-        <> "            DROP TRIGGER IF EXISTS " <> updateTriggerName <> " ON \"" <> tableName <> "\";\n"
-        <> "            CREATE TRIGGER " <> updateTriggerName <> " AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
-        <> "        EXCEPTION\n"
-        <> "            WHEN duplicate_object THEN null; -- another connection installed the triggers first\n"
-        <> "        END;\n"
-        <> "    END IF;\n"
-        <> "EXCEPTION\n"
-        <> "    WHEN SQLSTATE 'XX000' THEN null; -- 'tuple concurrently updated': another connection installed it first\n"
+        -- PostgreSQL encodes AFTER ROW INSERT as 5 and AFTER ROW UPDATE as 17 in pg_trigger.tgtype.
+        <> repairTriggerSQL insertTriggerName "5" insertTriggerDefinition
+        <> repairTriggerSQL updateTriggerName "17" updateTriggerDefinition
         <> "END; $$"
     where
         functionName = "notify_job_queued_" <> tableName
         insertTriggerName = "did_insert_job_" <> tableName
         updateTriggerName = "did_update_job_" <> tableName
+        insertTriggerDefinition = "AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "()"
+        updateTriggerDefinition = "AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "()"
+        triggerExistsSQL triggerName = "EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> triggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass)"
+        triggerHealthySQL triggerName triggerType =
+            "EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> triggerName <> "'::name"
+            <> " AND tgrelid = '" <> tableName <> "'::regclass"
+            <> " AND tgenabled = 'O'"
+            <> " AND tgfoid = to_regproc('" <> functionName <> "')"
+            <> " AND tgqual IS NOT NULL"
+            <> " AND position('job_status_not_started' IN pg_get_triggerdef(oid)) > 0"
+            <> " AND position('job_status_retry' IN pg_get_triggerdef(oid)) > 0"
+            <> " AND tgtype = " <> triggerType <> ")"
+        repairTriggerSQL triggerName triggerType triggerDefinition =
+            "    IF " <> triggerExistsSQL triggerName <> " AND NOT " <> triggerHealthySQL triggerName triggerType <> " THEN\n"
+            <> "        DROP TRIGGER " <> triggerName <> " ON \"" <> tableName <> "\";\n"
+            <> "    END IF;\n"
+            <> "    IF NOT " <> triggerHealthySQL triggerName triggerType <> " THEN\n"
+            <> "        CREATE TRIGGER " <> triggerName <> " " <> triggerDefinition <> ";\n"
+            <> "    END IF;\n"
 
 -- | Retuns the event name of the event that the pg notify trigger dispatches
 channelName :: ByteString -> ByteString

--- a/ihp/IHP/Job/Queue/Watch.hs
+++ b/ihp/IHP/Job/Queue/Watch.hs
@@ -31,7 +31,7 @@ import Data.Functor.Contravariant (contramap)
 
 -- | Calls a callback every time something is inserted, updated or deleted in a given database table.
 --
--- In the background this function creates and validates database triggers that notify this function about
+-- In the background this function creates database triggers and checks that they exist. The triggers notify this function about
 -- table changes using @pg_notify@. If installing the triggers fails temporarily, jobs are still found by the
 -- poller and trigger installation is retried.
 --
@@ -158,9 +158,10 @@ ensureNotificationTriggers pool tableName = do
 -- INSERTs/UPDATEs on the job table would queue up behind that pending lock request,
 -- stalling job processing until the backup finished.
 --
--- When a trigger is missing (first install or after @make db@), a short @lock_timeout@
--- makes the DDL fail fast instead of blocking; the caller falls back to the poller and
--- retries later. Healthy triggers are never dropped.
+-- When a trigger is missing (first install or after @make db@), the table lock required
+-- by @CREATE TRIGGER@ is acquired with @NOWAIT@. This prevents the repair from queuing
+-- behind an active writer and then blocking later writes. The caller falls back to the
+-- poller and retries later. Healthy triggers are never dropped.
 --
 -- The non-blocking advisory lock ensures only one process attempts installation at a
 -- time. Other processes immediately fall back to polling instead of queuing behind it.
@@ -181,6 +182,10 @@ createNotificationTriggerSQL tableName =
             <> "    RETURN new;"
             <> "\nEND;\n"
             <> "$BODY$ language plpgsql;\n"
+        <> "    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> insertTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass)\n"
+        <> "       OR NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> updateTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass) THEN\n"
+        <> "        LOCK TABLE \"" <> tableName <> "\" IN SHARE ROW EXCLUSIVE MODE NOWAIT;\n"
+        <> "    END IF;\n"
         <> "    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> insertTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass) THEN\n"
         <> "        CREATE TRIGGER " <> insertTriggerName <> " AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
         <> "    END IF;\n"

--- a/ihp/IHP/Job/Queue/Watch.hs
+++ b/ihp/IHP/Job/Queue/Watch.hs
@@ -26,7 +26,7 @@ import qualified Hasql.Connection as HasqlConnection
 import qualified Hasql.Statement as Hasql
 import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Decoders as Decoders
-import Control.Concurrent.STM (TBQueue, TVar, atomically, newTVarIO, readTVarIO, writeTVar)
+import Control.Concurrent.STM (TBQueue, atomically)
 import Data.Functor.Contravariant (contramap)
 
 -- | Calls a callback every time something is inserted, updated or deleted in a given database table.
@@ -46,35 +46,27 @@ import Data.Functor.Contravariant (contramap)
 -- You will see that @"Something changed in the projects table"@ is printed onto the screen.
 watchForJob :: (?context :: context, HasField "logger" context FastLogger) => HasqlPool.Pool -> PGListener.PGListener -> Text -> Int -> TBQueue JobWorkerProcessMessage -> ResourceT IO (PGListener.Subscription, ReleaseKey)
 watchForJob pool pgListener tableName pollInterval onNewJob =
-    watchForJobWithPollerTriggerRepair False pool pgListener tableName pollInterval onNewJob
+    watchForJobWithPollerTriggerRepair True pool pgListener tableName pollInterval onNewJob
 
--- | Like 'watchForJob' but allows enabling a poller-side trigger integrity check.
--- Useful in development to recover from missing triggers after `make db`.
+-- | Like 'watchForJob' but allows disabling the poller-side trigger integrity check.
 watchForJobWithPollerTriggerRepair :: (?context :: context, HasField "logger" context FastLogger) => Bool -> HasqlPool.Pool -> PGListener.PGListener -> Text -> Int -> TBQueue JobWorkerProcessMessage -> ResourceT IO (PGListener.Subscription, ReleaseKey)
 watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener tableName pollInterval onNewJob = do
     let tableNameBS = cs tableName
-    triggerRepairNeeded <- liftIO (newTVarIO False)
     liftIO do
         result <- Exception.tryAny (runPool pool (HasqlSession.script (createNotificationTriggerSQL tableNameBS)))
         case result of
-            Left err -> do
-                atomically (writeTVar triggerRepairNeeded True)
-                ?context.logger (toLogStr ("Failed to install notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller and retrying later."))
-            Right _ -> atomically (writeTVar triggerRepairNeeded False)
+            Left err -> ?context.logger (toLogStr ("Failed to install notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller."))
+            Right _ -> pure ()
 
         -- Recreate notification triggers when PGListener reconnects (e.g. after `make db` drops the database)
         PGListener.onReconnect (\connection -> do
             result <- HasqlConnection.use connection (HasqlSession.script (createNotificationTriggerSQL tableNameBS))
             case result of
-                Left err -> do
-                    atomically (writeTVar triggerRepairNeeded True)
-                    ?context.logger (toLogStr ("Failed to recreate notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller and retrying later."))
-                Right _ -> do
-                    atomically (writeTVar triggerRepairNeeded False)
-                    ?context.logger (toLogStr ("Recreated notification triggers for " <> tableName))
+                Left err -> ?context.logger (toLogStr ("Failed to recreate notification triggers for " <> tableName <> ": " <> tshow err <> ". Falling back to poller."))
+                Right _ -> ?context.logger (toLogStr ("Recreated notification triggers for " <> tableName))
             ) pgListener
 
-    poller <- pollForJobWithTriggerRepairState enablePollerTriggerRepair triggerRepairNeeded pool tableName pollInterval onNewJob
+    poller <- pollForJob enablePollerTriggerRepair pool tableName pollInterval onNewJob
     subscription <- liftIO $ pgListener |> PGListener.subscribe (channelName tableNameBS) (const (do
             didWrite <- atomically $ tryWriteTBQueue onNewJob JobAvailable
             unless didWrite (?context.logger (toLogStr ("Job queue full for " <> tableName)))
@@ -91,16 +83,11 @@ watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener tab
 -- This function returns a Async. Call 'cancel' on the async to stop polling the database.
 pollForJob :: (?context :: context, HasField "logger" context FastLogger) => Bool -> HasqlPool.Pool -> Text -> Int -> TBQueue JobWorkerProcessMessage -> ResourceT IO ReleaseKey
 pollForJob enablePollerTriggerRepair pool tableName pollInterval onNewJob = do
-    triggerRepairNeeded <- liftIO (newTVarIO False)
-    pollForJobWithTriggerRepairState enablePollerTriggerRepair triggerRepairNeeded pool tableName pollInterval onNewJob
-
-pollForJobWithTriggerRepairState :: (?context :: context, HasField "logger" context FastLogger) => Bool -> TVar Bool -> HasqlPool.Pool -> Text -> Int -> TBQueue JobWorkerProcessMessage -> ResourceT IO ReleaseKey
-pollForJobWithTriggerRepairState enablePollerTriggerRepair triggerRepairNeeded pool tableName pollInterval onNewJob = do
     let sql = "SELECT COUNT(*) FROM " <> tableName
             <> " WHERE " <> pendingJobConditionSQL
     let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
     let statement = Hasql.unpreparable sql Encoders.noParams decoder
-    let handler isFirstPoll = do
+    let handler = forever do
             pollResult <- Exception.tryAny do
                 count :: Int <- fromIntegral <$> runPool pool (HasqlSession.statement () statement)
 
@@ -114,50 +101,38 @@ pollForJobWithTriggerRepairState enablePollerTriggerRepair triggerRepairNeeded p
                 Left exception -> ?context.logger (toLogStr ("Job poller: " <> tshow exception))
                 Right _ -> pure ()
 
-            repairNeeded <- readTVarIO triggerRepairNeeded
-            -- After a startup failure, first poll once before retrying so the
-            -- fallback remains useful and we don't immediately repeat a timed-out DDL request.
-            when (enablePollerTriggerRepair || (repairNeeded && not isFirstPoll)) do
-                repairResult <- Exception.tryAny (ensureNotificationTriggers pool tableName)
-                case repairResult of
-                    Left exception -> ?context.logger (toLogStr ("Job poller: Failed to repair notification triggers for " <> tableName <> ": " <> tshow exception))
-                    Right _ -> atomically (writeTVar triggerRepairNeeded False)
-
             -- Add up to 2 seconds of jitter to avoid all job queues polling at the same time
             jitter <- Random.randomRIO (0, 2000000)
             let pollIntervalWithJitter = pollInterval + jitter
 
             Concurrent.threadDelay pollIntervalWithJitter
-            handler False
 
-    fst <$> allocate (Async.async (handler True)) Async.cancel
+            when enablePollerTriggerRepair do
+                repairResult <- Exception.tryAny (ensureNotificationTriggers pool tableName)
+                case repairResult of
+                    Left exception -> ?context.logger (toLogStr ("Job poller: Failed to repair notification triggers for " <> tableName <> ": " <> tshow exception))
+                    Right _ -> pure ()
+
+    fst <$> allocate (Async.async handler) Async.cancel
 
 notificationTriggersHealthy :: HasqlPool.Pool -> Text -> IO Bool
 notificationTriggersHealthy pool tableName = do
     let insertTriggerName = "did_insert_job_" <> tableName
     let updateTriggerName = "did_update_job_" <> tableName
-    let functionName = "notify_job_queued_" <> tableName
     let sql = "SELECT COUNT(*) FROM pg_trigger t"
             <> " JOIN pg_class c ON t.tgrelid = c.oid"
             <> " JOIN pg_namespace n ON c.relnamespace = n.oid"
             <> " WHERE n.nspname = current_schema()"
             <> " AND c.relname = $1::name"
             <> " AND NOT t.tgisinternal"
-            <> " AND t.tgenabled = 'O'"
-            <> " AND t.tgfoid = to_regproc($4)"
-            <> " AND t.tgqual IS NOT NULL"
-            <> " AND position('job_status_not_started' IN pg_get_triggerdef(t.oid)) > 0"
-            <> " AND position('job_status_retry' IN pg_get_triggerdef(t.oid)) > 0"
-            <> " AND ((t.tgname = $2::name AND t.tgtype = 5)"
-            <> "   OR (t.tgname = $3::name AND t.tgtype = 17))"
+            <> " AND (t.tgname = $2::name OR t.tgname = $3::name)"
     let encoder =
-            contramap (\(tableNameParam, _, _, _) -> tableNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
-            <> contramap (\(_, insertTriggerNameParam, _, _) -> insertTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
-            <> contramap (\(_, _, updateTriggerNameParam, _) -> updateTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
-            <> contramap (\(_, _, _, functionNameParam) -> functionNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
+            contramap (\(tableNameParam, _, _) -> tableNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
+            <> contramap (\(_, insertTriggerNameParam, _) -> insertTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
+            <> contramap (\(_, _, updateTriggerNameParam) -> updateTriggerNameParam) (Encoders.param (Encoders.nonNullable Encoders.text))
     let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
     let statement = Hasql.unpreparable sql encoder decoder
-    count :: Int <- fromIntegral <$> runPool pool (HasqlSession.statement (tableName, insertTriggerName, updateTriggerName, functionName) statement)
+    count :: Int <- fromIntegral <$> runPool pool (HasqlSession.statement (tableName, insertTriggerName, updateTriggerName) statement)
     pure (count == 2)
 
 ensureNotificationTriggers :: (?context :: context, HasField "logger" context FastLogger) => HasqlPool.Pool -> Text -> IO ()
@@ -166,16 +141,16 @@ ensureNotificationTriggers pool tableName = do
     unless healthy do
         let insertTriggerName = "did_insert_job_" <> tableName
         let updateTriggerName = "did_update_job_" <> tableName
-        ?context.logger (toLogStr ("Job poller: Missing or invalid notification triggers for " <> tableName <> " (" <> insertTriggerName <> ", " <> updateTriggerName <> "). Repairing."))
+        ?context.logger (toLogStr ("Job poller: Missing notification triggers for " <> tableName <> " (" <> insertTriggerName <> ", " <> updateTriggerName <> "). Recreating."))
         runPool pool (HasqlSession.script (createNotificationTriggerSQL (cs tableName)))
-        ?context.logger (toLogStr ("Job poller: Repaired notification triggers for " <> tableName))
+        ?context.logger (toLogStr ("Job poller: Recreated notification triggers for " <> tableName))
 
 -- | Returns a SQL script to create the notification trigger.
 --
 -- The function body is always updated via @CREATE OR REPLACE FUNCTION@, which only
 -- locks the function's row in @pg_proc@, not the job table.
 --
--- The trigger DDL is only executed when a trigger is missing or invalid:
+-- The trigger DDL is only executed when a trigger is missing:
 -- @DROP TRIGGER@ takes an @AccessExclusiveLock@ on the job table, which conflicts with
 -- every other lock — even the @AccessShareLock@s held by a running @pg_dump@. Running
 -- DROP + CREATE TRIGGER unconditionally on every start meant a job worker (re)started
@@ -183,12 +158,14 @@ ensureNotificationTriggers pool tableName = do
 -- INSERTs/UPDATEs on the job table would queue up behind that pending lock request,
 -- stalling job processing until the backup finished.
 --
--- When a trigger is missing or invalid (first install, after @make db@, or after manual
--- changes), a short @lock_timeout@ makes the DDL fail fast instead of blocking; the
--- caller falls back to the poller and retries later. Healthy triggers are never dropped.
+-- When a trigger is missing (first install or after @make db@), a short @lock_timeout@
+-- makes the DDL fail fast instead of blocking; the caller falls back to the poller and
+-- retries later. Healthy triggers are never dropped.
 --
 -- The non-blocking advisory lock ensures only one process attempts installation at a
 -- time. Other processes immediately fall back to polling instead of queuing behind it.
+-- Changes to an existing trigger definition require an explicit migration because
+-- worker startup deliberately never drops a healthy, existing trigger.
 createNotificationTriggerSQL :: ByteString -> Text
 createNotificationTriggerSQL tableName =
         cs $
@@ -204,33 +181,17 @@ createNotificationTriggerSQL tableName =
             <> "    RETURN new;"
             <> "\nEND;\n"
             <> "$BODY$ language plpgsql;\n"
-        -- PostgreSQL encodes AFTER ROW INSERT as 5 and AFTER ROW UPDATE as 17 in pg_trigger.tgtype.
-        <> repairTriggerSQL insertTriggerName "5" insertTriggerDefinition
-        <> repairTriggerSQL updateTriggerName "17" updateTriggerDefinition
+        <> "    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> insertTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass) THEN\n"
+        <> "        CREATE TRIGGER " <> insertTriggerName <> " AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "    END IF;\n"
+        <> "    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> updateTriggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass) THEN\n"
+        <> "        CREATE TRIGGER " <> updateTriggerName <> " AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "    END IF;\n"
         <> "END; $$"
     where
         functionName = "notify_job_queued_" <> tableName
         insertTriggerName = "did_insert_job_" <> tableName
         updateTriggerName = "did_update_job_" <> tableName
-        insertTriggerDefinition = "AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "()"
-        updateTriggerDefinition = "AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH ROW WHEN (NEW.status = 'job_status_not_started' OR NEW.status = 'job_status_retry') EXECUTE PROCEDURE " <> functionName <> "()"
-        triggerExistsSQL triggerName = "EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> triggerName <> "'::name AND tgrelid = '" <> tableName <> "'::regclass)"
-        triggerHealthySQL triggerName triggerType =
-            "EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = '" <> triggerName <> "'::name"
-            <> " AND tgrelid = '" <> tableName <> "'::regclass"
-            <> " AND tgenabled = 'O'"
-            <> " AND tgfoid = to_regproc('" <> functionName <> "')"
-            <> " AND tgqual IS NOT NULL"
-            <> " AND position('job_status_not_started' IN pg_get_triggerdef(oid)) > 0"
-            <> " AND position('job_status_retry' IN pg_get_triggerdef(oid)) > 0"
-            <> " AND tgtype = " <> triggerType <> ")"
-        repairTriggerSQL triggerName triggerType triggerDefinition =
-            "    IF " <> triggerExistsSQL triggerName <> " AND NOT " <> triggerHealthySQL triggerName triggerType <> " THEN\n"
-            <> "        DROP TRIGGER " <> triggerName <> " ON \"" <> tableName <> "\";\n"
-            <> "    END IF;\n"
-            <> "    IF NOT " <> triggerHealthySQL triggerName triggerType <> " THEN\n"
-            <> "        CREATE TRIGGER " <> triggerName <> " " <> triggerDefinition <> ";\n"
-            <> "    END IF;\n"
 
 -- | Retuns the event name of the event that the pg notify trigger dispatches
 channelName :: ByteString -> ByteString

--- a/ihp/IHP/Job/Runner/WorkerLoop.hs
+++ b/ihp/IHP/Job/Runner/WorkerLoop.hs
@@ -6,7 +6,6 @@ module IHP.Job.Runner.WorkerLoop
 
 import IHP.Prelude
 import IHP.ControllerPrelude
-import qualified IHP.Environment as Environment
 import qualified IHP.Job.Queue as Queue
 import qualified Control.Exception.Safe as Exception
 import qualified Control.Concurrent as Concurrent
@@ -129,8 +128,7 @@ jobWorkerFetchAndRunLoop JobWorkerArgs { .. } = do
 
     dispatcher <- allocate (async (dispatcherLoop `Exception.finally` cancelAllWorkers)) cancel
 
-    let enablePollerTriggerRepair = frameworkConfig.environment == Environment.Development
-    (subscription, pollerReleaseKey) <- Queue.watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener (tableName @job) (queuePollInterval @job) action
+    (subscription, pollerReleaseKey) <- Queue.watchForJob pool pgListener (tableName @job) (queuePollInterval @job) action
 
     -- Start stale job recovery if configured
     staleRecoveryReleaseKey <- case staleJobTimeout @job of

--- a/ihp/Test/Test/JobQueueSpec.hs
+++ b/ihp/Test/Test/JobQueueSpec.hs
@@ -78,6 +78,29 @@ tests = do
                         JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` True)
                     (Async.cancel lock)
 
+        it "fails immediately without blocking job writes when the trigger table lock is unavailable" do
+            withJobWatcher False \pool -> do
+                dropUpdateNotificationTrigger pool testTableName
+                writer <- Async.async (holdRowExclusiveLock pool testTableName)
+                Exception.finally
+                    (do
+                        didAcquireLock <- waitUntil 2_000_000 (rowExclusiveLockHeld pool testTableName)
+                        didAcquireLock `shouldBe` True
+
+                        repairResult <- timeout 1_000_000 (Exception.try (ensureTestNotificationTriggers pool testTableName) :: IO (Either HasqlError ()))
+                        case repairResult of
+                            Just (Left _) -> pure ()
+                            Just (Right _) -> expectationFailure "trigger repair unexpectedly succeeded while a writer held the table lock"
+                            Nothing -> expectationFailure "trigger repair waited for the table lock"
+
+                        writeResult <- timeout 1_000_000 (insertTestJob pool testTableName)
+                        writeResult `shouldBe` Just ()
+                        writerState <- Async.poll writer
+                        case writerState of
+                            Nothing -> pure ()
+                            Just _ -> expectationFailure "writer lock was released before the job insert completed")
+                    (Async.cancel writer)
+
         it "does not wait for another trigger installer" do
             withJobWatcher False \pool -> do
                 lock <- Async.async (holdTriggerInstallLock pool testTableName)
@@ -208,6 +231,33 @@ accessShareLockHeld pool tableName = do
     let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
     let statement = Hasql.unpreparable sql encoder decoder
     runPool pool (HasqlSession.statement tableName statement)
+
+holdRowExclusiveLock :: HasqlPool.Pool -> Text -> IO ()
+holdRowExclusiveLock pool tableName =
+    runScript pool $
+        "BEGIN;"
+        <> "SET LOCAL application_name = 'ihp_job_queue_row_exclusive_test';"
+        <> "LOCK TABLE \"" <> tableName <> "\" IN ROW EXCLUSIVE MODE;"
+        <> "SELECT pg_sleep(3);"
+        <> "ROLLBACK;"
+
+rowExclusiveLockHeld :: HasqlPool.Pool -> Text -> IO Bool
+rowExclusiveLockHeld pool tableName = do
+    let sql = "SELECT EXISTS ("
+            <> " SELECT 1 FROM pg_locks l"
+            <> " JOIN pg_stat_activity a ON a.pid = l.pid"
+            <> " WHERE l.relation = $1::regclass"
+            <> " AND l.mode = 'RowExclusiveLock'"
+            <> " AND l.granted"
+            <> " AND a.application_name = 'ihp_job_queue_row_exclusive_test')"
+    let encoder = Encoders.param (Encoders.nonNullable Encoders.text)
+    let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
+    let statement = Hasql.unpreparable sql encoder decoder
+    runPool pool (HasqlSession.statement tableName statement)
+
+insertTestJob :: HasqlPool.Pool -> Text -> IO ()
+insertTestJob pool tableName =
+    runScript pool ("INSERT INTO \"" <> tableName <> "\" (id) VALUES ('00000000-0000-0000-0000-000000000001');")
 
 holdTriggerInstallLock :: HasqlPool.Pool -> Text -> IO ()
 holdTriggerInstallLock pool tableName = do

--- a/ihp/Test/Test/JobQueueSpec.hs
+++ b/ihp/Test/Test/JobQueueSpec.hs
@@ -54,8 +54,8 @@ tests = do
                 didRecover <- waitUntil 6_000_000 (JobQueue.notificationTriggersHealthy pool longTestTableName)
                 didRecover `shouldBe` True
 
-        it "retries a failed startup install when poller repair is disabled" do
-            withJobWatcherForMissingTable False testTableName \pool -> do
+        it "retries a failed startup install with the default watcher" do
+            withJobWatcherForMissingTable testTableName \pool -> do
                 createTestTable pool testTableName
                 didRecover <- waitUntil 6_000_000 (JobQueue.notificationTriggersHealthy pool testTableName)
                 didRecover `shouldBe` True
@@ -77,20 +77,6 @@ tests = do
                             Just _ -> expectationFailure "ACCESS SHARE lock was released before trigger repair completed"
                         JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` True)
                     (Async.cancel lock)
-
-        it "replaces disabled notification triggers" do
-            withJobWatcher False \pool -> do
-                disableInsertNotificationTrigger pool testTableName
-                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` False
-                ensureTestNotificationTriggers pool testTableName
-                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` True
-
-        it "replaces notification triggers with an invalid definition" do
-            withJobWatcher False \pool -> do
-                createInvalidInsertNotificationTrigger pool testTableName
-                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` False
-                ensureTestNotificationTriggers pool testTableName
-                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` True
 
         it "does not wait for another trigger installer" do
             withJobWatcher False \pool -> do
@@ -130,8 +116,8 @@ withJobWatcherForTable enablePollerTriggerRepair tableName action = do
                         liftIO (action pool `Exception.finally` PGListener.unsubscribe subscription pgListener))
             (dropTestArtifacts pool tableName)
 
-withJobWatcherForMissingTable :: Bool -> Text -> (HasqlPool.Pool -> IO ()) -> IO ()
-withJobWatcherForMissingTable enablePollerTriggerRepair tableName action = do
+withJobWatcherForMissingTable :: Text -> (HasqlPool.Pool -> IO ()) -> IO ()
+withJobWatcherForMissingTable tableName action = do
     withDB \modelContext logger databaseUrl -> do
         let ?context = TestContext { logger = logger }
         let pool = modelContext.hasqlPool
@@ -143,7 +129,7 @@ withJobWatcherForMissingTable enablePollerTriggerRepair tableName action = do
                 PGListener.withPGListener databaseUrl logger \pgListener -> do
                     runResourceT do
                         queue <- liftIO (atomically (newTBQueue 32))
-                        (subscription, _) <- JobQueue.watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener tableName 100000 queue
+                        (subscription, _) <- JobQueue.watchForJob pool pgListener tableName 100000 queue
                         liftIO (action pool `Exception.finally` PGListener.unsubscribe subscription pgListener))
             (dropTestArtifacts pool tableName)
 
@@ -199,19 +185,6 @@ dropNotificationTriggers pool tableName =
 dropUpdateNotificationTrigger :: HasqlPool.Pool -> Text -> IO ()
 dropUpdateNotificationTrigger pool tableName =
     runScript pool ("DROP TRIGGER IF EXISTS " <> updateTriggerName tableName <> " ON \"" <> tableName <> "\";")
-
-disableInsertNotificationTrigger :: HasqlPool.Pool -> Text -> IO ()
-disableInsertNotificationTrigger pool tableName =
-    runScript pool ("ALTER TABLE \"" <> tableName <> "\" DISABLE TRIGGER " <> insertTriggerName tableName <> ";")
-
-createInvalidInsertNotificationTrigger :: HasqlPool.Pool -> Text -> IO ()
-createInvalidInsertNotificationTrigger pool tableName =
-    runScript pool $
-        "DROP TRIGGER " <> insertTriggerName tableName <> " ON \"" <> tableName <> "\";"
-        <> "CREATE TRIGGER " <> insertTriggerName tableName
-        <> " AFTER INSERT ON \"" <> tableName <> "\""
-        <> " FOR EACH ROW WHEN (NEW.status = 'job_status_retry')"
-        <> " EXECUTE PROCEDURE " <> triggerFunctionName tableName <> "();"
 
 holdAccessShareLock :: HasqlPool.Pool -> Text -> IO ()
 holdAccessShareLock pool tableName =

--- a/ihp/Test/Test/JobQueueSpec.hs
+++ b/ihp/Test/Test/JobQueueSpec.hs
@@ -3,16 +3,22 @@ module Test.JobQueueSpec where
 import Test.Hspec
 import IHP.Prelude
 import qualified IHP.Job.Queue as JobQueue
+import IHP.Job.Queue.Pool (runPool)
 import IHP.ModelSupport (createModelContext, releaseModelContext, HasqlError (..), noopLogger)
 import System.Log.FastLogger (FastLogger)
 import qualified IHP.PGListener as PGListener
 import qualified Hasql.Pool as HasqlPool
 import qualified Hasql.Session as HasqlSession
+import qualified Hasql.Statement as Hasql
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Decoders as Decoders
 import Control.Monad.Trans.Resource (runResourceT)
 import Control.Concurrent.STM (atomically, newTBQueue)
 import qualified Control.Concurrent as Concurrent
+import qualified Control.Concurrent.Async as Async
 import qualified Control.Exception as Exception
 import System.Environment (lookupEnv)
+import System.Timeout (timeout)
 
 data TestContext = TestContext
     { logger :: FastLogger
@@ -48,6 +54,60 @@ tests = do
                 didRecover <- waitUntil 6_000_000 (JobQueue.notificationTriggersHealthy pool longTestTableName)
                 didRecover `shouldBe` True
 
+        it "retries a failed startup install when poller repair is disabled" do
+            withJobWatcherForMissingTable False testTableName \pool -> do
+                createTestTable pool testTableName
+                didRecover <- waitUntil 6_000_000 (JobQueue.notificationTriggersHealthy pool testTableName)
+                didRecover `shouldBe` True
+
+        it "creates only the missing trigger while an ACCESS SHARE lock is held" do
+            withJobWatcher False \pool -> do
+                dropUpdateNotificationTrigger pool testTableName
+                lock <- Async.async (holdAccessShareLock pool testTableName)
+                Exception.finally
+                    (do
+                        didAcquireLock <- waitUntil 2_000_000 (accessShareLockHeld pool testTableName)
+                        didAcquireLock `shouldBe` True
+
+                        repairResult <- timeout 2_000_000 (ensureTestNotificationTriggers pool testTableName)
+                        repairResult `shouldBe` Just ()
+                        lockState <- Async.poll lock
+                        case lockState of
+                            Nothing -> pure ()
+                            Just _ -> expectationFailure "ACCESS SHARE lock was released before trigger repair completed"
+                        JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` True)
+                    (Async.cancel lock)
+
+        it "replaces disabled notification triggers" do
+            withJobWatcher False \pool -> do
+                disableInsertNotificationTrigger pool testTableName
+                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` False
+                ensureTestNotificationTriggers pool testTableName
+                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` True
+
+        it "replaces notification triggers with an invalid definition" do
+            withJobWatcher False \pool -> do
+                createInvalidInsertNotificationTrigger pool testTableName
+                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` False
+                ensureTestNotificationTriggers pool testTableName
+                JobQueue.notificationTriggersHealthy pool testTableName `shouldReturn` True
+
+        it "does not wait for another trigger installer" do
+            withJobWatcher False \pool -> do
+                lock <- Async.async (holdTriggerInstallLock pool testTableName)
+                Exception.finally
+                    (do
+                        didAcquireLock <- waitUntil 2_000_000 (triggerInstallLockHeld pool)
+                        didAcquireLock `shouldBe` True
+
+                        let install = runScript pool (JobQueue.createNotificationTriggerSQL (cs testTableName))
+                        installResult <- timeout 1_000_000 (Exception.try install :: IO (Either HasqlError ()))
+                        case installResult of
+                            Just (Left _) -> pure ()
+                            Just (Right _) -> expectationFailure "concurrent trigger installation unexpectedly succeeded"
+                            Nothing -> expectationFailure "concurrent trigger installation waited for the advisory lock")
+                    (Async.cancel lock)
+
 withJobWatcher :: Bool -> (HasqlPool.Pool -> IO ()) -> IO ()
 withJobWatcher enablePollerTriggerRepair =
     withJobWatcherForTable enablePollerTriggerRepair testTableName
@@ -62,6 +122,23 @@ withJobWatcherForTable enablePollerTriggerRepair tableName action = do
             (do
                 dropTestArtifacts pool tableName
                 createTestTable pool tableName
+
+                PGListener.withPGListener databaseUrl logger \pgListener -> do
+                    runResourceT do
+                        queue <- liftIO (atomically (newTBQueue 32))
+                        (subscription, _) <- JobQueue.watchForJobWithPollerTriggerRepair enablePollerTriggerRepair pool pgListener tableName 100000 queue
+                        liftIO (action pool `Exception.finally` PGListener.unsubscribe subscription pgListener))
+            (dropTestArtifacts pool tableName)
+
+withJobWatcherForMissingTable :: Bool -> Text -> (HasqlPool.Pool -> IO ()) -> IO ()
+withJobWatcherForMissingTable enablePollerTriggerRepair tableName action = do
+    withDB \modelContext logger databaseUrl -> do
+        let ?context = TestContext { logger = logger }
+        let pool = modelContext.hasqlPool
+
+        Exception.finally
+            (do
+                dropTestArtifacts pool tableName
 
                 PGListener.withPGListener databaseUrl logger \pgListener -> do
                     runResourceT do
@@ -118,6 +195,73 @@ dropNotificationTriggers pool tableName =
     runScript pool $
         "DROP TRIGGER IF EXISTS " <> insertTriggerName tableName <> " ON \"" <> tableName <> "\";"
         <> "DROP TRIGGER IF EXISTS " <> updateTriggerName tableName <> " ON \"" <> tableName <> "\";"
+
+dropUpdateNotificationTrigger :: HasqlPool.Pool -> Text -> IO ()
+dropUpdateNotificationTrigger pool tableName =
+    runScript pool ("DROP TRIGGER IF EXISTS " <> updateTriggerName tableName <> " ON \"" <> tableName <> "\";")
+
+disableInsertNotificationTrigger :: HasqlPool.Pool -> Text -> IO ()
+disableInsertNotificationTrigger pool tableName =
+    runScript pool ("ALTER TABLE \"" <> tableName <> "\" DISABLE TRIGGER " <> insertTriggerName tableName <> ";")
+
+createInvalidInsertNotificationTrigger :: HasqlPool.Pool -> Text -> IO ()
+createInvalidInsertNotificationTrigger pool tableName =
+    runScript pool $
+        "DROP TRIGGER " <> insertTriggerName tableName <> " ON \"" <> tableName <> "\";"
+        <> "CREATE TRIGGER " <> insertTriggerName tableName
+        <> " AFTER INSERT ON \"" <> tableName <> "\""
+        <> " FOR EACH ROW WHEN (NEW.status = 'job_status_retry')"
+        <> " EXECUTE PROCEDURE " <> triggerFunctionName tableName <> "();"
+
+holdAccessShareLock :: HasqlPool.Pool -> Text -> IO ()
+holdAccessShareLock pool tableName =
+    runScript pool $
+        "BEGIN;"
+        <> "SET LOCAL application_name = 'ihp_job_queue_access_share_test';"
+        <> "LOCK TABLE \"" <> tableName <> "\" IN ACCESS SHARE MODE;"
+        <> "SELECT pg_sleep(3);"
+        <> "ROLLBACK;"
+
+accessShareLockHeld :: HasqlPool.Pool -> Text -> IO Bool
+accessShareLockHeld pool tableName = do
+    let sql = "SELECT EXISTS ("
+            <> " SELECT 1 FROM pg_locks l"
+            <> " JOIN pg_stat_activity a ON a.pid = l.pid"
+            <> " WHERE l.relation = $1::regclass"
+            <> " AND l.mode = 'AccessShareLock'"
+            <> " AND l.granted"
+            <> " AND a.application_name = 'ihp_job_queue_access_share_test')"
+    let encoder = Encoders.param (Encoders.nonNullable Encoders.text)
+    let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
+    let statement = Hasql.unpreparable sql encoder decoder
+    runPool pool (HasqlSession.statement tableName statement)
+
+holdTriggerInstallLock :: HasqlPool.Pool -> Text -> IO ()
+holdTriggerInstallLock pool tableName = do
+    let functionName = triggerFunctionName tableName
+    runScript pool $
+        "BEGIN;"
+        <> "SET LOCAL application_name = 'ihp_job_queue_trigger_install_test';"
+        <> "SELECT pg_advisory_xact_lock(hashtext(current_schema()), hashtext('" <> functionName <> "'::name::text));"
+        <> "SELECT pg_sleep(3);"
+        <> "ROLLBACK;"
+
+triggerInstallLockHeld :: HasqlPool.Pool -> IO Bool
+triggerInstallLockHeld pool = do
+    let sql = "SELECT EXISTS ("
+            <> " SELECT 1 FROM pg_locks l"
+            <> " JOIN pg_stat_activity a ON a.pid = l.pid"
+            <> " WHERE l.locktype = 'advisory'"
+            <> " AND l.granted"
+            <> " AND a.application_name = 'ihp_job_queue_trigger_install_test')"
+    let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
+    let statement = Hasql.unpreparable sql Encoders.noParams decoder
+    runPool pool (HasqlSession.statement () statement)
+
+ensureTestNotificationTriggers :: HasqlPool.Pool -> Text -> IO ()
+ensureTestNotificationTriggers pool tableName = do
+    let ?context = TestContext { logger = noopLogger }
+    JobQueue.ensureNotificationTriggers pool tableName
 
 dropTestArtifacts :: HasqlPool.Pool -> Text -> IO ()
 dropTestArtifacts pool tableName =


### PR DESCRIPTION
## Summary

- retry missing job notification triggers from the normal poller in production while keeping job polling available
- use a non-blocking, schema-aware advisory lock and acquire the table lock required by `CREATE TRIGGER` with `NOWAIT`
- create insert and update triggers independently, so worker startup never drops a healthy trigger
- add PostgreSQL integration coverage for startup recovery, lock contention, long identifiers, and concurrent installers

## Root cause

PR #2755 made trigger installation fail fast during table lock contention, but a startup timeout left production workers in polling-only mode until a reconnect or restart.

This follow-up enables the existing poller-side integrity check in production and isolates repair failures from normal job polling. Trigger repair never waits in the table lock queue: if a normal writer currently holds a conflicting lock, repair fails immediately and retries later without blocking subsequent job inserts or updates.

The runtime path deliberately checks only whether the expected triggers exist; changing an existing trigger definition remains an explicit migration.

## Validation

- loaded `Watch.hs`, `WorkerLoop.hs`, and `JobQueueSpec.hs` together in GHCi through the cached Nix development shell
- ran all 8 job queue tests against an ephemeral PostgreSQL 17 instance: 8 examples, 0 failures
- `git diff --check`
