### PR TITLE
Reduce type-family work for large schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `sqlExecTyped` now also supports known typed no-result utility statements such as `SET CONSTRAINTS ...`, returning `()` after successful execution. ([#2747](https://github.com/digitallyinduced/ihp/issues/2747))
 - Fixed the IDE codegen "Preview" buttons failing with `405 Method Not Allowed`: the `New*` ToolServer routes were declared GET-only in the routes-DSL migration, but the codegen views submit their preview and option forms via POST. They now accept `GET|POST` again, as AutoRoute did in v1.5. ([#2743](https://github.com/digitallyinduced/ihp/issues/2743), [#2744](https://github.com/digitallyinduced/ihp/pull/2744))
 
+### Performance, Build, and Tooling
+
+- Reduced type-family work for model and query code by removing unnecessary table-name `KnownSymbol` constraints and generating direct model ID metadata, keeping common paths such as `currentUserId` shallow on large schemas. ([#2766](https://github.com/digitallyinduced/ihp/issues/2766))
+
 ### Breaking Changes
 
 - `typedSql` now tracks conservative query cardinality and statement result
@@ -56,7 +60,6 @@
 
 ### Performance, Build, and Tooling
 
-- Reduced type-family work for model and query code by removing unnecessary table-name `KnownSymbol` constraints and generating direct model ID metadata, keeping common paths such as `currentUserId` shallow on large schemas. ([#2766](https://github.com/digitallyinduced/ihp/issues/2766))
 - HSX rendering now uses a direct `ByteString.Builder` markup backend instead of the Blaze `MarkupM` tree, giving 2-4x faster HSX rendering in benchmarks. `respondHtml` / `respondSvg` use WAI builders directly for zero-copy responses. ([#2563](https://github.com/digitallyinduced/ihp/pull/2563))
 - `pathTo` and `renderFieldForUrl` are marked `NOINLINE` to reduce Core bloat, and the new routes DSL caches the merged route trie at application construction time. ([#2524](https://github.com/digitallyinduced/ihp/pull/2524), [#2652](https://github.com/digitallyinduced/ihp/pull/2652))
 - Nix production builds now compile web, worker, and script executables in separate derivations, allowing more parallelism and better cache reuse. ([#2715](https://github.com/digitallyinduced/ihp/pull/2715))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ### Performance, Build, and Tooling
 
+- Reduced type-family work for model and query code by removing unnecessary table-name `KnownSymbol` constraints and generating direct model ID metadata, keeping common paths such as `currentUserId` shallow on large schemas. ([#2766](https://github.com/digitallyinduced/ihp/issues/2766))
 - HSX rendering now uses a direct `ByteString.Builder` markup backend instead of the Blaze `MarkupM` tree, giving 2-4x faster HSX rendering in benchmarks. `respondHtml` / `respondSvg` use WAI builders directly for zero-copy responses. ([#2563](https://github.com/digitallyinduced/ihp/pull/2563))
 - `pathTo` and `renderFieldForUrl` are marked `NOINLINE` to reduce Core bloat, and the new routes DSL caches the merged route trie at application construction time. ([#2524](https://github.com/digitallyinduced/ihp/pull/2524), [#2652](https://github.com/digitallyinduced/ihp/pull/2652))
 - Nix production builds now compile web, worker, and script executables in separate derivations, allowing more parallelism and better cache reuse. ([#2715](https://github.com/digitallyinduced/ihp/pull/2715))

--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -220,7 +220,9 @@ tests = do
                     instance Default (Id' "users") where def = Id def
 
                     instance IHP.ModelSupport.Table (User') where
+                        type TableId (User') = Id' "users"
                         tableName = "users"
+                        modelId (User id ids electricityUnitPrice meta) = id
                         columnNames = ["id","ids","electricity_unit_price"]
                         primaryKeyColumnNames = ["id"]
 
@@ -320,7 +322,9 @@ tests = do
                     instance Default (Id' "users") where def = Id def
 
                     instance IHP.ModelSupport.Table (User') where
+                        type TableId (User') = Id' "users"
                         tableName = "users"
+                        modelId (User id ids electricityUnitPrice meta) = id
                         columnNames = ["id","ids","electricity_unit_price"]
                         primaryKeyColumnNames = ["id"]
 
@@ -419,7 +423,9 @@ tests = do
                     instance Default (Id' "users") where def = Id def
 
                     instance IHP.ModelSupport.Table (User') where
+                        type TableId (User') = Id' "users"
                         tableName = "users"
+                        modelId (User id ts meta) = id
                         columnNames = ["id","ts"]
                         primaryKeyColumnNames = ["id"]
 
@@ -552,7 +558,9 @@ tests = do
                     instance Default (Id' "landing_pages") where def = Id def
 
                     instance IHP.ModelSupport.Table (LandingPage' paragraphCtasLandingPages paragraphCtasToLandingPages) where
+                        type TableId (LandingPage' paragraphCtasLandingPages paragraphCtasToLandingPages) = Id' "landing_pages"
                         tableName = "landing_pages"
+                        modelId (LandingPage id paragraphCtasLandingPages paragraphCtasToLandingPages meta) = id
                         columnNames = ["id"]
                         primaryKeyColumnNames = ["id"]
 
@@ -682,7 +690,9 @@ tests = do
             it "should compile Table instance" $ \statement -> do
                 getInstanceDecl "IHP.ModelSupport.Table" compileOutput `shouldBe` [trimming|
                     instance IHP.ModelSupport.Table (Thing' others) where
+                        type TableId (Thing' others) = Id' "things"
                         tableName = "things"
+                        modelId (Thing thingArbitraryIdent others meta) = thingArbitraryIdent
                         columnNames = ["thing_arbitrary_ident"]
                         primaryKeyColumnNames = ["thing_arbitrary_ident"]
 
@@ -742,7 +752,9 @@ tests = do
             it "should compile Table instance" $ \statement -> do
                 getInstanceDecl "IHP.ModelSupport.Table" compileOutput `shouldBe` [trimming|
                     instance IHP.ModelSupport.Table (BitPartRef' bitRef partRef) where
+                        type TableId (BitPartRef' bitRef partRef) = Id' "bit_part_refs"
                         tableName = "bit_part_refs"
+                        modelId (BitPartRef bitRef partRef meta) = Id (bitRef, partRef)
                         columnNames = ["bit_ref","part_ref"]
                         primaryKeyColumnNames = ["bit_ref","part_ref"]
 
@@ -914,7 +926,9 @@ tests = do
                     instance Default (Id' "posts") where def = Id def
 
                     instance IHP.ModelSupport.Table (Post') where
+                        type TableId (Post') = Id' "posts"
                         tableName = "posts"
+                        modelId (Post id title userId meta) = id
                         columnNames = ["id","title","user_id"]
                         primaryKeyColumnNames = ["id"]
 
@@ -1446,7 +1460,9 @@ tests = do
             it "should include inherited columns in Table instance" do
                 getInstanceDecl "IHP.ModelSupport.Table" compileOutput `shouldBe` [trimming|
                     instance IHP.ModelSupport.Table (PostRevision') where
+                        type TableId (PostRevision') = Id' "post_revisions"
                         tableName = "post_revisions"
+                        modelId (PostRevision id revisionContent title body meta) = id
                         columnNames = ["id","revision_content","title","body"]
                         primaryKeyColumnNames = ["id"]
 

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -1089,7 +1089,9 @@ instance QueryBuilder.FilterPrimaryKey "#{name}" where
 compileTableInstance :: (?schema :: Schema, ?compilerOptions :: CompilerOptions) => CreateTable -> Text
 compileTableInstance table@(CreateTable { name, constraints }) = cs [i|
 instance #{instanceHead} where
+    type TableId (#{compileTypePattern table}) = Id' "#{name}"
     tableName = \"#{name}\"
+    modelId (#{compileDataTypePattern table}) = #{compilePrimaryKeyValue table}
     columnNames = #{columnNames}
     primaryKeyColumnNames = #{primaryKeyColumnNames}
 |]
@@ -1208,13 +1210,15 @@ compileFieldBitInstances table@(CreateTable { name }) = unlines (map compileInst
 compileHasFieldId :: (?schema :: Schema, ?compilerOptions :: CompilerOptions) => CreateTable -> Text
 compileHasFieldId table@CreateTable { name, primaryKeyConstraint } = cs [i|
 instance HasField "id" #{tableNameToModelName name} (Id' "#{name}") where
-    getField (#{compileDataTypePattern table}) = #{compilePrimaryKeyValue}
+    getField (#{compileDataTypePattern table}) = #{compilePrimaryKeyValue table}
     {-# INLINE getField #-}
 |]
-    where
-        compilePrimaryKeyValue = case primaryKeyColumnNames primaryKeyConstraint of
-            [id] -> columnNameToFieldName id
-            ids -> "Id (" <> commaSep (map columnNameToFieldName ids) <> ")"
+
+compilePrimaryKeyValue :: CreateTable -> Text
+compilePrimaryKeyValue CreateTable { primaryKeyConstraint } =
+    case primaryKeyColumnNames primaryKeyConstraint of
+        [id] -> columnNameToFieldName id
+        ids -> "Id (" <> commaSep (map columnNameToFieldName ids) <> ")"
 
 needsHasFieldId :: CreateTable -> Bool
 needsHasFieldId CreateTable { columns, primaryKeyConstraint } =
@@ -1729,5 +1733,4 @@ compileDynamicCreateManyStatement moduleName qualifiedModelName tableName writab
         , "decoder :: Decoders.Result [" <> qualifiedModelName <> "]"
         , "decoder = Decoders.rowList RowDecoder.rowDecoder"
         ]
-
 

--- a/ihp/IHP/Fetch.hs
+++ b/ihp/IHP/Fetch.hs
@@ -40,17 +40,17 @@ class Fetchable fetchable model | fetchable -> model where
     fetchOneOrNothing :: (Table model, FromRowHasql model, ?modelContext :: ModelContext) => fetchable -> IO (Maybe model)
     fetchOne :: (Table model, FromRowHasql model, ?modelContext :: ModelContext) => fetchable -> IO model
 
-instance (model ~ GetModelByTableName table, KnownSymbol table) => Fetchable (QueryBuilder table) model where
+instance model ~ GetModelByTableName table => Fetchable (QueryBuilder table) model where
     type instance FetchResult (QueryBuilder table) model = [model]
     fetch :: (Table model, FromRowHasql model, ?modelContext :: ModelContext) => QueryBuilder table -> IO [model]
     fetch !queryBuilder = do
-        trackTableRead (tableName @model)
+        trackTableRead (queryBuilderTableName queryBuilder)
         let pool = ?modelContext.hasqlPool
         sqlStatementHasql pool () (buildQueryListStatement queryBuilder)
 
     fetchOneOrNothing :: (?modelContext :: ModelContext) => (Table model, FromRowHasql model) => QueryBuilder table -> IO (Maybe model)
     fetchOneOrNothing !queryBuilder = do
-        trackTableRead (tableName @model)
+        trackTableRead (queryBuilderTableName queryBuilder)
         let pool = ?modelContext.hasqlPool
         sqlStatementHasql pool () (buildQueryMaybeStatement queryBuilder)
 
@@ -74,9 +74,9 @@ instance (model ~ GetModelByTableName table, KnownSymbol table) => Fetchable (Qu
 -- > activeUsers <- query @User
 -- >     |> filterWhere (#active, True)
 -- >     |> fetchVector
-fetchVector :: forall model table. (Table model, model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext) => QueryBuilder table -> IO (Vector model)
+fetchVector :: forall model table. (Table model, model ~ GetModelByTableName table, FromRowHasql model, ?modelContext :: ModelContext) => QueryBuilder table -> IO (Vector model)
 fetchVector !queryBuilder = do
-    trackTableRead (tableName @model)
+    trackTableRead (queryBuilderTableName queryBuilder)
     let pool = ?modelContext.hasqlPool
     sqlStatementHasql pool () (buildQueryVectorStatement queryBuilder)
 
@@ -93,9 +93,9 @@ fetchVector !queryBuilder = do
 -- >         |> filterWhere (#isActive, True)
 -- >         |> fetchCount
 -- >     -- SELECT COUNT(*) FROM projects WHERE is_active = true
-fetchCount :: forall table. (?modelContext :: ModelContext, KnownSymbol table) => QueryBuilder table -> IO Int
+fetchCount :: forall table. (?modelContext :: ModelContext) => QueryBuilder table -> IO Int
 fetchCount !queryBuilder = do
-    trackTableRead (symbolToText @table)
+    trackTableRead (queryBuilderTableName queryBuilder)
     let pool = ?modelContext.hasqlPool
     fromIntegral <$> sqlStatementHasql pool () (buildCountStatement queryBuilder)
 
@@ -109,29 +109,29 @@ fetchCount !queryBuilder = do
 -- >         |> filterWhere (#isUnread, True)
 -- >         |> fetchExists
 -- >     -- SELECT EXISTS (SELECT * FROM messages WHERE is_unread = true)
-fetchExists :: forall table. (?modelContext :: ModelContext, KnownSymbol table) => QueryBuilder table -> IO Bool
+fetchExists :: forall table. (?modelContext :: ModelContext) => QueryBuilder table -> IO Bool
 fetchExists !queryBuilder = do
-    trackTableRead (symbolToText @table)
+    trackTableRead (queryBuilderTableName queryBuilder)
     let pool = ?modelContext.hasqlPool
     sqlStatementHasql pool () (buildExistsStatement queryBuilder)
 
-genericFetchId :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Id' table -> IO [model]
-genericFetchId !id = query @model |> filterWhereId id |> fetch
+genericFetchId :: forall table model. (Table model, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, FilterPrimaryKey table) => Id' table -> IO [model]
+genericFetchId !id = (def :: QueryBuilder table) |> filterWhereId id |> fetch
 
-genericfetchIdOneOrNothing :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Id' table -> IO (Maybe model)
-genericfetchIdOneOrNothing !id = query @model |> filterWhereId id |> fetchOneOrNothing
+genericfetchIdOneOrNothing :: forall table model. (Table model, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, FilterPrimaryKey table) => Id' table -> IO (Maybe model)
+genericfetchIdOneOrNothing !id = (def :: QueryBuilder table) |> filterWhereId id |> fetchOneOrNothing
 
-genericFetchIdOne :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Id' table -> IO model
-genericFetchIdOne !id = query @model |> filterWhereId id |> fetchOne
+genericFetchIdOne :: forall table model. (Table model, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, FilterPrimaryKey table) => Id' table -> IO model
+genericFetchIdOne !id = (def :: QueryBuilder table) |> filterWhereId id |> fetchOne
 
-genericFetchIds :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder [PrimaryKey (GetTableName model)]) => [Id model] -> IO [model]
-genericFetchIds !ids = query @model |> filterWhereIdIn ids |> fetch
+genericFetchIds :: forall table model. (Table model, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, DefaultParamEncoder [PrimaryKey table]) => [Id' table] -> IO [model]
+genericFetchIds !ids = (def :: QueryBuilder table) |> filterWhereIdIn ids |> fetch
 
-genericfetchIdsOneOrNothing :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder [PrimaryKey (GetTableName model)]) => [Id model] -> IO (Maybe model)
-genericfetchIdsOneOrNothing !ids = query @model |> filterWhereIdIn ids |> fetchOneOrNothing
+genericfetchIdsOneOrNothing :: forall table model. (Table model, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, DefaultParamEncoder [PrimaryKey table]) => [Id' table] -> IO (Maybe model)
+genericfetchIdsOneOrNothing !ids = (def :: QueryBuilder table) |> filterWhereIdIn ids |> fetchOneOrNothing
 
-genericFetchIdsOne :: forall table model. (Table model, KnownSymbol table, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder [PrimaryKey (GetTableName model)]) => [Id model] -> IO model
-genericFetchIdsOne !ids = query @model |> filterWhereIdIn ids |> fetchOne
+genericFetchIdsOne :: forall table model. (Table model, FromRowHasql model, ?modelContext :: ModelContext, model ~ GetModelByTableName table, DefaultParamEncoder [PrimaryKey table]) => [Id' table] -> IO model
+genericFetchIdsOne !ids = (def :: QueryBuilder table) |> filterWhereIdIn ids |> fetchOne
 
 findBy !field !value !queryBuilder = queryBuilder |> filterWhere (field, value) |> fetchOne
 
@@ -141,13 +141,13 @@ findMaybeBy !field !value !queryBuilder = queryBuilder |> filterWhere (field, va
 findManyBy !field !value !queryBuilder = queryBuilder |> filterWhere (field, value) |> fetch
 -- Step.findOneByWorkflowId id    ==    queryBuilder |> findBy #templateId id
 
-instance (model ~ GetModelById (Id' table), GetTableName model ~ table, FilterPrimaryKey table) => Fetchable (Id' table) model where
+instance (model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Fetchable (Id' table) model where
     type FetchResult (Id' table) model = model
     fetch = genericFetchIdOne
     fetchOneOrNothing = genericfetchIdOneOrNothing
     fetchOne = genericFetchIdOne
 
-instance (model ~ GetModelById (Id' table), GetTableName model ~ table, FilterPrimaryKey table) => Fetchable (Maybe (Id' table)) model where
+instance (model ~ GetModelByTableName table, GetTableName model ~ table, FilterPrimaryKey table) => Fetchable (Maybe (Id' table)) model where
     type FetchResult (Maybe (Id' table)) model = [model]
     fetch (Just a) = genericFetchId a
     fetch Nothing = pure []
@@ -156,7 +156,7 @@ instance (model ~ GetModelById (Id' table), GetTableName model ~ table, FilterPr
     fetchOne (Just a) = genericFetchIdOne a
     fetchOne Nothing = error "Fetchable (Maybe Id): Failed to fetch because given id is 'Nothing', 'Just id' was expected"
 
-instance (model ~ GetModelById (Id' table), GetModelByTableName table ~ model, GetTableName model ~ table, DefaultParamEncoder [PrimaryKey table]) => Fetchable [Id' table] model where
+instance (model ~ GetModelByTableName table, GetTableName model ~ table, DefaultParamEncoder [PrimaryKey table]) => Fetchable [Id' table] model where
     type FetchResult [Id' table] model = [model]
     fetch = genericFetchIds
     fetchOneOrNothing = genericfetchIdsOneOrNothing
@@ -181,7 +181,6 @@ instance (model ~ GetModelById (Id' table), GetModelByTableName table ~ model, G
 fetchLatest :: forall table model.
     ( ?modelContext :: ModelContext
     , model ~ GetModelByTableName table
-    , KnownSymbol table
     , HasField "createdAt" model UTCTime
     , Table model
     , FromRowHasql model
@@ -210,7 +209,6 @@ fetchLatestBy :: forall table createdAt model.
     ( ?modelContext :: ModelContext
     , KnownSymbol createdAt
     , model ~ GetModelByTableName table
-    , KnownSymbol table
     , HasField createdAt model UTCTime
     , Table model
     , FromRowHasql model

--- a/ihp/IHP/Fetch/Statement.hs
+++ b/ihp/IHP/Fetch/Statement.hs
@@ -23,14 +23,13 @@ import qualified Hasql.Decoders as Decoders
 import IHP.QueryBuilder.Types (QueryBuilder(..), SQLQuery(..))
 import IHP.QueryBuilder.Compiler (buildQuery)
 import IHP.QueryBuilder.HasqlCompiler (buildStatement, buildWrappedStatement)
-import GHC.TypeLits (KnownSymbol)
 import Data.Int (Int64)
 import Data.Vector (Vector)
 
 -- | Build a statement that fetches all rows matching a query builder.
 buildQueryListStatement :: forall model table.
     ( Table model
-    , model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model
+    , model ~ GetModelByTableName table, FromRowHasql model
     ) => QueryBuilder table -> Hasql.Statement () [model]
 buildQueryListStatement !queryBuilder =
     buildStatement (buildQuery queryBuilder) (Decoders.rowList (hasqlRowDecoder @model))
@@ -38,7 +37,7 @@ buildQueryListStatement !queryBuilder =
 -- | Like 'buildQueryListStatement', but returns a 'Vector' instead of a list.
 buildQueryVectorStatement :: forall model table.
     ( Table model
-    , model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model
+    , model ~ GetModelByTableName table, FromRowHasql model
     ) => QueryBuilder table -> Hasql.Statement () (Vector model)
 buildQueryVectorStatement !queryBuilder =
     buildStatement (buildQuery queryBuilder) (Decoders.rowVector (hasqlRowDecoder @model))
@@ -46,21 +45,17 @@ buildQueryVectorStatement !queryBuilder =
 -- | Build a statement that fetches at most one row (adds LIMIT 1).
 buildQueryMaybeStatement :: forall model table.
     ( Table model
-    , model ~ GetModelByTableName table, KnownSymbol table, FromRowHasql model
+    , model ~ GetModelByTableName table, FromRowHasql model
     ) => QueryBuilder table -> Hasql.Statement () (Maybe model)
 buildQueryMaybeStatement !queryBuilder =
     buildStatement ((buildQuery queryBuilder) { limitClause = Just 1 }) (Decoders.rowMaybe (hasqlRowDecoder @model))
 
 -- | Build a @SELECT COUNT(*)@ statement wrapping a query builder.
-buildCountStatement :: forall table.
-    ( KnownSymbol table
-    ) => QueryBuilder table -> Hasql.Statement () Int64
+buildCountStatement :: QueryBuilder table -> Hasql.Statement () Int64
 buildCountStatement !queryBuilder =
     buildWrappedStatement "SELECT COUNT(*) FROM (" (buildQuery queryBuilder) ") AS _count_values" (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8)))
 
 -- | Build a @SELECT EXISTS@ statement wrapping a query builder.
-buildExistsStatement :: forall table.
-    ( KnownSymbol table
-    ) => QueryBuilder table -> Hasql.Statement () Bool
+buildExistsStatement :: QueryBuilder table -> Hasql.Statement () Bool
 buildExistsStatement !queryBuilder =
     buildWrappedStatement "SELECT EXISTS (" (buildQuery queryBuilder) ") AS _exists_values" (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))

--- a/ihp/IHP/FetchPipelined.hs
+++ b/ihp/IHP/FetchPipelined.hs
@@ -56,7 +56,6 @@ import Data.Functor.Contravariant.Divisible (conquer)
 fetchPipelined :: forall model table.
     ( Table model
     , model ~ GetModelByTableName table
-    , KnownSymbol table
     , FromRowHasql model
     ) => QueryBuilder table -> Pipeline.Pipeline [model]
 fetchPipelined !queryBuilder = Pipeline.statement () (buildQueryListStatement queryBuilder)
@@ -73,7 +72,6 @@ fetchPipelined !queryBuilder = Pipeline.statement () (buildQueryListStatement qu
 fetchVectorPipelined :: forall model table.
     ( Table model
     , model ~ GetModelByTableName table
-    , KnownSymbol table
     , FromRowHasql model
     ) => QueryBuilder table -> Pipeline.Pipeline (Vector model)
 fetchVectorPipelined !queryBuilder = Pipeline.statement () (buildQueryVectorStatement queryBuilder)
@@ -90,7 +88,6 @@ fetchVectorPipelined !queryBuilder = Pipeline.statement () (buildQueryVectorStat
 fetchOneOrNothingPipelined :: forall model table.
     ( Table model
     , model ~ GetModelByTableName table
-    , KnownSymbol table
     , FromRowHasql model
     ) => QueryBuilder table -> Pipeline.Pipeline (Maybe model)
 fetchOneOrNothingPipelined !queryBuilder = Pipeline.statement () (buildQueryMaybeStatement queryBuilder)
@@ -104,9 +101,7 @@ fetchOneOrNothingPipelined !queryBuilder = Pipeline.statement () (buildQueryMayb
 -- >     users <- query @User |> fetchPipelined
 -- >     userCount <- query @User |> filterWhere (#active, True) |> fetchCountPipelined
 -- >     pure (users, userCount)
-fetchCountPipelined :: forall table.
-    ( KnownSymbol table
-    ) => QueryBuilder table -> Pipeline.Pipeline Int
+fetchCountPipelined :: forall table. QueryBuilder table -> Pipeline.Pipeline Int
 fetchCountPipelined !queryBuilder = fromIntegral <$> Pipeline.statement () (buildCountStatement queryBuilder)
 {-# INLINE fetchCountPipelined #-}
 
@@ -118,9 +113,7 @@ fetchCountPipelined !queryBuilder = fromIntegral <$> Pipeline.statement () (buil
 -- >     users <- query @User |> fetchPipelined
 -- >     hasUnread <- query @Message |> filterWhere (#isUnread, True) |> fetchExistsPipelined
 -- >     pure (users, hasUnread)
-fetchExistsPipelined :: forall table.
-    ( KnownSymbol table
-    ) => QueryBuilder table -> Pipeline.Pipeline Bool
+fetchExistsPipelined :: forall table. QueryBuilder table -> Pipeline.Pipeline Bool
 fetchExistsPipelined !queryBuilder = Pipeline.statement () (buildExistsStatement queryBuilder)
 {-# INLINE fetchExistsPipelined #-}
 

--- a/ihp/IHP/FetchRelated.hs
+++ b/ihp/IHP/FetchRelated.hs
@@ -29,7 +29,6 @@ class CollectionFetchRelated relatedFieldValue relatedModel where
             HasField relatedField model relatedFieldValue,
             UpdateField relatedField model (Include relatedField model) relatedFieldValue (FetchResult relatedFieldValue relatedModel),
             Fetchable relatedFieldValue relatedModel,
-            KnownSymbol (GetTableName relatedModel),
             FromRowHasql relatedModel,
             KnownSymbol relatedField
         ) => Proxy relatedField -> [model] -> IO [Include relatedField model]
@@ -46,7 +45,6 @@ class CollectionFetchRelatedOrNothing relatedFieldValue relatedModel where
             HasField relatedField model (Maybe relatedFieldValue),
             UpdateField relatedField model (Include relatedField model) (Maybe relatedFieldValue) (Maybe (FetchResult relatedFieldValue relatedModel)),
             Fetchable relatedFieldValue relatedModel,
-            KnownSymbol (GetTableName relatedModel),
             FromRowHasql relatedModel,
             KnownSymbol relatedField
         ) => Proxy relatedField -> [model] -> IO [Include relatedField model]
@@ -69,8 +67,7 @@ instance (
         Eq (PrimaryKey tableName)
         , Show (PrimaryKey tableName)
         , HasField "id" relatedModel (Id' tableName)
-        , relatedModel ~ GetModelByTableName (GetTableName relatedModel)
-        , GetTableName relatedModel ~ tableName
+        , relatedModel ~ GetModelByTableName tableName
         , Table relatedModel
         , DefaultParamEncoder [PrimaryKey tableName]
         ) => CollectionFetchRelated (Id' tableName) relatedModel where
@@ -79,13 +76,12 @@ instance (
             HasField relatedField model (Id' tableName),
             UpdateField relatedField model (Include relatedField model) (Id' tableName) (FetchResult (Id' tableName) relatedModel),
             Fetchable (Id' tableName) relatedModel,
-            KnownSymbol (GetTableName relatedModel),
             FromRowHasql relatedModel,
             KnownSymbol relatedField,
             Table relatedModel
         ) => Proxy relatedField -> [model] -> IO [Include relatedField model]
     collectionFetchRelated relatedField model = do
-        relatedModels :: [relatedModel] <- query @relatedModel |> filterWhereIdIn (map (getField @relatedField) model) |> fetch
+        relatedModels :: [relatedModel] <- (def :: QueryBuilder tableName) |> filterWhereIdIn (map (getField @relatedField) model) |> fetch
         let
             assignRelated :: model -> Include relatedField model
             assignRelated model =
@@ -120,8 +116,7 @@ instance (
 instance (
         Eq (PrimaryKey tableName)
         , HasField "id" relatedModel (Id' tableName)
-        , relatedModel ~ GetModelByTableName (GetTableName relatedModel)
-        , GetTableName relatedModel ~ tableName
+        , relatedModel ~ GetModelByTableName tableName
         , Table relatedModel
         , DefaultParamEncoder [PrimaryKey tableName]
         ) => CollectionFetchRelatedOrNothing (Id' tableName) relatedModel where
@@ -130,12 +125,11 @@ instance (
             HasField relatedField model (Maybe (Id' tableName)),
             UpdateField relatedField model (Include relatedField model) (Maybe (Id' tableName)) (Maybe (FetchResult (Id' tableName) relatedModel)),
             Fetchable (Id' tableName) relatedModel,
-            KnownSymbol (GetTableName relatedModel),
             FromRowHasql relatedModel,
             KnownSymbol relatedField
         ) => Proxy relatedField -> [model] -> IO [Include relatedField model]
     collectionFetchRelatedOrNothing relatedField model = do
-        relatedModels :: [relatedModel] <- query @relatedModel |> filterWhereIdIn (mapMaybe (getField @relatedField) model) |> fetch
+        relatedModels :: [relatedModel] <- (def :: QueryBuilder tableName) |> filterWhereIdIn (mapMaybe (getField @relatedField) model) |> fetch
         let
             assignRelated :: model -> Include relatedField model
             assignRelated model =
@@ -168,7 +162,6 @@ instance (relatedModel ~ GetModelByTableName relatedTable, Table relatedModel) =
             HasField relatedField model (QueryBuilder relatedTable),
             UpdateField relatedField model (Include relatedField model) (QueryBuilder relatedTable) (FetchResult (QueryBuilder relatedTable) relatedModel),
             Fetchable (QueryBuilder relatedTable) relatedModel,
-            KnownSymbol (GetTableName relatedModel),
             FromRowHasql relatedModel,
             KnownSymbol relatedField
         ) => Proxy relatedField -> [model] -> IO [Include relatedField model]
@@ -209,7 +202,6 @@ fetchRelated :: forall model field fieldValue fetchModel. (
         UpdateField field model (Include field model) fieldValue (FetchResult fieldValue fetchModel),
         HasField field model fieldValue,
         FromRowHasql fetchModel,
-        KnownSymbol (GetTableName fetchModel),
         Fetchable fieldValue fetchModel,
         Table fetchModel
     ) => Proxy field -> model -> IO (Include field model)
@@ -224,7 +216,6 @@ fetchRelatedOrNothing :: forall model field fieldValue fetchModel. (
         UpdateField field model (Include field model) (Maybe fieldValue) (Maybe (FetchResult fieldValue fetchModel)),
         HasField field model (Maybe fieldValue),
         FromRowHasql fetchModel,
-        KnownSymbol (GetTableName fetchModel),
         Fetchable fieldValue fetchModel,
         Table fetchModel
     ) => Proxy field -> model -> IO (Include field model)
@@ -241,7 +232,6 @@ maybeFetchRelatedOrNothing :: forall model field fieldValue fetchModel. (
         UpdateField field model (Include field model) (Maybe fieldValue) (Maybe (FetchResult fieldValue fetchModel)),
         HasField field model (Maybe fieldValue),
         FromRowHasql fetchModel,
-        KnownSymbol (GetTableName fetchModel),
         Fetchable fieldValue fetchModel,
         Table fetchModel
     ) => Proxy field -> Maybe model -> IO (Maybe (Include field model))

--- a/ihp/IHP/LoginSupport/Helper/Controller.hs
+++ b/ihp/IHP/LoginSupport/Helper/Controller.hs
@@ -49,8 +49,8 @@ currentUser = fromMaybe (redirectToLogin (newSessionUrl (Proxy @user))) currentU
 {-# INLINABLE currentUser #-}
 
 -- | Returns the ID of the current user. Redirects to login if not logged in.
-currentUserId :: forall user userId. (?request :: Request, ?respond :: Respond, HasNewSessionUrl user, HasField "id" user userId, Typeable user, user ~ CurrentUserRecord) => userId
-currentUserId = (currentUser @user).id
+currentUserId :: forall user. (?request :: Request, ?respond :: Respond, HasNewSessionUrl user, ModelSupport.Table user, Typeable user, user ~ CurrentUserRecord) => ModelSupport.TableId user
+currentUserId = ModelSupport.modelId (currentUser @user)
 {-# INLINABLE currentUserId #-}
 
 -- | Ensures that a user is logged in. Redirects to login page if not.
@@ -85,8 +85,8 @@ currentAdmin = fromMaybe (redirectToLogin (newSessionUrl (Proxy @admin))) curren
 {-# INLINABLE currentAdmin #-}
 
 -- | Returns the ID of the current admin. Redirects to login if not logged in.
-currentAdminId :: forall admin adminId. (?request :: Request, ?respond :: Respond, HasNewSessionUrl admin, HasField "id" admin adminId, Typeable admin, admin ~ CurrentAdminRecord) => adminId
-currentAdminId = (currentAdmin @admin).id
+currentAdminId :: forall admin. (?request :: Request, ?respond :: Respond, HasNewSessionUrl admin, ModelSupport.Table admin, Typeable admin, admin ~ CurrentAdminRecord) => ModelSupport.TableId admin
+currentAdminId = ModelSupport.modelId (currentAdmin @admin)
 {-# INLINABLE currentAdminId #-}
 
 -- | Returns the current admin's UUID or 'Nothing' if not logged in.

--- a/ihp/IHP/LoginSupport/Helper/View.hs
+++ b/ihp/IHP/LoginSupport/Helper/View.hs
@@ -18,8 +18,8 @@ import qualified Network.Wai as Wai
 currentUser :: (?request :: Wai.Request, user ~ CurrentUserRecord, Typeable user) => user
 currentUser = fromMaybe (error "Application.Helper.View.currentUser: Not logged in") currentUserOrNothing
 
-currentUserId :: forall user userId. (?request :: Wai.Request, HasField "id" user userId, Typeable user, user ~ CurrentUserRecord) => userId
-currentUserId = (currentUser @user).id
+currentUserId :: forall user. (?request :: Wai.Request, ModelSupport.Table user, Typeable user, user ~ CurrentUserRecord) => ModelSupport.TableId user
+currentUserId = ModelSupport.modelId (currentUser @user)
 
 -- | Returns the current user or 'Nothing'.
 --

--- a/ihp/IHP/ModelSupport.hs
+++ b/ihp/IHP/ModelSupport.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, ConstraintKinds, TypeOperators, GADTs, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE MultiParamTypeClasses, TypeFamilies, FlexibleContexts, AllowAmbiguousTypes, UndecidableInstances, FlexibleInstances, IncoherentInstances, DataKinds, PolyKinds, TypeApplications, ScopedTypeVariables, ConstraintKinds, TypeOperators, GADTs, GeneralizedNewtypeDeriving, DefaultSignatures, CPP #-}
 
 module IHP.ModelSupport
 ( module IHP.ModelSupport
@@ -651,10 +651,13 @@ rollbackTransaction = case ?modelContext.transactionRunner of
     Nothing -> error "rollbackTransaction: Not in a transaction"
 {-# INLINABLE rollbackTransaction #-}
 
--- | Access meta data for a database table
-class
-    ( KnownSymbol (GetTableName record)
-    ) => Table record where
+-- | Access meta data for a database table.
+--
+-- Generated instances provide the term-level metadata directly. The default
+-- implementations keep hand-written instances source-compatible without
+-- forcing every use of @Table record@ to also solve @KnownSymbol
+-- (GetTableName record)@.
+class Table record where
     -- | Returns the table name of a given model.
     --
     -- __Example:__
@@ -664,8 +667,24 @@ class
     --
 
     tableName :: Text
+    default tableName :: KnownSymbol (GetTableName record) => Text
     tableName = symbolToText @(GetTableName record)
     {-# INLINE tableName #-}
+
+    -- | The ID type of this table. Generated instances set this directly to a
+    -- concrete @Id' "table_name"@, avoiding a @GetTableName@ reduction on
+    -- common paths such as 'currentUserId'.
+    type TableId record
+    type TableId record = Id record
+
+    -- | Returns the primary-key value of a record.
+    --
+    -- Schema-generated instances provide an implementation. The fallback
+    -- keeps existing hand-written 'Table' instances source-compatible; such
+    -- instances should define this method before calling it.
+    modelId :: record -> TableId record
+    modelId _ = error "Table.modelId: no implementation provided by this Table instance"
+    {-# INLINE modelId #-}
 
     -- | Returns the list of column names for a given model
     --
@@ -1063,4 +1082,3 @@ withoutQueryLogging callback =
         let ?modelContext = modelContext { logger = noopLogger }
         in
             callback
-

--- a/ihp/IHP/ModelSupport/Types.hs
+++ b/ihp/IHP/ModelSupport/Types.hs
@@ -148,7 +148,7 @@ deriving instance (Eq (PrimaryKey table)) => Eq (Id' table)
 deriving instance (Ord (PrimaryKey table)) => Ord (Id' table)
 deriving instance (Hashable (PrimaryKey table)) => Hashable (Id' table)
 deriving instance (KnownSymbol table, Data (PrimaryKey table)) => Data (Id' table)
-deriving instance (KnownSymbol table, NFData (PrimaryKey table)) => NFData (Id' table)
+deriving instance NFData (PrimaryKey table) => NFData (Id' table)
 
 -- | We need to map the model to its table name to prevent infinite recursion in the model data definition
 -- E.g. `type Project = Project' { id :: Id Project }` will not work

--- a/ihp/IHP/Pagination/ControllerFunctions.hs
+++ b/ihp/IHP/Pagination/ControllerFunctions.hs
@@ -18,7 +18,7 @@ import IHP.Pagination.Types ( Options(..), Pagination(..) )
 import IHP.Pagination.Internal ( pageSize', page, offset' )
 import IHP.QueryBuilder ( QueryBuilder, filterWhereILike, limit, offset )
 import IHP.Fetch (fetchCount)
-import IHP.ModelSupport (GetModelByTableName, sqlQueryHasql, Table)
+import IHP.ModelSupport (GetModelByTableName, sqlQueryHasql)
 import IHP.Hasql.FromRow (FromRowHasql(..))
 import IHP.Hasql.Encoders (ToSnippetParams(..), sqlToSnippet)
 import Network.Wai (Request)
@@ -53,8 +53,7 @@ paginate :: forall controller table .
     (?request::Request
     , ?modelContext :: ModelContext
     , ?theAction :: controller
-    , ?request :: Request
-    , KnownSymbol table) =>
+    , ?request :: Request) =>
     QueryBuilder table
     -> IO (QueryBuilder table, Pagination)
 paginate = paginateWithOptions defaultPaginationOptions
@@ -84,8 +83,7 @@ paginateWithOptions :: forall controller table .
     (?request::Request
     , ?modelContext :: ModelContext
     , ?theAction :: controller
-    , ?request :: Request
-    , KnownSymbol table) =>
+    , ?request :: Request) =>
     Options
     -> QueryBuilder table
     -> IO (QueryBuilder table, Pagination)
@@ -129,8 +127,6 @@ filterList :: forall name table model .
     , KnownSymbol name
     , HasField name model Text
     , model ~ GetModelByTableName table
-    , KnownSymbol table
-    , Table model
     ) =>
     Proxy name
     -> QueryBuilder table

--- a/ihp/IHP/QueryBuilder.hs
+++ b/ihp/IHP/QueryBuilder.hs
@@ -21,6 +21,7 @@ module IHP.QueryBuilder
 , OrderByDirection (..)
 , FilterOperator (..)
 , MatchSensitivity (..)
+, queryBuilderTableName
   -- * Type Classes
 , DefaultScope (..)
 , EqOrIsOperator

--- a/ihp/IHP/QueryBuilder/Compiler.hs
+++ b/ihp/IHP/QueryBuilder/Compiler.hs
@@ -71,7 +71,7 @@ query = let tn = tableName @model
 
 -- | Extract the SQLQuery from a QueryBuilder.
 {-# INLINE buildQuery #-}
-buildQuery :: forall table. KnownSymbol table => QueryBuilder table -> SQLQuery
+buildQuery :: QueryBuilder table -> SQLQuery
 buildQuery (QueryBuilder sq) = sq
 
 -- | Build a qualified column name like @tablename.column_name@ from a table name

--- a/ihp/IHP/QueryBuilder/Filter.hs
+++ b/ihp/IHP/QueryBuilder/Filter.hs
@@ -40,6 +40,7 @@ import Hasql.Implicits.Encoders (DefaultParamEncoder(..))
 import IHP.Hasql.Encoders () -- Import for DefaultParamEncoder instances
 import IHP.QueryBuilder.Compiler (qualifiedColumnName)
 import Data.Functor.Contravariant (contramap)
+import qualified Data.Text as Text
 
 -- | Build a 'ConditionValue' from any 'DefaultParamEncoder' value.
 paramValue :: DefaultParamEncoder a => a -> ConditionValue
@@ -89,11 +90,11 @@ condValueForOp _ value = paramValue value
 -- For case-insensitive versions of these operators, see 'filterWhereILike' and 'filterWhereIMatches'.
 --
 -- When your condition is too complex, use a raw sql query with 'IHP.ModelSupport.sqlQuery'.
-filterWhere :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhere :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhere (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = let op = toEqOrIsOperator value in ColumnCondition columnName op (condValueForOp op value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhere #-}
 
 -- | Like 'filterWhere' but negates the condition.
@@ -105,11 +106,11 @@ filterWhere (name, value) queryBuilder = addCondition condition queryBuilder
 -- >     |> fetch
 -- > -- SELECT * FROM projects WHERE user_id != '23d5ea33-b28e-4f0a-99b3-77a3564a2546'
 --
-filterWhereNot :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereNot :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereNot (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = let op = negateFilterOperator (toEqOrIsOperator value) in ColumnCondition columnName op (condValueForOp op value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereNot #-}
 
 -- | Adds a @WHERE x IN (y)@ condition to the query.
@@ -123,7 +124,7 @@ filterWhereNot (name, value) queryBuilder = addCondition condition queryBuilder
 --
 -- For negation use 'filterWhereNotIn'
 --
-filterWhereIn :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder [value], DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, EqOrIsOperator value, Table model) => (Proxy name, [value]) -> QueryBuilder table -> QueryBuilder table
+filterWhereIn :: forall name table model value. (KnownSymbol name, DefaultParamEncoder [value], DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, EqOrIsOperator value) => (Proxy name, [value]) -> QueryBuilder table -> QueryBuilder table
 filterWhereIn (name, value) queryBuilder =
         case head nullValues of
             Nothing -> addCondition inCondition queryBuilder -- All values non null
@@ -143,7 +144,7 @@ filterWhereIn (name, value) queryBuilder =
 
         inCondition = ColumnCondition columnName InOp (paramValue nonNullValues) Nothing Nothing
 
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereIn #-}
 
 -- Like 'filterWhereIn', but case insensitive.
@@ -155,7 +156,7 @@ filterWhereIn (name, value) queryBuilder =
 -- >     |> fetch
 -- > -- SELECT * FROM users WHERE LOWER(email) IN ('user1@example.com', 'user2@example.com')
 --
-filterWhereInCaseInsensitive :: forall name table model value. ( KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, EqOrIsOperator value, Table model) => (Proxy name, [Text]) -> QueryBuilder table -> QueryBuilder table
+filterWhereInCaseInsensitive :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, EqOrIsOperator value) => (Proxy name, [Text]) -> QueryBuilder table -> QueryBuilder table
 filterWhereInCaseInsensitive (name, values) queryBuilder =
         case head nullValues of
             Nothing -> addCondition inCondition queryBuilder
@@ -175,7 +176,7 @@ filterWhereInCaseInsensitive (name, values) queryBuilder =
         inCondition = ColumnCondition lowerColumnName InOp (paramValue lowerValues) Nothing Nothing
 
         lowerColumnName = "LOWER(" <> columnName <> ")"
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 
 {-# INLINE filterWhereInCaseInsensitive #-}
 
@@ -191,7 +192,7 @@ filterWhereInCaseInsensitive (name, values) queryBuilder =
 --
 -- The inclusive version of this function is called 'filterWhereIn'.
 --
-filterWhereNotIn :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder [value], DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, EqOrIsOperator value) => (Proxy name, [value]) -> QueryBuilder table -> QueryBuilder table
+filterWhereNotIn :: forall name table model value. (KnownSymbol name, DefaultParamEncoder [value], DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, EqOrIsOperator value) => (Proxy name, [value]) -> QueryBuilder table -> QueryBuilder table
 filterWhereNotIn (_, []) queryBuilder = queryBuilder -- Handle empty case by ignoring query part: `WHERE x NOT IN ()`
 filterWhereNotIn (name, value) queryBuilder =
         case head nullValues of
@@ -208,7 +209,7 @@ filterWhereNotIn (name, value) queryBuilder =
 
         notInCondition = ColumnCondition columnName NotInOp (paramValue nonNullValues) Nothing Nothing
 
-        columnName = qualifiedColumnName (symbolToText @table) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereNotIn #-}
 
 
@@ -220,11 +221,11 @@ filterWhereNotIn (name, value) queryBuilder =
 -- >     |> filterWhereLike (#title, "%" <> searchTerm <> "%")
 -- >     |> fetch
 -- > -- SELECT * FROM articles WHERE title LIKE '%..%'
-filterWhereLike :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereLike :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereLike (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName (LikeOp CaseSensitive) (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereLike #-}
 
 
@@ -236,11 +237,11 @@ filterWhereLike (name, value) queryBuilder = addCondition condition queryBuilder
 -- >     |> filterWhereILike (#title, "%" <> searchTerm <> "%")
 -- >     |> fetch
 -- > -- SELECT * FROM articles WHERE title ILIKE '%..%'
-filterWhereILike :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereILike :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereILike (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName (LikeOp CaseInsensitive) (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereILike #-}
 
 
@@ -252,20 +253,20 @@ filterWhereILike (name, value) queryBuilder = addCondition condition queryBuilde
 -- >     |> filterWhereMatches (#name, "^(M(rs|r|iss)|Dr|Sir). ")
 -- >     |> fetch
 -- > -- SELECT * FROM articles WHERE title ~ '^(M(rs|r|iss)|Dr|Sir). '
-filterWhereMatches :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, table ~ GetTableName model, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereMatches :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereMatches (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName (MatchesOp CaseSensitive) (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereMatches #-}
 
 
 -- | Adds a @WHERE x ~* y@ condition to the query. Case-insensitive version of 'filterWhereMatches'.
-filterWhereIMatches :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereIMatches :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereIMatches (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName (MatchesOp CaseInsensitive) (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereIMatches #-}
 
 
@@ -280,10 +281,8 @@ filterWhereIMatches (name, value) queryBuilder = addCondition condition queryBui
 -- >     |> fetch
 -- > -- SELECT * FROM posts WHERE scheduled_at <= NOW()
 filterWherePast
-    :: ( KnownSymbol table
-       , KnownSymbol name
+    :: ( KnownSymbol name
        , HasField name (GetModelByTableName table) value
-       , Table (GetModelByTableName table)
        )
     => Proxy name -> QueryBuilder table -> QueryBuilder table
 filterWherePast name = filterWhereSql (name, "<= NOW()")
@@ -300,10 +299,8 @@ filterWherePast name = filterWhereSql (name, "<= NOW()")
 -- >     |> fetch
 -- > -- SELECT * FROM posts WHERE scheduled_at > NOW()
 filterWhereFuture
-    :: ( KnownSymbol table
-       , KnownSymbol name
+    :: ( KnownSymbol name
        , HasField name (GetModelByTableName table) value
-       , Table (GetModelByTableName table)
        )
     => Proxy name -> QueryBuilder table -> QueryBuilder table
 filterWhereFuture name = filterWhereSql (name, "> NOW()")
@@ -319,11 +316,11 @@ filterWhereFuture name = filterWhereSql (name, "> NOW()")
 -- > -- SELECT * FROM assignments WHERE grade > 80
 --
 -- See also: 'filterWhereLarger', 'filterWhereGreaterThanOrEqualTo', 'filterWhereAtLeast'
-filterWhereGreaterThan :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereGreaterThan :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereGreaterThan (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName GreaterThanOp (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereGreaterThan #-}
 
 -- | Alias for 'filterWhereGreaterThan'. Adds a @WHERE x > y@ condition to the query.
@@ -334,7 +331,7 @@ filterWhereGreaterThan (name, value) queryBuilder = addCondition condition query
 -- >     |> filterWhereLarger (#grade, 80)
 -- >     |> fetch
 -- > -- SELECT * FROM assignments WHERE grade > 80
-filterWhereLarger :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereLarger :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereLarger = filterWhereGreaterThan
 {-# INLINE filterWhereLarger #-}
 
@@ -348,11 +345,11 @@ filterWhereLarger = filterWhereGreaterThan
 -- > -- SELECT * FROM assignments WHERE grade >= 80
 --
 -- See also: 'filterWhereAtLeast', 'filterWhereGreaterThan', 'filterWhereLarger'
-filterWhereGreaterThanOrEqualTo :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereGreaterThanOrEqualTo :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereGreaterThanOrEqualTo (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName GreaterThanOrEqualToOp (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereGreaterThanOrEqualTo #-}
 
 -- | Alias for 'filterWhereGreaterThanOrEqualTo'. Adds a @WHERE x >= y@ condition to the query.
@@ -363,7 +360,7 @@ filterWhereGreaterThanOrEqualTo (name, value) queryBuilder = addCondition condit
 -- >     |> filterWhereAtLeast (#grade, 80)
 -- >     |> fetch
 -- > -- SELECT * FROM assignments WHERE grade >= 80
-filterWhereAtLeast :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereAtLeast :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereAtLeast = filterWhereGreaterThanOrEqualTo
 {-# INLINE filterWhereAtLeast #-}
 
@@ -377,11 +374,11 @@ filterWhereAtLeast = filterWhereGreaterThanOrEqualTo
 -- > -- SELECT * FROM assignments WHERE grade < 60
 --
 -- See also: 'filterWhereSmaller', 'filterWhereLessThanOrEqualTo', 'filterWhereAtMost'
-filterWhereLessThan :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereLessThan :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereLessThan (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName LessThanOp (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereLessThan #-}
 
 -- | Alias for 'filterWhereLessThan'. Adds a @WHERE x < y@ condition to the query.
@@ -392,7 +389,7 @@ filterWhereLessThan (name, value) queryBuilder = addCondition condition queryBui
 -- >     |> filterWhereSmaller (#grade, 60)
 -- >     |> fetch
 -- > -- SELECT * FROM assignments WHERE grade < 60
-filterWhereSmaller :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereSmaller :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereSmaller = filterWhereLessThan
 {-# INLINE filterWhereSmaller #-}
 
@@ -406,11 +403,11 @@ filterWhereSmaller = filterWhereLessThan
 -- > -- SELECT * FROM assignments WHERE grade <= 60
 --
 -- See also: 'filterWhereAtMost', 'filterWhereLessThan', 'filterWhereSmaller'
-filterWhereLessThanOrEqualTo :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereLessThanOrEqualTo :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereLessThanOrEqualTo (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName LessThanOrEqualToOp (paramValue value) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereLessThanOrEqualTo #-}
 
 -- | Alias for 'filterWhereLessThanOrEqualTo'. Adds a @WHERE x <= y@ condition to the query.
@@ -421,7 +418,7 @@ filterWhereLessThanOrEqualTo (name, value) queryBuilder = addCondition condition
 -- >     |> filterWhereAtMost (#grade, 60)
 -- >     |> fetch
 -- > -- SELECT * FROM assignments WHERE grade <= 60
-filterWhereAtMost :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereAtMost :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereAtMost = filterWhereLessThanOrEqualTo
 {-# INLINE filterWhereAtMost #-}
 
@@ -437,11 +434,11 @@ filterWhereAtMost = filterWhereLessThanOrEqualTo
 -- >     |> fetch
 -- > -- SELECT * FROM projects WHERE started_at < current_timestamp - interval '1 day'
 --
-filterWhereSql :: forall name table model value. (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, Table model) => (Proxy name, Text) -> QueryBuilder table -> QueryBuilder table
+filterWhereSql :: forall name table model value. (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table) => (Proxy name, Text) -> QueryBuilder table -> QueryBuilder table
 filterWhereSql (name, sqlCondition) queryBuilder = addCondition condition queryBuilder
     where
         condition = ColumnCondition columnName SqlOp (Literal sqlCondition) Nothing Nothing
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereSql #-}
 
 -- | Adds a @WHERE LOWER(x) = LOWER(y)@ condition to the query.
@@ -457,21 +454,27 @@ filterWhereSql (name, sqlCondition) queryBuilder = addCondition condition queryB
 --
 -- >>> CREATE UNIQUE INDEX users_email_index ON users ((LOWER(email)));
 --
-filterWhereCaseInsensitive :: forall name table model value. (KnownSymbol table, KnownSymbol name, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table, Table model) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
+filterWhereCaseInsensitive :: forall name table model value. (KnownSymbol name, DefaultParamEncoder value, HasField name model value, EqOrIsOperator value, model ~ GetModelByTableName table) => (Proxy name, value) -> QueryBuilder table -> QueryBuilder table
 filterWhereCaseInsensitive (name, value) queryBuilder = addCondition condition queryBuilder
     where
         condition = let op = toEqOrIsOperator value in ColumnCondition columnName op (condValueForOp op value) (Just "LOWER") (Just "LOWER")
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (queryBuilderTableName queryBuilder) (symbolToText @name)
 {-# INLINE filterWhereCaseInsensitive #-}
 
 
-filterWhereIdIn :: forall table model. (KnownSymbol table, Table model, model ~ GetModelByTableName table, DefaultParamEncoder [PrimaryKey (GetTableName model)]) => [Id model] -> QueryBuilder table -> QueryBuilder table
+filterWhereIdIn :: forall table model. (Table model, model ~ GetModelByTableName table, DefaultParamEncoder [PrimaryKey table]) => [Id' table] -> QueryBuilder table -> QueryBuilder table
 filterWhereIdIn values queryBuilder =
     -- We don't need to treat null values differently here, because primary keys imply not-null
     -- Extract the raw primary key values from the Id wrappers
     let
         rawPrimaryKeys = map (\(Id pk) -> pk) values
-        condition = ColumnCondition (primaryKeyConditionColumnSelector @model) InOp (paramValue rawPrimaryKeys) Nothing Nothing
+        condition = ColumnCondition primaryKeySelector InOp (paramValue rawPrimaryKeys) Nothing Nothing
+        table = queryBuilderTableName queryBuilder
+        qualifyColumnName column = table <> "." <> column
+        primaryKeySelector = case primaryKeyColumnNames @model of
+            [] -> error . cs $ "Impossible happened in filterWhereIdIn. No primary keys found for table " <> table <> ". At least one primary key is required."
+            [column] -> qualifyColumnName column
+            columns -> "(" <> Text.intercalate ", " (map qualifyColumnName columns) <> ")"
      in
         addCondition condition queryBuilder
 {-# INLINE filterWhereIdIn #-}

--- a/ihp/IHP/QueryBuilder/HasqlCompiler.hs
+++ b/ihp/IHP/QueryBuilder/HasqlCompiler.hs
@@ -56,7 +56,7 @@ buildWrappedStatement prefix sqlQuery suffix decoder =
 
 -- | Compile a QueryBuilder to SQL text (for testing / error messages).
 -- Discards the encoder.
-toSQL :: forall table. KnownSymbol table => QueryBuilder table -> Text
+toSQL :: QueryBuilder table -> Text
 toSQL queryBuilder =
     let (sql, _) = compileQuery emptyCompilerState (buildQuery queryBuilder)
     in sql

--- a/ihp/IHP/QueryBuilder/Order.hs
+++ b/ihp/IHP/QueryBuilder/Order.hs
@@ -31,11 +31,11 @@ import IHP.QueryBuilder.Compiler (qualifiedColumnName)
 -- >     |> orderBy #createdAt -- >     |> limit 10
 -- >     |> fetch
 -- > -- SELECT * FROM books LIMIT 10 ORDER BY created_at ASC
-orderByAsc :: forall name model table value. (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, Table model) => Proxy name -> QueryBuilder table -> QueryBuilder table
+orderByAsc :: forall name model table value. (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table) => Proxy name -> QueryBuilder table -> QueryBuilder table
 orderByAsc !name (QueryBuilder sq) =
     QueryBuilder sq { orderByClause = orderByClause sq <> [OrderByClause { orderByColumn = columnName, orderByDirection = Asc }] }
     where
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (selectFrom sq) (symbolToText @name)
 {-# INLINE orderByAsc #-}
 
 -- | Adds an @ORDER BY .. DESC@ to your query.
@@ -49,15 +49,15 @@ orderByAsc !name (QueryBuilder sq) =
 -- >     |> limit 10
 -- >     |> fetch
 -- > -- SELECT * FROM projects LIMIT 10 ORDER BY created_at DESC
-orderByDesc :: forall name model table value. (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, Table model) => Proxy name -> QueryBuilder table -> QueryBuilder table
+orderByDesc :: forall name model table value. (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table) => Proxy name -> QueryBuilder table -> QueryBuilder table
 orderByDesc !name (QueryBuilder sq) =
     QueryBuilder sq { orderByClause = orderByClause sq <> [OrderByClause { orderByColumn = columnName, orderByDirection = Desc }] }
     where
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (selectFrom sq) (symbolToText @name)
 {-# INLINE orderByDesc #-}
 
 -- | Alias for 'orderByAsc'
-orderBy :: (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, Table model) => Proxy name -> QueryBuilder table -> QueryBuilder table
+orderBy :: (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table) => Proxy name -> QueryBuilder table -> QueryBuilder table
 orderBy !name = orderByAsc name
 {-# INLINE orderBy #-}
 
@@ -115,9 +115,9 @@ distinct (QueryBuilder sq) =
 -- >     |> distinctOn #categoryId
 -- >     |> fetch
 -- > -- SELECT DISTINCT ON (category_id) * FROM books
-distinctOn :: forall name model value table. (KnownSymbol table, KnownSymbol name, HasField name model value, model ~ GetModelByTableName table, Table model) => Proxy name -> QueryBuilder table -> QueryBuilder table
+distinctOn :: forall name model value table. (KnownSymbol name, HasField name model value, model ~ GetModelByTableName table) => Proxy name -> QueryBuilder table -> QueryBuilder table
 distinctOn !name (QueryBuilder sq) =
     QueryBuilder sq { distinctOnClause = Just columnName }
     where
-        columnName = qualifiedColumnName (tableName @model) (symbolToText @name)
+        columnName = qualifiedColumnName (selectFrom sq) (symbolToText @name)
 {-# INLINE distinctOn #-}

--- a/ihp/IHP/QueryBuilder/Types.hs
+++ b/ihp/IHP/QueryBuilder/Types.hs
@@ -17,6 +17,7 @@ module IHP.QueryBuilder.Types
   -- * Helpers
 , addCondition
 , qualifyAndJoinColumns
+, queryBuilderTableName
   -- * Type Classes
 , DefaultScope (..)
 , EqOrIsOperator (..)
@@ -131,12 +132,20 @@ sqlQueryEq a b =
     condEq _ _ = False
 
 -- | Display QueryBuilder's as their sql query inside HSX
-instance KnownSymbol table => ToHtml (QueryBuilder table) where
+instance ToHtml (QueryBuilder table) where
     toHtml queryBuilder = toHtml (toSQLQueryBuilder queryBuilder)
       where
         -- Inline SQL generation for ToHtml to avoid circular imports
         toSQLQueryBuilder :: QueryBuilder table -> Text
-        toSQLQueryBuilder qb = "QueryBuilder<" <> symbolToText @table <> ">"
+        toSQLQueryBuilder qb = "QueryBuilder<" <> queryBuilderTableName qb <> ">"
+
+-- | Returns the term-level table name stored in a query builder.
+--
+-- Query builders already carry this value in their 'SQLQuery', so callers do
+-- not need to recover it through @KnownSymbol table@.
+queryBuilderTableName :: QueryBuilder table -> Text
+queryBuilderTableName = selectFrom . unQueryBuilder
+{-# INLINE queryBuilderTableName #-}
 
 -- | ORDER BY direction
 data OrderByDirection = Asc | Desc deriving (Eq, Show, GHC.Generics.Generic, DeepSeq.NFData)

--- a/ihp/IHP/QueryBuilder/Union.hs
+++ b/ihp/IHP/QueryBuilder/Union.hs
@@ -15,7 +15,6 @@ module IHP.QueryBuilder.Union
 import IHP.Prelude
 import IHP.ModelSupport
 import IHP.QueryBuilder.Types
-import IHP.QueryBuilder.Compiler (query)
 
 -- | Merges the results of two query builders by ORing their WHERE conditions.
 --
@@ -54,9 +53,9 @@ queryUnion (QueryBuilder first) (QueryBuilder second) =
 -- >
 -- >      projects <- fetch theQuery
 -- >      render IndexView { .. }
-queryUnionList :: forall table. (Table (GetModelByTableName table), KnownSymbol table, GetTableName (GetModelByTableName table) ~ table) => [QueryBuilder table] -> QueryBuilder table
+queryUnionList :: forall table. Table (GetModelByTableName table) => [QueryBuilder table] -> QueryBuilder table
 -- For empty list, create a condition that is always false: id <> id (which is always false for non-null)
-queryUnionList [] = addCondition (ColumnCondition "id" NotEqOp (Literal "id") Nothing Nothing) (query @(GetModelByTableName table) @table)
+queryUnionList [] = addCondition (ColumnCondition "id" NotEqOp (Literal "id") Nothing Nothing) (def :: QueryBuilder table)
 queryUnionList [single] = single
 queryUnionList (first:rest) =
     let QueryBuilder firstSq = first

--- a/ihp/Test/Test/LoginSupport/AuthVaultSpec.hs
+++ b/ihp/Test/Test/LoginSupport/AuthVaultSpec.hs
@@ -14,7 +14,8 @@ import Network.HTTP.Types.Status (status200)
 import IHP.LoginSupport.Types (CurrentUserRecord, CurrentAdminRecord, currentUserVaultKey, currentAdminVaultKey)
 import IHP.LoginSupport.Middleware (authMiddlewareWith, userIdMiddleware, adminIdMiddleware, parseSessionUUID)
 import IHP.Controller.Session (sessionVaultKey)
-import IHP.ModelSupport.Types (PrimaryKey, Id' (Id))
+import IHP.ModelSupport.Types (PrimaryKey, Id' (Id), GetModelByTableName)
+import IHP.ModelSupport (Table (..))
 import qualified IHP.LoginSupport.Helper.Controller as Controller
 import qualified IHP.LoginSupport.Helper.View as View
 import qualified Data.Vault.Lazy as Vault
@@ -44,6 +45,14 @@ tests = do
                 let app = userMiddleware (Just user) $ \req respond -> do
                         let ?request = req
                         View.currentUserOrNothing `shouldBe` Just user
+                        respond $ Wai.responseLBS status200 [] ""
+                runSession (request defaultRequest >> pure ()) app
+
+            it "returns the generated table ID from View.currentUserId" do
+                let user = TestUser { id = "00000000-0000-0000-0000-000000000001" }
+                let app = userMiddleware (Just user) $ \req respond -> do
+                        let ?request = req
+                        View.currentUserId @TestUser `shouldBe` user.id
                         respond $ Wai.responseLBS status200 [] ""
                 runSession (request defaultRequest >> pure ()) app
 
@@ -161,9 +170,25 @@ type instance CurrentUserRecord = TestUser
 type instance CurrentAdminRecord = TestAdmin
 
 type instance GetTableName TestUser = "test_users"
+type instance GetModelByTableName "test_users" = TestUser
 type instance PrimaryKey "test_users" = UUID
 type instance GetTableName TestAdmin = "test_admins"
+type instance GetModelByTableName "test_admins" = TestAdmin
 type instance PrimaryKey "test_admins" = UUID
+
+instance Table TestUser where
+    type TableId TestUser = Id' "test_users"
+    tableName = "test_users"
+    modelId TestUser { id } = id
+    columnNames = ["id"]
+    primaryKeyColumnNames = ["id"]
+
+instance Table TestAdmin where
+    type TableId TestAdmin = Id' "test_admins"
+    tableName = "test_admins"
+    modelId TestAdmin { id } = id
+    columnNames = ["id"]
+    primaryKeyColumnNames = ["id"]
 
 -- | Middleware that stores a known user, using the same code path as the real middleware.
 userMiddleware :: Maybe TestUser -> Wai.Middleware


### PR DESCRIPTION
## Summary

- remove redundant table-name KnownSymbol constraints from Table and the query, fetch, and pagination APIs
- compile queries from their stored runtime table name and simplify type-family equalities
- generate direct TableId/modelId metadata and use it in login helpers, while retaining defaults for handwritten Table instances

Closes #2766.

## Compile-time measurements

On the 349-table application from #2766:

- currentUserId GHC phase: 825.3 ms -> 791.7 ms (4.1% faster)
- 25-filter query GHC phase: 249.3 ms -> 240.7 ms (3.5% faster)
- cold generated-model compile: 82.15 s -> 82.93 s (+0.9%, effectively unchanged)

The current 349-table checkout does not itself reproduce the reduction-depth overflow; the issue reports that a few additional tables trigger it.

## Validation

- core: 572 examples, 0 failures, 25 pending database-dependent examples
- IDE: 442 examples, 0 failures
- schema compiler: 47 examples, 0 failures
- query builder: 52 examples, 0 failures
- login support: 16 examples, 0 failures
- GHC 9.12 Nix check, including tests and Haddock
- schema compiler GHC 9.12 package build