### PR TITLE
Parse pg_dump CREATE FUNCTION SET TO options

### DIFF
--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -983,9 +983,22 @@ qualifiedIdentifier = do
         char '.'
     identifier
 
+-- | Parses a (possibly schema-qualified) function name.
+--
+-- Like 'qualifiedIdentifier' this normalizes the default @public@ schema away
+-- (@public.foo@ becomes @foo@) so function names compare equal regardless of
+-- whether they were written qualified or not. Unlike 'qualifiedIdentifier' it
+-- preserves non-@public@ schemas (e.g. @private.sync_access@) as emitted by
+-- pg_dump.
+functionIdentifier :: Parser Text
 functionIdentifier = do
     schemaOrName <- identifier
-    maybe schemaOrName (\name -> schemaOrName <> "." <> name) <$> optional (char '.' >> identifier)
+    maybeName <- optional (char '.' >> identifier)
+    pure $ case maybeName of
+        Nothing -> schemaOrName
+        Just name
+            | schemaOrName == "public" -> name
+            | otherwise -> schemaOrName <> "." <> name
 
 addColumn tableName = do
     lexeme "COLUMN"
@@ -1036,7 +1049,7 @@ dropType = do
 dropFunction = do
     lexeme "DROP"
     lexeme "FUNCTION"
-    functionName <- qualifiedIdentifier
+    functionName <- functionIdentifier
     char ';'
     pure DropFunction { functionName }
 

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -698,7 +698,7 @@ createFunction = do
     lexeme "CREATE"
     orReplace <- isJust <$> optional (lexeme "OR" >> lexeme "REPLACE")
     lexeme "FUNCTION"
-    functionName <- qualifiedIdentifier
+    functionName <- functionIdentifier
     functionArguments <- between (char '(') (char ')') (functionArgument `sepBy` (char ',' >> space))
     space
     lexeme "RETURNS"
@@ -752,7 +752,7 @@ parseFunctionSetting :: Parser FunctionOption
 parseFunctionSetting = do
     symbol' "SET"
     settingName <- qualifiedIdentifier
-    symbol "="
+    symbol "=" <|> symbol' "TO"
     settingValue <- Text.strip . cs <$> someTill anySingle (lookAhead functionOptionBoundary)
     space
     pure (FunctionSettingOption FunctionSetting { settingName, settingValue })
@@ -982,6 +982,10 @@ qualifiedIdentifier = do
         lexeme "public"
         char '.'
     identifier
+
+functionIdentifier = do
+    schemaOrName <- identifier
+    maybe schemaOrName (\name -> schemaOrName <> "." <> name) <$> optional (char '.' >> identifier)
 
 addColumn tableName = do
     lexeme "COLUMN"

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -233,6 +233,30 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should round-trip a schema-qualified CREATE FUNCTION" do
+            -- parse -> compile -> parse must preserve a non-public schema like `private.`
+            let statement = CreateFunction
+                    { functionName = "private.sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = True
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "search_path"
+                            , settingValue = "public, private, pg_temp"
+                            }
+                        ]
+                    }
+            parseSql (compileSql [statement]) `shouldBe` statement
+
+        it "should round-trip a schema-qualified DROP FUNCTION" do
+            -- Guards against the CREATE/DROP asymmetry: both must accept `private.` names
+            let statement = DropFunction { functionName = "private.sync_access" }
+            parseSql (compileSql [statement]) `shouldBe` statement
+
         it "should compile a CREATE INDEX with VARIADIC function arguments" do
             let sql = "CREATE INDEX agent_runs_ingest_gmail_message_latest_idx ON agent_runs USING BTREE (organization_id, jsonb_extract_path_text(input, VARIADIC ARRAY['gmailMessageId'::TEXT]), COALESCE(completed_at, last_event_at, started_at, created_at) DESC, id DESC) WHERE type = ('ingest'::agent_run_type) AND jsonb_extract_path_text(input, VARIADIC ARRAY['source'::TEXT]) = ('gmail_email_ingest'::TEXT);\n"
             let statement = CreateIndex

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -249,6 +249,66 @@ spec = do
                         ]
                     }
 
+        it "should parse CREATE FUNCTION SET options with TO and an unqualified name" do
+            -- Isolates the `SET ... TO ...` change from the schema-qualified name change
+            let sql = "CREATE OR REPLACE FUNCTION sync_access()\nRETURNS TRIGGER\nLANGUAGE plpgsql\nSECURITY DEFINER\nSET search_path TO 'public'\nAS $$BEGIN\n    RETURN NEW;\nEND;$$;"
+            parseSql sql `shouldBe` CreateFunction
+                    { functionName = "sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = True
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "search_path"
+                            , settingValue = "'public'"
+                            }
+                        ]
+                    }
+
+        it "should preserve a non-public schema on CREATE FUNCTION with = style settings" do
+            -- Isolates the schema-qualified name change from the `SET ... TO ...` change
+            let sql = "CREATE OR REPLACE FUNCTION private.sync_access()\nRETURNS TRIGGER\nLANGUAGE plpgsql\nSECURITY DEFINER\nSET search_path = public, private, pg_temp\nAS $$BEGIN\n    RETURN NEW;\nEND;$$;"
+            parseSql sql `shouldBe` CreateFunction
+                    { functionName = "private.sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = True
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "search_path"
+                            , settingValue = "public, private, pg_temp"
+                            }
+                        ]
+                    }
+
+        it "should normalize the default public schema away on CREATE FUNCTION" do
+            -- Keeps function names comparable regardless of an explicit `public.` prefix,
+            -- matching how `qualifiedIdentifier` treats every other identifier.
+            let sql = "CREATE OR REPLACE FUNCTION public.sync_access()\nRETURNS TRIGGER\nAS $$BEGIN\n    RETURN NEW;\nEND;$$ language plpgsql;"
+            parseSql sql `shouldBe` CreateFunction
+                    { functionName = "sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = False
+                    , functionSettings = []
+                    }
+
+        it "should parse DROP FUNCTION with a non-public schema-qualified name" do
+            -- DROP FUNCTION must accept the same schema-qualified names as CREATE FUNCTION
+            parseSql "DROP FUNCTION private.sync_access;" `shouldBe` DropFunction { functionName = "private.sync_access" }
+
+        it "should normalize the default public schema away on DROP FUNCTION" do
+            parseSql "DROP FUNCTION public.sync_access;" `shouldBe` DropFunction { functionName = "sync_access" }
+
         it "should parse a pg_dump CREATE INDEX with VARIADIC function arguments" do
             let sql = "CREATE INDEX agent_runs_ingest_gmail_message_latest_idx ON public.agent_runs USING btree (organization_id, jsonb_extract_path_text(input, VARIADIC ARRAY['gmailMessageId'::text]), COALESCE(completed_at, last_event_at, started_at, created_at) DESC, id DESC) WHERE ((type = 'ingest'::public.agent_run_type) AND (jsonb_extract_path_text(input, VARIADIC ARRAY['source'::text]) = 'gmail_email_ingest'::text));"
             parseSql sql `shouldBe` CreateIndex

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -231,6 +231,24 @@ spec = do
                         ]
                     }
 
+        it "should parse pg_dump CREATE FUNCTION SET options with TO" do
+            let sql = "CREATE OR REPLACE FUNCTION private.sync_access()\nRETURNS TRIGGER\nLANGUAGE plpgsql\nSECURITY DEFINER\nSET search_path TO 'public', 'private', 'pg_temp'\nAS $$BEGIN\n    RETURN NEW;\nEND;$$;"
+            parseSql sql `shouldBe` CreateFunction
+                    { functionName = "private.sync_access"
+                    , functionArguments = []
+                    , functionBody = "BEGIN\n    RETURN NEW;\nEND;"
+                    , orReplace = True
+                    , returns = PTrigger
+                    , language = "plpgsql"
+                    , securityDefiner = True
+                    , functionSettings =
+                        [ FunctionSetting
+                            { settingName = "search_path"
+                            , settingValue = "'public', 'private', 'pg_temp'"
+                            }
+                        ]
+                    }
+
         it "should parse a pg_dump CREATE INDEX with VARIADIC function arguments" do
             let sql = "CREATE INDEX agent_runs_ingest_gmail_message_latest_idx ON public.agent_runs USING btree (organization_id, jsonb_extract_path_text(input, VARIADIC ARRAY['gmailMessageId'::text]), COALESCE(completed_at, last_event_at, started_at, created_at) DESC, id DESC) WHERE ((type = 'ingest'::public.agent_run_type) AND (jsonb_extract_path_text(input, VARIADIC ARRAY['source'::text]) = 'gmail_email_ingest'::text));"
             parseSql sql `shouldBe` CreateIndex


### PR DESCRIPTION
Supersedes #2684 (by @vcombey), with the review feedback from that PR applied. vcombey's original commit is preserved with authorship; the second commit addresses the review.

## What changed

- Accept `SET <name> TO <value>` inside `CREATE FUNCTION` options in `ihp-postgres-parser` (in addition to `SET <name> = <value>`).
- Preserve schema-qualified function names such as `private.sync_access` when parsing `CREATE FUNCTION`, while normalizing the default `public.` schema away (`public.foo` → `foo`) so function names stay comparable regardless of an explicit prefix — matching how `qualifiedIdentifier` treats every other identifier.
- Use the same schema-aware identifier parser for `DROP FUNCTION`, so `DROP FUNCTION private.sync_access;` parses symmetrically with `CREATE FUNCTION` (fixes a CREATE/DROP asymmetry).
- Add a type signature + Haddock to `functionIdentifier`.
- Add parser tests isolating the `SET ... TO ...` change and the schema-prefix change, `public.`-normalization tests for both CREATE and DROP, and `parse → compile → parse` round-trip tests for schema-qualified `CREATE`/`DROP FUNCTION`.

## Why

PostgreSQL `pg_dump` can emit function options with `TO` instead of `=`, and can qualify functions with a non-`public` schema. The parser previously failed before IHP could load this schema output.

## Validation

`ihp-postgres-parser` `ParserSpec` + `CompilerSpec`: 79 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)