### PR TITLE
Track QueryBuilder reads for AutoRefresh

### DIFF
--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -14,7 +14,10 @@ import IHP.Controller.Session
 import qualified Network.Wai.Internal as Wai
 import qualified Data.Binary.Builder as ByteString
 import qualified Data.Set as Set
+import qualified Data.Map.Strict as Map
+import Data.Dynamic (fromDynamic)
 import IHP.ModelSupport
+import IHP.QueryBuilder.Types (QueryBuilderRead)
 import qualified Control.Exception as Exception
 import qualified Control.Concurrent.MVar as MVar
 import qualified Data.Maybe as Maybe
@@ -83,12 +86,19 @@ autoRefresh runAction = do
                     -- values back into the renderView callback is enough.
                     let originalRequest = ?request
                     let renderView = \waiRequest waiRespond -> do
-                            earlyReturnMiddleware (\_ respond -> do
-                                let ?request = originalRequest
-                                let ?context = ?request
-                                let ?respond = respond
-                                action ?theAction
-                                ) waiRequest waiRespond
+                            withTableReadTracker do
+                                result <- earlyReturnMiddleware (\_ respond -> do
+                                    let ?request = originalRequest
+                                    let ?context = ?request
+                                    let ?respond = respond
+                                    action ?theAction
+                                    ) waiRequest waiRespond
+                                trackedTableReads <- readIORef ?trackedTableReads
+                                let readDependencies = buildAutoRefreshReadDependencies trackedTableReads
+                                let tables = Map.keysSet readDependencies
+                                updateSession autoRefreshServer id (\session -> session { tables, readDependencies })
+                                registerNewNotificationTriggers ?touchedTables autoRefreshServer
+                                pure result
 
                     -- We save the allowed session ids to the session cookie to only grant a client access
                     -- to sessions it initially opened itself
@@ -102,12 +112,14 @@ autoRefresh runAction = do
                             runAction
 
                         -- After the action completes, set up the auto refresh session
-                        tables <- readIORef ?touchedTables
+                        trackedTableReads <- readIORef ?trackedTableReads
+                        let readDependencies = buildAutoRefreshReadDependencies trackedTableReads
+                        let tables = Map.keysSet readDependencies
                         lastPing <- getCurrentTime
                         case capturedResponse of
                             Just lastResponse -> do
                                 event <- MVar.newEmptyMVar
-                                let session = AutoRefreshSession { id, renderView, event, tables, lastResponse, lastPing }
+                                let session = AutoRefreshSession { id, renderView, event, tables, readDependencies, lastResponse, lastPing }
                                 modifyIORef' autoRefreshServer (\s -> s { sessions = session:s.sessions } )
                                 async (gcSessions autoRefreshServer)
                                 registerNotificationTrigger ?touchedTables autoRefreshServer
@@ -185,6 +197,37 @@ captureResponseBody originalRespond action = do
     result <- action capturingRespond
     captured <- readIORef bodyRef
     pure (result, captured)
+
+-- | Convert generic model-layer read tracking into the QueryBuilder-specific
+-- dependencies retained by AutoRefresh.
+--
+-- A whole-table or unknown read is absorbing: a later QueryBuilder read of the
+-- same table must not make the session look safe to filter.
+buildAutoRefreshReadDependencies :: [TrackedTableRead] -> Map.Map Text AutoRefreshReadDependency
+buildAutoRefreshReadDependencies = foldl' addRead Map.empty
+    where
+        addRead dependencies TrackedTableRead { trackedTableName, trackedQuery } =
+            case trackedQuery >>= fromDynamic @QueryBuilderRead of
+                Nothing -> Map.insert trackedTableName AutoRefreshWholeTable dependencies
+                Just queryRead -> Map.alter (addQueryRead queryRead) trackedTableName dependencies
+
+        addQueryRead queryRead Nothing = Just (AutoRefreshQueryBuilderReads [queryRead])
+        addQueryRead _ (Just AutoRefreshWholeTable) = Just AutoRefreshWholeTable
+        addQueryRead queryRead (Just (AutoRefreshQueryBuilderReads queryReads)) =
+            Just (AutoRefreshQueryBuilderReads (queryRead:queryReads))
+
+-- | Subscribe only to tables that appeared during a rerender and are not yet
+-- known to the AutoRefresh server. This avoids reinstalling development
+-- triggers on every rerender while still allowing an action's dependencies to
+-- change over time.
+registerNewNotificationTriggers :: (?modelContext :: ModelContext, ?request :: Request) => IORef (Set Text) -> IORef AutoRefreshServer -> IO ()
+registerNewNotificationTriggers touchedTablesVar autoRefreshServer = do
+    touchedTables <- readIORef touchedTablesVar
+    subscribedTables <- (.subscribedTables) <$> readIORef autoRefreshServer
+    let newTables = touchedTables `Set.difference` subscribedTables
+    unless (Set.null newTables) do
+        newTablesVar <- newIORef newTables
+        registerNotificationTrigger newTablesVar autoRefreshServer
 
 registerNotificationTrigger :: (?modelContext :: ModelContext, ?request :: Request) => IORef (Set Text) -> IORef AutoRefreshServer -> IO ()
 registerNotificationTrigger touchedTablesVar autoRefreshServer = do

--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -17,7 +17,8 @@ import qualified Data.Set as Set
 import qualified Data.Map.Strict as Map
 import Data.Dynamic (fromDynamic)
 import IHP.ModelSupport
-import IHP.QueryBuilder.Types (QueryBuilderRead)
+import IHP.QueryBuilder.Types (QueryBuilderRead (..), QueryBuilderReadKind (..))
+import qualified IHP.ModelSupport.TableReadTracker as TableReadTracker
 import qualified Control.Exception as Exception
 import qualified Control.Concurrent.MVar as MVar
 import qualified Data.Maybe as Maybe
@@ -37,6 +38,10 @@ import IHP.Environment (Environment(..))
 {-# NOINLINE globalAutoRefreshServerVar #-}
 globalAutoRefreshServerVar :: MVar.MVar (Maybe (IORef AutoRefreshServer))
 globalAutoRefreshServerVar = unsafePerformIO (MVar.newMVar Nothing)
+
+{-# NOINLINE notificationTriggerRegistrationLock #-}
+notificationTriggerRegistrationLock :: MVar.MVar ()
+notificationTriggerRegistrationLock = unsafePerformIO (MVar.newMVar ())
 
 getOrCreateAutoRefreshServer :: (?request :: Request) => IO (IORef AutoRefreshServer)
 getOrCreateAutoRefreshServer =
@@ -86,18 +91,19 @@ autoRefresh runAction = do
                     -- values back into the renderView callback is enough.
                     let originalRequest = ?request
                     let renderView = \waiRequest waiRespond -> do
-                            withTableReadTracker do
+                            withAutoRefreshReadTracker do
                                 result <- earlyReturnMiddleware (\_ respond -> do
                                     let ?request = originalRequest
                                     let ?context = ?request
                                     let ?respond = respond
                                     action ?theAction
                                     ) waiRequest waiRespond
-                                trackedTableReads <- readIORef ?trackedTableReads
-                                let readDependencies = buildAutoRefreshReadDependencies trackedTableReads
-                                let tables = Map.keysSet readDependencies
-                                updateSession autoRefreshServer id (\session -> session { tables, readDependencies })
-                                registerNewNotificationTriggers ?touchedTables autoRefreshServer
+                                readDependencies <- readIORef ?autoRefreshReadDependencies
+                                commitAutoRefreshReadDependencies
+                                    (registerNewNotificationTriggers ?touchedTables autoRefreshServer)
+                                    autoRefreshServer
+                                    id
+                                    readDependencies
                                 pure result
 
                     -- We save the allowed session ids to the session cookie to only grant a client access
@@ -106,23 +112,23 @@ autoRefresh runAction = do
                     -- Otherwise you might try to guess session UUIDs to access other peoples auto refresh sessions
                     setSession "autoRefreshSessions" (map UUID.toText (id:availableSessions) |> Text.intercalate "")
 
-                    withTableReadTracker do
+                    withAutoRefreshReadTracker do
                         (result, capturedResponse) <- captureResponseBody ?respond \respond -> do
                             let ?respond = respond
                             runAction
 
                         -- After the action completes, set up the auto refresh session
-                        trackedTableReads <- readIORef ?trackedTableReads
-                        let readDependencies = buildAutoRefreshReadDependencies trackedTableReads
+                        readDependencies <- readIORef ?autoRefreshReadDependencies
                         let tables = Map.keysSet readDependencies
                         lastPing <- getCurrentTime
                         case capturedResponse of
                             Just lastResponse -> do
                                 event <- MVar.newEmptyMVar
-                                let session = AutoRefreshSession { id, renderView, event, tables, readDependencies, lastResponse, lastPing }
-                                modifyIORef' autoRefreshServer (\s -> s { sessions = session:s.sessions } )
-                                async (gcSessions autoRefreshServer)
+                                let session = TrackedAutoRefreshSession { id, renderView, event, tables, readDependencies, lastResponse, lastPing }
                                 registerNotificationTrigger ?touchedTables autoRefreshServer
+                                atomicModifyIORef' autoRefreshServer (\s -> (s { sessions = session:s.sessions }, ()))
+                                _ <- async (gcSessions autoRefreshServer)
+                                pure ()
                             Nothing -> pure () -- Response wasn't a builder type, can't do auto refresh
 
                         pure result
@@ -140,7 +146,9 @@ instance WSApp AutoRefreshWSApp where
         availableSessions <- getAvailableSessions autoRefreshServer
 
         when (sessionId `elem` availableSessions) do
-            AutoRefreshSession { renderView, event } <- getSessionById autoRefreshServer sessionId
+            session <- getSessionById autoRefreshServer sessionId
+            let renderView = session.renderView
+            let event = session.event
 
             let handleOtherException :: SomeException -> IO ()
                 handleOtherException ex = ?context.frameworkConfig.logger (toLogStr ("AutoRefresh: Failed to re-render view: " <> tshow ex))
@@ -176,7 +184,7 @@ instance WSApp AutoRefreshWSApp where
         getState >>= \case
             AutoRefreshActive { sessionId } -> do
                 autoRefreshServer <- getOrCreateAutoRefreshServer
-                modifyIORef' autoRefreshServer (\server -> server { sessions = filter (\AutoRefreshSession { id } -> id /= sessionId) server.sessions })
+                atomicModifyIORef' autoRefreshServer (\server -> (server { sessions = filter (\session -> session.id /= sessionId) server.sessions }, ()))
             AwaitingSessionID -> pure ()
 
 
@@ -198,78 +206,139 @@ captureResponseBody originalRespond action = do
     captured <- readIORef bodyRef
     pure (result, captured)
 
--- | Convert generic model-layer read tracking into the QueryBuilder-specific
--- dependencies retained by AutoRefresh.
---
--- A whole-table or unknown read is absorbing: a later QueryBuilder read of the
--- same table must not make the session look safe to filter.
-buildAutoRefreshReadDependencies :: [TrackedTableRead] -> Map.Map Text AutoRefreshReadDependency
-buildAutoRefreshReadDependencies = foldl' addRead Map.empty
+-- | Maximum structured reads retained for a table in one rendered response.
+-- Above this limit AutoRefresh falls back to a constant-size whole-table
+-- dependency instead of retaining an unbounded number of encoder closures.
+maxAutoRefreshQueryBuilderReadsPerTable :: Int
+maxAutoRefreshQueryBuilderReadsPerTable = 64
+
+-- | Maximum returned keys retained for one row query.
+maxAutoRefreshPrimaryKeysPerRead :: Int
+maxAutoRefreshPrimaryKeysPerRead = 1024
+
+-- | Track reads for AutoRefresh without changing the public ModelContext or
+-- 'withTableReadTracker' APIs. Dependencies are aggregated and bounded while
+-- the action runs, rather than collecting an unbounded intermediate list.
+withAutoRefreshReadTracker :: (?modelContext :: ModelContext)
+    => (( ?modelContext :: ModelContext
+        , ?touchedTables :: IORef (Set Text)
+        , ?autoRefreshReadDependencies :: IORef (Map.Map Text AutoRefreshReadDependency)
+        ) => IO a)
+    -> IO a
+withAutoRefreshReadTracker trackedSection = do
+    touchedTablesVar <- newIORef Set.empty
+    readDependenciesVar <- newIORef Map.empty
+    let trackTableReadCallback tableName =
+            atomicModifyIORef' touchedTablesVar (\tables -> (Set.insert tableName tables, ()))
+    let collectRead trackedRead =
+            atomicModifyIORef' readDependenciesVar (\dependencies -> (addTrackedRead trackedRead dependencies, ()))
+    let oldModelContext = ?modelContext
+    let ?modelContext = oldModelContext { trackTableReadCallback = Just trackTableReadCallback }
+    let ?touchedTables = touchedTablesVar
+    let ?autoRefreshReadDependencies = readDependenciesVar
+    TableReadTracker.withTrackedTableReadCallback trackTableReadCallback collectRead trackedSection
+
+addTrackedRead :: TableReadTracker.TrackedTableRead -> Map.Map Text AutoRefreshReadDependency -> Map.Map Text AutoRefreshReadDependency
+addTrackedRead trackedRead dependencies = case trackedRead of
+    TableReadTracker.TrackedWholeTableRead tableName ->
+        addWholeTableReadDependency tableName dependencies
+    TableReadTracker.TrackedStructuredTableRead tableName dynamicRead ->
+        case fromDynamic @QueryBuilderRead dynamicRead of
+            Nothing -> addWholeTableReadDependency tableName dependencies
+            Just queryBuilderRead -> addQueryBuilderReadDependency tableName queryBuilderRead dependencies
+
+-- | A manual or unknown read is absorbing for the table.
+addWholeTableReadDependency :: Text -> Map.Map Text AutoRefreshReadDependency -> Map.Map Text AutoRefreshReadDependency
+addWholeTableReadDependency tableName =
+    Map.insert tableName AutoRefreshWholeTable
+
+-- | Add a bounded structured read. Row reads without canonical returned keys,
+-- oversized result sets, and tables exceeding the read limit safely degrade to
+-- a whole-table dependency and release all retained queries for that table.
+addQueryBuilderReadDependency :: Text -> QueryBuilderRead -> Map.Map Text AutoRefreshReadDependency -> Map.Map Text AutoRefreshReadDependency
+addQueryBuilderReadDependency tableName queryBuilderRead =
+    Map.alter addRead tableName
     where
-        addRead dependencies TrackedTableRead { trackedTableName, trackedQuery } =
-            case trackedQuery >>= fromDynamic @QueryBuilderRead of
-                Nothing -> Map.insert trackedTableName AutoRefreshWholeTable dependencies
-                Just queryRead -> Map.alter (addQueryRead queryRead) trackedTableName dependencies
+        addRead _ | cannotRetainRead = Just AutoRefreshWholeTable
+        addRead Nothing = Just (AutoRefreshQueryBuilderReads [queryBuilderRead])
+        addRead (Just AutoRefreshWholeTable) = Just AutoRefreshWholeTable
+        addRead (Just (AutoRefreshQueryBuilderReads queryReads))
+            | length queryReads >= maxAutoRefreshQueryBuilderReadsPerTable = Just AutoRefreshWholeTable
+            | otherwise = Just (AutoRefreshQueryBuilderReads (queryBuilderRead:queryReads))
 
-        addQueryRead queryRead Nothing = Just (AutoRefreshQueryBuilderReads [queryRead])
-        addQueryRead _ (Just AutoRefreshWholeTable) = Just AutoRefreshWholeTable
-        addQueryRead queryRead (Just (AutoRefreshQueryBuilderReads queryReads)) =
-            Just (AutoRefreshQueryBuilderReads (queryRead:queryReads))
+        cannotRetainRead = case queryBuilderRead.queryBuilderReadKind of
+            QueryBuilderRows ->
+                null queryBuilderRead.queryBuilderPrimaryKeyColumns
+                || case queryBuilderRead.queryBuilderResultPrimaryKeys of
+                    Nothing -> True
+                    Just primaryKeys -> length primaryKeys > maxAutoRefreshPrimaryKeysPerRead
+            QueryBuilderCount -> False
+            QueryBuilderExists -> False
 
--- | Subscribe only to tables that appeared during a rerender and are not yet
--- known to the AutoRefresh server. This avoids reinstalling development
--- triggers on every rerender while still allowing an action's dependencies to
--- change over time.
+-- | Register every new table first and only then publish the new dependency
+-- snapshot. If registration throws, the session continues to describe the HTML
+-- that is still displayed by the client.
+commitAutoRefreshReadDependencies
+    :: IO ()
+    -> IORef AutoRefreshServer
+    -> UUID
+    -> Map.Map Text AutoRefreshReadDependency
+    -> IO ()
+commitAutoRefreshReadDependencies registerNewTables autoRefreshServer sessionId readDependencies = do
+    registerNewTables
+    updateSession autoRefreshServer sessionId (setAutoRefreshReadDependencies readDependencies)
+
+-- | Register tables touched by a rerender. Production registration skips
+-- already subscribed tables; development registration deliberately reinstalls
+-- their idempotent trigger SQL because @make db@ may have recreated the DB.
 registerNewNotificationTriggers :: (?modelContext :: ModelContext, ?request :: Request) => IORef (Set Text) -> IORef AutoRefreshServer -> IO ()
-registerNewNotificationTriggers touchedTablesVar autoRefreshServer = do
-    touchedTables <- readIORef touchedTablesVar
-    subscribedTables <- (.subscribedTables) <$> readIORef autoRefreshServer
-    let newTables = touchedTables `Set.difference` subscribedTables
-    unless (Set.null newTables) do
-        newTablesVar <- newIORef newTables
-        registerNotificationTrigger newTablesVar autoRefreshServer
+registerNewNotificationTriggers = registerNotificationTrigger
 
 registerNotificationTrigger :: (?modelContext :: ModelContext, ?request :: Request) => IORef (Set Text) -> IORef AutoRefreshServer -> IO ()
-registerNotificationTrigger touchedTablesVar autoRefreshServer = do
-    touchedTables <- Set.toList <$> readIORef touchedTablesVar
-    subscribedTables <- (.subscribedTables) <$> (autoRefreshServer |> readIORef)
+registerNotificationTrigger touchedTablesVar autoRefreshServer =
+    MVar.withMVar notificationTriggerRegistrationLock \_ -> do
+        touchedTables <- Set.toList <$> readIORef touchedTablesVar
+        subscribedTables <- (.subscribedTables) <$> readIORef autoRefreshServer
 
-    let subscriptionRequired = touchedTables |> filter (\table -> subscribedTables |> Set.notMember table)
+        let subscriptionRequired = touchedTables |> filter (\table -> subscribedTables |> Set.notMember table)
 
-    -- In development, always re-run trigger SQL for all touched tables because
-    -- `make db` drops and recreates the database, destroying triggers that were
-    -- previously installed. The trigger SQL is idempotent so re-running is safe.
-    -- In production, only install triggers for newly seen tables.
-    let isDevelopment = ?request.frameworkConfig.environment == Development
+        -- In development, always re-run trigger SQL for all touched tables because
+        -- `make db` drops and recreates the database, destroying triggers that were
+        -- previously installed. The trigger SQL is idempotent so re-running is safe.
+        -- In production, only install triggers for newly seen tables.
+        let isDevelopment = ?request.frameworkConfig.environment == Development
 
-    modifyIORef' autoRefreshServer (\server -> server { subscribedTables = server.subscribedTables <> Set.fromList subscriptionRequired })
-
-    pgListener <- (.pgListener) <$> readIORef autoRefreshServer
-    subscriptions <- subscriptionRequired |> mapM (\table -> do
-        -- We need to add the trigger from the main IHP database role other we will get this error:
-        -- ERROR:  permission denied for schema public
-        withRowLevelSecurityDisabled do
-            let pool = ?modelContext.hasqlPool
-            runSessionHasql pool (HasqlSession.script (notificationTriggerSQL table))
-
-        pgListener |> PGListener.subscribe (channelName table) \notification -> do
-                sessions <- (.sessions) <$> readIORef autoRefreshServer
-                sessions
-                    |> filter (\session -> table `Set.member` session.tables)
-                    |> map (\session -> session.event)
-                    |> mapM (\event -> MVar.tryPutMVar event ())
-                pure ())
-
-    -- Re-run trigger SQL for already-subscribed tables in dev mode
-    when isDevelopment do
-        let alreadySubscribed = touchedTables |> filter (\table -> subscribedTables |> Set.member table)
-        forM_ alreadySubscribed \table -> do
+        pgListener <- (.pgListener) <$> readIORef autoRefreshServer
+        forM_ subscriptionRequired \table -> do
+            -- We need to add the trigger from the main IHP database role other we will get this error:
+            -- ERROR:  permission denied for schema public
             withRowLevelSecurityDisabled do
                 let pool = ?modelContext.hasqlPool
                 runSessionHasql pool (HasqlSession.script (notificationTriggerSQL table))
 
-    modifyIORef' autoRefreshServer (\s -> s { subscriptions = s.subscriptions <> subscriptions })
-    pure ()
+            subscription <- pgListener |> PGListener.subscribe (channelName table) \_notification -> do
+                    sessions <- (.sessions) <$> readIORef autoRefreshServer
+                    sessions
+                        |> filter (\session -> table `Set.member` session.tables)
+                        |> map (\session -> session.event)
+                        |> mapM (\event -> MVar.tryPutMVar event ())
+                    pure ()
+
+            atomicModifyIORef' autoRefreshServer \server ->
+                ( server
+                    { subscriptions = server.subscriptions <> [subscription]
+                    , subscribedTables = Set.insert table server.subscribedTables
+                    }
+                , ()
+                )
+
+        -- Re-run trigger SQL for already-subscribed tables in dev mode
+        when isDevelopment do
+            let alreadySubscribed = touchedTables |> filter (\table -> subscribedTables |> Set.member table)
+            forM_ alreadySubscribed \table -> do
+                withRowLevelSecurityDisabled do
+                    let pool = ?modelContext.hasqlPool
+                    runSessionHasql pool (HasqlSession.script (notificationTriggerSQL table))
 
 -- | Returns the ids of all sessions available to the client based on what sessions are found in the session cookie
 getAvailableSessions :: (?request :: Request) => IORef AutoRefreshServer -> IO [UUID]
@@ -289,7 +358,7 @@ getSessionById :: IORef AutoRefreshServer -> UUID -> IO AutoRefreshSession
 getSessionById autoRefreshServer sessionId = do
     autoRefreshServer <- readIORef autoRefreshServer
     autoRefreshServer.sessions
-        |> find (\AutoRefreshSession { id } -> id == sessionId)
+        |> find (\session -> session.id == sessionId)
         |> Maybe.fromMaybe (error "getSessionById: Could not find the session")
         |> pure
 
@@ -297,8 +366,7 @@ getSessionById autoRefreshServer sessionId = do
 updateSession :: IORef AutoRefreshServer -> UUID -> (AutoRefreshSession -> AutoRefreshSession) -> IO ()
 updateSession server sessionId updateFunction = do
     let updateSession' session = if session.id == sessionId then updateFunction session else session
-    modifyIORef' server (\server -> server { sessions = map updateSession' server.sessions })
-    pure ()
+    atomicModifyIORef' server (\server -> (server { sessions = map updateSession' server.sessions }, ()))
 
 -- | Returns 'True' when the rendered html differs from the session's latest
 -- known response.
@@ -319,11 +387,11 @@ sessionResponseHasChanged autoRefreshServer sessionId html = do
 gcSessions :: IORef AutoRefreshServer -> IO ()
 gcSessions autoRefreshServer = do
     now <- getCurrentTime
-    modifyIORef' autoRefreshServer (\autoRefreshServer -> autoRefreshServer { sessions = filter (not . isSessionExpired now) autoRefreshServer.sessions })
+    atomicModifyIORef' autoRefreshServer (\server -> (server { sessions = filter (not . isSessionExpired now) server.sessions }, ()))
 
 -- | A session is expired if it was not pinged in the last 60 seconds
 isSessionExpired :: UTCTime -> AutoRefreshSession -> Bool
-isSessionExpired now AutoRefreshSession { lastPing } = (now `diffUTCTime` lastPing) > (secondsToNominalDiffTime 60)
+isSessionExpired now session = (now `diffUTCTime` session.lastPing) > (secondsToNominalDiffTime 60)
 
 -- | Returns the event name of the event that the pg notify trigger dispatches
 channelName :: Text -> ByteString

--- a/ihp/IHP/AutoRefresh/Types.hs
+++ b/ihp/IHP/AutoRefresh/Types.hs
@@ -23,9 +23,15 @@ data AutoRefreshState = AutoRefreshEnabled { sessionId :: !UUID }
 data AutoRefreshReadDependency
     = AutoRefreshWholeTable
     | AutoRefreshQueryBuilderReads ![QueryBuilderRead]
-    deriving (Show)
+    deriving (Eq, Show)
 
-data AutoRefreshSession = AutoRefreshSession
+-- | AutoRefresh session state.
+--
+-- The original 'AutoRefreshSession' constructor is retained unchanged for
+-- source compatibility. Sessions created by AutoRefresh use
+-- 'TrackedAutoRefreshSession' to retain bounded structured dependencies.
+data AutoRefreshSession
+    = AutoRefreshSession
         { id :: !UUID
         -- | A callback to rerun an action within the given request and respond
         , renderView :: !(Request -> Respond -> IO ResponseReceived)
@@ -33,14 +39,48 @@ data AutoRefreshSession = AutoRefreshSession
         , event :: !(MVar ())
         -- | All tables this auto refresh session watches
         , tables :: !(Set Text)
-        -- | Structured QueryBuilder reads, or a conservative whole-table
-        -- dependency when raw SQL or another unknown read touched the table.
-        , readDependencies :: !(Map.Map Text AutoRefreshReadDependency)
         -- | The last rendered html of this action. Initially this is the result of the initial page rendering
         , lastResponse :: !LByteString
         -- | Keep track of the last ping to this session to close it after too much time has passed without anything happening
         , lastPing :: !UTCTime
         }
+    | TrackedAutoRefreshSession
+        { id :: !UUID
+        , renderView :: !(Request -> Respond -> IO ResponseReceived)
+        , event :: !(MVar ())
+        , tables :: !(Set Text)
+        -- | Structured QueryBuilder reads, or a conservative whole-table
+        -- dependency when raw SQL or another unknown read touched the table.
+        , readDependencies :: !(Map.Map Text AutoRefreshReadDependency)
+        , lastResponse :: !LByteString
+        , lastPing :: !UTCTime
+        }
+
+-- | Read dependencies for a session. Sessions constructed through the legacy
+-- constructor conservatively depend on every touched table.
+getAutoRefreshReadDependencies :: AutoRefreshSession -> Map.Map Text AutoRefreshReadDependency
+getAutoRefreshReadDependencies TrackedAutoRefreshSession { readDependencies } = readDependencies
+getAutoRefreshReadDependencies AutoRefreshSession { tables } =
+    Map.fromSet (const AutoRefreshWholeTable) tables
+
+-- | Replace a session's dependencies and upgrade legacy sessions to the
+-- tracked representation.
+setAutoRefreshReadDependencies :: Map.Map Text AutoRefreshReadDependency -> AutoRefreshSession -> AutoRefreshSession
+setAutoRefreshReadDependencies readDependencies session = case session of
+    TrackedAutoRefreshSession {} -> session
+        { tables = Map.keysSet readDependencies
+        , readDependencies
+        }
+    AutoRefreshSession { id, renderView, event, lastResponse, lastPing } ->
+        TrackedAutoRefreshSession
+            { id
+            , renderView
+            , event
+            , tables = Map.keysSet readDependencies
+            , readDependencies
+            , lastResponse
+            , lastPing
+            }
 
 data AutoRefreshServer = AutoRefreshServer
         { subscriptions :: [PGListener.Subscription]

--- a/ihp/IHP/AutoRefresh/Types.hs
+++ b/ihp/IHP/AutoRefresh/Types.hs
@@ -9,9 +9,22 @@ import IHP.Prelude
 import Wai.Request.Params.Middleware (Respond)
 import Control.Concurrent.MVar (MVar)
 import qualified IHP.PGListener as PGListener
+import qualified Data.Map.Strict as Map
+import IHP.QueryBuilder.Types (QueryBuilderRead)
 import Network.Wai (Request, ResponseReceived)
 
 data AutoRefreshState = AutoRefreshEnabled { sessionId :: !UUID }
+
+-- | The reads of a table that an AutoRefresh session depends on.
+--
+-- A manual or unknown read is an absorbing whole-table dependency. Only when
+-- every read of a table came from the QueryBuilder do we retain the structured
+-- queries for future relevance checks.
+data AutoRefreshReadDependency
+    = AutoRefreshWholeTable
+    | AutoRefreshQueryBuilderReads ![QueryBuilderRead]
+    deriving (Show)
+
 data AutoRefreshSession = AutoRefreshSession
         { id :: !UUID
         -- | A callback to rerun an action within the given request and respond
@@ -20,6 +33,9 @@ data AutoRefreshSession = AutoRefreshSession
         , event :: !(MVar ())
         -- | All tables this auto refresh session watches
         , tables :: !(Set Text)
+        -- | Structured QueryBuilder reads, or a conservative whole-table
+        -- dependency when raw SQL or another unknown read touched the table.
+        , readDependencies :: !(Map.Map Text AutoRefreshReadDependency)
         -- | The last rendered html of this action. Initially this is the result of the initial page rendering
         , lastResponse :: !LByteString
         -- | Keep track of the last ping to this session to close it after too much time has passed without anything happening

--- a/ihp/IHP/Fetch.hs
+++ b/ihp/IHP/Fetch.hs
@@ -30,6 +30,7 @@ where
 import IHP.Prelude
 import IHP.ModelSupport
 import IHP.QueryBuilder
+import IHP.QueryBuilder.Types (SQLQuery (..), QueryBuilderRead (..), QueryBuilderReadKind (..))
 import IHP.Hasql.FromRow (FromRowHasql(..))
 import Hasql.Implicits.Encoders (DefaultParamEncoder)
 import IHP.Fetch.Statement (buildQueryListStatement, buildQueryVectorStatement, buildQueryMaybeStatement, buildCountStatement, buildExistsStatement)
@@ -44,13 +45,19 @@ instance (model ~ GetModelByTableName table, KnownSymbol table) => Fetchable (Qu
     type instance FetchResult (QueryBuilder table) model = [model]
     fetch :: (Table model, FromRowHasql model, ?modelContext :: ModelContext) => QueryBuilder table -> IO [model]
     fetch !queryBuilder = do
-        trackTableRead (tableName @model)
+        trackQueryRead (tableName @model) QueryBuilderRead
+            { trackedSqlQuery = buildQuery queryBuilder
+            , queryBuilderReadKind = QueryBuilderRows
+            }
         let pool = ?modelContext.hasqlPool
         sqlStatementHasql pool () (buildQueryListStatement queryBuilder)
 
     fetchOneOrNothing :: (?modelContext :: ModelContext) => (Table model, FromRowHasql model) => QueryBuilder table -> IO (Maybe model)
     fetchOneOrNothing !queryBuilder = do
-        trackTableRead (tableName @model)
+        trackQueryRead (tableName @model) QueryBuilderRead
+            { trackedSqlQuery = (buildQuery queryBuilder) { limitClause = Just 1 }
+            , queryBuilderReadKind = QueryBuilderRows
+            }
         let pool = ?modelContext.hasqlPool
         sqlStatementHasql pool () (buildQueryMaybeStatement queryBuilder)
 
@@ -76,7 +83,10 @@ instance (model ~ GetModelByTableName table, KnownSymbol table) => Fetchable (Qu
 -- >     |> fetchVector
 fetchVector :: forall model table. (Table model, model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext) => QueryBuilder table -> IO (Vector model)
 fetchVector !queryBuilder = do
-    trackTableRead (tableName @model)
+    trackQueryRead (tableName @model) QueryBuilderRead
+        { trackedSqlQuery = buildQuery queryBuilder
+        , queryBuilderReadKind = QueryBuilderRows
+        }
     let pool = ?modelContext.hasqlPool
     sqlStatementHasql pool () (buildQueryVectorStatement queryBuilder)
 
@@ -95,7 +105,10 @@ fetchVector !queryBuilder = do
 -- >     -- SELECT COUNT(*) FROM projects WHERE is_active = true
 fetchCount :: forall table. (?modelContext :: ModelContext, KnownSymbol table) => QueryBuilder table -> IO Int
 fetchCount !queryBuilder = do
-    trackTableRead (symbolToText @table)
+    trackQueryRead (symbolToText @table) QueryBuilderRead
+        { trackedSqlQuery = buildQuery queryBuilder
+        , queryBuilderReadKind = QueryBuilderCount
+        }
     let pool = ?modelContext.hasqlPool
     fromIntegral <$> sqlStatementHasql pool () (buildCountStatement queryBuilder)
 
@@ -111,7 +124,10 @@ fetchCount !queryBuilder = do
 -- >     -- SELECT EXISTS (SELECT * FROM messages WHERE is_unread = true)
 fetchExists :: forall table. (?modelContext :: ModelContext, KnownSymbol table) => QueryBuilder table -> IO Bool
 fetchExists !queryBuilder = do
-    trackTableRead (symbolToText @table)
+    trackQueryRead (symbolToText @table) QueryBuilderRead
+        { trackedSqlQuery = buildQuery queryBuilder
+        , queryBuilderReadKind = QueryBuilderExists
+        }
     let pool = ?modelContext.hasqlPool
     sqlStatementHasql pool () (buildExistsStatement queryBuilder)
 

--- a/ihp/IHP/Fetch.hs
+++ b/ihp/IHP/Fetch.hs
@@ -30,10 +30,21 @@ where
 import IHP.Prelude
 import IHP.ModelSupport
 import IHP.QueryBuilder
-import IHP.QueryBuilder.Types (SQLQuery (..), QueryBuilderRead (..), QueryBuilderReadKind (..))
+import IHP.QueryBuilder.Types (QueryBuilderRead (..), QueryBuilderReadKind (..), QueryBuilderPrimaryKey)
+import IHP.QueryBuilder.Tracking (isQueryBuilderReadTrackingEnabled, trackQueryBuilderRead)
 import IHP.Hasql.FromRow (FromRowHasql(..))
 import Hasql.Implicits.Encoders (DefaultParamEncoder)
-import IHP.Fetch.Statement (buildQueryListStatement, buildQueryVectorStatement, buildQueryMaybeStatement, buildCountStatement, buildExistsStatement)
+import IHP.Fetch.Statement
+    ( buildQueryListStatement
+    , buildQueryVectorStatement
+    , buildQueryMaybeStatement
+    , buildTrackedQueryListStatement
+    , buildTrackedQueryVectorStatement
+    , buildTrackedQueryMaybeStatement
+    , buildCountStatement
+    , buildExistsStatement
+    )
+import qualified Data.Vector as Vector
 
 class Fetchable fetchable model | fetchable -> model where
     type FetchResult fetchable model
@@ -45,21 +56,36 @@ instance (model ~ GetModelByTableName table, KnownSymbol table) => Fetchable (Qu
     type instance FetchResult (QueryBuilder table) model = [model]
     fetch :: (Table model, FromRowHasql model, ?modelContext :: ModelContext) => QueryBuilder table -> IO [model]
     fetch !queryBuilder = do
-        trackQueryRead (tableName @model) QueryBuilderRead
-            { trackedSqlQuery = buildQuery queryBuilder
-            , queryBuilderReadKind = QueryBuilderRows
-            }
+        structuredTracking <- isQueryBuilderReadTrackingEnabled
         let pool = ?modelContext.hasqlPool
-        sqlStatementHasql pool () (buildQueryListStatement queryBuilder)
+        let primaryKeyColumns = primaryKeyColumnNames @model
+        if structuredTracking && not (null primaryKeyColumns)
+            then do
+                rowsWithPrimaryKeys <- sqlStatementHasql pool () (buildTrackedQueryListStatement queryBuilder)
+                let (rows, resultPrimaryKeys) = unzip rowsWithPrimaryKeys
+                trackRowsQuery @model structuredTracking queryBuilder primaryKeyColumns (Just resultPrimaryKeys)
+                pure rows
+            else do
+                rows <- sqlStatementHasql pool () (buildQueryListStatement queryBuilder)
+                trackRowsQuery @model structuredTracking queryBuilder primaryKeyColumns Nothing
+                pure rows
 
     fetchOneOrNothing :: (?modelContext :: ModelContext) => (Table model, FromRowHasql model) => QueryBuilder table -> IO (Maybe model)
     fetchOneOrNothing !queryBuilder = do
-        trackQueryRead (tableName @model) QueryBuilderRead
-            { trackedSqlQuery = (buildQuery queryBuilder) { limitClause = Just 1 }
-            , queryBuilderReadKind = QueryBuilderRows
-            }
+        structuredTracking <- isQueryBuilderReadTrackingEnabled
         let pool = ?modelContext.hasqlPool
-        sqlStatementHasql pool () (buildQueryMaybeStatement queryBuilder)
+        let primaryKeyColumns = primaryKeyColumnNames @model
+        if structuredTracking && not (null primaryKeyColumns)
+            then do
+                rowWithPrimaryKey <- sqlStatementHasql pool () (buildTrackedQueryMaybeStatement queryBuilder)
+                let row = fst <$> rowWithPrimaryKey
+                let resultPrimaryKeys = maybe [] (pure . snd) rowWithPrimaryKey
+                trackRowsQuery @model structuredTracking queryBuilder primaryKeyColumns (Just resultPrimaryKeys)
+                pure row
+            else do
+                row <- sqlStatementHasql pool () (buildQueryMaybeStatement queryBuilder)
+                trackRowsQuery @model structuredTracking queryBuilder primaryKeyColumns Nothing
+                pure row
 
     fetchOne :: (?modelContext :: ModelContext) => (Table model, FromRowHasql model) => QueryBuilder table -> IO model
     fetchOne !queryBuilder = do
@@ -83,12 +109,19 @@ instance (model ~ GetModelByTableName table, KnownSymbol table) => Fetchable (Qu
 -- >     |> fetchVector
 fetchVector :: forall model table. (Table model, model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext) => QueryBuilder table -> IO (Vector model)
 fetchVector !queryBuilder = do
-    trackQueryRead (tableName @model) QueryBuilderRead
-        { trackedSqlQuery = buildQuery queryBuilder
-        , queryBuilderReadKind = QueryBuilderRows
-        }
+    structuredTracking <- isQueryBuilderReadTrackingEnabled
     let pool = ?modelContext.hasqlPool
-    sqlStatementHasql pool () (buildQueryVectorStatement queryBuilder)
+    let primaryKeyColumns = primaryKeyColumnNames @model
+    if structuredTracking && not (null primaryKeyColumns)
+        then do
+            rowsWithPrimaryKeys <- sqlStatementHasql pool () (buildTrackedQueryVectorStatement queryBuilder)
+            let (rows, resultPrimaryKeys) = Vector.unzip rowsWithPrimaryKeys
+            trackRowsQuery @model structuredTracking queryBuilder primaryKeyColumns (Just (Vector.toList resultPrimaryKeys))
+            pure rows
+        else do
+            rows <- sqlStatementHasql pool () (buildQueryVectorStatement queryBuilder)
+            trackRowsQuery @model structuredTracking queryBuilder primaryKeyColumns Nothing
+            pure rows
 
 -- | Returns the count of records selected by the query builder.
 --
@@ -105,12 +138,16 @@ fetchVector !queryBuilder = do
 -- >     -- SELECT COUNT(*) FROM projects WHERE is_active = true
 fetchCount :: forall table. (?modelContext :: ModelContext, KnownSymbol table) => QueryBuilder table -> IO Int
 fetchCount !queryBuilder = do
-    trackQueryRead (symbolToText @table) QueryBuilderRead
+    structuredTracking <- isQueryBuilderReadTrackingEnabled
+    let pool = ?modelContext.hasqlPool
+    count <- fromIntegral <$> sqlStatementHasql pool () (buildCountStatement queryBuilder)
+    trackQueryBuilderRead (symbolToText @table) (if structuredTracking then Just QueryBuilderRead
         { trackedSqlQuery = buildQuery queryBuilder
         , queryBuilderReadKind = QueryBuilderCount
-        }
-    let pool = ?modelContext.hasqlPool
-    fromIntegral <$> sqlStatementHasql pool () (buildCountStatement queryBuilder)
+        , queryBuilderPrimaryKeyColumns = []
+        , queryBuilderResultPrimaryKeys = Nothing
+        } else Nothing)
+    pure count
 
 -- | Checks whether the query has any results.
 --
@@ -124,12 +161,31 @@ fetchCount !queryBuilder = do
 -- >     -- SELECT EXISTS (SELECT * FROM messages WHERE is_unread = true)
 fetchExists :: forall table. (?modelContext :: ModelContext, KnownSymbol table) => QueryBuilder table -> IO Bool
 fetchExists !queryBuilder = do
-    trackQueryRead (symbolToText @table) QueryBuilderRead
+    structuredTracking <- isQueryBuilderReadTrackingEnabled
+    let pool = ?modelContext.hasqlPool
+    exists <- sqlStatementHasql pool () (buildExistsStatement queryBuilder)
+    trackQueryBuilderRead (symbolToText @table) (if structuredTracking then Just QueryBuilderRead
         { trackedSqlQuery = buildQuery queryBuilder
         , queryBuilderReadKind = QueryBuilderExists
-        }
-    let pool = ?modelContext.hasqlPool
-    sqlStatementHasql pool () (buildExistsStatement queryBuilder)
+        , queryBuilderPrimaryKeyColumns = []
+        , queryBuilderResultPrimaryKeys = Nothing
+        } else Nothing)
+    pure exists
+
+trackRowsQuery :: forall model table.
+    (Table model, KnownSymbol table, ?modelContext :: ModelContext)
+    => Bool
+    -> QueryBuilder table
+    -> [Text]
+    -> Maybe [QueryBuilderPrimaryKey]
+    -> IO ()
+trackRowsQuery structuredTracking queryBuilder primaryKeyColumns resultPrimaryKeys =
+    trackQueryBuilderRead (tableName @model) (if structuredTracking then Just QueryBuilderRead
+        { trackedSqlQuery = buildQuery queryBuilder
+        , queryBuilderReadKind = QueryBuilderRows
+        , queryBuilderPrimaryKeyColumns = primaryKeyColumns
+        , queryBuilderResultPrimaryKeys = resultPrimaryKeys
+        } else Nothing)
 
 genericFetchId :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Id' table -> IO [model]
 genericFetchId !id = query @model |> filterWhereId id |> fetch

--- a/ihp/IHP/Fetch/Statement.hs
+++ b/ihp/IHP/Fetch/Statement.hs
@@ -11,6 +11,9 @@ module IHP.Fetch.Statement
 ( buildQueryListStatement
 , buildQueryVectorStatement
 , buildQueryMaybeStatement
+, buildTrackedQueryListStatement
+, buildTrackedQueryVectorStatement
+, buildTrackedQueryMaybeStatement
 , buildCountStatement
 , buildExistsStatement
 ) where
@@ -20,12 +23,16 @@ import IHP.ModelSupport (Table(..), GetModelByTableName)
 import IHP.Hasql.FromRow (FromRowHasql(..))
 import qualified Hasql.Statement as Hasql
 import qualified Hasql.Decoders as Decoders
-import IHP.QueryBuilder.Types (QueryBuilder(..), SQLQuery(..))
+import IHP.QueryBuilder.Types (QueryBuilder(..), QueryBuilderPrimaryKey (..), SQLQuery(..))
 import IHP.QueryBuilder.Compiler (buildQuery)
 import IHP.QueryBuilder.HasqlCompiler (buildStatement, buildWrappedStatement)
 import GHC.TypeLits (KnownSymbol)
 import Data.Int (Int64)
 import Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Aeson as Aeson
 
 -- | Build a statement that fetches all rows matching a query builder.
 buildQueryListStatement :: forall model table.
@@ -50,6 +57,55 @@ buildQueryMaybeStatement :: forall model table.
     ) => QueryBuilder table -> Hasql.Statement () (Maybe model)
 buildQueryMaybeStatement !queryBuilder =
     buildStatement ((buildQuery queryBuilder) { limitClause = Just 1 }) (Decoders.rowMaybe (hasqlRowDecoder @model))
+
+-- | Build a row query that also returns the canonical primary key as JSON.
+-- The original query is wrapped in a CTE, preserving its filtering, ordering,
+-- distinctness, limit and offset semantics.
+buildTrackedQueryListStatement :: forall model table.
+    ( Table model
+    , model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model
+    ) => QueryBuilder table -> Hasql.Statement () [(model, QueryBuilderPrimaryKey)]
+buildTrackedQueryListStatement !queryBuilder =
+    buildTrackedStatement @model (buildQuery queryBuilder) (Decoders.rowList trackedRowDecoder)
+
+-- | Vector variant of 'buildTrackedQueryListStatement'.
+buildTrackedQueryVectorStatement :: forall model table.
+    ( Table model
+    , model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model
+    ) => QueryBuilder table -> Hasql.Statement () (Vector (model, QueryBuilderPrimaryKey))
+buildTrackedQueryVectorStatement !queryBuilder =
+    buildTrackedStatement @model (buildQuery queryBuilder) (Decoders.rowVector trackedRowDecoder)
+
+-- | Maybe variant of 'buildTrackedQueryListStatement', adding @LIMIT 1@.
+buildTrackedQueryMaybeStatement :: forall model table.
+    ( Table model
+    , model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model
+    ) => QueryBuilder table -> Hasql.Statement () (Maybe (model, QueryBuilderPrimaryKey))
+buildTrackedQueryMaybeStatement !queryBuilder =
+    buildTrackedStatement @model ((buildQuery queryBuilder) { limitClause = Just 1 }) (Decoders.rowMaybe trackedRowDecoder)
+
+buildTrackedStatement :: forall model result.
+    (Table model, FromRowHasql model) => SQLQuery -> Decoders.Result result -> Hasql.Statement () result
+buildTrackedStatement sqlQuery decoder =
+    buildWrappedStatement
+        "WITH _ihp_tracked_query AS ("
+        sqlQuery
+        (") SELECT _ihp_tracked_query.*, jsonb_build_array("
+            <> Text.intercalate ", " (map qualifyPrimaryKeyColumn (primaryKeyColumnNames @model))
+            <> ") AS _ihp_primary_key FROM _ihp_tracked_query")
+        decoder
+
+trackedRowDecoder :: forall model. (FromRowHasql model) => Decoders.Row (model, QueryBuilderPrimaryKey)
+trackedRowDecoder = (,)
+    <$> hasqlRowDecoder @model
+    <*> (aesonPrimaryKey <$> Decoders.column (Decoders.nonNullable Decoders.jsonb))
+    where
+        aesonPrimaryKey (Aeson.Array values) = QueryBuilderPrimaryKey (Vector.toList values)
+        aesonPrimaryKey value = QueryBuilderPrimaryKey [value]
+
+qualifyPrimaryKeyColumn :: Text -> Text
+qualifyPrimaryKeyColumn columnName =
+    "_ihp_tracked_query.\"" <> Text.replace "\"" "\"\"" columnName <> "\""
 
 -- | Build a @SELECT COUNT(*)@ statement wrapping a query builder.
 buildCountStatement :: forall table.

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -918,9 +918,20 @@ instance Default Aeson.Value where
 --
 trackTableRead :: (?modelContext :: ModelContext) => Text -> IO ()
 trackTableRead tableName = case ?modelContext.trackTableReadCallback of
-    Just callback -> callback tableName
+    Just callback -> callback TrackedTableRead { trackedTableName = tableName, trackedQuery = Nothing }
     Nothing -> pure ()
 {-# INLINABLE trackTableRead #-}
+
+-- | Track a table read together with a structured query value.
+--
+-- QueryBuilder fetch functions use this to retain the query that produced a
+-- rendered result. Raw SQL should continue to call 'trackTableRead', which is
+-- intentionally treated as a conservative whole-table dependency.
+trackQueryRead :: forall query. (Typeable query, ?modelContext :: ModelContext) => Text -> query -> IO ()
+trackQueryRead tableName query = case ?modelContext.trackTableReadCallback of
+    Just callback -> callback TrackedTableRead { trackedTableName = tableName, trackedQuery = Just (toDyn query) }
+    Nothing -> pure ()
+{-# INLINABLE trackQueryRead #-}
 
 -- | Track all tables in SELECT queries executed within the given IO action.
 --
@@ -935,13 +946,17 @@ trackTableRead tableName = case ?modelContext.trackTableReadCallback of
 -- >     tables <- readIORef ?touchedTables
 -- >     -- tables = Set.fromList ["projects", "users"]
 -- >
-withTableReadTracker :: (?modelContext :: ModelContext) => ((?modelContext :: ModelContext, ?touchedTables :: IORef (Set.Set Text)) => IO a) -> IO a
+withTableReadTracker :: (?modelContext :: ModelContext) => ((?modelContext :: ModelContext, ?touchedTables :: IORef (Set.Set Text), ?trackedTableReads :: IORef [TrackedTableRead]) => IO a) -> IO a
 withTableReadTracker trackedSection = do
     touchedTablesVar <- newIORef Set.empty
-    let trackTableReadCallback = Just \tableName -> modifyIORef' touchedTablesVar (Set.insert tableName)
+    trackedTableReadsVar <- newIORef []
+    let trackTableReadCallback = Just \trackedRead -> do
+            modifyIORef' touchedTablesVar (Set.insert trackedRead.trackedTableName)
+            modifyIORef' trackedTableReadsVar (trackedRead:)
     let oldModelContext = ?modelContext
     let ?modelContext = oldModelContext { trackTableReadCallback }
     let ?touchedTables = touchedTablesVar
+    let ?trackedTableReads = trackedTableReadsVar
     trackedSection
 
 
@@ -1055,4 +1070,3 @@ withoutQueryLogging callback =
         let ?modelContext = modelContext { logger = noopLogger }
         in
             callback
-

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -72,6 +72,7 @@ import IHP.Hasql.FromRow (FromRowHasql(..), HasqlDecodeColumn(..))
 import IHP.Hasql.Encoders (ToSnippetParams(..), sqlToSnippet)
 import IHP.Hasql.Pool (usePoolWithRetry)
 import IHP.PGSimpleCompat ()
+import qualified IHP.ModelSupport.TableReadTracker as TableReadTracker
 
 -- | Provides a mock ModelContext to be used when a database connection is not available
 notConnectedModelContext :: FastLogger -> ModelContext
@@ -918,20 +919,11 @@ instance Default Aeson.Value where
 --
 trackTableRead :: (?modelContext :: ModelContext) => Text -> IO ()
 trackTableRead tableName = case ?modelContext.trackTableReadCallback of
-    Just callback -> callback TrackedTableRead { trackedTableName = tableName, trackedQuery = Nothing }
+    Just callback -> do
+        callback tableName
+        TableReadTracker.trackWholeTableRead callback tableName
     Nothing -> pure ()
 {-# INLINABLE trackTableRead #-}
-
--- | Track a table read together with a structured query value.
---
--- QueryBuilder fetch functions use this to retain the query that produced a
--- rendered result. Raw SQL should continue to call 'trackTableRead', which is
--- intentionally treated as a conservative whole-table dependency.
-trackQueryRead :: forall query. (Typeable query, ?modelContext :: ModelContext) => Text -> query -> IO ()
-trackQueryRead tableName query = case ?modelContext.trackTableReadCallback of
-    Just callback -> callback TrackedTableRead { trackedTableName = tableName, trackedQuery = Just (toDyn query) }
-    Nothing -> pure ()
-{-# INLINABLE trackQueryRead #-}
 
 -- | Track all tables in SELECT queries executed within the given IO action.
 --
@@ -946,17 +938,13 @@ trackQueryRead tableName query = case ?modelContext.trackTableReadCallback of
 -- >     tables <- readIORef ?touchedTables
 -- >     -- tables = Set.fromList ["projects", "users"]
 -- >
-withTableReadTracker :: (?modelContext :: ModelContext) => ((?modelContext :: ModelContext, ?touchedTables :: IORef (Set.Set Text), ?trackedTableReads :: IORef [TrackedTableRead]) => IO a) -> IO a
+withTableReadTracker :: (?modelContext :: ModelContext) => ((?modelContext :: ModelContext, ?touchedTables :: IORef (Set.Set Text)) => IO a) -> IO a
 withTableReadTracker trackedSection = do
     touchedTablesVar <- newIORef Set.empty
-    trackedTableReadsVar <- newIORef []
-    let trackTableReadCallback = Just \trackedRead -> do
-            modifyIORef' touchedTablesVar (Set.insert trackedRead.trackedTableName)
-            modifyIORef' trackedTableReadsVar (trackedRead:)
+    let trackTableReadCallback = Just \tableName -> modifyIORef' touchedTablesVar (Set.insert tableName)
     let oldModelContext = ?modelContext
     let ?modelContext = oldModelContext { trackTableReadCallback }
     let ?touchedTables = touchedTablesVar
-    let ?trackedTableReads = trackedTableReadsVar
     trackedSection
 
 

--- a/ihp/IHP/ModelSupport/TableReadTracker.hs
+++ b/ihp/IHP/ModelSupport/TableReadTracker.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Internal support for attaching structured metadata to the existing
+-- 'ModelContext' table-read callback without changing its public type.
+module IHP.ModelSupport.TableReadTracker
+    ( TrackedTableRead (..)
+    , withTrackedTableReadCallback
+    , hasTrackedTableReadCallback
+    , trackWholeTableRead
+    , trackStructuredTableRead
+    ) where
+
+import Prelude
+import Control.Concurrent.MVar (MVar)
+import qualified Control.Concurrent.MVar as MVar
+import qualified Control.Exception as Exception
+import Data.Dynamic (Dynamic)
+import Data.Text (Text)
+import Data.Unique (Unique, newUnique)
+import System.IO.Unsafe (unsafePerformIO)
+import System.Mem.StableName (StableName, makeStableName)
+
+type TableReadCallback = Text -> IO ()
+
+-- | A read observed through the private structured tracking channel.
+-- Unknown structured values are handled conservatively by the consumer.
+data TrackedTableRead
+    = TrackedWholeTableRead !Text
+    | TrackedStructuredTableRead !Text !Dynamic
+
+data RegisteredTracker = RegisteredTracker
+    { registrationId :: !Unique
+    , callbackName :: !(StableName TableReadCallback)
+    , handleRead :: !(TrackedTableRead -> IO ())
+    }
+
+{-# NOINLINE registeredTrackers #-}
+registeredTrackers :: MVar [RegisteredTracker]
+registeredTrackers = unsafePerformIO (MVar.newMVar [])
+
+-- | Install a structured tracker for the dynamic extent of an action.
+-- The stable name associates metadata with the unchanged public callback and
+-- continues to work when the model context is used from a child thread.
+withTrackedTableReadCallback :: TableReadCallback -> (TrackedTableRead -> IO ()) -> IO a -> IO a
+withTrackedTableReadCallback callback handleRead action =
+    Exception.bracket register unregister (const action)
+    where
+        register = do
+            registrationId <- newUnique
+            callbackName <- makeStableName callback
+            MVar.modifyMVar_ registeredTrackers \trackers ->
+                pure (RegisteredTracker { registrationId, callbackName, handleRead } : trackers)
+            pure registrationId
+
+        unregister registrationId =
+            MVar.modifyMVar_ registeredTrackers \trackers ->
+                pure (filter (\RegisteredTracker { registrationId = currentId } -> currentId /= registrationId) trackers)
+
+-- | Whether structured metadata is currently consumed for this callback.
+hasTrackedTableReadCallback :: TableReadCallback -> IO Bool
+hasTrackedTableReadCallback callback = do
+    callbackName <- makeStableName callback
+    trackers <- MVar.readMVar registeredTrackers
+    pure (any (\RegisteredTracker { callbackName = currentName } -> currentName == callbackName) trackers)
+
+trackWholeTableRead :: TableReadCallback -> Text -> IO ()
+trackWholeTableRead callback tableName =
+    dispatch callback (TrackedWholeTableRead tableName)
+
+trackStructuredTableRead :: TableReadCallback -> Text -> Dynamic -> IO ()
+trackStructuredTableRead callback tableName structuredRead =
+    dispatch callback (TrackedStructuredTableRead tableName structuredRead)
+
+dispatch :: TableReadCallback -> TrackedTableRead -> IO ()
+dispatch callback trackedRead = do
+    callbackName <- makeStableName callback
+    trackers <- MVar.readMVar registeredTrackers
+    let matchingTrackers = filter (\RegisteredTracker { callbackName = currentName } -> currentName == callbackName) trackers
+    mapM_ (\RegisteredTracker { handleRead } -> handleRead trackedRead) matchingTrackers

--- a/ihp/IHP/ModelSupport/Types.hs
+++ b/ihp/IHP/ModelSupport/Types.hs
@@ -16,7 +16,6 @@ module IHP.ModelSupport.Types
   ModelContext (..)
 , RowLevelSecurityContext (..)
 , TransactionRunner (..)
-, TrackedTableRead (..)
   -- * Type Families
 , GetModelById
 , GetTableName
@@ -91,24 +90,10 @@ data ModelContext = ModelContext
     , transactionRunner :: Maybe TransactionRunner -- ^ When set, queries are sent through this runner instead of 'HasqlPool.use' directly
     , logger :: FastLogger
     , queryLoggingEnabled :: !Bool
-    -- | A callback that is called whenever a table is accessed using a SELECT query.
-    -- QueryBuilder reads attach their structured query as a 'Dynamic'; manual
-    -- 'trackTableRead' calls leave it empty and therefore remain a conservative
-    -- whole-table dependency.
-    , trackTableReadCallback :: Maybe (TrackedTableRead -> IO ())
+    -- | A callback that is called whenever a specific table is accessed using a SELECT query
+    , trackTableReadCallback :: Maybe (Text -> IO ())
     -- | Is set to a value if row level security was enabled at runtime
     , rowLevelSecurity :: Maybe RowLevelSecurityContext
-    }
-
--- | A database read captured while rendering a controller action.
---
--- The query is kept behind 'Dynamic' so the model layer does not depend on the
--- QueryBuilder and create an import cycle. Consumers that understand a query
--- type can recover it with 'fromDynamic'; unknown query types must be treated
--- as a whole-table dependency.
-data TrackedTableRead = TrackedTableRead
-    { trackedTableName :: !Text
-    , trackedQuery :: !(Maybe Dynamic)
     }
 
 -- | When row level security is enabled at runtime, this keeps track of the current

--- a/ihp/IHP/ModelSupport/Types.hs
+++ b/ihp/IHP/ModelSupport/Types.hs
@@ -16,6 +16,7 @@ module IHP.ModelSupport.Types
   ModelContext (..)
 , RowLevelSecurityContext (..)
 , TransactionRunner (..)
+, TrackedTableRead (..)
   -- * Type Families
 , GetModelById
 , GetTableName
@@ -90,10 +91,24 @@ data ModelContext = ModelContext
     , transactionRunner :: Maybe TransactionRunner -- ^ When set, queries are sent through this runner instead of 'HasqlPool.use' directly
     , logger :: FastLogger
     , queryLoggingEnabled :: !Bool
-    -- | A callback that is called whenever a specific table is accessed using a SELECT query
-    , trackTableReadCallback :: Maybe (Text -> IO ())
+    -- | A callback that is called whenever a table is accessed using a SELECT query.
+    -- QueryBuilder reads attach their structured query as a 'Dynamic'; manual
+    -- 'trackTableRead' calls leave it empty and therefore remain a conservative
+    -- whole-table dependency.
+    , trackTableReadCallback :: Maybe (TrackedTableRead -> IO ())
     -- | Is set to a value if row level security was enabled at runtime
     , rowLevelSecurity :: Maybe RowLevelSecurityContext
+    }
+
+-- | A database read captured while rendering a controller action.
+--
+-- The query is kept behind 'Dynamic' so the model layer does not depend on the
+-- QueryBuilder and create an import cycle. Consumers that understand a query
+-- type can recover it with 'fromDynamic'; unknown query types must be treated
+-- as a whole-table dependency.
+data TrackedTableRead = TrackedTableRead
+    { trackedTableName :: !Text
+    , trackedQuery :: !(Maybe Dynamic)
     }
 
 -- | When row level security is enabled at runtime, this keeps track of the current

--- a/ihp/IHP/QueryBuilder/Tracking.hs
+++ b/ihp/IHP/QueryBuilder/Tracking.hs
@@ -1,0 +1,26 @@
+-- | Internal bridge between QueryBuilder fetches and AutoRefresh metadata.
+module IHP.QueryBuilder.Tracking
+    ( isQueryBuilderReadTrackingEnabled
+    , trackQueryBuilderRead
+    ) where
+
+import IHP.Prelude
+import Data.Dynamic (toDyn)
+import IHP.QueryBuilder.Types (QueryBuilderRead)
+import qualified IHP.ModelSupport.TableReadTracker as TableReadTracker
+
+-- | Whether the current public table-read callback has a structured consumer.
+isQueryBuilderReadTrackingEnabled :: (?modelContext :: ModelContext) => IO Bool
+isQueryBuilderReadTrackingEnabled = case ?modelContext.trackTableReadCallback of
+    Nothing -> pure False
+    Just callback -> TableReadTracker.hasTrackedTableReadCallback callback
+
+-- | Notify the unchanged public table tracker, then optionally attach the
+-- structured QueryBuilder read for AutoRefresh's private consumer.
+trackQueryBuilderRead :: (?modelContext :: ModelContext) => Text -> Maybe QueryBuilderRead -> IO ()
+trackQueryBuilderRead tableName queryBuilderRead = case ?modelContext.trackTableReadCallback of
+    Nothing -> pure ()
+    Just callback -> do
+        callback tableName
+        forM_ queryBuilderRead \read ->
+            TableReadTracker.trackStructuredTableRead callback tableName (toDyn read)

--- a/ihp/IHP/QueryBuilder/Types.hs
+++ b/ihp/IHP/QueryBuilder/Types.hs
@@ -16,6 +16,7 @@ module IHP.QueryBuilder.Types
 , MatchSensitivity (..)
 , QueryBuilderRead (..)
 , QueryBuilderReadKind (..)
+, QueryBuilderPrimaryKey (..)
   -- * Helpers
 , addCondition
 , qualifyAndJoinColumns
@@ -33,6 +34,7 @@ import qualified GHC.Generics
 import qualified Hasql.Encoders as Encoders
 import qualified Prelude
 import qualified Data.Text as Text
+import qualified Data.Aeson as Aeson
 
 -- | Represents whether string matching should be case-sensitive or not
 data MatchSensitivity = CaseSensitive | CaseInsensitive deriving (Show, Eq)
@@ -167,7 +169,26 @@ data SQLQuery = SQLQuery
 data QueryBuilderRead = QueryBuilderRead
     { trackedSqlQuery :: !SQLQuery
     , queryBuilderReadKind :: !QueryBuilderReadKind
+    -- | Canonical database column names making up the table's primary key.
+    , queryBuilderPrimaryKeyColumns :: ![Text]
+    -- | Primary keys returned by a row fetch. 'Nothing' means that this result
+    -- shape has no row identity (e.g. count/exists), or the table has no key.
+    , queryBuilderResultPrimaryKeys :: !(Maybe [QueryBuilderPrimaryKey])
     } deriving (Show)
+
+instance Eq QueryBuilderRead where
+    first == second =
+        sqlQueryEq first.trackedSqlQuery second.trackedSqlQuery
+        && first.queryBuilderReadKind == second.queryBuilderReadKind
+        && first.queryBuilderPrimaryKeyColumns == second.queryBuilderPrimaryKeyColumns
+        && first.queryBuilderResultPrimaryKeys == second.queryBuilderResultPrimaryKeys
+
+-- | A primary key as database JSON values in canonical column order.
+-- This represents scalar, custom-column, and composite primary keys without
+-- adding constraints to the public Fetchable API.
+newtype QueryBuilderPrimaryKey = QueryBuilderPrimaryKey
+    { primaryKeyValues :: [Aeson.Value]
+    } deriving (Eq, Show)
 
 -- | The result shape consumed from a tracked QueryBuilder query.
 data QueryBuilderReadKind

--- a/ihp/IHP/QueryBuilder/Types.hs
+++ b/ihp/IHP/QueryBuilder/Types.hs
@@ -14,6 +14,8 @@ module IHP.QueryBuilder.Types
 , OrderByDirection (..)
 , FilterOperator (..)
 , MatchSensitivity (..)
+, QueryBuilderRead (..)
+, QueryBuilderReadKind (..)
   -- * Helpers
 , addCondition
 , qualifyAndJoinColumns
@@ -156,6 +158,23 @@ data SQLQuery = SQLQuery
     -- Built once at query construction time so the compiler avoids re-qualifying
     -- and re-joining the column list on every compilation.
     } deriving (Show)
+
+-- | Describes how a QueryBuilder query contributed to a rendered response.
+--
+-- AutoRefresh retains this value so it can later decide whether a row change
+-- can affect the rendered result without reconstructing query semantics from
+-- rendered SQL.
+data QueryBuilderRead = QueryBuilderRead
+    { trackedSqlQuery :: !SQLQuery
+    , queryBuilderReadKind :: !QueryBuilderReadKind
+    } deriving (Show)
+
+-- | The result shape consumed from a tracked QueryBuilder query.
+data QueryBuilderReadKind
+    = QueryBuilderRows
+    | QueryBuilderCount
+    | QueryBuilderExists
+    deriving (Eq, Show)
 
 
 instance SetField "selectFrom" SQLQuery Text where setField value sqlQuery = sqlQuery { selectFrom = value }

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -13,12 +13,16 @@ import IHP.FrameworkConfig
 import IHP.ControllerPrelude hiding (get, request)
 import Network.Wai
 import Network.HTTP.Types
-import IHP.AutoRefresh (globalAutoRefreshServerVar, sessionResponseHasChanged, updateSession)
+import IHP.AutoRefresh (buildAutoRefreshReadDependencies, globalAutoRefreshServerVar, sessionResponseHasChanged, updateSession)
 import IHP.AutoRefresh.Types
 import IHP.AutoRefresh.View (autoRefreshMeta)
+import IHP.QueryBuilder.Types (QueryBuilderRead (..), QueryBuilderReadKind (..), SQLQuery (..))
 import qualified Control.Concurrent.MVar as MVar
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Dynamic (toDyn)
 import qualified IHP.PGListener as PGListener
 import System.Log.FastLogger (FastLogger)
 import IHP.Server (initMiddlewareStack)
@@ -94,6 +98,55 @@ testLogger = noopLogger
 tests :: Spec
 tests = beforeAll (mockContextNoDatabase WebApplication config) do
     describe "AutoRefresh" do
+        describe "read dependency tracking" do
+            let sqlQuery = SQLQuery
+                    { selectFrom = "tasks"
+                    , distinctClause = False
+                    , distinctOnClause = Nothing
+                    , whereCondition = Nothing
+                    , orderByClause = []
+                    , limitClause = Nothing
+                    , offsetClause = Nothing
+                    , columns = ["id"]
+                    , columnsSql = "tasks.id"
+                    }
+            let queryRead = QueryBuilderRead
+                    { trackedSqlQuery = sqlQuery
+                    , queryBuilderReadKind = QueryBuilderRows
+                    }
+            let structuredRead = TrackedTableRead
+                    { trackedTableName = "tasks"
+                    , trackedQuery = Just (toDyn queryRead)
+                    }
+            let wholeTableRead = TrackedTableRead
+                    { trackedTableName = "tasks"
+                    , trackedQuery = Nothing
+                    }
+
+            it "retains structured QueryBuilder reads" $ \_ -> do
+                let dependencies = buildAutoRefreshReadDependencies [structuredRead]
+                case Map.lookup "tasks" dependencies of
+                    Just (AutoRefreshQueryBuilderReads [trackedRead]) -> do
+                        trackedRead.trackedSqlQuery.selectFrom `shouldBe` "tasks"
+                        trackedRead.queryBuilderReadKind `shouldBe` QueryBuilderRows
+                    _ -> expectationFailure "Expected a structured QueryBuilder dependency"
+
+            it "keeps whole-table reads absorbing regardless of read order" $ \_ -> do
+                forM_ [[wholeTableRead, structuredRead], [structuredRead, wholeTableRead]] \reads ->
+                    Map.lookup "tasks" (buildAutoRefreshReadDependencies reads)
+                        `shouldSatisfy` \case
+                            Just AutoRefreshWholeTable -> True
+                            _ -> False
+
+            it "collects structured and manual reads through the model context" $ withContext do
+                withTableReadTracker do
+                    trackQueryRead "tasks" queryRead
+                    trackTableRead "users"
+
+                    readIORef ?touchedTables `shouldReturn` Set.fromList ["tasks", "users"]
+                    trackedReads <- readIORef ?trackedTableReads
+                    length trackedReads `shouldBe` 2
+
         describe "autoRefreshMeta" do
             it "renders the ihp-auto-refresh-id meta tag on the initial response" $ withContext do
                 MVar.modifyMVar_ globalAutoRefreshServerVar (\_ -> pure Nothing)
@@ -160,6 +213,7 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                             , renderView = \_ respond -> respond (Wai.responseLBS status200 [] "")
                             , event
                             , tables = mempty
+                            , readDependencies = mempty
                             , lastResponse = "resolved"
                             , lastPing = now
                             }

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -13,23 +13,57 @@ import IHP.FrameworkConfig
 import IHP.ControllerPrelude hiding (get, request)
 import Network.Wai
 import Network.HTTP.Types
-import IHP.AutoRefresh (buildAutoRefreshReadDependencies, globalAutoRefreshServerVar, sessionResponseHasChanged, updateSession)
+import IHP.AutoRefresh
+    ( addQueryBuilderReadDependency
+    , addWholeTableReadDependency
+    , commitAutoRefreshReadDependencies
+    , globalAutoRefreshServerVar
+    , sessionResponseHasChanged
+    , updateSession
+    , withAutoRefreshReadTracker
+    )
 import IHP.AutoRefresh.Types
 import IHP.AutoRefresh.View (autoRefreshMeta)
-import IHP.QueryBuilder.Types (QueryBuilderRead (..), QueryBuilderReadKind (..), SQLQuery (..))
+import IHP.QueryBuilder.Types (QueryBuilderRead (..), QueryBuilderReadKind (..), QueryBuilderPrimaryKey (..), SQLQuery (..))
+import IHP.Hasql.FromRow (FromRowHasql (..), HasqlDecodeColumn (..))
 import qualified Control.Concurrent.MVar as MVar
+import qualified Control.Exception as Exception
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Data.Dynamic (toDyn)
+import qualified Data.Aeson as Aeson
 import qualified IHP.PGListener as PGListener
+import qualified Hasql.Pool as HasqlPool
+import qualified Hasql.Session as HasqlSession
 import System.Log.FastLogger (FastLogger)
+import System.Environment (lookupEnv)
 import IHP.Server (initMiddlewareStack)
 import Network.Wai.Test (runSession, request, SResponse(..), simpleBody)
 import IHP.Test.Mocking
 import qualified Data.UUID as UUID
 import qualified Network.Wai as Wai
+
+data AutoRefreshCompositeItem = AutoRefreshCompositeItem
+    { tenantId :: UUID
+    , itemId :: Int
+    , name :: Text
+    }
+    deriving (Eq, Show)
+
+type instance GetTableName AutoRefreshCompositeItem = "auto_refresh_composite_items"
+type instance GetModelByTableName "auto_refresh_composite_items" = AutoRefreshCompositeItem
+type instance PrimaryKey "auto_refresh_composite_items" = (UUID, Int)
+
+instance Table AutoRefreshCompositeItem where
+    columnNames = ["tenant_id", "item_id", "name"]
+    primaryKeyColumnNames = ["tenant_id", "item_id"]
+
+instance FromRowHasql AutoRefreshCompositeItem where
+    hasqlRowDecoder = AutoRefreshCompositeItem
+        <$> hasqlColumnDecoder
+        <*> hasqlColumnDecoder
+        <*> hasqlColumnDecoder
 
 data WebApplication = WebApplication deriving (Eq, Show, Data)
 
@@ -95,6 +129,43 @@ callActionWithQueryParams pgListener controller queryParams = do
 testLogger :: FastLogger
 testLogger = noopLogger
 
+withAutoRefreshDB :: (ModelContext -> IO ()) -> IO ()
+withAutoRefreshDB action = do
+    envUrl <- lookupEnv "DATABASE_URL"
+    let databaseUrl = maybe "postgresql:///postgres" cs envUrl
+    modelContext <- createModelContext databaseUrl noopLogger
+    let pool = modelContext.hasqlPool
+    let setup = runHasqlScript pool
+            "DROP TABLE IF EXISTS auto_refresh_composite_items;\
+            \CREATE TABLE auto_refresh_composite_items (\
+            \tenant_id UUID NOT NULL, item_id INT NOT NULL, name TEXT NOT NULL,\
+            \PRIMARY KEY (tenant_id, item_id));\
+            \INSERT INTO auto_refresh_composite_items (tenant_id, item_id, name) VALUES\
+            \('a0000000-0000-0000-0000-000000000001', 7, 'tracked');"
+    let teardown = do
+            _ <- HasqlPool.use pool (HasqlSession.script "DROP TABLE IF EXISTS auto_refresh_composite_items;")
+            releaseModelContext modelContext
+    result <- Exception.try (setup >> action modelContext `Exception.finally` teardown)
+    case result of
+        Right () -> pure ()
+        Left (HasqlError (HasqlPool.ConnectionUsageError _)) ->
+            pendingWith "PostgreSQL not available (set DATABASE_URL or start a local Postgres)"
+        Left exception -> Exception.throwIO exception
+
+runHasqlScript :: HasqlPool.Pool -> Text -> IO ()
+runHasqlScript pool sql = do
+    result <- HasqlPool.use pool (HasqlSession.script sql)
+    case result of
+        Left error -> Exception.throwIO (HasqlError error)
+        Right () -> pure ()
+
+getOnlyAutoRefreshSession :: IORef AutoRefreshServer -> IO AutoRefreshSession
+getOnlyAutoRefreshSession serverRef = do
+    server <- readIORef serverRef
+    case server.sessions of
+        session:_ -> pure session
+        [] -> error "Expected AutoRefresh session"
+
 tests :: Spec
 tests = beforeAll (mockContextNoDatabase WebApplication config) do
     describe "AutoRefresh" do
@@ -113,39 +184,74 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
             let queryRead = QueryBuilderRead
                     { trackedSqlQuery = sqlQuery
                     , queryBuilderReadKind = QueryBuilderRows
-                    }
-            let structuredRead = TrackedTableRead
-                    { trackedTableName = "tasks"
-                    , trackedQuery = Just (toDyn queryRead)
-                    }
-            let wholeTableRead = TrackedTableRead
-                    { trackedTableName = "tasks"
-                    , trackedQuery = Nothing
+                    , queryBuilderPrimaryKeyColumns = ["id"]
+                    , queryBuilderResultPrimaryKeys = Just [QueryBuilderPrimaryKey [Aeson.String "task-1"]]
                     }
 
             it "retains structured QueryBuilder reads" $ \_ -> do
-                let dependencies = buildAutoRefreshReadDependencies [structuredRead]
+                let dependencies = addQueryBuilderReadDependency "tasks" queryRead Map.empty
                 case Map.lookup "tasks" dependencies of
                     Just (AutoRefreshQueryBuilderReads [trackedRead]) -> do
                         trackedRead.trackedSqlQuery.selectFrom `shouldBe` "tasks"
                         trackedRead.queryBuilderReadKind `shouldBe` QueryBuilderRows
+                        trackedRead.queryBuilderPrimaryKeyColumns `shouldBe` ["id"]
+                        trackedRead.queryBuilderResultPrimaryKeys
+                            `shouldBe` Just [QueryBuilderPrimaryKey [Aeson.String "task-1"]]
                     _ -> expectationFailure "Expected a structured QueryBuilder dependency"
 
             it "keeps whole-table reads absorbing regardless of read order" $ \_ -> do
-                forM_ [[wholeTableRead, structuredRead], [structuredRead, wholeTableRead]] \reads ->
-                    Map.lookup "tasks" (buildAutoRefreshReadDependencies reads)
+                let structuredThenWhole =
+                        addWholeTableReadDependency "tasks" (addQueryBuilderReadDependency "tasks" queryRead Map.empty)
+                let wholeThenStructured =
+                        addQueryBuilderReadDependency "tasks" queryRead (addWholeTableReadDependency "tasks" Map.empty)
+                forM_ [structuredThenWhole, wholeThenStructured] \dependencies ->
+                    Map.lookup "tasks" dependencies
                         `shouldSatisfy` \case
                             Just AutoRefreshWholeTable -> True
                             _ -> False
 
-            it "collects structured and manual reads through the model context" $ withContext do
+            it "keeps the existing withTableReadTracker API and manual reads conservative" $ withContext do
                 withTableReadTracker do
-                    trackQueryRead "tasks" queryRead
                     trackTableRead "users"
+                    readIORef ?touchedTables `shouldReturn` Set.singleton "users"
 
-                    readIORef ?touchedTables `shouldReturn` Set.fromList ["tasks", "users"]
-                    trackedReads <- readIORef ?trackedTableReads
-                    length trackedReads `shouldBe` 2
+                withAutoRefreshReadTracker do
+                    trackTableRead "users"
+                    readIORef ?touchedTables `shouldReturn` Set.singleton "users"
+                    dependencies <- readIORef ?autoRefreshReadDependencies
+                    Map.lookup "users" dependencies `shouldSatisfy` \case
+                        Just AutoRefreshWholeTable -> True
+                        _ -> False
+
+            it "falls back to constant-size tracking after too many queries" $ \_ -> do
+                let dependencies = foldl' (\current _ -> addQueryBuilderReadDependency "tasks" queryRead current) Map.empty [1..65 :: Int]
+                Map.lookup "tasks" dependencies `shouldSatisfy` \case
+                    Just AutoRefreshWholeTable -> True
+                    _ -> False
+
+            it "captures canonical composite keys through a real fetch" $ \_ ->
+                withAutoRefreshDB \modelContext -> do
+                    let ?modelContext = modelContext
+                    withAutoRefreshReadTracker do
+                        items <- query @AutoRefreshCompositeItem |> fetch
+                        items `shouldBe` [AutoRefreshCompositeItem
+                            { tenantId = "a0000000-0000-0000-0000-000000000001"
+                            , itemId = 7
+                            , name = "tracked"
+                            }]
+
+                        dependencies <- readIORef ?autoRefreshReadDependencies
+                        case Map.lookup "auto_refresh_composite_items" dependencies of
+                            Just (AutoRefreshQueryBuilderReads [trackedRead]) -> do
+                                trackedRead.queryBuilderReadKind `shouldBe` QueryBuilderRows
+                                trackedRead.queryBuilderPrimaryKeyColumns `shouldBe` ["tenant_id", "item_id"]
+                                trackedRead.queryBuilderResultPrimaryKeys `shouldBe` Just
+                                    [ QueryBuilderPrimaryKey
+                                        [ Aeson.String "a0000000-0000-0000-0000-000000000001"
+                                        , Aeson.Number 7
+                                        ]
+                                    ]
+                            _ -> expectationFailure "Expected one tracked composite-key fetch"
 
         describe "autoRefreshMeta" do
             it "renders the ihp-auto-refresh-id meta tag on the initial response" $ withContext do
@@ -213,7 +319,6 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                             , renderView = \_ respond -> respond (Wai.responseLBS status200 [] "")
                             , event
                             , tables = mempty
-                            , readDependencies = mempty
                             , lastResponse = "resolved"
                             , lastPing = now
                             }
@@ -230,3 +335,40 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
 
                 sessionResponseHasChanged serverRef UUID.nil "resolved" `shouldReturn` True
                 sessionResponseHasChanged serverRef UUID.nil "unresolved" `shouldReturn` False
+
+            it "publishes rerender dependencies only after registration succeeds" $ withContext do
+                event <- MVar.newEmptyMVar
+                now <- getCurrentTime
+                let oldDependencies = Map.singleton "old_table" AutoRefreshWholeTable
+                let newDependencies = Map.singleton "new_table" AutoRefreshWholeTable
+                let session = TrackedAutoRefreshSession
+                        { id = UUID.nil
+                        , renderView = \_ respond -> respond (Wai.responseLBS status200 [] "")
+                        , event
+                        , tables = Map.keysSet oldDependencies
+                        , readDependencies = oldDependencies
+                        , lastResponse = "old"
+                        , lastPing = now
+                        }
+                serverRef <- newIORef AutoRefreshServer
+                    { subscriptions = []
+                    , sessions = [session]
+                    , subscribedTables = mempty
+                    , pgListener = error "pgListener unused in dependency commit test"
+                    }
+
+                failed <- Exception.try @SomeException $
+                    commitAutoRefreshReadDependencies
+                        (Exception.throwIO (userError "subscription failed"))
+                        serverRef
+                        UUID.nil
+                        newDependencies
+                failed `shouldSatisfy` \case
+                    Left _ -> True
+                    Right _ -> False
+                getAutoRefreshReadDependencies <$> getOnlyAutoRefreshSession serverRef
+                    `shouldReturn` oldDependencies
+
+                commitAutoRefreshReadDependencies (pure ()) serverRef UUID.nil newDependencies
+                getAutoRefreshReadDependencies <$> getOnlyAutoRefreshSession serverRef
+                    `shouldReturn` newDependencies

--- a/ihp/ihp.cabal
+++ b/ihp/ihp.cabal
@@ -289,6 +289,8 @@ library
     autogen-modules: Paths_ihp
     other-modules:
         Paths_ihp
+        IHP.ModelSupport.TableReadTracker
+        IHP.QueryBuilder.Tracking
 
 source-repository head
     type:     git


### PR DESCRIPTION
## Summary

- retain structured reads from the normal IHP QueryBuilder instead of reducing every fetch to a table name
- capture canonical primary-key values returned by row fetches, including custom and composite keys
- distinguish row, count, and exists reads while keeping manual/raw SQL reads conservative
- preserve the existing `ModelContext.trackTableReadCallback` and `withTableReadTracker` APIs through an internal metadata bridge
- bound retained queries and result keys, falling back to whole-table dependencies when a safe bound or row identity is unavailable
- register notification triggers before publishing a rerender's dependency snapshot, with retry-safe and atomic session updates

## Why

This is a QueryBuilder-focused foundation for improving the approach discussed in #2305.

AutoRefresh currently records only a `Set Text` of table names. That is not enough to determine whether an INSERT, UPDATE, or DELETE can affect an action's rendered result. The previous smart-filtering prototype extracted row IDs and WHERE conditions into separate maps, which lost query semantics such as ordering, limits, offsets, counts, and existence checks.

This change retains the compiled `SQLQuery` and the canonical keys actually returned by row queries. It does not change notification filtering yet; current table-level refresh behavior remains in place while the data needed for safe relevance checks is introduced.

## Impact

The public `autoRefresh do ...`, `ModelContext.trackTableReadCallback`, and `withTableReadTracker` APIs remain unchanged. The original `AutoRefreshSession` constructor also remains available for compatibility.

Normal QueryBuilder fetches are tracked automatically. Outside AutoRefresh they continue to use the existing statements. Inside AutoRefresh, row queries are wrapped in a CTE that preserves their filtering, ordering, distinctness, limit, and offset while also returning primary-key values as JSON.

Manual `trackTableRead` calls, tables without usable primary keys, oversized result sets, and unknown structured reads remain conservative whole-table dependencies. Tracking retains at most 64 queries per table and 1024 returned keys per query.

Trigger registration is serialized and only committed to server state after both trigger installation and PGListener subscription succeed. A failed rerender registration leaves the previous dependency snapshot intact, and development rerenders reinstall idempotent trigger SQL after `make db` recreates the database.

## Follow-up work

- reuse or extract DataSync's row-notification infrastructure
- implement conservative relevance checks from the tracked `SQLQuery` and returned keys
- keep complex or unsupported queries on the whole-table fallback
- add end-to-end PostgreSQL notification relevance coverage

## Validation

- loaded the changed modules with GHC 9.10.3 and `-Werror=unused-imports`
- ran the complete IHP GHCi suite: 577 examples, 0 failures (26 database-dependent examples pending)
- ran the focused AutoRefresh suite against an isolated PostgreSQL instance: 10 examples, 0 failures
- ran the Nix package check phase with PostgreSQL: 577 examples, 0 failures, including the composite-primary-key fetch
- `git diff --check`
