### PR TITLE
Speed up production server builds

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -21,6 +21,8 @@
 , ihpSchemaSql ? null       # Path to IHPSchema.sql (required when buildWithPostgres = true)
 , migrationCheck ? null     # Optional derivation that validates Application/Migration before building the app
 , previousIntermediates ? null # Optional intermediate output from a previous optimized app library build
+, buildStaticLibraries ? true # Build static Haskell libraries in addition to shared libraries
+, ghcAllocationArea ? null # Optional GHC compile-time RTS allocation area, e.g. "128M"
 }:
 
 let
@@ -166,7 +168,7 @@ CABAL_EOF
     # Every generated table expands into several modules. With large schemas,
     # split sections create enough archive members for the final library
     # assembly to exceed the platform's argument-size limit.
-    modelsPackage = pkgs.haskell.lib.overrideCabal (
+    modelsPackage = configureHaskellBuild (pkgs.haskell.lib.overrideCabal (
         pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
             ghc.callPackage ({ mkDerivation, base, ihp, basic-prelude, text, bytestring, time, uuid, aeson, postgresql-simple, deepseq, data-default, scientific, string-conversions, hasql, hasql-dynamic-statements, hasql-implicits, hasql-mapping, hasql-postgresql-types, hasql-pool, unordered-containers, postgresql-types }: mkDerivation {
                 pname = "${appName}-models";
@@ -200,7 +202,7 @@ CABAL_EOF
         ))
     ) (old: {
         configureFlags = (old.configureFlags or []) ++ [ "--disable-split-sections" ];
-    });
+    }));
 
     allHaskellPackages =
         (if withHoogle
@@ -420,7 +422,22 @@ CABAL_EOF
         '';
     });
 
-    appLibPackageBase = pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
+    configureHaskellBuild = pkg:
+        pkgs.haskell.lib.overrideCabal
+            (if buildStaticLibraries then pkg else pkgs.haskell.lib.disableStaticLibraries pkg)
+            (old: {
+                configureFlags = (old.configureFlags or [])
+                    ++ pkgs.lib.optionals (!buildStaticLibraries) [
+                        "--disable-library-vanilla"
+                    ]
+                    ++ pkgs.lib.optionals (ghcAllocationArea != null) [
+                        "--ghc-option=+RTS"
+                        "--ghc-option=-A${ghcAllocationArea}"
+                        "--ghc-option=-RTS"
+                    ];
+            });
+
+    appLibPackageBase = configureHaskellBuild (pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
         ghc.callPackage ({ mkDerivation, base }: mkDerivation {
             pname = "${appName}-lib";
             version = "0.1.0";
@@ -431,7 +448,7 @@ CABAL_EOF
             inherit previousIntermediates;
             license = pkgs.lib.licenses.free;
         }) {}
-    ));
+    )));
 
     appLibPackage =
         if buildWithPostgres
@@ -463,6 +480,7 @@ CABAL_EOF
                 ''}
 
                 ghc -j1 +RTS -N1 -RTS \
+                    ${pkgs.lib.optionalString (!buildStaticLibraries) "-dynamic"} \
                     -O${if optimized then optimizationLevel else "0"} ${splitSections} \
                     ${pkgs.lib.optionalString (mainIs != null) "-main-is '${mainIs}'"} \
                     $(make print-ghc-options) \

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -131,20 +131,20 @@ ihpFlake:
                     default = "1";
                 };
 
-                unoptimizedBuildStaticLibraries = lib.mkOption {
+                buildStaticLibraries = lib.mkOption {
                     description = ''
-                        Whether the unoptimized production-server build compiles static
-                        Haskell libraries in addition to shared libraries.
+                        Whether production-server builds compile static Haskell libraries
+                        in addition to shared libraries.
                     '';
                     type = lib.types.bool;
                     default = true;
                 };
 
-                unoptimizedGhcAllocationArea = lib.mkOption {
+                ghcAllocationArea = lib.mkOption {
                     description = ''
-                        Optional GHC compile-time RTS allocation area for the unoptimized
-                        production-server build, such as "128M". When unset, the nixpkgs
-                        Haskell builder default is used.
+                        Optional GHC compile-time RTS allocation area for production-server
+                        builds, such as "128M". When unset, the nixpkgs Haskell builder
+                        default is used.
                     '';
                     type = lib.types.nullOr lib.types.str;
                     default = null;
@@ -230,8 +230,7 @@ ihpFlake:
                 static = self'.packages.static;
                 inherit buildWithPostgres;
                 previousIntermediates = if optimized then cfg.previousAppLibIntermediates else null;
-                buildStaticLibraries = optimized || cfg.unoptimizedBuildStaticLibraries;
-                ghcAllocationArea = if optimized then null else cfg.unoptimizedGhcAllocationArea;
+                inherit (cfg) buildStaticLibraries ghcAllocationArea;
                 appSchemaSql = "${self'.packages.schema}/Schema.sql";
                 ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";
             };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -131,6 +131,25 @@ ihpFlake:
                     default = "1";
                 };
 
+                unoptimizedBuildStaticLibraries = lib.mkOption {
+                    description = ''
+                        Whether the unoptimized production-server build compiles static
+                        Haskell libraries in addition to shared libraries.
+                    '';
+                    type = lib.types.bool;
+                    default = true;
+                };
+
+                unoptimizedGhcAllocationArea = lib.mkOption {
+                    description = ''
+                        Optional GHC compile-time RTS allocation area for the unoptimized
+                        production-server build, such as "128M". When unset, the nixpkgs
+                        Haskell builder default is used.
+                    '';
+                    type = lib.types.nullOr lib.types.str;
+                    default = null;
+                };
+
                 previousAppLibIntermediates = lib.mkOption {
                     description = ''
                         Intermediate output from a previous optimized application build.
@@ -211,6 +230,8 @@ ihpFlake:
                 static = self'.packages.static;
                 inherit buildWithPostgres;
                 previousIntermediates = if optimized then cfg.previousAppLibIntermediates else null;
+                buildStaticLibraries = optimized || cfg.unoptimizedBuildStaticLibraries;
+                ghcAllocationArea = if optimized then null else cfg.unoptimizedGhcAllocationArea;
                 appSchemaSql = "${self'.packages.schema}/Schema.sql";
                 ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";
             };


### PR DESCRIPTION
## What changed

- Add `ihp.buildStaticLibraries`, defaulting to `true` for compatibility.
- Add `ihp.ghcAllocationArea`, defaulting to the nixpkgs Haskell builder setting.
- Apply both settings to generated models and the application library for unoptimized and optimized production-server builds.
- Link production-server executables dynamically when static libraries are disabled.

## Why

Large IHP applications currently compile both vanilla/static and dynamic Haskell objects. Template Haskell and typed SQL require the dynamic interfaces, but a dynamically linked server executable does not also need a second vanilla object-code copy.

On a 2,224-module generated models package and an 800-module application package, shared-only libraries plus `-A128M` produced:

| Phase | Before | After | Change |
| --- | ---: | ---: | ---: |
| Generated models | 98s | 60s | -39% |
| Application library | 200s | 147s | -26% |
| Combined | 298s | 207s | -31% |
| Models output | 391 MiB | 170 MiB | -57% |
| Application output | 447 MiB | 196 MiB | -56% |

An isolated `-A64M` versus `-A128M` models test improved 67s to 63s, so avoiding duplicate object-code flavors accounts for most of the gain. The allocation-area option remains opt-in to avoid increasing memory unless an application explicitly chooses that tradeoff.

## Validation

- Evaluated downstream `.#default` and `.#optimized-prod-server` derivations with both new options enabled.
- Confirmed both targets configure the generated models and application library with `--disable-library-vanilla` and `-A128M` and link the server executable dynamically.
- Completed the full downstream `.#default` build on a remote aarch64-darwin builder.
- Confirmed generated models and the application compile only `.dyn_o` objects.
- Confirmed both `RunProdServer` and `RunJobs` link dynamically.
- Smoke-started `RunProdServer`; it reached `Server started`.
- `git diff --check` passes.