### PR TITLE
Prune disconnected DataSync subscriptions before reconnect

### DIFF
--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -1,4 +1,4 @@
-import { DataSubscription } from './ihp-datasync.js';
+import { DataSubscription, DataSyncController } from './ihp-datasync.js';
 
 function makeSubscription(records) {
     const query = {
@@ -68,5 +68,30 @@ describe('DataSubscription.onUpdate', () => {
         // Subsequent append should work normally (flag cleared)
         sub.onUpdate('1', null, { name: '456' });
         expect(sub.records[0].name).toBe('Anrufbeantworter123456');
+    });
+});
+
+describe('DataSubscription disconnect cleanup', () => {
+    test('removes an unused subscription locally after its socket was closed', async () => {
+        const controller = DataSyncController.getInstance();
+        const sub = makeSubscription([]);
+        sub.isClosed = true;
+        controller.dataSubscriptions.push(sub);
+
+        await sub.close();
+
+        expect(controller.dataSubscriptions).not.toContain(sub);
+        expect(sub.isConnected).toBe(false);
+    });
+
+    test('schedules unused-subscription pruning before reconnect', async () => {
+        const sub = makeSubscription([]);
+        let pruned = false;
+        sub.closeIfNotUsed = () => { pruned = true; };
+
+        sub.onDataSyncClosed();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(pruned).toBe(true);
     });
 });

--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -1,4 +1,5 @@
 import { DataSubscription, DataSyncController } from './ihp-datasync.js';
+import { jest } from '@jest/globals';
 
 function makeSubscription(records) {
     const query = {
@@ -72,6 +73,16 @@ describe('DataSubscription.onUpdate', () => {
 });
 
 describe('DataSubscription disconnect cleanup', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        DataSyncController.instance = null;
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
     test('removes an unused subscription locally after its socket was closed', async () => {
         const controller = DataSyncController.getInstance();
         const sub = makeSubscription([]);
@@ -84,14 +95,55 @@ describe('DataSubscription disconnect cleanup', () => {
         expect(sub.isConnected).toBe(false);
     });
 
-    test('schedules unused-subscription pruning before reconnect', async () => {
+    test('prunes an unused subscription after the React commit grace period', async () => {
+        const controller = DataSyncController.getInstance();
         const sub = makeSubscription([]);
-        let pruned = false;
-        sub.closeIfNotUsed = () => { pruned = true; };
+        controller.dataSubscriptions.push(sub);
 
         sub.onDataSyncClosed();
-        await new Promise(resolve => setTimeout(resolve, 0));
 
-        expect(pruned).toBe(true);
+        jest.advanceTimersByTime(999);
+        expect(controller.dataSubscriptions).toContain(sub);
+
+        jest.advanceTimersByTime(1);
+        await Promise.resolve();
+        expect(controller.dataSubscriptions).not.toContain(sub);
+    });
+
+    test('keeps a subscription when React commits before reconnect', () => {
+        const controller = DataSyncController.getInstance();
+        const sub = makeSubscription([]);
+        controller.dataSubscriptions.push(sub);
+
+        sub.onDataSyncClosed();
+        jest.advanceTimersByTime(100);
+        const unsubscribe = sub.subscribe(() => {});
+        jest.advanceTimersByTime(900);
+
+        expect(controller.dataSubscriptions).toContain(sub);
+        expect(sub.subscribers).toHaveLength(1);
+
+        unsubscribe();
+    });
+
+    test('notifies local stores only once when close is repeated', async () => {
+        const controller = DataSyncController.getInstance();
+        const sub = makeSubscription([]);
+        const replacement = makeSubscription([]);
+        const store = new Map([['test', sub]]);
+        let closeNotifications = 0;
+        sub.isClosed = true;
+        sub.onClose = () => {
+            closeNotifications++;
+            store.delete('test');
+        };
+        controller.dataSubscriptions.push(sub);
+
+        await sub.close();
+        store.set('test', replacement);
+        await sub.close();
+
+        expect(closeNotifications).toBe(1);
+        expect(store.get('test')).toBe(replacement);
     });
 });

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -15,6 +15,8 @@ import type {
 } from './types.js';
 import { APPEND_NEW_RECORD, PREPEND_NEW_RECORD, NewRecordBehaviour } from './types.js';
 
+const UNUSED_SUBSCRIPTION_CLOSE_DELAY = 1000;
+
 type EventListeners = {
     [K in DataSyncEventType]: DataSyncEventMap[K][];
 };
@@ -270,6 +272,8 @@ class DataSubscription {
     newRecordBehaviour: number;
     optimisticCreatedPendingRecordIds: UUID[];
     optimisticUpdatedPendingRecordIds: Set<UUID>;
+    private closeNotificationSent: boolean;
+    private closeIfNotUsedTimeout: ReturnType<typeof setTimeout> | null;
 
     constructor(query: DynamicSQLQuery, options: DataSubscriptionOptions | null = null, cache: Map<string, DataRecord[]> | null = null) {
         if (typeof query !== "object" || !('table' in query)) {
@@ -310,6 +314,8 @@ class DataSubscription {
 
         this.optimisticCreatedPendingRecordIds = [];
         this.optimisticUpdatedPendingRecordIds = new Set();
+        this.closeNotificationSent = false;
+        this.closeIfNotUsedTimeout = null;
     }
 
     detectNewRecordBehaviour(): number {
@@ -386,13 +392,14 @@ class DataSubscription {
 
     async close(): Promise<void> {
         const dataSyncController = DataSyncController.getInstance();
+        this.cancelScheduledCloseIfNotUsed();
 
         if (this.isClosed) {
             // A dropped WebSocket marks every subscription as closed. There is
             // no server-side subscription left to delete, but an unused React
             // subscription still needs to be removed from the local store and
             // reconnect list.
-            this.onClose();
+            this.notifyClose();
             this.detachFromDataSyncController(dataSyncController);
             return;
         }
@@ -406,7 +413,7 @@ class DataSubscription {
         // Set isClosed early as we need to prevent a second close() from triggering another DeleteDataSubscription message
         // also we don't want to receive any further messages, and onMessage will not process if isClosed == true
         this.isClosed = true;
-        this.onClose();
+        this.notifyClose();
 
         try {
             await dataSyncController.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId: this.subscriptionId });
@@ -427,16 +434,23 @@ class DataSubscription {
         this.isConnected = false;
     }
 
+    private notifyClose(): void {
+        if (this.closeNotificationSent) {
+            return;
+        }
+
+        this.closeNotificationSent = true;
+        this.onClose();
+    }
+
     onDataSyncClosed(): void {
         this.isClosed = true;
         this.isConnected = false;
 
-        // The controller reconnects after one second. Prune subscriptions that
-        // React no longer uses before that reconnect replays dataSubscriptions.
-        // Deferring by one task lets an in-flight React commit subscribe first.
-        setTimeout(() => {
-            this.closeIfNotUsed();
-        }, 0);
+        // The controller reconnects after one second. This timeout is registered
+        // before the reconnect timeout, so unused subscriptions are pruned first.
+        // A React commit that subscribes in the meantime cancels the cleanup.
+        this.scheduleCloseIfNotUsed();
     }
 
     async onDataSyncReconnect(): Promise<void> {
@@ -492,6 +506,7 @@ class DataSubscription {
     }
 
     subscribe(callback: (records: DataRecord[] | null) => void): () => void {
+        this.cancelScheduledCloseIfNotUsed();
         this.subscribers.push(callback);
 
         return () => {
@@ -502,8 +517,23 @@ class DataSubscription {
 
             // We delay the close as react could be re-rendering a component
             // we garbage collect this connecetion once it's clearly not used anymore
-            setTimeout(this.closeIfNotUsed.bind(this), 1000);
+            this.scheduleCloseIfNotUsed();
         };
+    }
+
+    scheduleCloseIfNotUsed(): void {
+        this.cancelScheduledCloseIfNotUsed();
+        this.closeIfNotUsedTimeout = setTimeout(() => {
+            this.closeIfNotUsedTimeout = null;
+            this.closeIfNotUsed();
+        }, UNUSED_SUBSCRIPTION_CLOSE_DELAY);
+    }
+
+    private cancelScheduledCloseIfNotUsed(): void {
+        if (this.closeIfNotUsedTimeout !== null) {
+            clearTimeout(this.closeIfNotUsedTimeout);
+            this.closeIfNotUsedTimeout = null;
+        }
     }
 
     updateSubscribers(): void {

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -385,7 +385,15 @@ class DataSubscription {
     }
 
     async close(): Promise<void> {
+        const dataSyncController = DataSyncController.getInstance();
+
         if (this.isClosed) {
+            // A dropped WebSocket marks every subscription as closed. There is
+            // no server-side subscription left to delete, but an unused React
+            // subscription still needs to be removed from the local store and
+            // reconnect list.
+            this.onClose();
+            this.detachFromDataSyncController(dataSyncController);
             return;
         }
 
@@ -400,9 +408,14 @@ class DataSubscription {
         this.isClosed = true;
         this.onClose();
 
-        const dataSyncController = DataSyncController.getInstance();
-        await dataSyncController.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId: this.subscriptionId });
+        try {
+            await dataSyncController.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId: this.subscriptionId });
+        } finally {
+            this.detachFromDataSyncController(dataSyncController);
+        }
+    }
 
+    private detachFromDataSyncController(dataSyncController: DataSyncController): void {
         dataSyncController.removeEventListener('message', this.onMessage);
         dataSyncController.removeEventListener('close', this.onDataSyncClosed);
         dataSyncController.removeEventListener('reconnect', this.onDataSyncReconnect);
@@ -417,6 +430,13 @@ class DataSubscription {
     onDataSyncClosed(): void {
         this.isClosed = true;
         this.isConnected = false;
+
+        // The controller reconnects after one second. Prune subscriptions that
+        // React no longer uses before that reconnect replays dataSubscriptions.
+        // Deferring by one task lets an in-flight React commit subscribe first.
+        setTimeout(() => {
+            this.closeIfNotUsed();
+        }, 0);
     }
 
     async onDataSyncReconnect(): Promise<void> {

--- a/ihp-datasync/data/DataSync/src/react.ts
+++ b/ihp-datasync/data/DataSync/src/react.ts
@@ -83,7 +83,11 @@ export class DataSubscriptionStore {
 
             const subscription = new DataSubscription(query, options, DataSubscriptionStore.cache);
             subscription.createOnServer();
-            subscription.onClose = () => { DataSubscriptionStore.queryMap.delete(key); };
+            subscription.onClose = () => {
+                if (DataSubscriptionStore.queryMap.get(key) === subscription) {
+                    DataSubscriptionStore.queryMap.delete(key);
+                }
+            };
 
             DataSubscriptionStore.queryMap.set(key, subscription);
 
@@ -92,9 +96,7 @@ export class DataSubscriptionStore {
             // to many open connections laying around by trying to close them a second after opening them.
             // A second is enough time for react to call the subscribe function. If it's not called by then,
             // we most likely deal with a dead subscription, so we close it.
-            setTimeout(() => {
-                subscription.closeIfNotUsed();
-            }, 1000);
+            subscription.scheduleCloseIfNotUsed();
 
             return subscription;
         }


### PR DESCRIPTION
## Summary

- detach unused DataSync subscriptions locally when their WebSocket has already closed
- prune unused subscriptions before the reconnect loop replays them
- always detach locally when deleting a server subscription fails
- add regression coverage for disconnected cleanup and reconnect pruning

## Root cause

`onDataSyncClosed` marks every `DataSubscription` as closed. Later, React's delayed `closeIfNotUsed` calls `close`, but `close` returned immediately for closed subscriptions. That left stale entries in both the React subscription store and `DataSyncController.dataSubscriptions`.

Long-lived browser tabs therefore replayed old, unused queries after every reconnect. Repeated application deploys could eventually hit the per-connection subscription limit and generate enough concurrent subscription work to exhaust the database connection pool.

## Impact

Disconnected tabs now discard queries that React no longer uses before reconnecting, while active subscriptions remain available for normal replay.

## Validation

- `nix build .#datasync-js --no-link`
- DataSync Jest suite
- TypeScript build and typecheck