### PR TITLE
Optimize AutoRefresh with parameter-aware query tracking

### DIFF
--- a/Guide/auto-refresh.markdown
+++ b/Guide/auto-refresh.markdown
@@ -56,6 +56,8 @@ When the page is rendered a small JavaScript function will connect back to the I
 
 Whenever an `INSERT`, `UPDATE` or `DELETE` happens to the tables used by your action IHP will rerun your action on the server-side. When the generated HTML looks different than the HTML generated on the initial page load it will send the new HTML to the browser using the WebSocket connection. The JavaScript listening on the WebSocket will use the new HTML to update the current page. It uses morphdom to only touch the parts of your current DOM that have changed.
 
+For QueryBuilder queries, Auto Refresh also tracks the primary keys returned by each query and retains the prepared query together with its bound parameters. When the table uses the conventional single-column `id` key, updates and deletes to unrelated rows can therefore be ignored. For inserts, and for updates that might make a row newly match, IHP reuses the captured parameterized query to check only the changed row before re-rendering. Custom and composite primary keys are retained for future relevance checks but currently use the conservative table-level refresh fallback. The captured query snapshot is replaced after every re-render.
+
 
 ### Using Auto Refresh
 
@@ -78,6 +80,37 @@ action ShowProjectAction { projectId } = autoRefresh do
 That's it. When you open your browser dev tools, you will see that a WebSocket connection has been started when opening the page. When we update the project from a different browser tab, we will see that the page instantly updates to reflect our changes.
 
 ## Advanced Auto Refresh
+
+### Notification Batching
+
+By default Auto Refresh does not add a batching delay. Each PostgreSQL
+notification is checked as soon as its listener worker can run, which preserves
+the real-time behaviour expected by latency-sensitive pages.
+
+For write-heavy applications with many connected users, you can opt into a
+short batching window in `Config/Config.hs`:
+
+```haskell
+config :: ConfigBuilder
+config = do
+    option (AutoRefreshBatchWindow 100)
+```
+
+The value is in milliseconds. During that window IHP accumulates changed row
+IDs per table, then performs one relevance check per connected session for the
+whole batch. Continuous writes use consecutive windows, so changes arriving
+while a batch is being processed are not lost.
+
+Set the value to `0` to disable the intentional delay:
+
+```haskell
+option (AutoRefreshBatchWindow 0)
+```
+
+The default is `0`. You can also set the same option through the
+`IHP_AUTO_REFRESH_BATCH_WINDOW_MS` environment variable. A positive window is
+useful for high-fan-out dashboards; leave it at zero when minimum update latency
+matters more than limiting the maximum relevance-check rate.
 
 ### Auto Refresh Only for Specific Tables
 
@@ -124,3 +157,25 @@ action StatsAction = autoRefresh do
 ```
 
 The [`trackTableRead`](https://ihp.digitallyinduced.com/api-docs/IHP-ModelSupport.html#v:trackTableRead) marks the table as accessed for Auto Refresh and leads to the table being watched.
+
+Manually tracked raw SQL uses the safe table-level fallback, because IHP only knows the table name in that case.
+
+### Typed SQL Queries with Auto Refresh
+
+Queries executed with `sqlQueryTyped [typedSql| ... |]` are tracked automatically. Typed SQL retains the query's bound parameters, so Auto Refresh can apply the same changed-row check as QueryBuilder when the query result directly exposes the table's conventional single-column `id` key:
+
+```haskell
+action ProjectTasksAction { projectId } = autoRefresh do
+    tasks <- sqlQueryTyped [typedSql|
+        SELECT id, title
+        FROM tasks
+        WHERE project_id = ${projectId}
+        ORDER BY created_at
+    |]
+
+    render TasksView { .. }
+```
+
+If the result does not expose the primary key, or the query reads a table with a composite/non-standard primary key, Auto Refresh still watches the detected table but falls back to refreshing for every change to that table.
+
+The fine-grained path is intended for direct, row-local queries like the example above. Query shapes where one row can change the output of another row (for example `OFFSET`, window functions, correlated subqueries or aggregates) need conservative table-level tracking. Until Typed SQL emits explicit safety metadata for these shapes, call `trackTableRead "tasks"` in the same `autoRefresh` action to force that fallback.

--- a/Guide/config.markdown
+++ b/Guide/config.markdown
@@ -716,6 +716,25 @@ config = do
     option (DataSyncMaxTransactionsPerConnection 20)
 ```
 
+### Auto Refresh
+
+Controls how long Auto Refresh accumulates PostgreSQL notifications before
+running relevance checks. The value is in milliseconds. The default of `0`
+adds no intentional delay; a positive value batches changes to reduce database
+work for write-heavy tables with many connected sessions.
+
+| | |
+|---|---|
+| **Type** | `AutoRefreshBatchWindow` |
+| **Default** | `0` |
+| **Env var** | `IHP_AUTO_REFRESH_BATCH_WINDOW_MS` |
+
+```haskell
+-- Config.hs
+config = do
+    option (AutoRefreshBatchWindow 100)
+```
+
 ### Row-Level Security
 
 Controls the PostgreSQL role used for queries with Row Level Security enabled.
@@ -783,6 +802,7 @@ These environment variables are read by IHP's server infrastructure and cannot b
 | `IHP_RLS_AUTHENTICATED_ROLE` | `ihp_authenticated` | Security |
 | `IHP_DATASYNC_MAX_SUBSCRIPTIONS_PER_CONNECTION` | `128` | DataSync |
 | `IHP_DATASYNC_MAX_TRANSACTIONS_PER_CONNECTION` | `10` | DataSync |
+| `IHP_AUTO_REFRESH_BATCH_WINDOW_MS` | `0` | AutoRefresh |
 | `IHP_SYSTEMD` | `False` | Deployment |
 | `IHP_STATIC` | Built-in | Static Files |
 | `APP_STATIC` | `static/` | Static Files |

--- a/ihp-typed-sql/IHP/TypedSql.hs
+++ b/ihp-typed-sql/IHP/TypedSql.hs
@@ -24,9 +24,13 @@ module IHP.TypedSql
 import qualified Hasql.Decoders                  as HasqlDecoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
 import qualified Hasql.Pipeline                  as HasqlPipeline
-import           IHP.ModelSupport                (sqlExecHasql, sqlExecHasqlCount, sqlQueryHasql)
+import           IHP.ModelSupport                (isTableReadTrackingEnabled, sqlExecHasql, sqlExecHasqlCount, sqlQueryHasql, trackTableReadWithQuery)
 import           IHP.Prelude
 import           GHC.TypeLits                    (ErrorMessage (Text), TypeError)
+import qualified Data.List                       as List
+import qualified Data.Set                        as Set
+import qualified Data.Text                       as Text
+import           IHP.QueryBuilder.HasqlHelpers   (quoteIdentifier)
 
 import           IHP.TypedSql.Quoter                 (typedSql, typedSqlStar)
 import           IHP.TypedSql.Types                  (QueryCardinality (..), QueryExecResult (..), SqlExecTypedResult,
@@ -34,15 +38,30 @@ import           IHP.TypedSql.Types                  (QueryCardinality (..), Que
 
 class DecodeTypedQuery (cardinality :: QueryCardinality) where
     typedQueryResultDecoder :: Proxy cardinality -> HasqlDecoders.Row result -> HasqlDecoders.Result (TypedQueryResult cardinality result)
+    typedQueryResultWithIdsDecoder :: Proxy cardinality -> HasqlDecoders.Row result -> HasqlDecoders.Result (TypedQueryResult cardinality result, [Text])
 
 instance DecodeTypedQuery 'ManyRows where
     typedQueryResultDecoder _ = HasqlDecoders.rowList
+    typedQueryResultWithIdsDecoder _ rowDecoder =
+        unzip <$> HasqlDecoders.rowList ((,) <$> rowDecoder <*> textColumn)
 
 instance DecodeTypedQuery 'AtMostOneRow where
     typedQueryResultDecoder _ = HasqlDecoders.rowMaybe
+    typedQueryResultWithIdsDecoder _ rowDecoder =
+        toResult <$> HasqlDecoders.rowMaybe ((,) <$> rowDecoder <*> textColumn)
+      where
+        toResult Nothing = (Nothing, [])
+        toResult (Just (row, rowId)) = (Just row, [rowId])
 
 instance DecodeTypedQuery 'ExactlyOneRow where
     typedQueryResultDecoder _ = HasqlDecoders.singleRow
+    typedQueryResultWithIdsDecoder _ rowDecoder =
+        toResult <$> HasqlDecoders.singleRow ((,) <$> rowDecoder <*> textColumn)
+      where
+        toResult (row, rowId) = (row, [rowId])
+
+textColumn :: HasqlDecoders.Row Text
+textColumn = HasqlDecoders.column (HasqlDecoders.nonNullable HasqlDecoders.text)
 
 -- | Run a typed SELECT query.
 --
@@ -58,8 +77,19 @@ instance DecodeTypedQuery 'ExactlyOneRow where
 -- > users <- sqlQueryTyped [typedSql| SELECT name FROM users |] -- IO [Text]
 -- > total <- sqlQueryTyped [typedSql| SELECT count(*) FROM users |] -- IO Int64
 sqlQueryTyped :: forall cardinality result. (?modelContext :: ModelContext, DecodeTypedQuery cardinality) => TypedQuery cardinality 'ReturnsRows result -> IO (TypedQueryResult cardinality result)
-sqlQueryTyped TypedQuery { tqSnippet, tqResultDecoder } =
-    runTypedSqlSession tqSnippet (typedQueryResultDecoder (Proxy :: Proxy cardinality) tqResultDecoder)
+sqlQueryTyped TypedQuery { tqSnippet, tqResultDecoder, tqAutoRefreshTables, tqAutoRefreshRowMatchingSafe } = do
+    structuredTracking <- isTableReadTrackingEnabled
+    case (structuredTracking, tqAutoRefreshRowMatchingSafe, firstTrackableTable tqAutoRefreshTables) of
+      (True, True, Just (trackedTable, idColumn)) -> do
+        let trackedSnippet = appendTrackedId tqSnippet idColumn
+        (result, rowIds) <- runTypedSqlSession trackedSnippet (typedQueryResultWithIdsDecoder (Proxy :: Proxy cardinality) tqResultDecoder)
+        trackTypedSqlQuery tqSnippet tqAutoRefreshTables (Just (trackedTable, idColumn, Set.fromList rowIds))
+        pure result
+      _ -> do
+        result <- runTypedSqlSession tqSnippet (typedQueryResultDecoder (Proxy :: Proxy cardinality) tqResultDecoder)
+        when structuredTracking $
+            trackTypedSqlQuery tqSnippet tqAutoRefreshTables Nothing
+        pure result
 
 -- | Run a typed query that can return many rows.
 --
@@ -151,3 +181,52 @@ sqlExecTyped TypedQuery { tqSnippet } =
 runTypedSqlSession :: (?modelContext :: ModelContext) => Snippet.Snippet -> HasqlDecoders.Result result -> IO result
 runTypedSqlSession snippet decoder =
     sqlQueryHasql ?modelContext.hasqlPool snippet decoder
+
+-- | Find the one result column that can identify rows for a physical table.
+firstTrackableTable :: [(Text, Maybe Text)] -> Maybe (Text, Text)
+firstTrackableTable [] = Nothing
+firstTrackableTable ((tableName, Just idColumn):_) = Just (tableName, idColumn)
+firstTrackableTable (_:tables) = firstTrackableTable tables
+
+-- | Append a textual row ID while preserving the original result columns.
+appendTrackedId :: Snippet.Snippet -> Text -> Snippet.Snippet
+appendTrackedId snippet idColumn =
+    Snippet.sql "SELECT _ihp_auto_refresh_record.*, _ihp_auto_refresh_record."
+    <> quoteIdentifier idColumn
+    <> Snippet.sql "::text FROM ("
+    <> snippet
+    <> Snippet.sql ") AS _ihp_auto_refresh_record"
+
+-- | Register Typed SQL reads with AutoRefresh.
+--
+-- The matcher closes over 'tqSnippet', so every bound parameter remains encoded
+-- exactly as it was for the original query. The captured model context retains
+-- RLS identity but deliberately drops an active transaction runner and tracker.
+trackTypedSqlQuery :: (?modelContext :: ModelContext) => Snippet.Snippet -> [(Text, Maybe Text)] -> Maybe (Text, Text, Set.Set Text) -> IO ()
+trackTypedSqlQuery snippet tables tracked = do
+    let capturedModelContext = ?modelContext
+            { transactionRunner = Nothing
+            , trackTableReadCallback = Nothing
+            }
+    forM_ tables \(tableName, maybeIdColumn) ->
+        case (tracked, maybeIdColumn) of
+            (Just (trackedTable, idColumn, rowIds), Just _)
+                | tableName == trackedTable -> do
+                    let matchesIds changedIds =
+                            let matchSnippet =
+                                    Snippet.sql "SELECT EXISTS (SELECT 1 FROM ("
+                                    <> snippet
+                                    <> Snippet.sql ") AS _ihp_auto_refresh_records WHERE _ihp_auto_refresh_records."
+                                    <> quoteIdentifier idColumn
+                                    <> Snippet.sql " = ANY (ARRAY(SELECT (jsonb_populate_record(NULL::"
+                                    <> quoteIdentifierPath tableName
+                                    <> Snippet.sql ", jsonb_build_object('id', _ihp_changed_id))).id FROM unnest("
+                                    <> Snippet.param (Set.toList changedIds)
+                                    <> Snippet.sql "::text[]) AS _ihp_changed_id)))"
+                            in let ?modelContext = capturedModelContext
+                               in sqlQueryHasql capturedModelContext.hasqlPool matchSnippet (HasqlDecoders.singleRow (HasqlDecoders.column (HasqlDecoders.nonNullable HasqlDecoders.bool)))
+                    trackTableReadWithQuery tableName (Just rowIds) (Just matchesIds)
+            _ -> trackTableReadWithQuery tableName Nothing Nothing
+
+quoteIdentifierPath :: Text -> Snippet.Snippet
+quoteIdentifierPath = mconcat . List.intersperse (Snippet.sql ".") . map quoteIdentifier . Text.splitOn "."

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -3,6 +3,7 @@ module IHP.TypedSql.ParamHints
     , extractParamHints
     , extractJoinNullableTables
     , parseSql
+    , sqlCodeOnly
     , extractParamHintsFromAst
     , extractJoinNullableTablesFromAst
     , extractReadTableNamesFromAst
@@ -13,6 +14,7 @@ module IHP.TypedSql.ParamHints
     ) where
 
 import           Data.Foldable                (foldMap, toList)
+import qualified Data.Char                    as Char
 import qualified Data.List                   as List
 import qualified Data.Map.Strict             as Map
 import qualified Data.Set                    as Set
@@ -40,13 +42,81 @@ data ParamHint = ParamHint
     deriving (Eq, Show)
 
 -- | Parse SQL into an AST. Returns Nothing if parsing fails.
--- Note: postgresql-syntax does not tolerate leading/trailing whitespace,
--- so we strip it before parsing.
+--
+-- @postgresql-syntax@ expects comments to have already been consumed by its
+-- lexer. Typed SQL accepts ordinary PostgreSQL comments, so remove them while
+-- preserving quoted strings, quoted identifiers and dollar-quoted bodies.
 parseSql :: String -> Maybe Ast.PreparableStmt
 parseSql sql =
-    case Parsing.run Parsing.preparableStmt (Text.strip (Text.pack sql)) of
+    case Parsing.run Parsing.preparableStmt (Text.strip (stripSqlComments (Text.pack sql))) of
         Left _err -> Nothing
         Right stmt -> Just stmt
+
+-- | Keep only executable SQL text, replacing comments and quoted values with
+-- whitespace. This is used by conservative keyword checks: a word such as
+-- @select@ inside a string or comment must not change query classification.
+sqlCodeOnly :: String -> String
+sqlCodeOnly = scanSql False
+
+stripSqlComments :: Text -> Text
+stripSqlComments = Text.pack . scanSql True . Text.unpack
+
+-- | A small PostgreSQL-aware scanner shared by parsing and keyword checks.
+-- Block comments can nest in PostgreSQL, and dollar quotes can use arbitrary
+-- tags, so a simple regular expression is not sufficient here.
+scanSql :: Bool -> String -> String
+scanSql keepQuoted = normal
+  where
+    quoted character = if keepQuoted then character else ' '
+    quotedText value = if keepQuoted then value else replicate (length value) ' '
+
+    normal [] = []
+    normal ('-':'-':rest) = ' ' : ' ' : lineComment rest
+    normal ('/':'*':rest) = ' ' : ' ' : blockComment 1 rest
+    normal ('E':'\'':rest) = 'E' : quoted '\'' : singleQuoted True rest
+    normal ('e':'\'':rest) = 'e' : quoted '\'' : singleQuoted True rest
+    normal ('\'':rest) = quoted '\'' : singleQuoted False rest
+    normal ('"':rest) = quoted '"' : doubleQuoted rest
+    normal input@('$':_) = case dollarDelimiter input of
+        Just (delimiter, rest) -> quotedText delimiter <> dollarQuoted delimiter rest
+        Nothing -> '$' : normal (drop 1 input)
+    normal (character:rest) = character : normal rest
+
+    lineComment [] = []
+    lineComment ('\n':rest) = '\n' : normal rest
+    lineComment (_:rest) = ' ' : lineComment rest
+
+    blockComment _ [] = []
+    blockComment depth ('/':'*':rest) = ' ' : ' ' : blockComment (depth + 1) rest
+    blockComment 1 ('*':'/':rest) = ' ' : ' ' : normal rest
+    blockComment depth ('*':'/':rest) = ' ' : ' ' : blockComment (depth - 1) rest
+    blockComment depth ('\n':rest) = '\n' : blockComment depth rest
+    blockComment depth (_:rest) = ' ' : blockComment depth rest
+
+    singleQuoted _ [] = []
+    singleQuoted escape ('\'':'\'':rest) = quoted '\'' : quoted '\'' : singleQuoted escape rest
+    singleQuoted True ('\\':character:rest) = quoted '\\' : quoted character : singleQuoted True rest
+    singleQuoted _ ('\'':rest) = quoted '\'' : normal rest
+    singleQuoted escape (character:rest) = quoted character : singleQuoted escape rest
+
+    doubleQuoted [] = []
+    doubleQuoted ('"':'"':rest) = quoted '"' : quoted '"' : doubleQuoted rest
+    doubleQuoted ('"':rest) = quoted '"' : normal rest
+    doubleQuoted (character:rest) = quoted character : doubleQuoted rest
+
+    dollarQuoted _ [] = []
+    dollarQuoted delimiter input
+        | delimiter `List.isPrefixOf` input =
+            quotedText delimiter <> normal (drop (length delimiter) input)
+    dollarQuoted delimiter ('\n':rest) = '\n' : dollarQuoted delimiter rest
+    dollarQuoted delimiter (character:rest) = quoted character : dollarQuoted delimiter rest
+
+    dollarDelimiter ('$':rest) =
+        let (tag, suffix) = span (\character -> Char.isAlphaNum character || character == '_') rest
+        in case suffix of
+            '$':after -> Just ('$' : tag <> "$", after)
+            _ -> Nothing
+    dollarDelimiter _ = Nothing
 
 -- | Extract parameter hints by parsing SQL and walking the AST.
 -- Falls back to empty map if parsing fails.
@@ -88,14 +158,17 @@ extractReadTableNamesFromAst statement = case statement of
 
 readTableNamesFromSelectStmt :: Set.Set Text -> Ast.SelectStmt -> Set.Set Text
 readTableNamesFromSelectStmt inheritedCtes = \case
-    Left (Ast.SelectNoParens maybeWith selectClause _sort _limit _lock) ->
+    Left (Ast.SelectNoParens maybeWith selectClause maybeSort maybeLimit _lock) ->
         let ctes = case maybeWith of
                 Just (Ast.WithClause _recursive values) -> toList values
                 Nothing -> []
             cteNames = Set.fromList (map cteName ctes)
             visibleCtes = inheritedCtes <> cteNames
             cteTables = foldMap (readTableNamesFromCte visibleCtes) ctes
-        in cteTables <> readTableNamesFromSelectClause visibleCtes selectClause
+        in cteTables
+            <> readTableNamesFromSelectClause visibleCtes selectClause
+            <> maybe Set.empty (readTableNamesFromSortClause visibleCtes) maybeSort
+            <> maybe Set.empty (readTableNamesFromSelectLimit visibleCtes) maybeLimit
     Right selectWithParens -> readTableNamesFromSelectWithParens inheritedCtes selectWithParens
 
 readTableNamesFromCte :: Set.Set Text -> Ast.CommonTableExpr -> Set.Set Text
@@ -120,8 +193,13 @@ readTableNamesFromSelectClause visibleCtes = \case
 
 readTableNamesFromSimpleSelect :: Set.Set Text -> Ast.SimpleSelect -> Set.Set Text
 readTableNamesFromSimpleSelect visibleCtes = \case
-    Ast.NormalSimpleSelect _targeting _into maybeFrom _where _group _having _window ->
-        maybe Set.empty (foldMap (readTableNamesFromTableRef visibleCtes) . toList) maybeFrom
+    Ast.NormalSimpleSelect targeting _into maybeFrom maybeWhere maybeGroup maybeHaving maybeWindow ->
+        maybe Set.empty (readTableNamesFromTargeting visibleCtes) targeting
+        <> maybe Set.empty (foldMap (readTableNamesFromTableRef visibleCtes) . toList) maybeFrom
+        <> maybe Set.empty (readTableNamesFromAExpr visibleCtes) maybeWhere
+        <> maybe Set.empty (foldMap (readTableNamesFromGroupByItem visibleCtes) . toList) maybeGroup
+        <> maybe Set.empty (readTableNamesFromAExpr visibleCtes) maybeHaving
+        <> maybe Set.empty (foldMap (readTableNamesFromWindowDefinition visibleCtes) . toList) maybeWindow
     Ast.BinSimpleSelect _op left _distinct right ->
         readTableNamesFromSelectClause visibleCtes left <> readTableNamesFromSelectClause visibleCtes right
     Ast.TableSimpleSelect relation ->
@@ -136,13 +214,251 @@ readTableNamesFromTableRef visibleCtes = \case
         in if tableName `Set.member` visibleCtes then Set.empty else Set.singleton tableName
     Ast.JoinTableRef joinedTable _alias -> readTableNamesFromJoinedTable visibleCtes joinedTable
     Ast.SelectTableRef _lateral subquery _alias -> readTableNamesFromSelectWithParens visibleCtes subquery
-    Ast.FuncTableRef _lateral _function _alias -> Set.empty
+    Ast.FuncTableRef _lateral function _alias -> readTableNamesFromFuncTable visibleCtes function
 
 readTableNamesFromJoinedTable :: Set.Set Text -> Ast.JoinedTable -> Set.Set Text
 readTableNamesFromJoinedTable visibleCtes = \case
     Ast.InParensJoinedTable inner -> readTableNamesFromJoinedTable visibleCtes inner
-    Ast.MethJoinedTable _method left right ->
-        readTableNamesFromTableRef visibleCtes left <> readTableNamesFromTableRef visibleCtes right
+    Ast.MethJoinedTable method left right ->
+        readTableNamesFromTableRef visibleCtes left
+        <> readTableNamesFromTableRef visibleCtes right
+        <> readTableNamesFromJoinMeth visibleCtes method
+
+readTableNamesFromTargeting :: Set.Set Text -> Ast.Targeting -> Set.Set Text
+readTableNamesFromTargeting visibleCtes = \case
+    Ast.NormalTargeting targets -> foldMap (readTableNamesFromTargetEl visibleCtes) targets
+    Ast.AllTargeting maybeTargets -> maybe Set.empty (foldMap (readTableNamesFromTargetEl visibleCtes)) maybeTargets
+    Ast.DistinctTargeting maybeExpressions targets ->
+        maybe Set.empty (foldMap (readTableNamesFromAExpr visibleCtes)) maybeExpressions
+        <> foldMap (readTableNamesFromTargetEl visibleCtes) targets
+
+readTableNamesFromTargetEl :: Set.Set Text -> Ast.TargetEl -> Set.Set Text
+readTableNamesFromTargetEl visibleCtes = \case
+    Ast.AliasedExprTargetEl expression _alias -> readTableNamesFromAExpr visibleCtes expression
+    Ast.ImplicitlyAliasedExprTargetEl expression _alias -> readTableNamesFromAExpr visibleCtes expression
+    Ast.ExprTargetEl expression -> readTableNamesFromAExpr visibleCtes expression
+    Ast.AsteriskTargetEl -> Set.empty
+
+readTableNamesFromAExpr :: Set.Set Text -> Ast.AExpr -> Set.Set Text
+readTableNamesFromAExpr visibleCtes = \case
+    Ast.CExprAExpr expression -> readTableNamesFromCExpr visibleCtes expression
+    Ast.TypecastAExpr expression _typeName -> recurse expression
+    Ast.CollateAExpr expression _collation -> recurse expression
+    Ast.AtTimeZoneAExpr left right -> recurse left <> recurse right
+    Ast.PlusAExpr expression -> recurse expression
+    Ast.MinusAExpr expression -> recurse expression
+    Ast.SymbolicBinOpAExpr left _operator right -> recurse left <> recurse right
+    Ast.PrefixQualOpAExpr _operator expression -> recurse expression
+    Ast.SuffixQualOpAExpr expression _operator -> recurse expression
+    Ast.AndAExpr left right -> recurse left <> recurse right
+    Ast.OrAExpr left right -> recurse left <> recurse right
+    Ast.NotAExpr expression -> recurse expression
+    Ast.VerbalExprBinOpAExpr left _not _operator right maybeEscape ->
+        recurse left <> recurse right <> maybe Set.empty recurse maybeEscape
+    Ast.ReversableOpAExpr expression _not operator ->
+        recurse expression <> readTableNamesFromReversableOp visibleCtes operator
+    Ast.IsnullAExpr expression -> recurse expression
+    Ast.NotnullAExpr expression -> recurse expression
+    Ast.OverlapsAExpr left right -> readTableNamesFromRow visibleCtes left <> readTableNamesFromRow visibleCtes right
+    Ast.SubqueryAExpr expression _operator _subType subquery ->
+        recurse expression <> either (readTableNamesFromSelectWithParens visibleCtes) recurse subquery
+    Ast.UniqueAExpr subquery -> readTableNamesFromSelectWithParens visibleCtes subquery
+    Ast.DefaultAExpr -> Set.empty
+  where
+    recurse = readTableNamesFromAExpr visibleCtes
+
+readTableNamesFromCExpr :: Set.Set Text -> Ast.CExpr -> Set.Set Text
+readTableNamesFromCExpr visibleCtes = \case
+    Ast.ColumnrefCExpr _ -> Set.empty
+    Ast.AexprConstCExpr _ -> Set.empty
+    Ast.ParamCExpr _ _ -> Set.empty
+    Ast.InParensCExpr expression _ -> readTableNamesFromAExpr visibleCtes expression
+    Ast.CaseCExpr expression -> readTableNamesFromCaseExpr visibleCtes expression
+    Ast.FuncCExpr expression -> readTableNamesFromFuncExpr visibleCtes expression
+    Ast.SelectWithParensCExpr subquery _ -> readTableNamesFromSelectWithParens visibleCtes subquery
+    Ast.ExistsCExpr subquery -> readTableNamesFromSelectWithParens visibleCtes subquery
+    Ast.ArrayCExpr value -> either (readTableNamesFromSelectWithParens visibleCtes) (readTableNamesFromArrayExpr visibleCtes) value
+    Ast.ExplicitRowCExpr maybeExpressions -> maybe Set.empty (foldMap (readTableNamesFromAExpr visibleCtes)) maybeExpressions
+    Ast.ImplicitRowCExpr (Ast.ImplicitRow expressions lastExpression) ->
+        foldMap (readTableNamesFromAExpr visibleCtes) expressions
+        <> readTableNamesFromAExpr visibleCtes lastExpression
+    Ast.GroupingCExpr expressions -> foldMap (readTableNamesFromAExpr visibleCtes) expressions
+
+readTableNamesFromFuncExpr :: Set.Set Text -> Ast.FuncExpr -> Set.Set Text
+readTableNamesFromFuncExpr visibleCtes = \case
+    Ast.ApplicationFuncExpr (Ast.FuncApplication _name maybeParams) maybeWithinGroup maybeFilter maybeOver ->
+        maybe Set.empty (readTableNamesFromFuncParams visibleCtes) maybeParams
+        <> maybe Set.empty (readTableNamesFromSortClause visibleCtes) maybeWithinGroup
+        <> maybe Set.empty (readTableNamesFromAExpr visibleCtes) maybeFilter
+        <> maybe Set.empty (readTableNamesFromOverClause visibleCtes) maybeOver
+    Ast.SubexprFuncExpr subexpr -> readTableNamesFromFuncSubexpr visibleCtes subexpr
+
+readTableNamesFromFuncTable :: Set.Set Text -> Ast.FuncTable -> Set.Set Text
+readTableNamesFromFuncTable visibleCtes = \case
+    Ast.FuncExprFuncTable expression _ordinality -> readWindowless expression
+    Ast.RowsFromFuncTable rows _ordinality -> foldMap (\(Ast.RowsfromItem expression _columns) -> readWindowless expression) rows
+  where
+    readWindowless (Ast.ApplicationFuncExprWindowless (Ast.FuncApplication _name maybeParams)) =
+        maybe Set.empty (readTableNamesFromFuncParams visibleCtes) maybeParams
+    readWindowless (Ast.CommonSubexprFuncExprWindowless subexpr) =
+        readTableNamesFromFuncSubexpr visibleCtes subexpr
+
+readTableNamesFromFuncParams :: Set.Set Text -> Ast.FuncApplicationParams -> Set.Set Text
+readTableNamesFromFuncParams visibleCtes = \case
+    Ast.NormalFuncApplicationParams _distinct expressions maybeSort ->
+        foldMap (readTableNamesFromFuncArgExpr visibleCtes) expressions
+        <> maybe Set.empty (readTableNamesFromSortClause visibleCtes) maybeSort
+    Ast.VariadicFuncApplicationParams maybeExpressions lastExpression maybeSort ->
+        maybe Set.empty (foldMap (readTableNamesFromFuncArgExpr visibleCtes)) maybeExpressions
+        <> readTableNamesFromFuncArgExpr visibleCtes lastExpression
+        <> maybe Set.empty (readTableNamesFromSortClause visibleCtes) maybeSort
+    Ast.StarFuncApplicationParams -> Set.empty
+
+readTableNamesFromFuncArgExpr :: Set.Set Text -> Ast.FuncArgExpr -> Set.Set Text
+readTableNamesFromFuncArgExpr visibleCtes = \case
+    Ast.ExprFuncArgExpr expression -> recurse expression
+    Ast.ColonEqualsFuncArgExpr _name expression -> recurse expression
+    Ast.EqualsGreaterFuncArgExpr _name expression -> recurse expression
+  where
+    recurse = readTableNamesFromAExpr visibleCtes
+
+readTableNamesFromFuncSubexpr :: Set.Set Text -> Ast.FuncExprCommonSubexpr -> Set.Set Text
+readTableNamesFromFuncSubexpr visibleCtes = \case
+    Ast.CollationForFuncExprCommonSubexpr expression -> recurse expression
+    Ast.CastFuncExprCommonSubexpr expression _ -> recurse expression
+    Ast.TreatFuncExprCommonSubexpr expression _ -> recurse expression
+    Ast.NullIfFuncExprCommonSubexpr left right -> recurse left <> recurse right
+    Ast.CoalesceFuncExprCommonSubexpr expressions -> foldMap recurse expressions
+    Ast.GreatestFuncExprCommonSubexpr expressions -> foldMap recurse expressions
+    Ast.LeastFuncExprCommonSubexpr expressions -> foldMap recurse expressions
+    Ast.ExtractFuncExprCommonSubexpr maybeList -> maybe Set.empty (\(Ast.ExtractList _ expression) -> recurse expression) maybeList
+    Ast.OverlayFuncExprCommonSubexpr (Ast.OverlayList source placing from maybeFor) ->
+        recurse source <> recurse placing <> recurse from <> maybe Set.empty recurse maybeFor
+    Ast.PositionFuncExprCommonSubexpr maybeList ->
+        maybe Set.empty (\(Ast.PositionList left right) -> recurseB left <> recurseB right) maybeList
+    Ast.SubstringFuncExprCommonSubexpr maybeList -> maybe Set.empty readSubstring maybeList
+    Ast.TrimFuncExprCommonSubexpr _modifier trimList -> readTrim trimList
+    _ -> Set.empty
+  where
+    recurse = readTableNamesFromAExpr visibleCtes
+    recurseB = readTableNamesFromBExpr visibleCtes
+    readSubstring (Ast.ExprSubstrList expression fromFor) = recurse expression <> readFromFor fromFor
+    readSubstring (Ast.ExprListSubstrList expressions) = foldMap recurse expressions
+    readFromFor (Ast.FromForSubstrListFromFor from for) = recurse from <> recurse for
+    readFromFor (Ast.ForFromSubstrListFromFor for from) = recurse for <> recurse from
+    readFromFor (Ast.FromSubstrListFromFor from) = recurse from
+    readFromFor (Ast.ForSubstrListFromFor for) = recurse for
+    readTrim (Ast.ExprFromExprListTrimList expression expressions) = recurse expression <> foldMap recurse expressions
+    readTrim (Ast.FromExprListTrimList expressions) = foldMap recurse expressions
+    readTrim (Ast.ExprListTrimList expressions) = foldMap recurse expressions
+
+readTableNamesFromCaseExpr :: Set.Set Text -> Ast.CaseExpr -> Set.Set Text
+readTableNamesFromCaseExpr visibleCtes (Ast.CaseExpr maybeArg whenClauses maybeDefault) =
+    maybe Set.empty recurse maybeArg
+    <> foldMap (\(Ast.WhenClause condition result) -> recurse condition <> recurse result) whenClauses
+    <> maybe Set.empty recurse maybeDefault
+  where
+    recurse = readTableNamesFromAExpr visibleCtes
+
+readTableNamesFromArrayExpr :: Set.Set Text -> Ast.ArrayExpr -> Set.Set Text
+readTableNamesFromArrayExpr visibleCtes = \case
+    Ast.ExprListArrayExpr expressions -> foldMap (readTableNamesFromAExpr visibleCtes) expressions
+    Ast.ArrayExprListArrayExpr arrays -> foldMap (readTableNamesFromArrayExpr visibleCtes) arrays
+    Ast.EmptyArrayExpr -> Set.empty
+
+readTableNamesFromRow :: Set.Set Text -> Ast.Row -> Set.Set Text
+readTableNamesFromRow visibleCtes = \case
+    Ast.ExplicitRowRow maybeExpressions -> maybe Set.empty (foldMap (readTableNamesFromAExpr visibleCtes)) maybeExpressions
+    Ast.ImplicitRowRow (Ast.ImplicitRow expressions lastExpression) ->
+        foldMap (readTableNamesFromAExpr visibleCtes) expressions
+        <> readTableNamesFromAExpr visibleCtes lastExpression
+
+readTableNamesFromReversableOp :: Set.Set Text -> Ast.AExprReversableOp -> Set.Set Text
+readTableNamesFromReversableOp visibleCtes = \case
+    Ast.DistinctFromAExprReversableOp expression -> recurse expression
+    Ast.BetweenAExprReversableOp _not lower upper -> readTableNamesFromBExpr visibleCtes lower <> recurse upper
+    Ast.BetweenSymmetricAExprReversableOp lower upper -> readTableNamesFromBExpr visibleCtes lower <> recurse upper
+    Ast.InAExprReversableOp (Ast.SelectInExpr subquery) -> readTableNamesFromSelectWithParens visibleCtes subquery
+    Ast.InAExprReversableOp (Ast.ExprListInExpr expressions) -> foldMap recurse expressions
+    _ -> Set.empty
+  where
+    recurse = readTableNamesFromAExpr visibleCtes
+
+readTableNamesFromBExpr :: Set.Set Text -> Ast.BExpr -> Set.Set Text
+readTableNamesFromBExpr visibleCtes = \case
+    Ast.CExprBExpr expression -> readTableNamesFromCExpr visibleCtes expression
+    Ast.TypecastBExpr expression _ -> recurse expression
+    Ast.PlusBExpr expression -> recurse expression
+    Ast.MinusBExpr expression -> recurse expression
+    Ast.SymbolicBinOpBExpr left _ right -> recurse left <> recurse right
+    Ast.QualOpBExpr _ expression -> recurse expression
+    Ast.IsOpBExpr expression _ _ -> recurse expression
+  where
+    recurse = readTableNamesFromBExpr visibleCtes
+
+readTableNamesFromJoinMeth :: Set.Set Text -> Ast.JoinMeth -> Set.Set Text
+readTableNamesFromJoinMeth visibleCtes = \case
+    Ast.QualJoinMeth _ (Ast.OnJoinQual expression) -> readTableNamesFromAExpr visibleCtes expression
+    _ -> Set.empty
+
+readTableNamesFromGroupByItem :: Set.Set Text -> Ast.GroupByItem -> Set.Set Text
+readTableNamesFromGroupByItem visibleCtes = \case
+    Ast.ExprGroupByItem expression -> recurse expression
+    Ast.RollupGroupByItem expressions -> foldMap recurse expressions
+    Ast.CubeGroupByItem expressions -> foldMap recurse expressions
+    Ast.GroupingSetsGroupByItem groups -> foldMap (readTableNamesFromGroupByItem visibleCtes) groups
+    Ast.EmptyGroupingSetGroupByItem -> Set.empty
+  where
+    recurse = readTableNamesFromAExpr visibleCtes
+
+readTableNamesFromSortClause :: Set.Set Text -> Ast.SortClause -> Set.Set Text
+readTableNamesFromSortClause visibleCtes = foldMap \case
+    Ast.UsingSortBy expression _ _ -> readTableNamesFromAExpr visibleCtes expression
+    Ast.AscDescSortBy expression _ _ -> readTableNamesFromAExpr visibleCtes expression
+
+readTableNamesFromWindowDefinition :: Set.Set Text -> Ast.WindowDefinition -> Set.Set Text
+readTableNamesFromWindowDefinition visibleCtes (Ast.WindowDefinition _name specification) =
+    readTableNamesFromWindowSpecification visibleCtes specification
+
+readTableNamesFromOverClause :: Set.Set Text -> Ast.OverClause -> Set.Set Text
+readTableNamesFromOverClause visibleCtes = \case
+    Ast.WindowOverClause specification -> readTableNamesFromWindowSpecification visibleCtes specification
+    Ast.ColIdOverClause _ -> Set.empty
+
+readTableNamesFromWindowSpecification :: Set.Set Text -> Ast.WindowSpecification -> Set.Set Text
+readTableNamesFromWindowSpecification visibleCtes (Ast.WindowSpecification _existing maybePartition maybeSort maybeFrame) =
+    maybe Set.empty (foldMap (readTableNamesFromAExpr visibleCtes)) maybePartition
+    <> maybe Set.empty (readTableNamesFromSortClause visibleCtes) maybeSort
+    <> maybe Set.empty (readTableNamesFromFrameClause visibleCtes) maybeFrame
+
+readTableNamesFromFrameClause :: Set.Set Text -> Ast.FrameClause -> Set.Set Text
+readTableNamesFromFrameClause visibleCtes (Ast.FrameClause _mode extent _exclusion) = case extent of
+    Ast.SingularFrameExtent bound -> readTableNamesFromFrameBound visibleCtes bound
+    Ast.BetweenFrameExtent lower upper ->
+        readTableNamesFromFrameBound visibleCtes lower <> readTableNamesFromFrameBound visibleCtes upper
+
+readTableNamesFromFrameBound :: Set.Set Text -> Ast.FrameBound -> Set.Set Text
+readTableNamesFromFrameBound visibleCtes = \case
+    Ast.PrecedingFrameBound expression -> readTableNamesFromAExpr visibleCtes expression
+    Ast.FollowingFrameBound expression -> readTableNamesFromAExpr visibleCtes expression
+    _ -> Set.empty
+
+readTableNamesFromSelectLimit :: Set.Set Text -> Ast.SelectLimit -> Set.Set Text
+readTableNamesFromSelectLimit visibleCtes = \case
+    Ast.LimitOffsetSelectLimit limitClause offsetClause -> readLimit limitClause <> readOffset offsetClause
+    Ast.OffsetLimitSelectLimit offsetClause limitClause -> readOffset offsetClause <> readLimit limitClause
+    Ast.LimitSelectLimit limitClause -> readLimit limitClause
+    Ast.OffsetSelectLimit offsetClause -> readOffset offsetClause
+  where
+    readLimit (Ast.LimitLimitClause value maybeExpression) =
+        readLimitValue value <> maybe Set.empty (readTableNamesFromAExpr visibleCtes) maybeExpression
+    readLimit (Ast.FetchOnlyLimitClause _ maybeValue _) = maybe Set.empty readFetchValue maybeValue
+    readLimitValue (Ast.ExprSelectLimitValue expression) = readTableNamesFromAExpr visibleCtes expression
+    readLimitValue Ast.AllSelectLimitValue = Set.empty
+    readOffset (Ast.ExprOffsetClause expression) = readTableNamesFromAExpr visibleCtes expression
+    readOffset (Ast.FetchFirstOffsetClause value _) = readFetchValue value
+    readFetchValue (Ast.ExprSelectFetchFirstValue expression) = readTableNamesFromCExpr visibleCtes expression
+    readFetchValue (Ast.NumSelectFetchFirstValue _ _) = Set.empty
 
 nullableTablesFromStmt :: Ast.PreparableStmt -> Set.Set Text
 nullableTablesFromStmt = \case

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -5,6 +5,7 @@ module IHP.TypedSql.ParamHints
     , parseSql
     , extractParamHintsFromAst
     , extractJoinNullableTablesFromAst
+    , extractReadTableNamesFromAst
     , extractNonNullableComputedColumnsFromAst
     , resolveParamHintTypes
     , detectStarSelects
@@ -75,6 +76,73 @@ extractJoinNullableTables sql =
 -- | Extract nullable tables from an already-parsed AST.
 extractJoinNullableTablesFromAst :: Ast.PreparableStmt -> Set.Set Text
 extractJoinNullableTablesFromAst = nullableTablesFromStmt
+
+-- | Extract the physical tables read by a SELECT statement.
+--
+-- DML statements deliberately return an empty set: a statement with RETURNING
+-- rows is not a table read for AutoRefresh purposes.
+extractReadTableNamesFromAst :: Ast.PreparableStmt -> Set.Set Text
+extractReadTableNamesFromAst statement = case statement of
+    Ast.SelectPreparableStmt selectStmt -> readTableNamesFromSelectStmt Set.empty selectStmt
+    _ -> Set.empty
+
+readTableNamesFromSelectStmt :: Set.Set Text -> Ast.SelectStmt -> Set.Set Text
+readTableNamesFromSelectStmt inheritedCtes = \case
+    Left (Ast.SelectNoParens maybeWith selectClause _sort _limit _lock) ->
+        let ctes = case maybeWith of
+                Just (Ast.WithClause _recursive values) -> toList values
+                Nothing -> []
+            cteNames = Set.fromList (map cteName ctes)
+            visibleCtes = inheritedCtes <> cteNames
+            cteTables = foldMap (readTableNamesFromCte visibleCtes) ctes
+        in cteTables <> readTableNamesFromSelectClause visibleCtes selectClause
+    Right selectWithParens -> readTableNamesFromSelectWithParens inheritedCtes selectWithParens
+
+readTableNamesFromCte :: Set.Set Text -> Ast.CommonTableExpr -> Set.Set Text
+readTableNamesFromCte visibleCtes (Ast.CommonTableExpr _name _cols _mat statement) =
+    case statement of
+        Ast.SelectPreparableStmt selectStmt -> readTableNamesFromSelectStmt visibleCtes selectStmt
+        _ -> Set.empty
+
+cteName :: Ast.CommonTableExpr -> Text
+cteName (Ast.CommonTableExpr name _cols _mat _statement) = identToText name
+
+readTableNamesFromSelectWithParens :: Set.Set Text -> Ast.SelectWithParens -> Set.Set Text
+readTableNamesFromSelectWithParens visibleCtes = \case
+    Ast.NoParensSelectWithParens selectNoParens ->
+        readTableNamesFromSelectStmt visibleCtes (Left selectNoParens)
+    Ast.WithParensSelectWithParens inner -> readTableNamesFromSelectWithParens visibleCtes inner
+
+readTableNamesFromSelectClause :: Set.Set Text -> Ast.SelectClause -> Set.Set Text
+readTableNamesFromSelectClause visibleCtes = \case
+    Left simpleSelect -> readTableNamesFromSimpleSelect visibleCtes simpleSelect
+    Right selectWithParens -> readTableNamesFromSelectWithParens visibleCtes selectWithParens
+
+readTableNamesFromSimpleSelect :: Set.Set Text -> Ast.SimpleSelect -> Set.Set Text
+readTableNamesFromSimpleSelect visibleCtes = \case
+    Ast.NormalSimpleSelect _targeting _into maybeFrom _where _group _having _window ->
+        maybe Set.empty (foldMap (readTableNamesFromTableRef visibleCtes) . toList) maybeFrom
+    Ast.BinSimpleSelect _op left _distinct right ->
+        readTableNamesFromSelectClause visibleCtes left <> readTableNamesFromSelectClause visibleCtes right
+    Ast.TableSimpleSelect relation ->
+        let tableName = relationExprName relation
+        in if tableName `Set.member` visibleCtes then Set.empty else Set.singleton tableName
+    Ast.ValuesSimpleSelect _ -> Set.empty
+
+readTableNamesFromTableRef :: Set.Set Text -> Ast.TableRef -> Set.Set Text
+readTableNamesFromTableRef visibleCtes = \case
+    Ast.RelationExprTableRef relation _alias _sample ->
+        let tableName = relationExprName relation
+        in if tableName `Set.member` visibleCtes then Set.empty else Set.singleton tableName
+    Ast.JoinTableRef joinedTable _alias -> readTableNamesFromJoinedTable visibleCtes joinedTable
+    Ast.SelectTableRef _lateral subquery _alias -> readTableNamesFromSelectWithParens visibleCtes subquery
+    Ast.FuncTableRef _lateral _function _alias -> Set.empty
+
+readTableNamesFromJoinedTable :: Set.Set Text -> Ast.JoinedTable -> Set.Set Text
+readTableNamesFromJoinedTable visibleCtes = \case
+    Ast.InParensJoinedTable inner -> readTableNamesFromJoinedTable visibleCtes inner
+    Ast.MethJoinedTable _method left right ->
+        readTableNamesFromTableRef visibleCtes left <> readTableNamesFromTableRef visibleCtes right
 
 nullableTablesFromStmt :: Ast.PreparableStmt -> Set.Set Text
 nullableTablesFromStmt = \case

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -9,9 +9,11 @@ module IHP.TypedSql.Quoter
     ) where
 
 import qualified Control.Exception              as Exception
+import           Control.Monad                  (guard)
 import           Data.Coerce                    (coerce)
 import qualified Data.Char                      as Char
 import qualified Data.List                      as List
+import qualified Data.List.NonEmpty             as NonEmpty
 import qualified Data.Map.Strict                as Map
 import qualified Data.Set                       as Set
 import qualified Data.String.Conversions        as CS
@@ -29,12 +31,12 @@ import           IHP.Hasql.Encoders              ()
 import           IHP.TypedSql.Cardinality      (inferCardinality)
 import           IHP.TypedSql.CompileTimeDatabase (dependentSchemaFiles)
 import           IHP.TypedSql.Decoders          (resultDecoderForColumns)
-import           IHP.TypedSql.Metadata          (DescribeColumn (..), DescribeResult (..), PgTypeInfo (..), TableMeta (..),
+import           IHP.TypedSql.Metadata          (ColumnMeta (..), DescribeColumn (..), DescribeResult (..), PgTypeInfo (..), TableMeta (..),
                                                  describeStatement)
 import           IHP.TypedSql.ParamHints        (extractParamHintsFromAst, extractJoinNullableTablesFromAst,
                                                  extractNonNullableComputedColumnsFromAst,
                                                  parseSql, resolveParamHintTypes, detectStarSelects,
-                                                 detectInsertWithoutColumns)
+                                                 detectInsertWithoutColumns, extractReadTableNamesFromAst)
 import           IHP.TypedSql.ParamEncoder      (typedSqlParam)
 import           IHP.TypedSql.Placeholders      (PlaceholderPlan (..), parseExpr,
                                                  planPlaceholders)
@@ -147,6 +149,33 @@ typedSqlExp allowStar rawSql = do
     let nonNullableColumns = maybe Set.empty extractNonNullableComputedColumnsFromAst parsedAst
     let queryCardinality = maybe ManyRows (inferCardinality drTables) parsedAst
     let queryExecResult = inferExecResult parsedAst (CS.cs ppDescribeSql) drColumns
+    let readTableNames = maybe Set.empty extractReadTableNamesFromAst parsedAst
+    let autoRefreshRowMatchingSafe = maybe False (isAutoRefreshRowMatchingSafe ppDescribeSql) parsedAst
+    let outputNameCounts =
+            drColumns
+                |> map (\DescribeColumn { dcName } -> (CS.cs dcName :: Text, 1 :: Int))
+                |> Map.fromListWith (+)
+    let primaryKeyOutputs =
+            drColumns
+                |> mapMaybe (\DescribeColumn { dcName, dcTable, dcAttnum } -> do
+                    attnum <- dcAttnum
+                    TableMeta { tmName, tmColumns, tmPrimaryKeys } <- Map.lookup dcTable drTables
+                    ColumnMeta { cmName } <- Map.lookup attnum tmColumns
+                    guard (Set.size tmPrimaryKeys == 1 && attnum `Set.member` tmPrimaryKeys)
+                    guard (cmName == "id")
+                    let outputName = CS.cs dcName :: Text
+                    guard (Map.findWithDefault 0 outputName outputNameCounts == 1)
+                    pure (tmName, outputName))
+                |> map (\(tableName, columnName) -> (tableName, [columnName]))
+                |> Map.fromListWith (<>)
+    let autoRefreshTables =
+            readTableNames
+                |> Set.toList
+                |> map (\tableName ->
+                    let idColumn = case Map.lookup tableName primaryKeyOutputs of
+                            Just [columnName] -> Just columnName
+                            _ -> Nothing
+                    in (tableName, idColumn))
 
     let isCompositeColumn =
             case drColumns of
@@ -181,13 +210,20 @@ typedSqlExp allowStar rawSql = do
                 pure (rt, decoder)
 
     snippetExpr <- buildSnippetExpression ppRuntimeSql paramSnippets
+    let autoRefreshTablesExpr = TH.ListE (map autoRefreshTableExp autoRefreshTables)
     let typedQueryExpr =
             TH.AppE
                 (TH.AppE
-                    (TH.ConE 'TypedQuery)
-                    snippetExpr
+                    (TH.AppE
+                        (TH.AppE
+                            (TH.ConE 'TypedQuery)
+                            snippetExpr
+                        )
+                        resultDecoder
+                    )
+                    autoRefreshTablesExpr
                 )
-                resultDecoder
+                (if autoRefreshRowMatchingSafe then TH.ConE 'True else TH.ConE 'False)
 
     pure
         ( TH.SigE
@@ -200,6 +236,55 @@ typedSqlExp allowStar rawSql = do
                 resultType
             )
         )
+
+autoRefreshTableExp :: (Text, Maybe Text) -> TH.Exp
+autoRefreshTableExp (tableName, maybeIdColumn) =
+    TH.TupE
+        [ Just (textExp tableName)
+        , Just case maybeIdColumn of
+            Nothing -> TH.ConE 'Nothing
+            Just idColumn -> TH.AppE (TH.ConE 'Just) (textExp idColumn)
+        ]
+  where
+    textExp value = TH.AppE (TH.VarE 'Text.pack) (TH.LitE (TH.StringL (CS.cs value)))
+
+-- | Fine-grained changed-row matching is only sound when one physical row
+-- cannot change the output associated with another row. Unknown and complex
+-- SELECT shapes deliberately fall back to table-level tracking.
+isAutoRefreshRowMatchingSafe :: String -> Ast.PreparableStmt -> Bool
+isAutoRefreshRowMatchingSafe sql = \case
+    Ast.SelectPreparableStmt
+        (Left (Ast.SelectNoParens
+            Nothing
+            (Left (Ast.NormalSimpleSelect _targeting Nothing (Just fromClause) _where Nothing Nothing Nothing))
+            _sort
+            maybeLimit
+            _lock)) ->
+                hasOneDirectTable fromClause
+                && not (maybe False selectLimitHasOffset maybeLimit)
+                && countKeyword "select" sql == 1
+                && countKeyword "over" sql == 0
+                && countKeyword "table" sql == 0
+    _ -> False
+  where
+    hasOneDirectTable fromClause = case NonEmpty.toList fromClause of
+        [Ast.RelationExprTableRef _relation _alias Nothing] -> True
+        _ -> False
+
+selectLimitHasOffset :: Ast.SelectLimit -> Bool
+selectLimitHasOffset = \case
+    Ast.LimitOffsetSelectLimit _ _ -> True
+    Ast.OffsetLimitSelectLimit _ _ -> True
+    Ast.OffsetSelectLimit _ -> True
+    Ast.LimitSelectLimit _ -> False
+
+countKeyword :: String -> String -> Int
+countKeyword keyword sql =
+    length (filter (== keyword) (Prelude.words (map normalize sql)))
+  where
+    normalize character
+        | Char.isAlphaNum character || character == '_' = Char.toLower character
+        | otherwise = ' '
 
 cardinalityType :: QueryCardinality -> TH.Type
 cardinalityType = \case

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -36,7 +36,8 @@ import           IHP.TypedSql.Metadata          (ColumnMeta (..), DescribeColumn
 import           IHP.TypedSql.ParamHints        (extractParamHintsFromAst, extractJoinNullableTablesFromAst,
                                                  extractNonNullableComputedColumnsFromAst,
                                                  parseSql, resolveParamHintTypes, detectStarSelects,
-                                                 detectInsertWithoutColumns, extractReadTableNamesFromAst)
+                                                 detectInsertWithoutColumns, extractReadTableNamesFromAst,
+                                                 sqlCodeOnly)
 import           IHP.TypedSql.ParamEncoder      (typedSqlParam)
 import           IHP.TypedSql.Placeholders      (PlaceholderPlan (..), parseExpr,
                                                  planPlaceholders)
@@ -262,11 +263,12 @@ isAutoRefreshRowMatchingSafe sql = \case
             _lock)) ->
                 hasOneDirectTable fromClause
                 && not (maybe False selectLimitHasOffset maybeLimit)
-                && countKeyword "select" sql == 1
-                && countKeyword "over" sql == 0
-                && countKeyword "table" sql == 0
+                && countKeyword "select" codeOnlySql == 1
+                && countKeyword "over" codeOnlySql == 0
+                && countKeyword "table" codeOnlySql == 0
     _ -> False
   where
+    codeOnlySql = sqlCodeOnly sql
     hasOneDirectTable fromClause = case NonEmpty.toList fromClause of
         [Ast.RelationExprTableRef _relation _alias Nothing] -> True
         _ -> False

--- a/ihp-typed-sql/IHP/TypedSql/Types.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Types.hs
@@ -11,7 +11,8 @@ import           Data.Kind                       (Type)
 import           GHC.TypeLits                    (ErrorMessage (Text), TypeError)
 import qualified Hasql.Decoders                as HasqlDecoders
 import qualified Hasql.DynamicStatements.Snippet as Snippet
-import           Prelude                         (Eq, Maybe, Show)
+import           Prelude                         (Bool, Eq, Maybe, Show)
+import           Data.Text                       (Text)
 
 -- | What the SQL parser can prove about how many rows a query returns.
 data QueryCardinality
@@ -49,4 +50,11 @@ type family SqlExecTypedResult (execResult :: QueryExecResult) :: Type where
 data TypedQuery (cardinality :: QueryCardinality) (execResult :: QueryExecResult) result = TypedQuery
     { tqSnippet       :: !Snippet.Snippet
     , tqResultDecoder :: !(HasqlDecoders.Row result)
+    -- | Tables read by the query and, when exposed by the result, the output
+    -- column containing that table's conventional single-column @id@ key.
+    -- AutoRefresh uses this runtime metadata to retain the parameterized query.
+    , tqAutoRefreshTables :: ![(Text, Maybe Text)]
+    -- | Whether the parser proved that each output row depends only on the
+    -- corresponding physical row. Complex shapes fall back to table tracking.
+    , tqAutoRefreshRowMatchingSafe :: !Bool
     }

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -13,7 +13,8 @@ import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullabl
                                                     extractNonNullableComputedColumnsFromAst,
                                                     extractReadTableNamesFromAst,
                                                     detectStarSelects,
-                                                    detectInsertWithoutColumns)
+                                                    detectInsertWithoutColumns,
+                                                    sqlCodeOnly)
 import           System.Directory                  (createDirectoryIfMissing,
                                                     doesFileExist,
                                                     findExecutable,
@@ -373,6 +374,17 @@ tests = do
         it "parseSql handles leading/trailing whitespace from quasiquoter" do
             parseSql " SELECT 1 " `shouldSatisfy` isJust
 
+        it "parseSql handles SQL comments without stripping comment markers from literals" do
+            parseSql "-- leading comment\nSELECT 'not -- a comment', $$not /* a comment */$$ /* trailing comment */" `shouldSatisfy` isJust
+
+        it "parseSql handles nested block comments" do
+            parseSql "/* outer /* nested */ comment */ SELECT 1" `shouldSatisfy` isJust
+
+        it "parseSql distinguishes standard and escape string backslashes" do
+            parseSql "SELECT 'trailing\\' /* comment */" `shouldSatisfy` isJust
+            Text.pack (sqlCodeOnly "SELECT E'escaped\\' hidden -- still in the string'")
+                `shouldNotSatisfy` Text.isInfixOf "hidden"
+
         it "extractJoinNullableTables detects LEFT JOIN nullable table" do
             let sql = " SELECT i.name, a.name FROM items i LEFT JOIN authors a ON a.id = i.aid LIMIT 1 "
             extractJoinNullableTables sql `shouldBe` Set.fromList ["authors"]
@@ -402,6 +414,12 @@ tests = do
         it "extractReadTableNamesFromAst follows CTEs and FROM subqueries" do
             let Just ast = parseSql "WITH visible AS (SELECT id FROM items) SELECT visible.id FROM (SELECT id FROM visible) visible"
             extractReadTableNamesFromAst ast `shouldBe` Set.singleton "items"
+
+        it "extractReadTableNamesFromAst follows target-list subqueries" do
+            let Just existsAst = parseSql "SELECT EXISTS (SELECT 1 FROM items WHERE id = 1)"
+            let Just scalarAst = parseSql "SELECT (SELECT COUNT(*) FROM items)"
+            extractReadTableNamesFromAst existsAst `shouldBe` Set.singleton "items"
+            extractReadTableNamesFromAst scalarAst `shouldBe` Set.singleton "items"
 
         it "extractNonNullableComputedColumns detects count(*)" do
             let Just ast = parseSql "SELECT count(*) FROM items"
@@ -1159,6 +1177,33 @@ runtimeModule = Text.unlines
     , "            |]"
     , "        when windowTrackingQuery.tqAutoRefreshRowMatchingSafe do"
     , "            error \"windowed Typed SQL query was incorrectly marked row-local\""
+    , ""
+    , "        let selectLiteralTrackingQuery = [typedSql|"
+    , "                SELECT id, 'select' AS marker"
+    , "                FROM typed_sql_test_items"
+    , "            |]"
+    , "        unless selectLiteralTrackingQuery.tqAutoRefreshRowMatchingSafe do"
+    , "            error \"a SQL keyword inside a literal disabled row-local tracking\""
+    , ""
+    , "        commentedTrackedReads <- withAutoRefreshReadTracker do"
+    , "            _ <- sqlQueryTyped [typedSql|"
+    , "                -- this comment must not disable AutoRefresh tracking"
+    , "                SELECT id, name FROM typed_sql_test_items"
+    , "                WHERE views > ${6 :: Int} /* retained parameter */"
+    , "            |]"
+    , "            readIORef ?autoRefreshReadDependencies"
+    , "        unless (Map.member \"typed_sql_test_items\" commentedTrackedReads) do"
+    , "            error \"commented Typed SQL query was not tracked\""
+    , ""
+    , "        nestedTrackedReads <- withAutoRefreshReadTracker do"
+    , "            _ <- sqlQueryTyped [typedSql|"
+    , "                SELECT EXISTS ("
+    , "                    SELECT 1 FROM typed_sql_test_items WHERE views > ${6 :: Int}"
+    , "                )"
+    , "            |]"
+    , "            readIORef ?autoRefreshReadDependencies"
+    , "        unless (Map.member \"typed_sql_test_items\" nestedTrackedReads) do"
+    , "            error \"target-list subquery was not tracked\""
     , ""
     , "        names <- sqlQueryTyped [typedSql|"
     , "            SELECT name FROM typed_sql_test_items"

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -11,6 +11,7 @@ import           IHP.ModelSupport                  (createModelContext,
 import           IHP.Prelude
 import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullableTables,
                                                     extractNonNullableComputedColumnsFromAst,
+                                                    extractReadTableNamesFromAst,
                                                     detectStarSelects,
                                                     detectInsertWithoutColumns)
 import           System.Directory                  (createDirectoryIfMissing,
@@ -391,6 +392,16 @@ tests = do
         it "extractJoinNullableTables returns empty for plain FROM" do
             let sql = " SELECT name FROM items LIMIT 1 "
             extractJoinNullableTables sql `shouldBe` Set.empty
+
+        it "extractReadTableNamesFromAst captures SELECT tables but not DML targets" do
+            let Just selectAst = parseSql "SELECT i.name FROM items i JOIN authors a ON a.id = i.author_id"
+            let Just updateAst = parseSql "UPDATE items SET name = 'changed' RETURNING id"
+            extractReadTableNamesFromAst selectAst `shouldBe` Set.fromList ["items", "authors"]
+            extractReadTableNamesFromAst updateAst `shouldBe` Set.empty
+
+        it "extractReadTableNamesFromAst follows CTEs and FROM subqueries" do
+            let Just ast = parseSql "WITH visible AS (SELECT id FROM items) SELECT visible.id FROM (SELECT id FROM visible) visible"
+            extractReadTableNamesFromAst ast `shouldBe` Set.singleton "items"
 
         it "extractNonNullableComputedColumns detects count(*)" do
             let Just ast = parseSql "SELECT count(*) FROM items"
@@ -1043,11 +1054,15 @@ runtimeModule = Text.unlines
     , ""
     , "import qualified Control.Exception as Exception"
     , "import IHP.Prelude"
-    , "import IHP.ModelSupport (Id'(..), ModelContext, PrimaryKey, createModelContext, releaseModelContext, noopLogger)"
+    , "import IHP.ModelSupport (Id'(..), ModelContext, PrimaryKey, TrackedQueryRead(..), createModelContext, releaseModelContext, noopLogger)"
+    , "import IHP.AutoRefresh (withAutoRefreshReadTracker)"
+    , "import IHP.AutoRefresh.Types (AutoRefreshReadDependency (..))"
     , "import IHP.Hasql.FromRow (FromRowHasql (..))"
     , "import IHP.FetchPipelined (pipeline)"
-    , "import IHP.TypedSql (sqlExecTyped, sqlQueryTyped, sqlQueryTypedRows, sqlQueryTypedOneOrNothing, sqlQueryTypedSingle, sqlQueryTypedMaybeColumn, sqlQueryTypedPipelined, sqlQueryTypedMaybeColumnPipelined, typedSql, typedSqlStar)"
+    , "import IHP.TypedSql (TypedQuery(..), sqlExecTyped, sqlQueryTyped, sqlQueryTypedRows, sqlQueryTypedOneOrNothing, sqlQueryTypedSingle, sqlQueryTypedMaybeColumn, sqlQueryTypedPipelined, sqlQueryTypedMaybeColumnPipelined, typedSql, typedSqlStar)"
     , "import qualified Hasql.Decoders as HasqlDecoders"
+    , "import qualified Data.Map.Strict as Map"
+    , "import qualified Data.Set as Set"
     , "import System.Environment (lookupEnv)"
     , ""
     , "type instance PrimaryKey \"typed_sql_test_items\" = UUID"
@@ -1094,6 +1109,56 @@ runtimeModule = Text.unlines
     , "            INSERT INTO typed_sql_test_items (id, author_id, name, views, score, tags)"
     , "            VALUES (${itemId2}, ${authorId}, ${(\"Second\" :: Text)}, ${8 :: Int}, ${(2.0 :: Double)}, ${([\"green\"] :: [Text])})"
     , "        |]"
+    , ""
+    , "        trackedReads <- withAutoRefreshReadTracker do"
+    , "            _ <- sqlQueryTyped [typedSql|"
+    , "                SELECT id, name FROM typed_sql_test_items"
+    , "                WHERE views > ${6 :: Int}"
+    , "            |]"
+    , "            readIORef ?autoRefreshReadDependencies"
+    , ""
+    , "        trackedRead <- case Map.lookup \"typed_sql_test_items\" trackedReads of"
+    , "            Just (AutoRefreshTrackedQueryReads [read]) -> pure read"
+    , "            other -> error (\"unexpected Typed SQL AutoRefresh metadata: \" <> show other)"
+    , ""
+    , "        when (trackedRead.trackedRowIds /= Just (Set.singleton (tshow itemId2))) do"
+    , "            error (\"unexpected Typed SQL tracked IDs: \" <> show trackedRead.trackedRowIds)"
+    , ""
+    , "        matchesIds <- case trackedRead.trackedQueryMatchesIds of"
+    , "            Just matcher -> pure matcher"
+    , "            Nothing -> error \"Typed SQL query matcher was not captured\""
+    , "        matchingIdMatches <- matchesIds (Set.singleton (tshow itemId2))"
+    , "        filteredIdMatches <- matchesIds (Set.singleton (tshow itemId1))"
+    , "        unless (matchingIdMatches && not filteredIdMatches) do"
+    , "            error \"Typed SQL matcher did not retain its bound views > 6 parameter\""
+    , ""
+    , "        let safeTrackingQuery = [typedSql|"
+    , "                SELECT id, name FROM typed_sql_test_items"
+    , "                WHERE views > ${6 :: Int}"
+    , "            |]"
+    , "        unless safeTrackingQuery.tqAutoRefreshRowMatchingSafe do"
+    , "            error \"direct single-table Typed SQL query was not marked row-local\""
+    , ""
+    , "        let offsetTrackingQuery = [typedSql|"
+    , "                SELECT id, name FROM typed_sql_test_items"
+    , "                ORDER BY name OFFSET 1"
+    , "            |]"
+    , "        when offsetTrackingQuery.tqAutoRefreshRowMatchingSafe do"
+    , "            error \"OFFSET Typed SQL query was incorrectly marked row-local\""
+    , ""
+    , "        offsetTrackedReads <- withAutoRefreshReadTracker do"
+    , "            _ <- sqlQueryTyped offsetTrackingQuery"
+    , "            readIORef ?autoRefreshReadDependencies"
+    , "        case Map.lookup \"typed_sql_test_items\" offsetTrackedReads of"
+    , "            Just AutoRefreshWholeTable -> pure ()"
+    , "            other -> error (\"OFFSET Typed SQL query did not fall back conservatively: \" <> show other)"
+    , ""
+    , "        let windowTrackingQuery = [typedSql|"
+    , "                SELECT id, row_number() OVER (ORDER BY name)"
+    , "                FROM typed_sql_test_items"
+    , "            |]"
+    , "        when windowTrackingQuery.tqAutoRefreshRowMatchingSafe do"
+    , "            error \"windowed Typed SQL query was incorrectly marked row-local\""
     , ""
     , "        names <- sqlQueryTyped [typedSql|"
     , "            SELECT name FROM typed_sql_test_items"

--- a/ihp/CHANGELOG.md
+++ b/ihp/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Add support for `CREATE INDEX ... NULLS [NOT] DISTINCT`.
 - Deprecate `sqlQuery` / `sqlExec` family in favor of explicitly named unsafe
   variants.
+- Add parameter-aware AutoRefresh relevance checks for QueryBuilder and Typed
+  SQL reads, plus opt-in notification batching through
+  `AutoRefreshBatchWindow` (default: `0` milliseconds).
 
 ## Fixes
 

--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -509,28 +509,32 @@ shouldRefreshForChangeBatchWithCache _ _ _ AutoRefreshChangeBatch { hasUnknownCh
 shouldRefreshForChangeBatchWithCache modelContext matcherCache (AutoRefreshQueryBuilderReads reads) batch =
     if null reads
         then pure True
-        else anyM (queryBuilderReadAffectsBatch modelContext matcherCache batch) reads
+        else queryBuilderReadsAffectBatch modelContext matcherCache reads batch
 shouldRefreshForChangeBatchWithCache _ _ (AutoRefreshTrackedQueryReads reads) batch =
     if null reads
         then pure True
         else trackedReadsAffectBatch reads batch
 
-queryBuilderReadAffectsBatch
+-- Check every read's already-visible IDs before running any retained matcher.
+-- A page commonly performs several reads of the same table. If a later read
+-- already contains an updated/deleted row, the refresh decision is known and
+-- no earlier read should issue an avoidable SELECT EXISTS query.
+queryBuilderReadsAffectBatch
     :: ModelContext
     -> IORef (Map.Map Text Bool)
+    -> [QueryBuilderRead]
     -> AutoRefreshChangeBatch
-    -> QueryBuilderRead
     -> IO Bool
-queryBuilderReadAffectsBatch modelContext matcherCache batch queryRead =
-    case queryBuilderReadRowIds queryRead of
-        Nothing -> pure True
-        Just visibleRowIds
-            | not (Set.null (visibleRowIds `Set.intersection` directlyAffectingIds)) -> pure True
-            | Set.null rowsToMatch -> pure False
-            | otherwise -> queryBuilderQueryAffects modelContext matcherCache rowsToMatch queryRead
+queryBuilderReadsAffectBatch modelContext matcherCache reads batch
+    | any isNothing visibleRowIds = pure True
+    | any directlyAffected (catMaybes visibleRowIds) = pure True
+    | Set.null rowsToMatch = pure False
+    | otherwise = anyM (queryBuilderQueryAffects modelContext matcherCache rowsToMatch) reads
   where
+    visibleRowIds = map queryBuilderReadRowIds reads
     directlyAffectingIds = batch.updatedRowIds <> batch.deletedRowIds
     rowsToMatch = batch.insertedRowIds <> batch.updatedRowIds
+    directlyAffected ids = not (Set.null (ids `Set.intersection` directlyAffectingIds))
 
 -- Only the conventional scalar @id@ can be matched against the compact trigger
 -- payload. Marc's retained custom/composite keys remain available in the

--- a/ihp/IHP/AutoRefresh.hs
+++ b/ihp/IHP/AutoRefresh.hs
@@ -17,10 +17,14 @@ import qualified Data.Set as Set
 import qualified Data.Map.Strict as Map
 import Data.Dynamic (fromDynamic)
 import IHP.ModelSupport
-import IHP.QueryBuilder.Types (QueryBuilderRead (..), QueryBuilderReadKind (..))
+import IHP.QueryBuilder.Types (Condition (..), ConditionValue (..), QueryBuilderRead (..), QueryBuilderReadKind (..), QueryBuilderPrimaryKey (..), SQLQuery (..))
+import IHP.QueryBuilder.HasqlCompiler (buildQueryMatchesRowsStatement)
+import qualified Data.Aeson as Aeson
 import qualified IHP.ModelSupport.TableReadTracker as TableReadTracker
 import qualified Control.Exception as Exception
+import Control.Concurrent (threadDelay)
 import qualified Control.Concurrent.MVar as MVar
+import Control.Monad (void)
 import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import IHP.WebSocket
@@ -58,7 +62,6 @@ autoRefresh :: (
     ?theAction :: action
     , Controller action
     , ?modelContext :: ModelContext
-    , ?request :: Request
     , ?request :: Request
     , ?respond :: Respond
     ) => ((?modelContext :: ModelContext, ?respond :: Respond, ?request :: Request) => IO ResponseReceived) -> IO ResponseReceived
@@ -216,6 +219,67 @@ maxAutoRefreshQueryBuilderReadsPerTable = 64
 maxAutoRefreshPrimaryKeysPerRead :: Int
 maxAutoRefreshPrimaryKeysPerRead = 1024
 
+-- | Convert the public millisecond configuration to the unit expected by
+-- 'threadDelay'. Zero deliberately stays zero: it means that AutoRefresh adds
+-- no batching delay to its real-time notification path.
+autoRefreshBatchWindowMicroseconds :: Int -> Int
+autoRefreshBatchWindowMicroseconds milliseconds = milliseconds * 1000
+
+-- | Bound the amount of row identity state retained during a burst. Overflow
+-- degrades to one conservative whole-table change instead of growing memory.
+maxAutoRefreshChangedRowsPerBatch :: Int
+maxAutoRefreshChangedRowsPerBatch = 4096
+
+data AutoRefreshChangeBatch = AutoRefreshChangeBatch
+    { insertedRowIds :: !(Set Text)
+    , updatedRowIds :: !(Set Text)
+    , deletedRowIds :: !(Set Text)
+    , hasUnknownChange :: !Bool
+    } deriving (Eq, Show)
+
+data AutoRefreshBatchWorkerState = AutoRefreshBatchWorkerState
+    { workerScheduled :: !Bool
+    , pendingChanges :: !AutoRefreshChangeBatch
+    }
+
+emptyAutoRefreshChangeBatch :: AutoRefreshChangeBatch
+emptyAutoRefreshChangeBatch = AutoRefreshChangeBatch
+    { insertedRowIds = Set.empty
+    , updatedRowIds = Set.empty
+    , deletedRowIds = Set.empty
+    , hasUnknownChange = False
+    }
+
+emptyAutoRefreshBatchWorkerState :: AutoRefreshBatchWorkerState
+emptyAutoRefreshBatchWorkerState = AutoRefreshBatchWorkerState
+    { workerScheduled = False
+    , pendingChanges = emptyAutoRefreshChangeBatch
+    }
+
+autoRefreshChangeBatchIsEmpty :: AutoRefreshChangeBatch -> Bool
+autoRefreshChangeBatchIsEmpty batch =
+    not batch.hasUnknownChange
+    && Set.null batch.insertedRowIds
+    && Set.null batch.updatedRowIds
+    && Set.null batch.deletedRowIds
+
+addAutoRefreshRowChange :: AutoRefreshRowChange -> AutoRefreshChangeBatch -> AutoRefreshChangeBatch
+addAutoRefreshRowChange _ batch | batch.hasUnknownChange = batch
+addAutoRefreshRowChange AutoRefreshRowChange { operation, rowId = Just changedId } batch =
+    boundBatch case operation of
+        "insert" -> batch { insertedRowIds = Set.insert changedId batch.insertedRowIds }
+        "update" -> batch { updatedRowIds = Set.insert changedId batch.updatedRowIds }
+        "delete" -> batch { deletedRowIds = Set.insert changedId batch.deletedRowIds }
+        _ -> conservativeBatch
+  where
+    boundBatch candidate
+        | Set.size (candidate.insertedRowIds <> candidate.updatedRowIds <> candidate.deletedRowIds) > maxAutoRefreshChangedRowsPerBatch = conservativeBatch
+        | otherwise = candidate
+addAutoRefreshRowChange AutoRefreshRowChange { rowId = Nothing } _ = conservativeBatch
+
+conservativeBatch :: AutoRefreshChangeBatch
+conservativeBatch = emptyAutoRefreshChangeBatch { hasUnknownChange = True }
+
 -- | Track reads for AutoRefresh without changing the public ModelContext or
 -- 'withTableReadTracker' APIs. Dependencies are aggregated and bounded while
 -- the action runs, rather than collecting an unbounded intermediate list.
@@ -244,8 +308,10 @@ addTrackedRead trackedRead dependencies = case trackedRead of
         addWholeTableReadDependency tableName dependencies
     TableReadTracker.TrackedStructuredTableRead tableName dynamicRead ->
         case fromDynamic @QueryBuilderRead dynamicRead of
-            Nothing -> addWholeTableReadDependency tableName dependencies
             Just queryBuilderRead -> addQueryBuilderReadDependency tableName queryBuilderRead dependencies
+            Nothing -> case fromDynamic @TrackedQueryRead dynamicRead of
+                Just queryRead -> addTrackedQueryReadDependency tableName queryRead dependencies
+                Nothing -> addWholeTableReadDependency tableName dependencies
 
 -- | A manual or unknown read is absorbing for the table.
 addWholeTableReadDependency :: Text -> Map.Map Text AutoRefreshReadDependency -> Map.Map Text AutoRefreshReadDependency
@@ -262,18 +328,41 @@ addQueryBuilderReadDependency tableName queryBuilderRead =
         addRead _ | cannotRetainRead = Just AutoRefreshWholeTable
         addRead Nothing = Just (AutoRefreshQueryBuilderReads [queryBuilderRead])
         addRead (Just AutoRefreshWholeTable) = Just AutoRefreshWholeTable
+        addRead (Just (AutoRefreshTrackedQueryReads _)) = Just AutoRefreshWholeTable
         addRead (Just (AutoRefreshQueryBuilderReads queryReads))
             | length queryReads >= maxAutoRefreshQueryBuilderReadsPerTable = Just AutoRefreshWholeTable
             | otherwise = Just (AutoRefreshQueryBuilderReads (queryBuilderRead:queryReads))
 
         cannotRetainRead = case queryBuilderRead.queryBuilderReadKind of
             QueryBuilderRows ->
-                null queryBuilderRead.queryBuilderPrimaryKeyColumns
+                isJust queryBuilderRead.trackedSqlQuery.offsetClause
+                || null queryBuilderRead.queryBuilderPrimaryKeyColumns
                 || case queryBuilderRead.queryBuilderResultPrimaryKeys of
                     Nothing -> True
                     Just primaryKeys -> length primaryKeys > maxAutoRefreshPrimaryKeysPerRead
             QueryBuilderCount -> False
             QueryBuilderExists -> False
+
+-- | Add a bounded executable read, currently produced by Typed SQL. Mixing
+-- different structured producers for one table falls back to the conservative
+-- whole-table dependency until they share a single relevance representation.
+addTrackedQueryReadDependency :: Text -> TrackedQueryRead -> Map.Map Text AutoRefreshReadDependency -> Map.Map Text AutoRefreshReadDependency
+addTrackedQueryReadDependency tableName queryRead =
+    Map.alter addRead tableName
+    where
+        addRead _ | cannotRetainRead = Just AutoRefreshWholeTable
+        addRead Nothing = Just (AutoRefreshTrackedQueryReads [queryRead])
+        addRead (Just AutoRefreshWholeTable) = Just AutoRefreshWholeTable
+        addRead (Just (AutoRefreshQueryBuilderReads _)) = Just AutoRefreshWholeTable
+        addRead (Just (AutoRefreshTrackedQueryReads queryReads))
+            | length queryReads >= maxAutoRefreshQueryBuilderReadsPerTable = Just AutoRefreshWholeTable
+            | otherwise = Just (AutoRefreshTrackedQueryReads (queryRead:queryReads))
+
+        cannotRetainRead =
+            isNothing queryRead.trackedQueryMatchesIds
+            || case queryRead.trackedRowIds of
+                Nothing -> True
+                Just rowIds -> Set.size rowIds > maxAutoRefreshPrimaryKeysPerRead
 
 -- | Register every new table first and only then publish the new dependency
 -- snapshot. If registration throws, the session continues to describe the HTML
@@ -309,6 +398,13 @@ registerNotificationTrigger touchedTablesVar autoRefreshServer =
         let isDevelopment = ?request.frameworkConfig.environment == Development
 
         pgListener <- (.pgListener) <$> readIORef autoRefreshServer
+        let matchingModelContext = ?modelContext
+                { transactionRunner = Nothing
+                , trackTableReadCallback = Nothing
+                , rowLevelSecurity = Nothing
+                }
+        let batchWindowMicroseconds =
+                autoRefreshBatchWindowMicroseconds ?request.frameworkConfig.autoRefreshBatchWindow
         forM_ subscriptionRequired \table -> do
             -- We need to add the trigger from the main IHP database role other we will get this error:
             -- ERROR:  permission denied for schema public
@@ -316,12 +412,15 @@ registerNotificationTrigger touchedTablesVar autoRefreshServer =
                 let pool = ?modelContext.hasqlPool
                 runSessionHasql pool (HasqlSession.script (notificationTriggerSQL table))
 
-            subscription <- pgListener |> PGListener.subscribe (channelName table) \_notification -> do
-                    sessions <- (.sessions) <$> readIORef autoRefreshServer
-                    sessions
-                        |> filter (\session -> table `Set.member` session.tables)
-                        |> map (\session -> session.event)
-                        |> mapM (\event -> MVar.tryPutMVar event ())
+            batchWorkerState <- MVar.newMVar emptyAutoRefreshBatchWorkerState
+            let processBatch batch =
+                    processAutoRefreshChangeBatch matchingModelContext autoRefreshServer table batch
+                        `Exception.catch` \(exception :: SomeException) ->
+                            matchingModelContext.logger (toLogStr ("AutoRefresh: Failed to process notification batch: " <> tshow exception))
+            subscription <- pgListener |> PGListener.subscribeJSON (channelName table) \change -> do
+                    startWorker <- enqueueAutoRefreshRowChange batchWorkerState change
+                    when startWorker do
+                        void (async (runAutoRefreshBatchWorker batchWindowMicroseconds batchWorkerState processBatch))
                     pure ()
 
             atomicModifyIORef' autoRefreshServer \server ->
@@ -339,6 +438,185 @@ registerNotificationTrigger touchedTablesVar autoRefreshServer =
                 withRowLevelSecurityDisabled do
                     let pool = ?modelContext.hasqlPool
                     runSessionHasql pool (HasqlSession.script (notificationTriggerSQL table))
+
+enqueueAutoRefreshRowChange :: MVar.MVar AutoRefreshBatchWorkerState -> AutoRefreshRowChange -> IO Bool
+enqueueAutoRefreshRowChange batchWorkerState change =
+    MVar.modifyMVar batchWorkerState \state -> do
+        let startWorker = not state.workerScheduled
+        let nextState = state
+                { workerScheduled = True
+                , pendingChanges = addAutoRefreshRowChange change state.pendingChanges
+                }
+        pure (nextState, startWorker)
+
+runAutoRefreshBatchWorker
+    :: Int
+    -> MVar.MVar AutoRefreshBatchWorkerState
+    -> (AutoRefreshChangeBatch -> IO ())
+    -> IO ()
+runAutoRefreshBatchWorker batchWindowMicroseconds batchWorkerState processBatch = do
+    when (batchWindowMicroseconds > 0) (threadDelay batchWindowMicroseconds)
+    batch <- MVar.modifyMVar batchWorkerState \state ->
+        pure (state { pendingChanges = emptyAutoRefreshChangeBatch }, state.pendingChanges)
+    unless (autoRefreshChangeBatchIsEmpty batch) (processBatch batch)
+    continue <- MVar.modifyMVar batchWorkerState \state ->
+        if autoRefreshChangeBatchIsEmpty state.pendingChanges
+            then pure (state { workerScheduled = False }, False)
+            else pure (state, True)
+    when continue (runAutoRefreshBatchWorker batchWindowMicroseconds batchWorkerState processBatch)
+
+processAutoRefreshChangeBatch
+    :: ModelContext
+    -> IORef AutoRefreshServer
+    -> Text
+    -> AutoRefreshChangeBatch
+    -> IO ()
+processAutoRefreshChangeBatch modelContext autoRefreshServer table batch = do
+    matcherCache <- newIORef Map.empty
+    sessions <- (.sessions) <$> readIORef autoRefreshServer
+    forM_ sessions \session ->
+        case Map.lookup table (getAutoRefreshReadDependencies session) of
+            Nothing -> pure ()
+            Just dependency -> do
+                shouldRefresh <- shouldRefreshForChangeBatchWithCache modelContext matcherCache dependency batch
+                when shouldRefresh (void (MVar.tryPutMVar session.event ()))
+
+-- | Backwards-compatible single-notification entry point. The live listener
+-- calls 'shouldRefreshForChangeBatchWithCache' after coalescing notifications.
+shouldRefreshForChange :: ModelContext -> AutoRefreshReadDependency -> AutoRefreshRowChange -> IO Bool
+shouldRefreshForChange modelContext dependency change = do
+    matcherCache <- newIORef Map.empty
+    shouldRefreshForChangeBatchWithCache
+        modelContext
+        matcherCache
+        dependency
+        (addAutoRefreshRowChange change emptyAutoRefreshChangeBatch)
+
+shouldRefreshForChangeBatch :: ModelContext -> AutoRefreshReadDependency -> AutoRefreshChangeBatch -> IO Bool
+shouldRefreshForChangeBatch modelContext dependency batch = do
+    matcherCache <- newIORef Map.empty
+    shouldRefreshForChangeBatchWithCache modelContext matcherCache dependency batch
+
+shouldRefreshForChangeBatchWithCache
+    :: ModelContext
+    -> IORef (Map.Map Text Bool)
+    -> AutoRefreshReadDependency
+    -> AutoRefreshChangeBatch
+    -> IO Bool
+shouldRefreshForChangeBatchWithCache _ _ _ batch | autoRefreshChangeBatchIsEmpty batch = pure False
+shouldRefreshForChangeBatchWithCache _ _ AutoRefreshWholeTable _ = pure True
+shouldRefreshForChangeBatchWithCache _ _ _ AutoRefreshChangeBatch { hasUnknownChange = True } = pure True
+shouldRefreshForChangeBatchWithCache modelContext matcherCache (AutoRefreshQueryBuilderReads reads) batch =
+    if null reads
+        then pure True
+        else anyM (queryBuilderReadAffectsBatch modelContext matcherCache batch) reads
+shouldRefreshForChangeBatchWithCache _ _ (AutoRefreshTrackedQueryReads reads) batch =
+    if null reads
+        then pure True
+        else trackedReadsAffectBatch reads batch
+
+queryBuilderReadAffectsBatch
+    :: ModelContext
+    -> IORef (Map.Map Text Bool)
+    -> AutoRefreshChangeBatch
+    -> QueryBuilderRead
+    -> IO Bool
+queryBuilderReadAffectsBatch modelContext matcherCache batch queryRead =
+    case queryBuilderReadRowIds queryRead of
+        Nothing -> pure True
+        Just visibleRowIds
+            | not (Set.null (visibleRowIds `Set.intersection` directlyAffectingIds)) -> pure True
+            | Set.null rowsToMatch -> pure False
+            | otherwise -> queryBuilderQueryAffects modelContext matcherCache rowsToMatch queryRead
+  where
+    directlyAffectingIds = batch.updatedRowIds <> batch.deletedRowIds
+    rowsToMatch = batch.insertedRowIds <> batch.updatedRowIds
+
+-- Only the conventional scalar @id@ can be matched against the compact trigger
+-- payload. Marc's retained custom/composite keys remain available in the
+-- dependency snapshot, but currently take the conservative refresh path.
+queryBuilderReadRowIds :: QueryBuilderRead -> Maybe (Set Text)
+queryBuilderReadRowIds QueryBuilderRead
+        { queryBuilderReadKind = QueryBuilderRows
+        , queryBuilderPrimaryKeyColumns = ["id"]
+        , queryBuilderResultPrimaryKeys = Just primaryKeys
+        } = Set.fromList <$> mapM primaryKeyText primaryKeys
+queryBuilderReadRowIds _ = Nothing
+
+primaryKeyText :: QueryBuilderPrimaryKey -> Maybe Text
+primaryKeyText (QueryBuilderPrimaryKey [value]) = case value of
+    Aeson.String text -> Just text
+    Aeson.Number _ -> Just (cs (Aeson.encode value))
+    Aeson.Bool True -> Just "true"
+    Aeson.Bool False -> Just "false"
+    _ -> Nothing
+primaryKeyText _ = Nothing
+
+queryBuilderQueryAffects
+    :: ModelContext
+    -> IORef (Map.Map Text Bool)
+    -> Set Text
+    -> QueryBuilderRead
+    -> IO Bool
+queryBuilderQueryAffects modelContext matcherCache changedIds queryRead = do
+    let runMatcher = do
+            let statement = buildQueryMatchesRowsStatement queryRead.trackedSqlQuery
+            let ?modelContext = modelContext
+            result <- Exception.try @SomeException $
+                sqlStatementHasql modelContext.hasqlPool (Set.toList changedIds) statement
+            pure (either (const True) (\value -> value) result)
+    case queryBuilderMatcherCacheKey changedIds queryRead of
+        Nothing -> runMatcher
+        Just cacheKey -> do
+            cached <- Map.lookup cacheKey <$> readIORef matcherCache
+            case cached of
+                Just result -> pure result
+                Nothing -> do
+                    result <- runMatcher
+                    atomicModifyIORef' matcherCache (\cache -> (Map.insert cacheKey result cache, ()))
+                    pure result
+
+-- Parameter encoders are intentionally opaque. We only share matcher results
+-- when the retained query has no condition parameters, so equality is exact.
+-- LIMIT values remain part of the shown SQLQuery and therefore of the key.
+queryBuilderMatcherCacheKey :: Set Text -> QueryBuilderRead -> Maybe Text
+queryBuilderMatcherCacheKey changedIds QueryBuilderRead { trackedSqlQuery }
+    | maybe False conditionHasParameter trackedSqlQuery.whereCondition = Nothing
+    | otherwise = Just
+        ( tshow trackedSqlQuery
+        <> "\NUL"
+        <> Text.intercalate "\NUL" (Set.toAscList changedIds)
+        )
+
+conditionHasParameter :: Condition -> Bool
+conditionHasParameter (ColumnCondition _ _ (Param _) _ _) = True
+conditionHasParameter (ColumnCondition _ _ (Literal _) _ _) = False
+conditionHasParameter (OrCondition left right) = conditionHasParameter left || conditionHasParameter right
+conditionHasParameter (AndCondition left right) = conditionHasParameter left || conditionHasParameter right
+
+trackedReadsAffectBatch :: [TrackedQueryRead] -> AutoRefreshChangeBatch -> IO Bool
+trackedReadsAffectBatch reads batch
+    | any visibleRowsAffected reads = pure True
+    | Set.null rowsToMatch = pure False
+    | otherwise = anyM (trackedQueryAffectsRead rowsToMatch) reads
+  where
+    directlyAffectingIds = batch.updatedRowIds <> batch.deletedRowIds
+    rowsToMatch = batch.insertedRowIds <> batch.updatedRowIds
+    visibleRowsAffected TrackedQueryRead { trackedRowIds = Nothing } = True
+    visibleRowsAffected TrackedQueryRead { trackedRowIds = Just ids } =
+        not (Set.null (ids `Set.intersection` directlyAffectingIds))
+
+trackedQueryAffectsRead :: Set Text -> TrackedQueryRead -> IO Bool
+trackedQueryAffectsRead _ TrackedQueryRead { trackedQueryMatchesIds = Nothing } = pure True
+trackedQueryAffectsRead changedIds TrackedQueryRead { trackedQueryMatchesIds = Just matchesIds } = do
+    result <- Exception.try @SomeException (matchesIds changedIds)
+    pure (either (const True) (\value -> value) result)
+
+anyM :: (a -> IO Bool) -> [a] -> IO Bool
+anyM _ [] = pure False
+anyM predicate (value:values) = do
+    matches <- predicate value
+    if matches then pure True else anyM predicate values
 
 -- | Returns the ids of all sessions available to the client based on what sessions are found in the session cookie
 getAvailableSessions :: (?request :: Request) => IORef AutoRefreshServer -> IO [UUID]
@@ -397,7 +675,7 @@ isSessionExpired now session = (now `diffUTCTime` session.lastPing) > (secondsTo
 channelName :: Text -> ByteString
 channelName tableName = "ar_did_change_" <> cs tableName
 
--- | Returns a SQL script to set up database notification triggers.
+-- | Returns SQL that installs a compact row-level notification trigger.
 --
 -- Wrapped in a DO $$ block with EXCEPTION handler because concurrent requests
 -- can race to CREATE OR REPLACE the same function, causing PostgreSQL to throw
@@ -408,21 +686,32 @@ notificationTriggerSQL tableName =
         "DO $$\n"
         <> "BEGIN\n"
         <> "    CREATE OR REPLACE FUNCTION " <> functionName <> "() RETURNS TRIGGER AS $BODY$"
+            <> "DECLARE\n"
+            <> "    payload TEXT;\n"
             <> "BEGIN\n"
-            <> "    PERFORM pg_notify('" <> cs (channelName tableName) <> "', '');\n"
-            <> "    RETURN new;\n"
+            <> "    IF (TG_OP = 'DELETE') THEN\n"
+            <> "        payload := jsonb_build_object('op', lower(TG_OP), 'id', to_jsonb(OLD)->>'id')::text;\n"
+            <> "        PERFORM pg_notify('" <> cs (channelName tableName) <> "', payload);\n"
+            <> "        RETURN OLD;\n"
+            <> "    ELSE\n"
+            <> "        payload := jsonb_build_object('op', lower(TG_OP), 'id', to_jsonb(NEW)->>'id')::text;\n"
+            <> "        PERFORM pg_notify('" <> cs (channelName tableName) <> "', payload);\n"
+            <> "        RETURN NEW;\n"
+            <> "    END IF;\n"
             <> "END;\n"
             <> "$BODY$ language plpgsql;\n"
         <> "    DROP TRIGGER IF EXISTS " <> insertTriggerName <> " ON " <> tableName <> ";\n"
-        <> "    CREATE TRIGGER " <> insertTriggerName <> " AFTER INSERT ON \"" <> tableName <> "\" FOR EACH STATEMENT EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "    CREATE TRIGGER " <> insertTriggerName <> " AFTER INSERT ON \"" <> tableName <> "\" FOR EACH ROW EXECUTE PROCEDURE " <> functionName <> "();\n"
         <> "    DROP TRIGGER IF EXISTS " <> updateTriggerName <> " ON " <> tableName <> ";\n"
-        <> "    CREATE TRIGGER " <> updateTriggerName <> " AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH STATEMENT EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "    CREATE TRIGGER " <> updateTriggerName <> " AFTER UPDATE ON \"" <> tableName <> "\" FOR EACH ROW EXECUTE PROCEDURE " <> functionName <> "();\n"
         <> "    DROP TRIGGER IF EXISTS " <> deleteTriggerName <> " ON " <> tableName <> ";\n"
-        <> "    CREATE TRIGGER " <> deleteTriggerName <> " AFTER DELETE ON \"" <> tableName <> "\" FOR EACH STATEMENT EXECUTE PROCEDURE " <> functionName <> "();\n"
+        <> "    CREATE TRIGGER " <> deleteTriggerName <> " AFTER DELETE ON \"" <> tableName <> "\" FOR EACH ROW EXECUTE PROCEDURE " <> functionName <> "();\n"
         <> "EXCEPTION\n"
         <> "    WHEN SQLSTATE 'XX000' THEN null; -- 'tuple concurrently updated': another connection installed it first\n"
         <> "END; $$"
     where
+        -- Reuse the existing names so installing the row-level variant also
+        -- replaces the legacy statement-level triggers during an upgrade.
         functionName = "ar_notify_did_change_" <> tableName
         insertTriggerName = "ar_did_insert_" <> tableName
         updateTriggerName = "ar_did_update_" <> tableName

--- a/ihp/IHP/AutoRefresh/Types.hs
+++ b/ihp/IHP/AutoRefresh/Types.hs
@@ -12,6 +12,8 @@ import qualified IHP.PGListener as PGListener
 import qualified Data.Map.Strict as Map
 import IHP.QueryBuilder.Types (QueryBuilderRead)
 import Network.Wai (Request, ResponseReceived)
+import IHP.ModelSupport.Types (TrackedQueryRead)
+import qualified Data.Aeson as Aeson
 
 data AutoRefreshState = AutoRefreshEnabled { sessionId :: !UUID }
 
@@ -23,6 +25,7 @@ data AutoRefreshState = AutoRefreshEnabled { sessionId :: !UUID }
 data AutoRefreshReadDependency
     = AutoRefreshWholeTable
     | AutoRefreshQueryBuilderReads ![QueryBuilderRead]
+    | AutoRefreshTrackedQueryReads ![TrackedQueryRead]
     deriving (Eq, Show)
 
 -- | AutoRefresh session state.
@@ -91,3 +94,17 @@ data AutoRefreshServer = AutoRefreshServer
 
 newAutoRefreshServer :: PGListener.PGListener -> AutoRefreshServer
 newAutoRefreshServer pgListener = AutoRefreshServer { subscriptions = [], sessions = [], subscribedTables = mempty, pgListener }
+
+-- | The small JSON payload emitted by AutoRefresh row-level triggers.
+-- Keeping only the operation and conventional row ID avoids DataSync's large
+-- payload storage path while providing everything needed for query matching.
+data AutoRefreshRowChange = AutoRefreshRowChange
+    { operation :: !Text
+    , rowId :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance Aeson.FromJSON AutoRefreshRowChange where
+    parseJSON = Aeson.withObject "AutoRefreshRowChange" \object ->
+        AutoRefreshRowChange
+            <$> object Aeson..: "op"
+            <*> object Aeson..:? "id"

--- a/ihp/IHP/FrameworkConfig.hs
+++ b/ihp/IHP/FrameworkConfig.hs
@@ -145,6 +145,9 @@ ihpDefaultConfig logger = do
     option $ DataSyncMaxSubscriptionsPerConnection dataSyncMaxSubscriptionsPerConnection
     option $ DataSyncMaxTransactionsPerConnection dataSyncMaxTransactionsPerConnection
 
+    autoRefreshBatchWindow <- envOrDefault "IHP_AUTO_REFRESH_BATCH_WINDOW_MS" 0
+    option $ AutoRefreshBatchWindow autoRefreshBatchWindow
+
     option $ CustomMiddleware id
     option $ AuthMiddleware id
 
@@ -152,6 +155,9 @@ ihpDefaultConfig logger = do
 
 instance EnvVarReader AppPort where
     envStringToValue string = AppPort <$> envStringToValue string
+
+instance EnvVarReader AutoRefreshBatchWindow where
+    envStringToValue string = AutoRefreshBatchWindow <$> envStringToValue string
 
 instance EnvVarReader RequestLogger.IPAddrSource where
     envStringToValue "FromHeader" = Right RequestLogger.FromHeader
@@ -191,6 +197,9 @@ buildFrameworkConfig rawLogger appConfig = do
             (RLSAuthenticatedRole rlsAuthenticatedRole) <- findOption @RLSAuthenticatedRole
             customMiddleware <- findOption @CustomMiddleware
             authenticationMiddleware <- findOption @AuthMiddleware
+            (AutoRefreshBatchWindow autoRefreshBatchWindow) <- findOption @AutoRefreshBatchWindow
+            when (autoRefreshBatchWindow < 0) do
+                error "AutoRefreshBatchWindow must be greater than or equal to 0 milliseconds"
             initializers <- fromMaybe [] <$> findOptionOrNothing @[Initializer]
 
             appConfig <- State.get

--- a/ihp/IHP/FrameworkConfig/Types.hs
+++ b/ihp/IHP/FrameworkConfig/Types.hs
@@ -26,6 +26,7 @@ module IHP.FrameworkConfig.Types
 , AuthMiddleware (..)
 , DataSyncMaxSubscriptionsPerConnection (..)
 , DataSyncMaxTransactionsPerConnection (..)
+, AutoRefreshBatchWindow (..)
 , Initializer (..)
 , FrameworkConfig (..)
 , ConfigProvider
@@ -111,6 +112,19 @@ newtype AuthMiddleware = AuthMiddleware Middleware
 newtype DataSyncMaxSubscriptionsPerConnection = DataSyncMaxSubscriptionsPerConnection Int
 newtype DataSyncMaxTransactionsPerConnection = DataSyncMaxTransactionsPerConnection Int
 
+-- | Time in milliseconds during which AutoRefresh accumulates database
+-- notifications before checking which sessions need to be re-rendered.
+--
+-- The default is @0@, which performs relevance checks without an intentional
+-- delay and preserves AutoRefresh's real-time behaviour. A positive value can
+-- reduce the amount of database work for write-heavy tables with many connected
+-- users by checking all changes received during the window as one batch.
+--
+-- __Example: batch notifications for 100 milliseconds__
+--
+-- > option (AutoRefreshBatchWindow 100)
+newtype AutoRefreshBatchWindow = AutoRefreshBatchWindow Int
+
 newtype Initializer = Initializer { onStartup :: (?context :: FrameworkConfig, ?modelContext :: ModelContext) => IO () }
 
 data FrameworkConfig = FrameworkConfig
@@ -173,6 +187,9 @@ data FrameworkConfig = FrameworkConfig
     -- | Authentication middleware that populates the request vault with the
     -- current user/admin. Runs after session and model context middlewares.
     , authenticationMiddleware :: !AuthMiddleware
+    -- | AutoRefresh notification batching window in milliseconds. A value of
+    -- @0@ means that no intentional batching delay is added.
+    , autoRefreshBatchWindow :: !Int
     , initializers :: ![Initializer]
     }
 

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -925,9 +925,30 @@ trackTableRead tableName = case ?modelContext.trackTableReadCallback of
     Nothing -> pure ()
 {-# INLINABLE trackTableRead #-}
 
--- | Track all tables in SELECT queries executed within the given IO action.
+-- | Track a table read together with the rows returned and an executable matcher.
 --
--- You can read the touched tables by this function by accessing the variable @?touchedTables@ inside your given IO action.
+-- The matcher must retain the bound parameters of the original query. AutoRefresh
+-- uses it to check whether an inserted or newly matching row belongs to this read.
+trackTableReadWithQuery :: (?modelContext :: ModelContext) => Text -> Maybe (Set.Set Text) -> Maybe (Set.Set Text -> IO Bool) -> IO ()
+trackTableReadWithQuery tableName rowIds queryMatchesIds = case ?modelContext.trackTableReadCallback of
+    Just callback -> do
+        callback tableName
+        TableReadTracker.trackStructuredTableRead callback tableName (toDyn TrackedQueryRead
+            { trackedRowIds = rowIds
+            , trackedQueryMatchesIds = queryMatchesIds
+            })
+    Nothing -> pure ()
+{-# INLINABLE trackTableReadWithQuery #-}
+
+-- | Whether the current model context is collecting table reads.
+--
+-- Fetch functions use this to avoid adding ID projections to ordinary queries.
+isTableReadTrackingEnabled :: (?modelContext :: ModelContext) => IO Bool
+isTableReadTrackingEnabled = case ?modelContext.trackTableReadCallback of
+    Nothing -> pure False
+    Just callback -> TableReadTracker.hasTrackedTableReadCallback callback
+
+-- | Track all tables in SELECT queries executed within the given IO action.
 --
 -- __Example:__
 --

--- a/ihp/IHP/ModelSupport/Types.hs
+++ b/ihp/IHP/ModelSupport/Types.hs
@@ -16,6 +16,7 @@ module IHP.ModelSupport.Types
   ModelContext (..)
 , RowLevelSecurityContext (..)
 , TransactionRunner (..)
+, TrackedQueryRead (..)
   -- * Type Families
 , GetModelById
 , GetTableName
@@ -66,7 +67,9 @@ import GHC.TypeLits
 import GHC.Types
 import Data.Data
 import Data.Dynamic
+import Data.Maybe (isJust)
 import System.Log.FastLogger (FastLogger)
+import qualified Data.Set as Set
 
 -- | Runner that executes a hasql Session on the current transaction's connection
 newtype TransactionRunner = TransactionRunner
@@ -90,11 +93,33 @@ data ModelContext = ModelContext
     , transactionRunner :: Maybe TransactionRunner -- ^ When set, queries are sent through this runner instead of 'HasqlPool.use' directly
     , logger :: FastLogger
     , queryLoggingEnabled :: !Bool
-    -- | A callback that is called whenever a specific table is accessed using a SELECT query
+    -- | A callback that is called whenever a specific table is accessed using a SELECT query.
     , trackTableReadCallback :: Maybe (Text -> IO ())
     -- | Is set to a value if row level security was enabled at runtime
     , rowLevelSecurity :: Maybe RowLevelSecurityContext
     }
+
+-- | Information captured for one SELECT performed while rendering an AutoRefresh action.
+--
+-- 'trackedRowIds' is 'Nothing' when the result shape does not expose a conventional
+-- @id@ column. 'trackedQueryMatchesIds' reruns the original parameterized query,
+-- restricted to a batch of changed row IDs. The function closes over the prepared
+-- query and therefore retains both its SQL and its bound parameters.
+data TrackedQueryRead = TrackedQueryRead
+    { trackedRowIds :: !(Maybe (Set.Set Text))
+    , trackedQueryMatchesIds :: !(Maybe (Set.Set Text -> IO Bool))
+    }
+
+instance Eq TrackedQueryRead where
+    first == second =
+        first.trackedRowIds == second.trackedRowIds
+        && isJust first.trackedQueryMatchesIds == isJust second.trackedQueryMatchesIds
+
+instance Show TrackedQueryRead where
+    show TrackedQueryRead { trackedRowIds, trackedQueryMatchesIds } =
+        "TrackedQueryRead { trackedRowIds = " <> show trackedRowIds
+        <> ", trackedQueryMatchesIds = " <> show (isJust trackedQueryMatchesIds)
+        <> " }"
 
 -- | When row level security is enabled at runtime, this keeps track of the current
 -- logged in user and the postgresql role to switch to.

--- a/ihp/IHP/QueryBuilder/HasqlCompiler.hs
+++ b/ihp/IHP/QueryBuilder/HasqlCompiler.hs
@@ -11,6 +11,8 @@ by threading a parameter counter and encoder accumulator through compilation.
 module IHP.QueryBuilder.HasqlCompiler
 ( buildStatement
 , buildWrappedStatement
+, buildQueryMatchesRowStatement
+, buildQueryMatchesRowsStatement
 , toSQL
 , compileOperator
 , CompilerState(..)
@@ -27,6 +29,7 @@ import Data.Functor.Contravariant.Divisible (conquer)
 import IHP.QueryBuilder.Types
 import IHP.QueryBuilder.Compiler (buildQuery)
 import qualified Data.List as List
+import qualified Data.Text as Text
 
 -- | Compile context: parameter counter + accumulated encoder.
 data CompilerState = CompilerState !Int !(Encoders.Params ())
@@ -53,6 +56,49 @@ buildWrappedStatement :: Text -> SQLQuery -> Text -> Decoders.Result a -> Hasql.
 buildWrappedStatement prefix sqlQuery suffix decoder =
     let (innerSql, CompilerState _ encoder) = compileQuery emptyCompilerState sqlQuery
     in Hasql.preparable (prefix <> innerSql <> suffix) encoder decoder
+
+-- | Build a statement that checks whether a row ID is present in a query result.
+--
+-- The query builder's parameters are already captured inside its @Params ()@
+-- encoder. They are lifted to the statement's 'Text' input and combined with a
+-- final, runtime row-ID parameter. This preserves the exact bound parameters of
+-- the original query instead of retaining SQL text alone.
+buildQueryMatchesRowStatement :: SQLQuery -> Hasql.Statement Text Bool
+buildQueryMatchesRowStatement sqlQuery =
+    let (innerSql, CompilerState nextParameter queryEncoder) = compileQuery emptyCompilerState sqlQuery
+        rowIdEncoder = Encoders.param (Encoders.nonNullable Encoders.text)
+        encoder = contramap (const ()) queryEncoder <> rowIdEncoder
+        tableType = quoteIdentifierPath sqlQuery.selectFrom
+        sql =
+            "SELECT EXISTS (SELECT 1 FROM (" <> innerSql
+            <> ") AS _ihp_auto_refresh_records WHERE _ihp_auto_refresh_records.id = "
+            <> "(jsonb_populate_record(NULL::" <> tableType
+            <> ", jsonb_build_object('id', $" <> tshow nextParameter <> "))).id)"
+        decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
+    in Hasql.preparable sql encoder decoder
+
+-- | Batched variant of 'buildQueryMatchesRowStatement'. The changed IDs arrive
+-- as text in the compact notification payload. @jsonb_populate_record@ converts
+-- them back to the table's real @id@ type, preserving primary-key index usage.
+buildQueryMatchesRowsStatement :: SQLQuery -> Hasql.Statement [Text] Bool
+buildQueryMatchesRowsStatement sqlQuery =
+    let (innerSql, CompilerState nextParameter queryEncoder) = compileQuery emptyCompilerState sqlQuery
+        rowIdsEncoder = Encoders.param (Encoders.nonNullable (Encoders.foldableArray (Encoders.nonNullable Encoders.text)))
+        encoder = contramap (const ()) queryEncoder <> rowIdsEncoder
+        tableType = quoteIdentifierPath sqlQuery.selectFrom
+        sql =
+            "SELECT EXISTS (SELECT 1 FROM (" <> innerSql
+            <> ") AS _ihp_auto_refresh_records WHERE _ihp_auto_refresh_records.id = ANY (ARRAY("
+            <> "SELECT (jsonb_populate_record(NULL::" <> tableType
+            <> ", jsonb_build_object('id', _ihp_changed_id))).id "
+            <> "FROM unnest($" <> tshow nextParameter <> "::text[]) AS _ihp_changed_id)))"
+        decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
+    in Hasql.preparable sql encoder decoder
+
+quoteIdentifierPath :: Text -> Text
+quoteIdentifierPath = Text.intercalate "." . map quoteIdentifierText . Text.splitOn "."
+  where
+    quoteIdentifierText name = "\"" <> Text.replace "\"" "\"\"" name <> "\""
 
 -- | Compile a QueryBuilder to SQL text (for testing / error messages).
 -- Discards the encoder.

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -29,6 +29,7 @@ import IHP.AutoRefresh
     , sessionResponseHasChanged
     , shouldRefreshForChange
     , shouldRefreshForChangeBatch
+    , shouldRefreshForChangeBatchWithCache
     , updateSession
     , withAutoRefreshReadTracker
     )
@@ -244,6 +245,38 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                                 |> filterWhereGreaterThan (#views, 6 :: Int))
                         }
                 queryBuilderMatcherCacheKey changedIds parameterizedRead `shouldBe` Nothing
+
+            it "checks every visible ID before running an earlier query matcher" $ \_ ->
+                withAutoRefreshDB \modelContext -> do
+                    matcherQueries <- newIORef (0 :: Int)
+                    let matchingModelContext = modelContext
+                            { queryLoggingEnabled = True
+                            , logger = \_ -> atomicModifyIORef' matcherQueries \count -> (count + 1, ())
+                            }
+                    let changedId = "b0000000-0000-0000-0000-000000000002"
+                    let earlierRead = queryRead
+                            { trackedSqlQuery = buildQuery
+                                (query @AutoRefreshItem
+                                    |> filterWhereGreaterThan (#views, 6 :: Int))
+                            , queryBuilderResultPrimaryKeys =
+                                Just [QueryBuilderPrimaryKey [Aeson.String "b0000000-0000-0000-0000-000000000001"]]
+                            }
+                    let directlyAffectedRead = earlierRead
+                            { queryBuilderResultPrimaryKeys =
+                                Just [QueryBuilderPrimaryKey [Aeson.String changedId]]
+                            }
+                    let batch = emptyAutoRefreshChangeBatch
+                            { updatedRowIds = Set.singleton changedId
+                            }
+                    matcherCache <- newIORef Map.empty
+
+                    shouldRefreshForChangeBatchWithCache
+                        matchingModelContext
+                        matcherCache
+                        (AutoRefreshQueryBuilderReads [earlierRead, directlyAffectedRead])
+                        batch
+                        `shouldReturn` True
+                    readIORef matcherQueries `shouldReturn` 0
 
             it "falls back to whole-table tracking for OFFSET queries" $ \_ -> do
                 let offsetRead = queryRead

--- a/ihp/Test/Test/AutoRefreshSpec.hs
+++ b/ihp/Test/Test/AutoRefreshSpec.hs
@@ -14,11 +14,21 @@ import IHP.ControllerPrelude hiding (get, request)
 import Network.Wai
 import Network.HTTP.Types
 import IHP.AutoRefresh
-    ( addQueryBuilderReadDependency
+    ( AutoRefreshChangeBatch (..)
+    , addAutoRefreshRowChange
+    , addQueryBuilderReadDependency
     , addWholeTableReadDependency
+    , autoRefreshBatchWindowMicroseconds
     , commitAutoRefreshReadDependencies
+    , emptyAutoRefreshBatchWorkerState
+    , emptyAutoRefreshChangeBatch
+    , enqueueAutoRefreshRowChange
     , globalAutoRefreshServerVar
+    , queryBuilderMatcherCacheKey
+    , runAutoRefreshBatchWorker
     , sessionResponseHasChanged
+    , shouldRefreshForChange
+    , shouldRefreshForChangeBatch
     , updateSession
     , withAutoRefreshReadTracker
     )
@@ -27,6 +37,7 @@ import IHP.AutoRefresh.View (autoRefreshMeta)
 import IHP.QueryBuilder.Types (QueryBuilderRead (..), QueryBuilderReadKind (..), QueryBuilderPrimaryKey (..), SQLQuery (..))
 import IHP.Hasql.FromRow (FromRowHasql (..), HasqlDecodeColumn (..))
 import qualified Control.Concurrent.MVar as MVar
+import qualified Control.Concurrent.Async as Async
 import qualified Control.Exception as Exception
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -63,6 +74,25 @@ instance FromRowHasql AutoRefreshCompositeItem where
     hasqlRowDecoder = AutoRefreshCompositeItem
         <$> hasqlColumnDecoder
         <*> hasqlColumnDecoder
+        <*> hasqlColumnDecoder
+
+data AutoRefreshItem = AutoRefreshItem
+    { autoRefreshItemId :: UUID
+    , views :: Int
+    }
+    deriving (Eq, Show)
+
+type instance GetTableName AutoRefreshItem = "auto_refresh_items"
+type instance GetModelByTableName "auto_refresh_items" = AutoRefreshItem
+type instance PrimaryKey "auto_refresh_items" = UUID
+
+instance Table AutoRefreshItem where
+    columnNames = ["id", "views"]
+    primaryKeyColumnNames = ["id"]
+
+instance FromRowHasql AutoRefreshItem where
+    hasqlRowDecoder = AutoRefreshItem
+        <$> hasqlColumnDecoder
         <*> hasqlColumnDecoder
 
 data WebApplication = WebApplication deriving (Eq, Show, Data)
@@ -136,14 +166,19 @@ withAutoRefreshDB action = do
     modelContext <- createModelContext databaseUrl noopLogger
     let pool = modelContext.hasqlPool
     let setup = runHasqlScript pool
-            "DROP TABLE IF EXISTS auto_refresh_composite_items;\
+            "DROP TABLE IF EXISTS auto_refresh_items;\
+            \DROP TABLE IF EXISTS auto_refresh_composite_items;\
             \CREATE TABLE auto_refresh_composite_items (\
             \tenant_id UUID NOT NULL, item_id INT NOT NULL, name TEXT NOT NULL,\
             \PRIMARY KEY (tenant_id, item_id));\
             \INSERT INTO auto_refresh_composite_items (tenant_id, item_id, name) VALUES\
-            \('a0000000-0000-0000-0000-000000000001', 7, 'tracked');"
+            \('a0000000-0000-0000-0000-000000000001', 7, 'tracked');\
+            \CREATE TABLE auto_refresh_items (id UUID PRIMARY KEY, views INT NOT NULL);\
+            \INSERT INTO auto_refresh_items (id, views) VALUES\
+            \('b0000000-0000-0000-0000-000000000001', 5),\
+            \('b0000000-0000-0000-0000-000000000002', 8);"
     let teardown = do
-            _ <- HasqlPool.use pool (HasqlSession.script "DROP TABLE IF EXISTS auto_refresh_composite_items;")
+            _ <- HasqlPool.use pool (HasqlSession.script "DROP TABLE IF EXISTS auto_refresh_items; DROP TABLE IF EXISTS auto_refresh_composite_items;")
             releaseModelContext modelContext
     result <- Exception.try (setup >> action modelContext `Exception.finally` teardown)
     case result of
@@ -199,6 +234,24 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                             `shouldBe` Just [QueryBuilderPrimaryKey [Aeson.String "task-1"]]
                     _ -> expectationFailure "Expected a structured QueryBuilder dependency"
 
+            it "shares only dependencies whose parameters can be compared exactly" $ \_ -> do
+                let changedIds = Set.singleton "task-2"
+                queryBuilderMatcherCacheKey changedIds queryRead `shouldSatisfy` isJust
+
+                let parameterizedRead = queryRead
+                        { trackedSqlQuery = buildQuery
+                            (query @AutoRefreshItem
+                                |> filterWhereGreaterThan (#views, 6 :: Int))
+                        }
+                queryBuilderMatcherCacheKey changedIds parameterizedRead `shouldBe` Nothing
+
+            it "falls back to whole-table tracking for OFFSET queries" $ \_ -> do
+                let offsetRead = queryRead
+                        { trackedSqlQuery = sqlQuery { offsetClause = Just 1 }
+                        }
+                let dependencies = addQueryBuilderReadDependency "tasks" offsetRead Map.empty
+                Map.lookup "tasks" dependencies `shouldBe` Just AutoRefreshWholeTable
+
             it "keeps whole-table reads absorbing regardless of read order" $ \_ -> do
                 let structuredThenWhole =
                         addWholeTableReadDependency "tasks" (addQueryBuilderReadDependency "tasks" queryRead Map.empty)
@@ -252,6 +305,36 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                                         ]
                                     ]
                             _ -> expectationFailure "Expected one tracked composite-key fetch"
+
+            it "matches changed rows against the retained parameterized QueryBuilder query" $ \_ ->
+                withAutoRefreshDB \modelContext -> do
+                    let ?modelContext = modelContext
+                    dependency <- withAutoRefreshReadTracker do
+                        items <- query @AutoRefreshItem
+                            |> filterWhereGreaterThan (#views, 6 :: Int)
+                            |> fetch
+                        items `shouldBe`
+                            [ AutoRefreshItem
+                                { autoRefreshItemId = "b0000000-0000-0000-0000-000000000002"
+                                , views = 8
+                                }
+                            ]
+
+                        dependencies <- readIORef ?autoRefreshReadDependencies
+                        case Map.lookup "auto_refresh_items" dependencies of
+                            Just dependency@(AutoRefreshQueryBuilderReads [_]) -> pure dependency
+                            _ -> expectationFailure "Expected one tracked QueryBuilder fetch" >> pure AutoRefreshWholeTable
+
+                    shouldRefreshForChange modelContext dependency AutoRefreshRowChange
+                        { operation = "insert"
+                        , rowId = Just "b0000000-0000-0000-0000-000000000002"
+                        }
+                        `shouldReturn` True
+                    shouldRefreshForChange modelContext dependency AutoRefreshRowChange
+                        { operation = "insert"
+                        , rowId = Just "b0000000-0000-0000-0000-000000000001"
+                        }
+                        `shouldReturn` False
 
         describe "autoRefreshMeta" do
             it "renders the ihp-auto-refresh-id meta tag on the initial response" $ withContext do
@@ -372,3 +455,129 @@ tests = beforeAll (mockContextNoDatabase WebApplication config) do
                 commitAutoRefreshReadDependencies (pure ()) serverRef UUID.nil newDependencies
                 getAutoRefreshReadDependencies <$> getOnlyAutoRefreshSession serverRef
                     `shouldReturn` newDependencies
+
+        describe "parameterized query filtering" do
+            it "uses the captured matcher for inserts" $ withContext do
+                let boundOwnerId = "owner-1" :: Text
+                let read = TrackedQueryRead
+                        { trackedRowIds = Just mempty
+                        , trackedQueryMatchesIds = Just (\changedIds -> pure (boundOwnerId == "owner-1" && "matching-row" `Set.member` changedIds))
+                        }
+                let dependency = AutoRefreshTrackedQueryReads [read]
+
+                shouldRefreshForChange ?modelContext dependency AutoRefreshRowChange { operation = "insert", rowId = Just "matching-row" }
+                    `shouldReturn` True
+                shouldRefreshForChange ?modelContext dependency AutoRefreshRowChange { operation = "insert", rowId = Just "other-row" }
+                    `shouldReturn` False
+
+            it "uses known IDs for deletes and updates" $ withContext do
+                let read = TrackedQueryRead
+                        { trackedRowIds = Just (Set.fromList ["visible-row"])
+                        , trackedQueryMatchesIds = Just (\changedIds -> pure ("newly-visible-row" `Set.member` changedIds))
+                        }
+                let dependency = AutoRefreshTrackedQueryReads [read]
+
+                shouldRefreshForChange ?modelContext dependency AutoRefreshRowChange { operation = "delete", rowId = Just "other-row" }
+                    `shouldReturn` False
+                shouldRefreshForChange ?modelContext dependency AutoRefreshRowChange { operation = "update", rowId = Just "visible-row" }
+                    `shouldReturn` True
+                shouldRefreshForChange ?modelContext dependency AutoRefreshRowChange { operation = "update", rowId = Just "newly-visible-row" }
+                    `shouldReturn` True
+
+            it "falls back to refreshing when tracking is incomplete or the matcher fails" $ withContext do
+                let untrackedRead = TrackedQueryRead
+                        { trackedRowIds = Nothing
+                        , trackedQueryMatchesIds = Nothing
+                        }
+                let failingRead = TrackedQueryRead
+                        { trackedRowIds = Just mempty
+                        , trackedQueryMatchesIds = Just (\_ -> throwIO (userError "matcher failed"))
+                        }
+
+                shouldRefreshForChange ?modelContext (AutoRefreshTrackedQueryReads [untrackedRead]) AutoRefreshRowChange { operation = "update", rowId = Just "row" }
+                    `shouldReturn` True
+                shouldRefreshForChange ?modelContext (AutoRefreshTrackedQueryReads [failingRead]) AutoRefreshRowChange { operation = "insert", rowId = Just "row" }
+                    `shouldReturn` True
+
+        describe "notification batching" do
+            it "has no intentional batching delay by default" $ \mockContext -> do
+                mockContext.frameworkConfig.autoRefreshBatchWindow `shouldBe` 0
+                autoRefreshBatchWindowMicroseconds mockContext.frameworkConfig.autoRefreshBatchWindow
+                    `shouldBe` 0
+
+            it "accepts an explicit batching window" $ \_ -> do
+                frameworkConfig <- buildFrameworkConfig testLogger do
+                    option Development
+                    option (AutoRefreshBatchWindow 100)
+                frameworkConfig.autoRefreshBatchWindow `shouldBe` 100
+                autoRefreshBatchWindowMicroseconds frameworkConfig.autoRefreshBatchWindow
+                    `shouldBe` 100000
+
+            it "coalesces a burst before running relevance checks" $ \_ -> do
+                workerState <- MVar.newMVar emptyAutoRefreshBatchWorkerState
+                processedBatches <- newIORef []
+                let changes =
+                        [ AutoRefreshRowChange { operation = "insert", rowId = Just ("row-" <> tshow number) }
+                        | number <- [1..10 :: Int]
+                        ]
+
+                starts <- forM changes (enqueueAutoRefreshRowChange workerState)
+                starts `shouldBe` (True : replicate 9 False)
+
+                worker <- Async.async $ runAutoRefreshBatchWorker 0 workerState \batch ->
+                    atomicModifyIORef' processedBatches (\batches -> (batch:batches, ()))
+                Async.wait worker
+
+                batches <- readIORef processedBatches
+                case batches of
+                    [batch] -> do
+                        batch.insertedRowIds `shouldBe` Set.fromList ["row-" <> tshow number | number <- [1..10 :: Int]]
+                        batch.updatedRowIds `shouldBe` Set.empty
+                        batch.deletedRowIds `shouldBe` Set.empty
+                    _ -> expectationFailure ("Expected one batch, got " <> cs (tshow (length batches)))
+
+            it "calls a retained Typed SQL matcher once for all changed IDs" $ withContext do
+                receivedBatches <- newIORef []
+                let read = TrackedQueryRead
+                        { trackedRowIds = Just Set.empty
+                        , trackedQueryMatchesIds = Just \changedIds -> do
+                            atomicModifyIORef' receivedBatches (\batches -> (changedIds:batches, ()))
+                            pure ("matching-row" `Set.member` changedIds)
+                        }
+                let batch = foldl'
+                        (flip addAutoRefreshRowChange)
+                        emptyAutoRefreshChangeBatch
+                        [ AutoRefreshRowChange { operation = "insert", rowId = Just "other-row" }
+                        , AutoRefreshRowChange { operation = "insert", rowId = Just "matching-row" }
+                        ]
+
+                shouldRefreshForChangeBatch ?modelContext (AutoRefreshTrackedQueryReads [read]) batch
+                    `shouldReturn` True
+                readIORef receivedBatches
+                    `shouldReturn` [Set.fromList ["other-row", "matching-row"]]
+
+            it "keeps a trailing batch when a change arrives during processing" $ \_ -> do
+                workerState <- MVar.newMVar emptyAutoRefreshBatchWorkerState
+                firstBatchStarted <- MVar.newEmptyMVar
+                releaseFirstBatch <- MVar.newEmptyMVar
+                processedBatches <- newIORef []
+                let firstChange = AutoRefreshRowChange { operation = "insert", rowId = Just "first-row" }
+                let trailingChange = AutoRefreshRowChange { operation = "insert", rowId = Just "trailing-row" }
+                let processBatch batch = do
+                        isFirst <- atomicModifyIORef' processedBatches \batches ->
+                            (batch:batches, null batches)
+                        when isFirst do
+                            MVar.putMVar firstBatchStarted ()
+                            MVar.takeMVar releaseFirstBatch
+
+                enqueueAutoRefreshRowChange workerState firstChange `shouldReturn` True
+                worker <- Async.async (runAutoRefreshBatchWorker 0 workerState processBatch)
+                MVar.takeMVar firstBatchStarted
+
+                enqueueAutoRefreshRowChange workerState trailingChange `shouldReturn` False
+                MVar.putMVar releaseFirstBatch ()
+                Async.wait worker
+
+                batches <- reverse <$> readIORef processedBatches
+                map (.insertedRowIds) batches
+                    `shouldBe` [Set.singleton "first-row", Set.singleton "trailing-row"]

--- a/ihp/Test/Test/QueryBuilderSpec.hs
+++ b/ihp/Test/Test/QueryBuilderSpec.hs
@@ -7,10 +7,12 @@ module Test.QueryBuilderSpec where
 import Test.Hspec
 import IHP.Prelude
 import IHP.QueryBuilder
+import IHP.QueryBuilder.HasqlCompiler (buildQueryMatchesRowStatement, buildQueryMatchesRowsStatement)
 import IHP.ModelSupport
 import IHP.Job.Types (JobStatus(..))
 import IHP.Job.Queue ()
 import Test.ModelFixtures
+import qualified Hasql.Statement as HasqlStatement
 
 tests = do
     describe "QueryBuilder" do
@@ -21,6 +23,23 @@ tests = do
                 let theQuery = query @Post
 
                 (toSQL theQuery) `shouldBe` ("SELECT " <> postColumns <> " FROM posts")
+
+            it "keeps bound parameter slots when building an AutoRefresh row matcher" do
+                let theQuery = query @Post
+                        |> filterWhere (#title, "Test" :: Text)
+                        |> filterWhere (#public, True)
+                let statement = buildQueryMatchesRowStatement (buildQuery theQuery)
+
+                HasqlStatement.toSql statement `shouldBe`
+                    cs ("SELECT EXISTS (SELECT 1 FROM (SELECT " <> postColumns <> " FROM posts WHERE (posts.title = $1) AND (posts.public = $2)) AS _ihp_auto_refresh_records WHERE _ihp_auto_refresh_records.id = (jsonb_populate_record(NULL::\"posts\", jsonb_build_object('id', $3))).id)" :: Text)
+
+            it "builds one type-aware matcher for a batch of changed IDs" do
+                let theQuery = query @Post
+                        |> filterWhere (#title, "Test" :: Text)
+                let statement = buildQueryMatchesRowsStatement (buildQuery theQuery)
+
+                HasqlStatement.toSql statement `shouldBe`
+                    cs ("SELECT EXISTS (SELECT 1 FROM (SELECT " <> postColumns <> " FROM posts WHERE posts.title = $1) AS _ihp_auto_refresh_records WHERE _ihp_auto_refresh_records.id = ANY (ARRAY(SELECT (jsonb_populate_record(NULL::\"posts\", jsonb_build_object('id', _ihp_changed_id))).id FROM unnest($2::text[]) AS _ihp_changed_id)))" :: Text)
 
         describe "filterWhere" do
             it "should produce a SQL with a WHERE condition" do


### PR DESCRIPTION
## Summary

- use the structured QueryBuilder reads introduced by #2760 to skip AutoRefresh rerenders for unrelated row changes
- capture TypedSQL table dependencies, returned row IDs, SQL snippets, and bound parameters
- batch row-level PostgreSQL notifications with an optional, configurable window that defaults to 0 ms
- fall back conservatively for unsupported query shapes, incomplete metadata, oversized dependency sets, and matcher failures
- harden PostgreSQL SQL parsing for comments, quoted content, CTEs, joins, expressions, and nested subqueries

## Why

AutoRefresh currently wakes every connected session that reads a changed table. At high fan-out, an unrelated write can therefore rerun every action and all of its queries.

PR #2760 already captures structured QueryBuilder reads. This stacked PR uses that metadata to decide whether a changed row can affect each rendered result before waking the session. TypedSQL gets an equivalent structured tracking path.

## How it works

PostgreSQL triggers now send the operation and conventional row ID. AutoRefresh keeps the IDs returned during the last render:

- updates and deletes of already visible rows refresh immediately without a matcher query
- deletes of invisible rows are ignored
- inserts and updates of invisible rows run one batched `SELECT EXISTS` against the retained parameterized query
- all changed IDs in a notification batch are checked by one matcher statement per retained read

TypedSQL metadata is generated by the quasiquoter. During an AutoRefresh render, safe single-table queries get a private textual ID projection while preserving the public result shape. The retained matcher closes over the original Hasql snippet, including its bound parameters.

The fine-grained path is deliberately bounded and conservative. OFFSET queries, complex or composite keys, missing IDs, mixed structured producers, more than 64 reads per table, more than 1024 returned IDs, or more than 4096 changed IDs fall back to whole-table refresh behavior.

## Notification batching

The default `AutoRefreshBatchWindow 0` adds no intentional latency. Applications can opt into a positive window through `Config.hs` or `IHP_AUTO_REFRESH_BATCH_WINDOW_MS` to coalesce write bursts and cap relevance-check frequency.

## Scope

This PR is stacked on #2760 and targets its `codex/track-autorefresh-queries` branch.

AutoRefresh tracking for `fetchPipelined` and `sqlQueryTypedPipelined` is intentionally excluded and will be proposed separately.

## Validation

- TypedSQL parser: 43 examples, 0 failures
- AutoRefresh, including PostgreSQL integration: 22 examples, 0 failures
- QueryBuilder: 54 examples, 0 failures
- TypedSQL runtime execution against PostgreSQL: 1 example, 0 failures
