### PR TITLE
Remove DefaultScope from QueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Breaking Changes
 
+- `DefaultScope` has been removed. `query @Model` now always starts without
+  implicit filters; define and use explicit query functions for reusable scopes.
 - `typedSql` now tracks conservative query cardinality and statement result
   kind in `TypedQuery`, and `sqlQueryTyped` returns `[result]`,
   `Maybe result`, or `result` depending on whether the query is inferred as

--- a/ihp/IHP/QueryBuilder.hs
+++ b/ihp/IHP/QueryBuilder.hs
@@ -22,7 +22,6 @@ module IHP.QueryBuilder
 , FilterOperator (..)
 , MatchSensitivity (..)
   -- * Type Classes
-, DefaultScope (..)
 , EqOrIsOperator
 , FilterPrimaryKey (..)
   -- * SQL Compilation

--- a/ihp/IHP/QueryBuilder/Compiler.hs
+++ b/ihp/IHP/QueryBuilder/Compiler.hs
@@ -53,10 +53,10 @@ negateFilterOperator SqlOp = SqlOp
 -- >    query @User
 -- >     |> filterWhere (#active, True)
 -- >     |> fetch
-query :: forall model table. (table ~ GetTableName model, Table model) => DefaultScope table => QueryBuilder table
+query :: forall model table. (table ~ GetTableName model, Table model) => QueryBuilder table
 query = let tn = tableName @model
             cols = columnNames @model
-        in (defaultScope @table) QueryBuilder { unQueryBuilder = SQLQuery
+        in QueryBuilder { unQueryBuilder = SQLQuery
     { selectFrom = tn
     , columns = cols
     , columnsSql = qualifyAndJoinColumns tn cols

--- a/ihp/IHP/QueryBuilder/Types.hs
+++ b/ihp/IHP/QueryBuilder/Types.hs
@@ -18,7 +18,6 @@ module IHP.QueryBuilder.Types
 , addCondition
 , qualifyAndJoinColumns
   -- * Type Classes
-, DefaultScope (..)
 , EqOrIsOperator (..)
 , FilterPrimaryKey (..)
 ) where
@@ -165,14 +164,6 @@ instance SetField "whereCondition" SQLQuery (Maybe Condition) where setField val
 instance SetField "orderByClause" SQLQuery [OrderByClause] where setField value sqlQuery = sqlQuery { orderByClause = value }
 instance SetField "limitClause" SQLQuery (Maybe Int64) where setField value sqlQuery = sqlQuery { limitClause = value }
 instance SetField "offsetClause" SQLQuery (Maybe Int64) where setField value sqlQuery = sqlQuery { offsetClause = value }
-
--- | Type class for default scoping of queries
-class DefaultScope table where
-    defaultScope :: QueryBuilder table -> QueryBuilder table
-
-instance {-# OVERLAPPABLE #-} DefaultScope table where
-    {-# INLINE defaultScope #-}
-    defaultScope queryBuilder = queryBuilder
 
 instance Table (GetModelByTableName table) => Default (QueryBuilder table) where
     {-# INLINE def #-}


### PR DESCRIPTION
## Summary

- remove the `DefaultScope` typeclass and its identity fallback instance
- make `query @Model` always start from an unfiltered query builder
- document the breaking change and recommend explicit reusable query functions

## Motivation

IHP itself has no custom `DefaultScope` instances or documentation for the feature. The overlappable identity instance adds an implicit customization point and constraint to every `query` call, while making query behavior less explicit.

## Verification

- `git diff --check`
- confirmed no code references to `DefaultScope` or `defaultScope` remain
- full `cabal build ihp` was attempted through `nix develop`, but the remote Nix builder stalled before Cabal started and the attempt was stopped