### PR TITLE
Guide: use Garage for local S3 storage, add initS3CompatibleStorage

### DIFF
--- a/Guide/config.markdown
+++ b/Guide/config.markdown
@@ -565,21 +565,21 @@ config = do
     initS3Storage "eu-central-1" "my-bucket-name"
 ```
 
-#### Minio Storage
+#### S3 Compatible Storage
 
-Stores files in a Minio-compatible object storage server.
+Stores files in a self-hosted S3 compatible object storage server such as [Garage](https://garagehq.deuxfleurs.fr/) or SeaweedFS. See [File Storage & Uploads](https://ihp.digitallyinduced.com/Guide/file-storage.html) for a local development setup.
 
 | Env var | Description |
 |---------|-------------|
-| `MINIO_ACCESS_KEY` | Minio access key |
-| `MINIO_SECRET_KEY` | Minio secret key |
+| `MINIO_ACCESS_KEY` | S3 access key |
+| `MINIO_SECRET_KEY` | S3 secret key |
 
 ```haskell
 -- Config.hs
 import IHP.FileStorage.Config
 
 config = do
-    initMinioStorage "https://minio.example.com" "my-bucket-name"
+    initMinioStorage "https://storage.example.com" "my-bucket-name"
 ```
 
 #### Filebase Storage
@@ -789,8 +789,8 @@ These environment variables are read by IHP's server infrastructure and cannot b
 | `IHP_STORAGE_DIR` | `static/` | File Storage |
 | `AWS_ACCESS_KEY_ID` | N/A | File Storage (S3) |
 | `AWS_SECRET_ACCESS_KEY` | N/A | File Storage (S3) |
-| `MINIO_ACCESS_KEY` | N/A | File Storage (Minio) |
-| `MINIO_SECRET_KEY` | N/A | File Storage (Minio) |
+| `MINIO_ACCESS_KEY` | N/A | File Storage (S3 compatible) |
+| `MINIO_SECRET_KEY` | N/A | File Storage (S3 compatible) |
 | `FILEBASE_KEY` | N/A | File Storage (Filebase) |
 | `FILEBASE_SECRET` | N/A | File Storage (Filebase) |
 | `IHP_IDE_BASEURL` | `http://localhost:<port+1>` | IDE |

--- a/Guide/config.markdown
+++ b/Guide/config.markdown
@@ -571,15 +571,17 @@ Stores files in a self-hosted S3 compatible object storage server such as [Garag
 
 | Env var | Description |
 |---------|-------------|
-| `MINIO_ACCESS_KEY` | S3 access key |
-| `MINIO_SECRET_KEY` | S3 secret key |
+| `AWS_ACCESS_KEY_ID` | S3 access key |
+| `AWS_SECRET_ACCESS_KEY` | S3 secret key |
+
+The legacy `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` env vars still work and take precedence when set.
 
 ```haskell
 -- Config.hs
 import IHP.FileStorage.Config
 
 config = do
-    initMinioStorage "https://storage.example.com" "my-bucket-name"
+    initS3CompatibleStorage "https://storage.example.com" "my-bucket-name"
 ```
 
 #### Filebase Storage
@@ -789,8 +791,8 @@ These environment variables are read by IHP's server infrastructure and cannot b
 | `IHP_STORAGE_DIR` | `static/` | File Storage |
 | `AWS_ACCESS_KEY_ID` | N/A | File Storage (S3) |
 | `AWS_SECRET_ACCESS_KEY` | N/A | File Storage (S3) |
-| `MINIO_ACCESS_KEY` | N/A | File Storage (S3 compatible) |
-| `MINIO_SECRET_KEY` | N/A | File Storage (S3 compatible) |
+| `MINIO_ACCESS_KEY` | N/A | File Storage (S3 compatible, legacy) |
+| `MINIO_SECRET_KEY` | N/A | File Storage (S3 compatible, legacy) |
 | `FILEBASE_KEY` | N/A | File Storage (Filebase) |
 | `FILEBASE_SECRET` | N/A | File Storage (Filebase) |
 | `IHP_IDE_BASEURL` | `http://localhost:<port+1>` | IDE |

--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -121,7 +121,7 @@ Open your `Config/Config.hs` and import `import IHP.FileStorage.Config`:
 import IHP.FileStorage.Config
 ```
 
-Then add a call to [`initMinioStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Config.html#v:initMinioStorage). Despite its name it works with any S3 compatible server:
+Then add a call to [`initS3CompatibleStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Config.html#v:initS3CompatibleStorage):
 
 ```haskell
 module Config where
@@ -137,13 +137,13 @@ config = do
     option (AppHostname "localhost")
 
     -- Local development, we use Garage.
-    initMinioStorage "http://127.0.0.1:3900" "ihp-bucket"
+    initS3CompatibleStorage "http://127.0.0.1:3900" "ihp-bucket"
 
     -- Or if you have a remote server:
-    -- initMinioStorage "https://storage.example.com" "my-bucket-name"
+    -- initS3CompatibleStorage "https://storage.example.com" "my-bucket-name"
 ```
 
-The access key and secret key have to be provided using the `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` env vars. These are plain S3 credentials, the naming is historical.
+The access key and secret key have to be provided using the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars, the same names the AWS CLI and other S3 tooling use.
 
 For easy development you can add these env vars to your `.envrc` file:
 
@@ -154,9 +154,11 @@ use devenv
 
 # ...
 # When working locally, these are the credentials imported above.
-export MINIO_ACCESS_KEY="GK00000000000000000000000f"
-export MINIO_SECRET_KEY="0000000000000000000000000000000000000000000000000000000000000000"
+export AWS_ACCESS_KEY_ID="GK00000000000000000000000f"
+export AWS_SECRET_ACCESS_KEY="0000000000000000000000000000000000000000000000000000000000000000"
 ```
+
+If your app already sets `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`, those keep working and take precedence.
 
 ### Filebase
 > Filebase provides an S3 compatible API on top of decentralized object storage systems such as Storj, Skynet, Sia and IPFS

--- a/Guide/file-storage.markdown
+++ b/Guide/file-storage.markdown
@@ -45,7 +45,7 @@ config = do
 ### S3
 
 AWS S3 is a popular cloud storage service that allows you to store and retrieve files. IHP provides a simple way to integrate with S3.
-See MinIo section below to learn how to setup an S3 compatible storage service for your local development. So your application can use the same code for
+See the Garage section below to learn how to setup an S3 compatible storage service for your local development. So your application can use the same code for
 both local development and production.
 
 Open your `Config/Config.hs` and import `import IHP.FileStorage.Config`:
@@ -87,22 +87,33 @@ export AWS_ACCESS_KEY_ID="YOUR KEY"            # <---------
 export AWS_SECRET_ACCESS_KEY="YOUR SECRET"     # <---------
 ```
 
-### Minio
+### Garage
 
-Enable MinIo in your `flake.nix`
+[Garage](https://garagehq.deuxfleurs.fr/) is a lightweight, S3 compatible object storage server. It's a good way to run an S3 compatible service locally, so your application can use the same code path for both local development and production.
+
+Enable Garage in your `flake.nix`
 
 ```nix
 devenv.shells.default = {
-    # Enable S3 compatibility with MinIO.
-    services.minio = {
+    # Enable S3 compatibility with Garage.
+    services.garage = {
         enable = true;
         buckets = [ "ihp-bucket" ];
+
+        # Garage has no default credentials. Import a fixed development key
+        # and grant it access to the bucket. The `key info` check keeps this
+        # idempotent across restarts.
+        afterStart = ''
+            garage key info ihp-dev > /dev/null 2>&1 \
+                || garage key import --yes -n ihp-dev GK00000000000000000000000f 0000000000000000000000000000000000000000000000000000000000000000
+            garage bucket allow --read --write --owner ihp-bucket --key ihp-dev
+        '';
     };
 
 };
 ```
 
-When working locally, the MinIO server is started by the `devenv up` command.
+When working locally, the Garage server is started by the `devenv up` command. Its S3 API listens on `http://127.0.0.1:3900`.
 
 Open your `Config/Config.hs` and import `import IHP.FileStorage.Config`:
 
@@ -110,7 +121,7 @@ Open your `Config/Config.hs` and import `import IHP.FileStorage.Config`:
 import IHP.FileStorage.Config
 ```
 
-Then add a call to [`initMinioStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Config.html#v:initMinioStorage):
+Then add a call to [`initMinioStorage`](https://ihp.digitallyinduced.com/api-docs/IHP-FileStorage-Config.html#v:initMinioStorage). Despite its name it works with any S3 compatible server:
 
 ```haskell
 module Config where
@@ -125,14 +136,14 @@ config = do
     option Development
     option (AppHostname "localhost")
 
-    -- Local development, we use MinIo.
-    initMinioStorage "http://127.0.0.1:9000" "ihp-bucket"
+    -- Local development, we use Garage.
+    initMinioStorage "http://127.0.0.1:3900" "ihp-bucket"
 
-    -- Or if you have a remote Minio server:
-    -- initMinioStorage "https://minio.example.com" "my-bucket-name"
+    -- Or if you have a remote server:
+    -- initMinioStorage "https://storage.example.com" "my-bucket-name"
 ```
 
-The Minio access key and secret key have to be provided using the `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` env vars.
+The access key and secret key have to be provided using the `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` env vars. These are plain S3 credentials, the naming is historical.
 
 For easy development you can add these env vars to your `.envrc` file:
 
@@ -142,9 +153,9 @@ source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cf
 use devenv
 
 # ...
-# When working locally, these are the default credentials.
-export MINIO_ACCESS_KEY="minioadmin"
-export MINIO_SECRET_KEY="minioadmin"
+# When working locally, these are the credentials imported above.
+export MINIO_ACCESS_KEY="GK00000000000000000000000f"
+export MINIO_SECRET_KEY="0000000000000000000000000000000000000000000000000000000000000000"
 ```
 
 ### Filebase

--- a/ihp/IHP/FileStorage/Config.hs
+++ b/ihp/IHP/FileStorage/Config.hs
@@ -6,6 +6,7 @@ Copyright: (c) digitally induced GmbH, 2021
 module IHP.FileStorage.Config
 ( initS3Storage
 , initStaticDirStorage
+, initS3CompatibleStorage
 , initMinioStorage
 , initFilebaseStorage
 ) where
@@ -50,8 +51,9 @@ initS3Storage region bucket = do
 
 -- | Stores files in a self-hosted S3 compatible object storage server, e.g. Garage or SeaweedFS.
 --
--- The access key and secret key have to be provided using the @MINIO_ACCESS_KEY@ and @MINIO_SECRET_KEY@ env vars.
--- The naming of these env vars is historical, they're plain S3 credentials.
+-- The access key and secret key are read from the @AWS_ACCESS_KEY_ID@ and @AWS_SECRET_ACCESS_KEY@ env vars,
+-- the same names the AWS CLI and other S3 tooling use. The legacy @MINIO_ACCESS_KEY@ and @MINIO_SECRET_KEY@
+-- env vars still take precedence when they are set.
 --
 -- __Example:__ Set up a S3 compatible storage in @Config.hs@
 --
@@ -66,18 +68,23 @@ initS3Storage region bucket = do
 -- > config = do
 -- >     option Development
 -- >     option (AppHostname "localhost")
--- >     initMinioStorage "https://storage.example.com" "my-bucket-name"
+-- >     initS3CompatibleStorage "https://storage.example.com" "my-bucket-name"
 --
-initMinioStorage :: HasCallStack => Text -> Text -> State.StateT TMap.TMap IO ()
-initMinioStorage server bucket = do
+initS3CompatibleStorage :: HasCallStack => Text -> Text -> State.StateT TMap.TMap IO ()
+initS3CompatibleStorage server bucket = do
     connectInfo <- server
         |> cs
         |> fromString
-        |> setCredsFrom [fromMinioEnv]
+        |> setCredsFrom [fromMinioEnv, fromAWSEnv]
         |> configIO
 
     let baseUrl = server <> "/" <> bucket <> "/"
     option S3Storage { connectInfo, bucket, baseUrl }
+
+-- | Alias for 'initS3CompatibleStorage', kept for backwards compatibility.
+initMinioStorage :: HasCallStack => Text -> Text -> State.StateT TMap.TMap IO ()
+initMinioStorage = initS3CompatibleStorage
+{-# DEPRECATED initMinioStorage "Use initS3CompatibleStorage instead" #-}
 
 -- | Stores files publicly visible inside the @static@ directory
 --

--- a/ihp/IHP/FileStorage/Config.hs
+++ b/ihp/IHP/FileStorage/Config.hs
@@ -48,9 +48,12 @@ initS3Storage region bucket = do
     let baseUrl = "https://" <> bucket <> ".s3." <> region <> ".amazonaws.com/"
     option S3Storage { connectInfo, bucket, baseUrl }
 
--- | The Minio access key and secret key have to be provided using the @MINIO_ACCESS_KEY@ and @MINIO_SECRET_KEY@ env vars.
+-- | Stores files in a self-hosted S3 compatible object storage server, e.g. Garage or SeaweedFS.
 --
--- __Example:__ Set up a minio storage in @Config.hs@
+-- The access key and secret key have to be provided using the @MINIO_ACCESS_KEY@ and @MINIO_SECRET_KEY@ env vars.
+-- The naming of these env vars is historical, they're plain S3 credentials.
+--
+-- __Example:__ Set up a S3 compatible storage in @Config.hs@
 --
 -- > module Config where
 -- >
@@ -63,7 +66,7 @@ initS3Storage region bucket = do
 -- > config = do
 -- >     option Development
 -- >     option (AppHostname "localhost")
--- >     initMinioStorage "https://minio.example.com" "my-bucket-name"
+-- >     initMinioStorage "https://storage.example.com" "my-bucket-name"
 --
 initMinioStorage :: HasCallStack => Text -> Text -> State.StateT TMap.TMap IO ()
 initMinioStorage server bucket = do


### PR DESCRIPTION
Closes #2769 (docs part).

The file storage guide told users to run MinIO for local development. That server is archived now, so the guide sets up [Garage](https://garagehq.deuxfleurs.fr/) instead via devenv's `services.garage`.

While in there: `initMinioStorage` and `MINIO_ACCESS_KEY` were never MinIO-specific — it's an S3 client that talks to any S3-compatible server. So:

- New `initS3CompatibleStorage`, with `initMinioStorage` kept as a `{-# DEPRECATED #-}` alias.
- Credentials now also read from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, the names the AWS CLI and the rest of the S3 tooling use. `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` are still tried first, so nothing existing breaks.

Files:

- `ihp/IHP/FileStorage/Config.hs` — new function + deprecated alias
- `Guide/file-storage.markdown` — Minio section → Garage section
- `Guide/config.markdown` — "Minio Storage" → "S3 Compatible Storage"

Verified `IHP.FileStorage.Config` loads in ghci (`Ok, 26 modules loaded`), and the devenv snippet end-to-end against garage 2.3.0: layout apply, `key import`, `bucket allow`, then an S3 PUT + GET with the imported credentials (both 200). The `key info || key import` guard is there because a bare re-import fails with `KeyAlreadyExists` on the second `devenv up`.

The `minio-hs` client itself is still stale (no release since 1.7.0, jailbroken in `NixSupport/overlay.nix`) — that's the other half of #2769 and left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
