### PR TITLE
Reuse intermediates from previous app builds

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -437,23 +437,35 @@ CABAL_EOF
                     ];
             });
 
-    appLibPackageBase = configureHaskellBuild (pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
+    mkAppLibPackage = withIntermediates: configureHaskellBuild (pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
         ghc.callPackage ({ mkDerivation, base }: mkDerivation {
             pname = "${appName}-lib";
             version = "0.1.0";
             src = appLibSrc;
             libraryHaskellDepends = [ base modelsPackage ] ++ builtins.filter (p: p != null) (haskellDeps ghc);
-            doInstallIntermediates = optimized;
-            enableSeparateIntermediatesOutput = optimized;
+            doInstallIntermediates = withIntermediates;
+            enableSeparateIntermediatesOutput = withIntermediates;
             inherit previousIntermediates;
             license = pkgs.lib.licenses.free;
         }) {}
     )));
 
-    appLibPackage =
+    withAppLibPostgres = pkg:
         if buildWithPostgres
-        then withBuildTimePostgres appLibPackageBase
-        else appLibPackageBase;
+        then withBuildTimePostgres pkg
+        else pkg;
+
+    # The executables link against a lib variant WITHOUT the intermediates
+    # output: a nix remote builder copies back every output of each derivation
+    # it builds, so the multi-GB .hi/.o tree would otherwise travel with every
+    # offloaded build even though only the next incremental compile needs it.
+    # The with-intermediates variant exists solely to seed that next build; it
+    # is published as passthru.appLibPackage so existing flakes that reference
+    # .intermediates (the optimized-app-lib-intermediates output consumed via
+    # the prevBuild input, including older revisions of consuming repos) keep
+    # evaluating unchanged.
+    appLibPackage = withAppLibPostgres (mkAppLibPackage false);
+    appLibPackageWithIntermediates = withAppLibPostgres (mkAppLibPackage optimized);
 
     allHaskellPackagesWithAppLib = ghc.ghcWithPackages (p: [ appLibPackage ]);
 
@@ -601,7 +613,14 @@ in
     pkgs.runCommand appName {
         inherit static binaries;
         nativeBuildInputs = [ pkgs.makeWrapper ];
-        passthru = { inherit appLibPackage scriptBinaries; migrationCheck = effectiveMigrationCheck; };
+        # appLibPackage stays the with-intermediates variant here: consumers
+        # reach it as passthru.appLibPackage.intermediates (see mkAppLibPackage).
+        passthru = {
+            appLibPackage = appLibPackageWithIntermediates;
+            appLibPackageForExecutables = appLibPackage;
+            inherit scriptBinaries;
+            migrationCheck = effectiveMigrationCheck;
+        };
     } ''
             test -e ${effectiveMigrationCheck}
 


### PR DESCRIPTION
## What changed

- add an opt-in `ihp.previousAppLibIntermediates` flake-module option
- export optimized app-library intermediates as a separate Nix output
- pass a previous intermediate output to the Haskell builder
- expose the app-library package through the production server passthru

## Why

Application source changes currently produce a fresh Nix build directory, so GHC recompiles the full application module graph even when most modules are unchanged. This makes optimized deployment builds unnecessarily slow.

The new option lets an application provide the intermediate output from its last successful build. GHC still performs its normal recompilation check and only reuses object and interface files that remain valid.

The behavior is opt-in and only enabled for optimized production builds. Existing applications and unoptimized builds remain unchanged.

## Validation

- `nix eval --raw .#checks.aarch64-darwin.boilerplate-optimized-prod-server.drvPath`
- end-to-end Belege test on an Apple Silicon remote builder:
  - cold app-library build phase: 7m24s (689 modules)
  - previous-intermediates build phase: 1m02s (9 affected application modules)
  - complete cached app-library derivation: 1m46.6s
  - full optimized production server successfully linked and packaged from the cached library

The full repository `nix flake check --no-build` also evaluated the affected optimized-production check successfully, but its aggregate result still contains pre-existing local `devenv` current-directory and GHC 9.14 evaluation failures.
