### PR TITLE
Prevent stale DataSync reconnect responses from reopening closed subscriptions

### DIFF
--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -146,4 +146,34 @@ describe('DataSubscription disconnect cleanup', () => {
         expect(closeNotifications).toBe(1);
         expect(store.get('test')).toBe(replacement);
     });
+
+    test('deletes a reconnect response that arrives after the subscription was closed', async () => {
+        const controller = DataSyncController.getInstance();
+        const sub = makeSubscription([]);
+        const sentMessages = [];
+        let resolveCreateOnServer;
+        sub.isClosed = true;
+        controller.dataSubscriptions.push(sub);
+        controller.sendMessage = (message) => {
+            sentMessages.push(message);
+            if (message.tag === 'CreateDataSubscription') {
+                return new Promise(resolve => { resolveCreateOnServer = resolve; });
+            }
+            return Promise.resolve({});
+        };
+
+        const reconnect = sub.onDataSyncReconnect();
+        await sub.close();
+        resolveCreateOnServer({ subscriptionId: 'reconnected-id', result: [] });
+        await reconnect;
+
+        expect(sentMessages).toEqual([
+            { tag: 'CreateDataSubscription', query: sub.query },
+            { tag: 'DeleteDataSubscription', subscriptionId: 'reconnected-id' },
+        ]);
+        expect(controller.dataSubscriptions).not.toContain(sub);
+        expect(sub.isClosed).toBe(true);
+        expect(sub.isConnected).toBe(false);
+        expect(sub.subscriptionId).toBe(null);
+    });
 });

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -274,6 +274,7 @@ class DataSubscription {
     optimisticUpdatedPendingRecordIds: Set<UUID>;
     private closeNotificationSent: boolean;
     private closeIfNotUsedTimeout: ReturnType<typeof setTimeout> | null;
+    private createOnServerGeneration: number;
 
     constructor(query: DynamicSQLQuery, options: DataSubscriptionOptions | null = null, cache: Map<string, DataRecord[]> | null = null) {
         if (typeof query !== "object" || !('table' in query)) {
@@ -316,6 +317,7 @@ class DataSubscription {
         this.optimisticUpdatedPendingRecordIds = new Set();
         this.closeNotificationSent = false;
         this.closeIfNotUsedTimeout = null;
+        this.createOnServerGeneration = 0;
     }
 
     detectNewRecordBehaviour(): number {
@@ -337,10 +339,16 @@ class DataSubscription {
 
     async createOnServer(): Promise<void> {
         const dataSyncController = DataSyncController.getInstance();
+        const createOnServerGeneration = this.createOnServerGeneration;
         try {
             const response = await dataSyncController.sendMessage({ tag: 'CreateDataSubscription', query: this.query });
             const subscriptionId = response.subscriptionId as UUID;
             const result = response.result as DataRecord[];
+
+            if (createOnServerGeneration !== this.createOnServerGeneration) {
+                await this.deleteStaleDataSubscription(dataSyncController, subscriptionId);
+                return;
+            }
 
             this.subscriptionId = subscriptionId;
 
@@ -395,6 +403,7 @@ class DataSubscription {
         this.cancelScheduledCloseIfNotUsed();
 
         if (this.isClosed) {
+            this.createOnServerGeneration++;
             // A dropped WebSocket marks every subscription as closed. There is
             // no server-side subscription left to delete, but an unused React
             // subscription still needs to be removed from the local store and
@@ -412,6 +421,7 @@ class DataSubscription {
 
         // Set isClosed early as we need to prevent a second close() from triggering another DeleteDataSubscription message
         // also we don't want to receive any further messages, and onMessage will not process if isClosed == true
+        this.createOnServerGeneration++;
         this.isClosed = true;
         this.notifyClose();
 
@@ -443,7 +453,16 @@ class DataSubscription {
         this.onClose();
     }
 
+    private async deleteStaleDataSubscription(dataSyncController: DataSyncController, subscriptionId: UUID): Promise<void> {
+        try {
+            await dataSyncController.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
+        } catch (error) {
+            console.error('Failed to delete a DataSubscription created after it was closed:', error);
+        }
+    }
+
     onDataSyncClosed(): void {
+        this.createOnServerGeneration++;
         this.isClosed = true;
         this.isConnected = false;
 


### PR DESCRIPTION
## Summary

- invalidate in-flight `CreateDataSubscription` attempts when a subscription disconnects or closes
- delete a server subscription returned by a stale reconnect response
- keep the detached local subscription closed and add regression coverage for the race

## Root cause

This is a follow-up to #2775 and addresses [the post-merge review finding](https://github.com/digitallyinduced/ihp/pull/2775#discussion_r3752936433).

If React unsubscribed after `onDataSyncReconnect()` sent `CreateDataSubscription` but before the response arrived, `close()` detached the local subscription while it was still marked closed. The late response then unconditionally reopened that detached object and left the newly created server subscription orphaned.

## Impact

Late reconnect responses can no longer resurrect detached subscriptions or accumulate duplicate server subscriptions for the same query.

## Validation

- `nix build .#datasync-js --no-link`
- 140 Jest tests
- TypeScript build and typecheck