### PR TITLE
Fix DataSync frontend state handling

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -565,7 +565,7 @@ that is defined in flake-module.nix
 
                 yarnOfflineCache = pkgs.fetchYarnDeps {
                     yarnLock = ./ihp-datasync/data/DataSync/yarn.lock;
-                    hash = "sha256-D9pLOT4afe8M29nKgJyNZhCj0KlF6X8ZQ0e8RZZsVsY=";
+                    hash = "sha256-qbkwBjpG2N0deFNWqTNRCnShqGO1d8r8bzHwhz5SVfQ=";
                 };
 
                 nativeBuildInputs = [ pkgs.nodejs pkgs.yarn pkgs.yarnConfigHook ];

--- a/ihp-datasync/IHP/DataSync/ChangeNotifications.hs
+++ b/ihp-datasync/IHP/DataSync/ChangeNotifications.hs
@@ -1,14 +1,23 @@
 module IHP.DataSync.ChangeNotifications
 ( channelName
+, globalInvalidationChannel
+, relationInvalidationChannel
+, invalidationChannelsForTable
+, InvalidationPlan (..)
+, resolveInvalidationPlan
+, makeInstallInvalidationPlan
 , ChangeNotification (..)
 , Change (..)
 , ChangeSet (..)
 , createNotificationFunction
 , installTableChangeTriggers
+, installGlobalInvalidationTriggers
+, makeCachedInstallGlobalInvalidationTriggers
 , makeCachedInstallTableChangeTriggers
 , makeInstallTableChangeTriggers
 , retrieveChanges
 , installTableChangeTriggersSession
+, installGlobalInvalidationTriggersSession
 , retrieveChangesSession
 ) where
 
@@ -30,6 +39,9 @@ import IHP.DataSync.Hasql (runSession)
 import IHP.PGVersion (defaultUuidFunction)
 import IHP.Environment (Environment(..))
 import System.IO.Unsafe (unsafePerformIO)
+import System.Mem.StableName (StableName, makeStableName)
+import qualified Data.List as List
+import qualified Data.Set as Set
 
 data ChangeNotification
     = DidInsert { id :: !UUID }
@@ -47,6 +59,18 @@ data Change
     = Change { col :: !Text, new :: !Value }
     | AppendChange { col :: !Text, append :: !Text }
     deriving (Eq, Show)
+
+data InvalidationPlan = InvalidationPlan
+    { channels :: !(Set.Set ByteString)
+    , relationOids :: ![Int64]
+    , missingRelationOids :: ![Int64]
+    , requiresGlobalFallback :: !Bool
+    } deriving (Eq, Show)
+
+data InvalidationInstallState = InvalidationInstallState
+    { globalFingerprint :: !(Maybe Text)
+    , functionReconciled :: !Bool
+    }
 
 -- | Returns the sql code to set up a database trigger. Mainly used by 'watchInsertOrUpdateTable'.
 --
@@ -180,6 +204,109 @@ createNotificationFunction uuidFunction table = [i|
         updateTriggerName = "did_update_" <> tableName
         deleteTriggerName = "did_delete_" <> tableName
 
+-- | Creates the payload-free trigger function. Relation triggers are installed
+-- separately so each table lock is released before attempting the next table.
+createGlobalInvalidationFunction :: Text
+createGlobalInvalidationFunction = [i|
+    DO $$
+    BEGIN
+        PERFORM pg_advisory_xact_lock(hashtext('#{functionName}'));
+
+        CREATE OR REPLACE FUNCTION public."#{functionName}"() RETURNS TRIGGER AS $BODY$
+        DECLARE
+            affected_relation OID;
+        BEGIN
+            -- Direct writes to an inherited/partition child use the child's
+            -- TG_RELID. Also notify every ancestor so a subscription querying
+            -- the parent relation cannot miss that change.
+            FOR affected_relation IN
+                WITH RECURSIVE affected_relations(oid) AS (
+                    SELECT TG_RELID
+                    UNION
+                    SELECT inheritance.inhparent
+                    FROM pg_catalog.pg_inherits inheritance
+                    JOIN affected_relations ON inheritance.inhrelid = affected_relations.oid
+                )
+                SELECT oid FROM affected_relations
+            LOOP
+                PERFORM pg_notify('#{relationInvalidationChannelPrefix}' || affected_relation::text, '');
+            END LOOP;
+            PERFORM pg_notify('#{globalInvalidationChannel}', '');
+            RETURN NULL;
+        END;
+        $BODY$ language plpgsql;
+    END; $$
+|]
+    where
+        functionName = "ihp_datasync_notify_invalidation"
+
+-- | Install the global statement trigger on one relation OID. The catalog row
+-- is revalidated inside the block because a migration may have dropped it
+-- after the initial scan. Each invocation is a separate implicit transaction,
+-- avoiding an accumulating schema-wide set of ShareRowExclusive locks.
+createGlobalInvalidationTrigger :: Int64 -> Text
+createGlobalInvalidationTrigger relationOid = [i|
+    DO $$
+    DECLARE
+        relation_schema TEXT;
+        relation_name TEXT;
+    BEGIN
+        PERFORM pg_advisory_xact_lock(hashtext('#{triggerName}:' || #{relationOid}::text));
+
+        SELECT n.nspname, c.relname
+        INTO relation_schema, relation_name
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.oid = #{relationOid}::oid
+          AND c.relkind IN ('r', 'p')
+          AND n.nspname <> 'information_schema'
+          AND n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+          AND has_table_privilege(c.oid, 'TRIGGER')
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_catalog.pg_depend extension_dependency
+              WHERE extension_dependency.classid = 'pg_catalog.pg_class'::regclass
+                AND extension_dependency.objid = c.oid
+                AND extension_dependency.deptype = 'e'
+          );
+
+        IF NOT FOUND THEN
+            RETURN;
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_trigger installed_trigger
+            WHERE installed_trigger.tgname = '#{triggerName}'
+              AND installed_trigger.tgrelid = #{relationOid}::oid
+              AND NOT installed_trigger.tgisinternal
+              AND installed_trigger.tgfoid = 'public.#{functionName}()'::regprocedure
+              AND installed_trigger.tgtype = 60
+              AND installed_trigger.tgenabled IN ('O', 'A')
+        ) THEN
+            IF EXISTS (
+                SELECT 1 FROM pg_catalog.pg_trigger conflicting_trigger
+                WHERE conflicting_trigger.tgname = '#{triggerName}'
+                  AND conflicting_trigger.tgrelid = #{relationOid}::oid
+                  AND NOT conflicting_trigger.tgisinternal
+            ) THEN
+                RAISE EXCEPTION 'Incompatible pre-existing trigger % on %.%',
+                    '#{triggerName}', relation_schema, relation_name;
+            END IF;
+            PERFORM set_config('lock_timeout', '5s', true);
+            EXECUTE format(
+                'CREATE TRIGGER %I AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON %I.%I FOR EACH STATEMENT EXECUTE PROCEDURE public.%I()',
+                '#{triggerName}',
+                relation_schema,
+                relation_name,
+                '#{functionName}'
+            );
+        END IF;
+    END; $$
+|]
+    where
+        functionName = "ihp_datasync_notify_invalidation"
+        triggerName = "ihp_datasync_invalidate"
+
 -- Statements
 
 retrieveChangesStatement :: Statement.Statement UUID Text
@@ -188,11 +315,48 @@ retrieveChangesStatement = Statement.preparable
     (Encoders.param (Encoders.nonNullable Encoders.uuid))
     (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.text)))
 
+eligibleGlobalInvalidationRelationsStatement :: Statement.Statement () [Int64]
+eligibleGlobalInvalidationRelationsStatement = Statement.preparable
+    "SELECT c.oid::bigint FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('r', 'p') AND n.nspname <> 'information_schema' AND n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\' AND has_table_privilege(c.oid, 'TRIGGER') AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_depend extension_dependency WHERE extension_dependency.classid = 'pg_catalog.pg_class'::regclass AND extension_dependency.objid = c.oid AND extension_dependency.deptype = 'e') ORDER BY c.oid"
+    Encoders.noParams
+    (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.int8)))
+
+globalInvalidationSchemaFingerprintStatement :: Statement.Statement () Text
+globalInvalidationSchemaFingerprintStatement = Statement.preparable
+    "SELECT COALESCE(string_agg(c.oid::text || ':' || CASE WHEN EXISTS (SELECT 1 FROM pg_catalog.pg_trigger installed_trigger WHERE installed_trigger.tgrelid = c.oid AND installed_trigger.tgname = 'ihp_datasync_invalidate' AND NOT installed_trigger.tgisinternal AND installed_trigger.tgfoid = to_regprocedure('public.ihp_datasync_notify_invalidation()') AND installed_trigger.tgtype = 60 AND installed_trigger.tgenabled IN ('O', 'A')) THEN '1' ELSE '0' END, ',' ORDER BY c.oid), '') FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('r', 'p') AND n.nspname <> 'information_schema' AND n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\' AND has_table_privilege(c.oid, 'TRIGGER') AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_depend extension_dependency WHERE extension_dependency.classid = 'pg_catalog.pg_class'::regclass AND extension_dependency.objid = c.oid AND extension_dependency.deptype = 'e')"
+    Encoders.noParams
+    (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.text)))
+
+invalidationDependenciesStatement :: Statement.Statement Text [(Int64, Bool, Bool, Bool, Bool)]
+invalidationDependenciesStatement = Statement.preparable
+    "WITH RECURSIVE selected_table AS (SELECT $1::regclass::oid AS relation_oid), policies AS (SELECT p.oid FROM pg_catalog.pg_policy p WHERE p.polrelid = (SELECT relation_oid FROM selected_table) AND p.polcmd IN ('r', '*')), policy_dependencies AS (SELECT dependency.* FROM policies JOIN pg_catalog.pg_depend dependency ON dependency.classid = 'pg_catalog.pg_policy'::regclass AND dependency.objid = policies.oid), root_dependencies AS (SELECT relation_oid FROM selected_table UNION SELECT dependency.refobjid FROM policy_dependencies dependency WHERE dependency.refclassid = 'pg_catalog.pg_class'::regclass), expanded_dependencies(relation_oid, is_root) AS (SELECT relation_oid, true FROM root_dependencies UNION SELECT inheritance.inhrelid, false FROM pg_catalog.pg_inherits inheritance JOIN expanded_dependencies ON inheritance.inhparent = expanded_dependencies.relation_oid), relation_dependencies AS (SELECT relation_oid, bool_or(is_root) AS is_root FROM expanded_dependencies GROUP BY relation_oid), opaque_policy AS (SELECT (EXISTS (SELECT 1 FROM policy_dependencies dependency JOIN pg_catalog.pg_proc referenced_function ON dependency.refclassid = 'pg_catalog.pg_proc'::regclass AND dependency.refobjid = referenced_function.oid JOIN pg_catalog.pg_namespace function_namespace ON function_namespace.oid = referenced_function.pronamespace WHERE function_namespace.nspname <> 'pg_catalog' AND NOT (function_namespace.nspname = 'public' AND referenced_function.proname = 'ihp_user_id' AND referenced_function.pronargs = 0 AND referenced_function.prolang = (SELECT oid FROM pg_catalog.pg_language WHERE lanname = 'sql') AND trim(trailing ';' from lower(regexp_replace(referenced_function.prosrc, '[[:space:]]+', '', 'g'))) = 'selectnullif(current_setting(''rls.ihp_user_id''),'''')::uuid')) OR EXISTS (SELECT 1 FROM policy_dependencies dependency JOIN pg_catalog.pg_class referenced_relation ON dependency.refclassid = 'pg_catalog.pg_class'::regclass AND dependency.refobjid = referenced_relation.oid WHERE referenced_relation.relkind = 'v') OR EXISTS (SELECT 1 FROM policy_dependencies dependency JOIN pg_catalog.pg_class referenced_relation ON dependency.refclassid = 'pg_catalog.pg_class'::regclass AND dependency.refobjid = referenced_relation.oid, selected_table WHERE referenced_relation.oid <> selected_table.relation_oid AND referenced_relation.relrowsecurity) OR EXISTS (SELECT 1 FROM policy_dependencies dependency JOIN pg_catalog.pg_operator referenced_operator ON dependency.refclassid = 'pg_catalog.pg_operator'::regclass AND dependency.refobjid = referenced_operator.oid JOIN pg_catalog.pg_namespace operator_namespace ON operator_namespace.oid = referenced_operator.oprnamespace WHERE operator_namespace.nspname <> 'pg_catalog')) AS required, EXISTS (SELECT 1 FROM policy_dependencies dependency JOIN pg_catalog.pg_class referenced_relation ON dependency.refclassid = 'pg_catalog.pg_class'::regclass AND dependency.refobjid = referenced_relation.oid WHERE referenced_relation.relkind NOT IN ('r', 'p', 'v')) AS has_unobservable_dependency) SELECT relation_dependencies.relation_oid::bigint, relation_dependencies.is_root, opaque_policy.required, (NOT opaque_policy.has_unobservable_dependency AND relation_namespace.nspname <> 'information_schema' AND relation_namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\' AND has_table_privilege(relation.oid, 'TRIGGER') AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_depend extension_dependency WHERE extension_dependency.classid = 'pg_catalog.pg_class'::regclass AND extension_dependency.objid = relation.oid AND extension_dependency.deptype = 'e')), EXISTS (SELECT 1 FROM pg_catalog.pg_trigger installed_trigger WHERE installed_trigger.tgrelid = relation.oid AND installed_trigger.tgname = 'ihp_datasync_invalidate' AND NOT installed_trigger.tgisinternal AND installed_trigger.tgfoid = to_regprocedure('public.ihp_datasync_notify_invalidation()') AND installed_trigger.tgtype = 60 AND installed_trigger.tgenabled IN ('O', 'A')) FROM relation_dependencies JOIN pg_catalog.pg_class relation ON relation.oid = relation_dependencies.relation_oid JOIN pg_catalog.pg_namespace relation_namespace ON relation_namespace.oid = relation.relnamespace CROSS JOIN opaque_policy WHERE relation.relkind IN ('r', 'p') ORDER BY relation_dependencies.relation_oid"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList ((,,,,) <$> Decoders.column (Decoders.nonNullable Decoders.int8) <*> Decoders.column (Decoders.nonNullable Decoders.bool) <*> Decoders.column (Decoders.nonNullable Decoders.bool) <*> Decoders.column (Decoders.nonNullable Decoders.bool) <*> Decoders.column (Decoders.nonNullable Decoders.bool)))
+
 -- Sessions
 
 installTableChangeTriggersSession :: Text -> RLS.TableWithRLS -> Session.Session ()
 installTableChangeTriggersSession uuidFunction table =
     Session.script (createNotificationFunction uuidFunction table)
+
+installGlobalInvalidationTriggersSession :: Session.Session ()
+installGlobalInvalidationTriggersSession = do
+    Session.script createGlobalInvalidationFunction
+    relationOids <- Session.statement () eligibleGlobalInvalidationRelationsStatement
+    forM_ relationOids (Session.script . createGlobalInvalidationTrigger)
+
+installInvalidationTriggersSession :: [Int64] -> Session.Session ()
+installInvalidationTriggersSession relationOids = do
+    Session.script createGlobalInvalidationFunction
+    forM_ relationOids (Session.script . createGlobalInvalidationTrigger)
+
+globalInvalidationSchemaFingerprintSession :: Session.Session Text
+globalInvalidationSchemaFingerprintSession =
+    Session.statement () globalInvalidationSchemaFingerprintStatement
+
+invalidationDependenciesSession :: Text -> Session.Session [(Int64, Bool, Bool, Bool, Bool)]
+invalidationDependenciesSession tableName =
+    Session.statement tableName invalidationDependenciesStatement
 
 retrieveChangesSession :: UUID -> Session.Session Text
 retrieveChangesSession uuid = Session.statement uuid retrieveChangesStatement
@@ -204,6 +368,115 @@ installTableChangeTriggers pool tableNameRLS = do
     uuidFunction <- defaultUuidFunction
     runSession pool (installTableChangeTriggersSession uuidFunction tableNameRLS)
     pure ()
+
+installGlobalInvalidationTriggers :: Hasql.Pool.Pool -> IO ()
+installGlobalInvalidationTriggers pool =
+    runSession pool installGlobalInvalidationTriggersSession
+
+-- | One reconciliation state per shared Hasql pool. The MVar prevents first
+-- subscriptions on many WebSockets from consuming the pool while they wait on
+-- database DDL locks. A catalog fingerprint detects newly created/recreated
+-- relations and manually removed triggers, so long-lived controllers do not
+-- retain a stale one-shot cache. Failed reconciliation leaves the old
+-- fingerprint in place and the next subscription retries.
+{-# NOINLINE globalInvalidationInstallStates #-}
+globalInvalidationInstallStates :: MVar [(StableName Hasql.Pool.Pool, MVar InvalidationInstallState)]
+globalInvalidationInstallStates = unsafePerformIO (newMVar [])
+
+invalidationInstallStateForPool :: Hasql.Pool.Pool -> IO (MVar InvalidationInstallState)
+invalidationInstallStateForPool pool = do
+    poolName <- makeStableName pool
+    modifyMVar globalInvalidationInstallStates \states ->
+        case List.find (\(existingPoolName, _) -> existingPoolName == poolName) states of
+            Just (_, existingState) -> pure (states, existingState)
+            Nothing -> do
+                state <- newMVar InvalidationInstallState
+                    { globalFingerprint = Nothing
+                    , functionReconciled = False
+                    }
+                pure ((poolName, state) : states, state)
+
+makeCachedInstallGlobalInvalidationTriggers :: Hasql.Pool.Pool -> IO (IO ())
+makeCachedInstallGlobalInvalidationTriggers pool = do
+    installState <- invalidationInstallStateForPool pool
+    pure $ modifyMVar_ installState \state -> do
+        currentFingerprint <- runSession pool globalInvalidationSchemaFingerprintSession
+        if state.functionReconciled && Just currentFingerprint == state.globalFingerprint
+            then pure state
+            else do
+                installGlobalInvalidationTriggers pool
+                reconciledFingerprint <- runSession pool globalInvalidationSchemaFingerprintSession
+                pure state
+                    { globalFingerprint = Just reconciledFingerprint
+                    , functionReconciled = True
+                    }
+
+-- | Build a serialized installer for a resolved subscription plan. Normal
+-- plans install only the base/RLS dependency relations (plus partition
+-- descendants). Schema-wide reconciliation is reserved for opaque policies
+-- whose function/view dependencies cannot be represented precisely.
+makeInstallInvalidationPlan :: Hasql.Pool.Pool -> IO (InvalidationPlan -> IO ())
+makeInstallInvalidationPlan pool = do
+    installState <- invalidationInstallStateForPool pool
+    pure \plan -> modifyMVar_ installState \state ->
+        if plan.requiresGlobalFallback
+            then do
+                currentFingerprint <- runSession pool globalInvalidationSchemaFingerprintSession
+                if state.functionReconciled && Just currentFingerprint == state.globalFingerprint
+                    then pure state
+                    else do
+                        installGlobalInvalidationTriggers pool
+                        reconciledFingerprint <- runSession pool globalInvalidationSchemaFingerprintSession
+                        pure state
+                            { globalFingerprint = Just reconciledFingerprint
+                            , functionReconciled = True
+                            }
+            else if state.functionReconciled && null plan.missingRelationOids
+                then pure state
+                else do
+                    -- Missing exact triggers can also mean the shared function
+                    -- was dropped CASCADE while this process-local state stayed
+                    -- warm. Reconcile the function whenever any trigger is missing.
+                    runSession pool (installInvalidationTriggersSession plan.missingRelationOids)
+                    pure state
+                        { globalFingerprint = Nothing
+                        , functionReconciled = True
+                        }
+
+-- | Resolve the relation-scoped invalidation channels required by a query on
+-- this RLS table. PostgreSQL records direct table references in policy
+-- expressions in @pg_depend@, including membership tables used by @EXISTS@.
+-- Policies that call an application-defined function are conservatively also
+-- subscribed to the global channel because dependencies hidden in a function
+-- body are not necessarily represented on the policy itself. The framework's
+-- relation-free @public.ihp_user_id()@ helper is explicitly safe-listed.
+--
+-- The global fallback observes DML on eligible ordinary and partitioned
+-- application relations. It cannot make time-dependent policy expressions or
+-- external state hidden inside an opaque function observable. Known direct
+-- dependencies that cannot be instrumented are therefore rejected instead of
+-- silently accepting a subscription that could become stale.
+resolveInvalidationPlan :: Hasql.Pool.Pool -> RLS.TableWithRLS -> IO InvalidationPlan
+resolveInvalidationPlan pool table = do
+    dependencies <- runSession pool (invalidationDependenciesSession table.tableName)
+    when (null dependencies || any (not . fourth) dependencies) do
+        throwIO (userError ("DataSync cannot install a safe invalidation trigger for every RLS dependency of " <> cs table.tableName))
+    let rootRelationOids = [relationOid | (relationOid, isRoot, _, _, _) <- dependencies, isRoot]
+    let relationOids = [relationOid | (relationOid, _, _, _, _) <- dependencies]
+    let missingRelationOids = [relationOid | (relationOid, _, _, _, isInstalled) <- dependencies, not isInstalled]
+    let relationChannels = Set.fromList (map relationInvalidationChannel rootRelationOids)
+    let requiresGlobalFallback = any third dependencies
+    let channels = if requiresGlobalFallback
+            then Set.insert globalInvalidationChannel relationChannels
+            else relationChannels
+    pure InvalidationPlan { channels, relationOids, missingRelationOids, requiresGlobalFallback }
+    where
+        third (_, _, value, _, _) = value
+        fourth (_, _, _, value, _) = value
+
+invalidationChannelsForTable :: Hasql.Pool.Pool -> RLS.TableWithRLS -> IO (Set.Set ByteString)
+invalidationChannelsForTable pool table =
+    (.channels) <$> resolveInvalidationPlan pool table
 
 -- | In development, always re-run trigger SQL because @make db@ drops and
 -- recreates the database, destroying previously installed triggers.
@@ -259,6 +532,19 @@ makeCachedInstallTableChangeTriggers pool = do
 -- | Returns the event name of the event that the pg notify trigger dispatches
 channelName :: RLS.TableWithRLS -> ByteString
 channelName table = "did_change_" <> (cs $ Text.replace "\"" "\"\"" table.tableName)
+
+-- | Payload-free channel used to invalidate queries affected by writes to
+-- relations other than the selected table (for example RLS membership tables).
+globalInvalidationChannel :: ByteString
+globalInvalidationChannel = "ihp_datasync_invalidate"
+
+relationInvalidationChannelPrefix :: ByteString
+relationInvalidationChannelPrefix = "ihp_datasync_invalidate_"
+
+-- | Payload-free invalidation channel emitted only for writes to one relation.
+relationInvalidationChannel :: Int64 -> ByteString
+relationInvalidationChannel relationOid =
+    relationInvalidationChannelPrefix <> cs (tshow relationOid)
 
 
 instance FromJSON ChangeNotification where

--- a/ihp-datasync/IHP/DataSync/ControllerImpl.hs
+++ b/ihp-datasync/IHP/DataSync/ControllerImpl.hs
@@ -6,6 +6,8 @@ import qualified Control.Exception.Safe as Exception
 import System.Log.FastLogger (toLogStr)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
+import qualified Data.Scientific as Scientific
 
 import Data.Aeson.TH
 import qualified Hasql.Decoders as Decoders
@@ -15,7 +17,9 @@ import qualified Hasql.Session as Session
 import IHP.DataSync.Hasql (runSession, runSessionOnConnection, withDedicatedConnection)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.UUID.V4 as UUID
+import qualified Control.Concurrent as Concurrent
 import qualified Control.Concurrent.MVar as MVar
+import Control.Monad (void)
 import IHP.DataSync.Types
 import IHP.DataSync.RowLevelSecurity
 import IHP.DataSync.DynamicQuery
@@ -33,6 +37,22 @@ import qualified Data.List as List
 
 $(deriveFromJSON defaultOptions ''DataSyncMessage)
 $(deriveToJSON defaultOptions { omitNothingFields = True } 'DataSyncResult)
+
+-- | The transport envelope deliberately lives outside 'DataSyncMessage'. Older
+-- Haskell callers can keep constructing @CreateDataSubscription query requestId@
+-- while newer wire clients advertise snapshot support with an extra JSON field.
+decodeDataSyncMessageEnvelope :: ByteString -> Either String (Maybe Int, DataSyncMessage)
+decodeDataSyncMessageEnvelope input = do
+    value <- Aeson.eitherDecodeStrict' input
+    message <- case Aeson.fromJSON value of
+        Aeson.Success decoded -> Right decoded
+        Aeson.Error errorMessage -> Left errorMessage
+    let protocolVersion = case value of
+            Aeson.Object fields -> case Aeson.lookup "protocolVersion" fields of
+                Just (Aeson.Number version) -> Scientific.toBoundedInteger version
+                _ -> Nothing
+            _ -> Nothing
+    pure (protocolVersion, message)
 
 type EnsureRLSEnabledFn = Text -> IO TableWithRLS
 type InstallTableChangeTriggerFn = TableWithRLS -> IO ()
@@ -53,7 +73,7 @@ runDataSyncController hasqlPool ensureRLSEnabled installTableChangeTriggers rece
     setState DataSyncReady { subscriptions = HashMap.empty, transactions = HashMap.empty }
 
     columnTypeLookup <- makeCachedColumnTypeLookup hasqlPool
-    handleMessage :: DataSyncMessage -> IO () <- buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJSON handleCustomMessage renamer columnTypeLookup
+    handleMessage :: Maybe Int -> DataSyncMessage -> IO () <- buildMessageHandlerWithProtocolVersion hasqlPool ensureRLSEnabled installTableChangeTriggers sendJSON handleCustomMessage renamer columnTypeLookup
 
 
     sem  <- newQSemN (maxSubscriptionsPerConnection * 2) -- needs to be larger than the subscriptions limit to trigger an error on overload. otherwise an overflow of connections might queue up silently
@@ -61,17 +81,20 @@ runDataSyncController hasqlPool ensureRLSEnabled installTableChangeTriggers rece
     -- Track Asyncs so we can cancel/wait on socket close
     childrenVar <- newTVarIO (HashMap.empty :: HashMap ThreadId (Async ()))
 
-    let spawnWorker decodedMessage = do
+    let spawnWorker protocolVersion decodedMessage = Exception.mask \restoreParent -> do
             tidReady <- MVar.newEmptyMVar
+            startGate <- MVar.newEmptyMVar
             a <- asyncWithUnmask \unmask -> do
-                -- Register myself
                 tid <- myThreadId
                 MVar.putMVar tidReady tid
+                -- The handler cannot finish and self-delete before the parent has
+                -- inserted this Async into childrenVar.
+                MVar.takeMVar startGate
                 -- Take/release concurrency slot entirely inside the worker
                 Exception.bracket_ (waitQSemN sem 1) (signalQSemN sem 1) do
                     Exception.finally
                         (unmask do
-                            result <- Exception.try (handleMessage decodedMessage)
+                            result <- Exception.try (handleMessage protocolVersion decodedMessage)
                             case result of
                                 Left (e :: Exception.SomeException) -> do
                                     let requestId    = decodedMessage.requestId
@@ -85,14 +108,17 @@ runDataSyncController hasqlPool ensureRLSEnabled installTableChangeTriggers rece
                             tid' <- myThreadId
                             atomically $ modifyTVar' childrenVar (HashMap.delete tid')
                         )
-            -- Parent stores the Async by ThreadId (no race thanks to tidReady)
-            tid <- MVar.takeMVar tidReady
-            atomically $ modifyTVar' childrenVar (HashMap.insert tid a)
+            let register = do
+                    tid <- MVar.takeMVar tidReady
+                    atomically $ modifyTVar' childrenVar (HashMap.insert tid a)
+                    MVar.putMVar startGate ()
+            register `Exception.onException` cancel a
+            restoreParent (pure ())
 
     let loop = forever do
-            msg <- Aeson.eitherDecodeStrict' <$> receiveData
+            msg <- decodeDataSyncMessageEnvelope <$> receiveData
             case msg of
-                Right decoded -> spawnWorker decoded
+                Right (protocolVersion, decoded) -> spawnWorker protocolVersion decoded
                 Left err      -> sendJSON FailedToDecodeMessageError { errorMessage = cs err }
 
     -- On websocket close: cancel and drain all children
@@ -116,12 +142,36 @@ buildMessageHandler ::
     )
     => Hasql.Pool.Pool -> EnsureRLSEnabledFn -> InstallTableChangeTriggerFn -> SendJSONFn -> HandleCustomMessageFn -> (Text -> Renamer) -> (Text -> IO ColumnTypeInfo) -> IO (DataSyncMessage -> IO ())
 buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJSON handleCustomMessage renamer columnTypeLookup = do
+    handleMessage <- buildMessageHandlerWithProtocolVersion hasqlPool ensureRLSEnabled installTableChangeTriggers sendJSON handleCustomMessage renamer columnTypeLookup
+    pure (handleMessage Nothing)
+
+-- | Internal wire-aware variant. The optional protocol version is kept out of
+-- the public 'DataSyncMessage' constructors for source compatibility.
+buildMessageHandlerWithProtocolVersion ::
+    ( HasField "id" CurrentUserRecord (Id' (GetTableName CurrentUserRecord))
+    , ?context :: Request
+    , ?request :: Request
+    , ?modelContext :: ModelContext
+    , ?state :: IORef DataSyncController
+    , Typeable CurrentUserRecord
+    , HasNewSessionUrl CurrentUserRecord
+    , Show (PrimaryKey (GetTableName CurrentUserRecord))
+    )
+    => Hasql.Pool.Pool -> EnsureRLSEnabledFn -> InstallTableChangeTriggerFn -> SendJSONFn -> HandleCustomMessageFn -> (Text -> Renamer) -> (Text -> IO ColumnTypeInfo) -> IO (Maybe Int -> DataSyncMessage -> IO ())
+buildMessageHandlerWithProtocolVersion hasqlPool ensureRLSEnabled _installTableChangeTriggers sendJSON handleCustomMessage renamer columnTypeLookup = do
     getRLSColumns <- makeCachedRLSPolicyColumns hasqlPool
+    subscriptionClosedSignals <- newIORef HashMap.empty
+    installInvalidationPlan <- ChangeNotifications.makeInstallInvalidationPlan hasqlPool
+    let ?subscriptionClosedSignals = subscriptionClosedSignals
+    let ?installInvalidationPlan = installInvalidationPlan
     pure (handleMessage getRLSColumns)
     where
             pgListener = ?request.pgListener
-            handleMessage :: (Text -> IO (Set.Set Text)) -> DataSyncMessage -> IO ()
-            handleMessage getRLSColumns DataSyncQuery { query, requestId, transactionId } = do
+            handleMessage ::
+                ( ?subscriptionClosedSignals :: IORef (HashMap UUID (MVar.MVar ()))
+                , ?installInvalidationPlan :: ChangeNotifications.InvalidationPlan -> IO ()
+                ) => (Text -> IO (Set.Set Text)) -> Maybe Int -> DataSyncMessage -> IO ()
+            handleMessage getRLSColumns _protocolVersion DataSyncQuery { query, requestId, transactionId } = do
                 ensureRLSEnabled (query.table)
 
                 columnTypes <- columnTypeLookup query.table
@@ -132,121 +182,145 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 sendJSON DataSyncResult { result, requestId }
 
-            handleMessage getRLSColumns CreateDataSubscription { query, requestId } = do
+            handleMessage _getRLSColumns protocolVersion CreateDataSubscription { query, requestId } = do
                 ensureBelowSubscriptionsLimit
 
                 tableNameRLS <- ensureRLSEnabled (query.table)
+                columnTypes <- columnTypeLookup query.table
+                let queryRenamer = renamer query.table
+                let tableHasUuidId = HashMap.lookup "id" columnTypes.typeMap == Just "uuid"
+                let supportsSnapshots = maybe False (>= 1) protocolVersion
+                let selectsId = case query.selectedColumns of
+                        SelectAll -> tableHasUuidId
+                        SelectSpecific columns -> any ((== "id") . queryRenamer.fieldToColumn) columns
+                when (not supportsSnapshots && (not tableHasUuidId || not selectsId)) do
+                    Exception.throwIO (userError "Legacy DataSubscriptions require the id column to be selected with UUID type; use protocolVersion 1 for projections without id")
 
                 subscriptionId <- UUID.nextRandom
 
-                -- Allocate the close handle as early as possible
-                -- to make DeleteDataSubscription calls succeed even when the DataSubscription is
-                -- not fully set up yet
                 close <- MVar.newEmptyMVar
-                atomicModifyIORef'' ?state (\state -> state |> modify #subscriptions (HashMap.insert subscriptionId close))
+                closed <- MVar.newEmptyMVar
 
-                columnTypes <- columnTypeLookup query.table
-                let querySnippet = compileQueryTyped (renamer query.table) columnTypes query
+                let querySnippet = compileQueryTyped queryRenamer columnTypes query
                 let stmt = compiledQueryStatement querySnippet
 
-                result :: [[Field]] <- sqlQueryWithRLS hasqlPool stmt
+                invalidationPlan <- ChangeNotifications.resolveInvalidationPlan hasqlPool tableNameRLS
+                ?installInvalidationPlan invalidationPlan
+                let subscriptionChannels = invalidationPlan.channels
 
-                let tableName = query.table
+                snapshotStateRef <- newIORef (Nothing :: Maybe (Int, [[Field]]))
+                initialReady <- MVar.newEmptyMVar
+                refreshSignal <- MVar.newEmptyMVar
 
-                -- Compute "sensitive columns": the union of columns referenced in the
-                -- WHERE clause and columns referenced in RLS policies. When an UPDATE
-                -- only touches columns outside this set, the record cannot leave the
-                -- result set or change RLS visibility, so we can skip the EXISTS check.
-                rlsCols <- getRLSColumns tableName
-                let whereColumns = maybe Set.empty conditionColumns (query.whereCondition)
-                let whereColumnsDb = Set.map (renamer tableName).fieldToColumn whereColumns
-                let sensitiveColumns = Set.union whereColumnsDb rlsCols
+                -- Legacy deltas are derived exclusively from two complete RLS-filtered
+                -- snapshots. Notification payloads can therefore never reveal a value
+                -- that is no longer visible to the current user. Re-deleting both the old
+                -- and new id sets also makes a retry safe after a partial socket write.
+                let sendLegacyReplacement previousResult nextResult = do
+                        let idsToClear = Set.fromList (recordIds previousResult <> recordIds nextResult)
+                        forM_ idsToClear \id ->
+                            sendJSON DidDelete { subscriptionId, id }
+                        forM_ nextResult \record ->
+                            sendJSON DidInsert { subscriptionId, record }
 
-                -- We need to keep track of all the ids of entities we're watching to make
-                -- sure that we only send update notifications to clients that can actually
-                -- access the record (e.g. if a RLS policy denies access)
-                let watchedRecordIds = recordIds result
+                let refreshSnapshot = do
+                        Just (revision, previousResult) <- readIORef snapshotStateRef
+                        nextResult :: [[Field]] <- sqlQueryWithRLS hasqlPool stmt
+                        let resultChanged = Aeson.toJSON nextResult /= Aeson.toJSON previousResult
+                        when resultChanged do
+                            let nextRevision = revision + 1
+                            if supportsSnapshots
+                                then sendJSON DidReplaceDataSubscription
+                                    { subscriptionId
+                                    , revision = nextRevision
+                                    , result = nextResult
+                                    }
+                                else sendLegacyReplacement previousResult nextResult
+                            -- Advance only after every wire message was sent. A transient
+                            -- send failure retries from the last fully delivered snapshot.
+                            writeIORef snapshotStateRef (Just (nextRevision, nextResult))
 
-                -- Store it in IORef as an INSERT requires us to add an id
-                watchedRecordIdsRef <- newIORef (Set.fromList watchedRecordIds)
+                let retryRefresh delay = do
+                        result <- Exception.tryAny refreshSnapshot
+                        case result of
+                            Right () -> pure ()
+                            Left exception -> do
+                                ?modelContext.logger (toLogStr ("DataSync subscription refresh failed: " <> displayException exception))
+                                Concurrent.threadDelay delay
+                                retryRefresh (min 5_000_000 (delay * 2))
 
-                -- Make sure the database triggers are there
-                installTableChangeTriggers tableNameRLS
+                let refreshWorker = forever do
+                        MVar.takeMVar refreshSignal
+                        MVar.readMVar initialReady
+                        retryRefresh 50_000
 
-                let handleUpdate id getChanges = do
-                        isWatchingRecord <- Set.member id <$> readIORef watchedRecordIdsRef
-                        when isWatchingRecord do
-                            changes <- getChanges
-                            let changedCols = Set.fromList (map (.col) changes)
-                            let affectsFilterOrRLS = not (Set.disjoint changedCols sensitiveColumns)
-                            let (changeSetVal, appendSetVal) = changesToValue (renamer tableName) changes
-                            if affectsFilterOrRLS
-                                then do
-                                    let existsSnippet = Snippet.sql "SELECT EXISTS(SELECT * FROM (" <> querySnippet <> Snippet.sql ") AS records WHERE records.id = " <> uuidParam id <> Snippet.sql " LIMIT 1)"
-                                    let existsStmt = Snippet.toPreparableStatement existsSnippet (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
-                                    isRecordInResultSet :: Bool <- sqlQueryScalarWithRLS hasqlPool existsStmt
-                                    if isRecordInResultSet
-                                        then sendJSON DidUpdate { subscriptionId, id, changeSet = changeSetVal, appendSet = appendSetVal }
-                                        else do
-                                            modifyIORef' watchedRecordIdsRef (Set.delete id)
-                                            sendJSON DidDelete { subscriptionId, id }
-                                else
-                                    sendJSON DidUpdate { subscriptionId, id, changeSet = changeSetVal, appendSet = appendSetVal }
+                let signalRefresh = void (MVar.tryPutMVar refreshSignal ())
+                let subscribe = subscribeToInvalidationChannels pgListener subscriptionChannels signalRefresh
+                let unsubscribe = unsubscribeAll pgListener
 
-                let callback notification = case notification of
-                            ChangeNotifications.DidInsert { id } -> do
-                                -- The new record could not be accessible to the current user with a RLS policy
-                                -- E.g. it could be a new record in a 'projects' table, but the project belongs
-                                -- to a different user, and thus the current user should not be able to see it.
-                                --
-                                -- The new record could also be not part of the WHERE condition of the initial query.
-                                -- Therefore we need to use the subscriptions WHERE condition to fetch the new record here.
-                                --
-                                -- To honor the RLS policies we therefore need to fetch the record as the current user
-                                -- If the result set is empty, we know the record is not accesible to us
-                                let filterSnippet = Snippet.sql "SELECT * FROM (" <> querySnippet <> Snippet.sql ") AS records WHERE records.id = " <> uuidParam id <> Snippet.sql " LIMIT 1"
-                                let filterStmt = Snippet.toPreparableStatement (wrapDynamicQuery filterSnippet) dynamicRowDecoder
-                                newRecord :: [[Field]] <- sqlQueryWithRLS hasqlPool filterStmt
+                let reserveSubscription = do
+                        atomicModifyIORef' ?subscriptionClosedSignals \signals ->
+                            (HashMap.insert subscriptionId closed signals, ())
+                        reserved <- atomicModifyIORef' ?state \state ->
+                            if HashMap.size state.subscriptions >= maxSubscriptionsPerConnection
+                                then (state, False)
+                                else (state |> modify #subscriptions (HashMap.insert subscriptionId close), True)
+                        unless reserved do
+                            atomicModifyIORef' ?subscriptionClosedSignals \signals ->
+                                (HashMap.delete subscriptionId signals, ())
+                            Exception.throwIO (userError ("You've reached the subscriptions limit of " <> cs (tshow maxSubscriptionsPerConnection) <> " subscriptions"))
 
-                                case headMay newRecord of
-                                    Just record -> do
-                                        -- Add the new record to 'watchedRecordIdsRef'
-                                        -- Otherwise the updates and deletes will not be dispatched to the client
-                                        modifyIORef' watchedRecordIdsRef (Set.insert id)
+                let releaseSubscription = do
+                        wasStillRegistered <- atomicModifyIORef' ?state \state ->
+                            let wasRegistered = HashMap.member subscriptionId state.subscriptions
+                            in (state |> modify #subscriptions (HashMap.delete subscriptionId), wasRegistered)
+                        void (MVar.tryPutMVar closed ())
+                        -- If DeleteDataSubscription removed the state entry, it owns
+                        -- this completion MVar until it has observed cleanup.
+                        when wasStillRegistered do
+                            atomicModifyIORef' ?subscriptionClosedSignals \signals ->
+                                (HashMap.delete subscriptionId signals, ())
 
-                                        sendJSON DidInsert { subscriptionId, record }
-                                    Nothing -> pure ()
-                            ChangeNotifications.DidUpdate { id, changeSet } ->
-                                handleUpdate id (ChangeNotifications.retrieveChanges hasqlPool changeSet)
-                            ChangeNotifications.DidUpdateLarge { id, payloadId } ->
-                                handleUpdate id (ChangeNotifications.retrieveChanges hasqlPool (ChangeNotifications.ExternalChangeSet { largePgNotificationId = payloadId }))
-                            ChangeNotifications.DidDelete { id } -> do
-                                -- Only send the notifcation if the deleted record was part of the initial
-                                -- results set
-                                isWatchingRecord <- Set.member id <$> readIORef watchedRecordIdsRef
-                                when isWatchingRecord do
-                                    sendJSON DidDelete { subscriptionId, id }
+                Exception.bracket_
+                    reserveSubscription
+                    releaseSubscription
+                    (Exception.bracket subscribe unsubscribe \_channelSubscriptions ->
+                        Exception.bracket (async refreshWorker) cancel \_refreshWorker ->
+                            Exception.finally
+                                (do
+                                    isListening <- PGListener.waitUntilListeningTo 10_000_000 subscriptionChannels pgListener
+                                    unless isListening do
+                                        Exception.throwIO (userError "Timed out waiting for PostgreSQL LISTEN while creating DataSubscription")
 
-                let subscribe = PGListener.subscribeJSON (ChangeNotifications.channelName tableNameRLS) callback pgListener
-                let unsubscribe subscription = PGListener.unsubscribe subscription pgListener
+                                    result :: [[Field]] <- sqlQueryWithRLS hasqlPool stmt
+                                    if supportsSnapshots
+                                        then sendJSON DidCreateDataSubscriptionV2
+                                            { subscriptionId
+                                            , requestId
+                                            , revision = 0
+                                            , result
+                                            }
+                                        else sendJSON DidCreateDataSubscription
+                                            { subscriptionId
+                                            , requestId
+                                            , result
+                                            }
+                                    writeIORef snapshotStateRef (Just (0, result))
+                                    MVar.putMVar initialReady ()
+                                    MVar.takeMVar close
+                                )
+                                (void (MVar.tryPutMVar initialReady ()))
+                    )
 
-                Exception.bracket subscribe unsubscribe \channelSubscription -> do
-                    sendJSON DidCreateDataSubscription { subscriptionId, requestId, result }
-
-                    MVar.takeMVar close
-
-            handleMessage getRLSColumns CreateCountSubscription { query, requestId } = do
+            handleMessage _getRLSColumns _protocolVersion CreateCountSubscription { query, requestId } = do
                 ensureBelowSubscriptionsLimit
 
                 tableNameRLS <- ensureRLSEnabled query.table
 
                 subscriptionId <- UUID.nextRandom
 
-                -- Allocate the close handle as early as possible
-                -- to make DeleteDataSubscription calls succeed even when the CountSubscription is
-                -- not fully set up yet
                 close <- MVar.newEmptyMVar
-                atomicModifyIORef'' ?state (\state -> state |> modify #subscriptions (HashMap.insert subscriptionId close))
+                closed <- MVar.newEmptyMVar
 
                 columnTypes <- columnTypeLookup query.table
                 let querySnippet = compileQueryTyped (renamer query.table) columnTypes query
@@ -255,42 +329,100 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
                 let countDecoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable (fromIntegral <$> Decoders.int8)))
                 let countStmt = Snippet.toPreparableStatement countSnippet countDecoder
 
-                count :: Int <- sqlQueryScalarWithRLS hasqlPool countStmt
-                countRef <- newIORef count
+                invalidationPlan <- ChangeNotifications.resolveInvalidationPlan hasqlPool tableNameRLS
+                ?installInvalidationPlan invalidationPlan
+                let subscriptionChannels = invalidationPlan.channels
 
-                installTableChangeTriggers tableNameRLS
+                countRef <- newIORef (Nothing :: Maybe Int)
+                initialReady <- MVar.newEmptyMVar
+                refreshSignal <- MVar.newEmptyMVar
 
-                let
-                    callback :: ChangeNotifications.ChangeNotification -> IO ()
-                    callback _ = do
+                let refreshCount = do
+                        Just lastCount <- readIORef countRef
                         newCount :: Int <- sqlQueryScalarWithRLS hasqlPool countStmt
-                        lastCount <- readIORef countRef
-
                         when (newCount /= lastCount) do
-                            writeIORef countRef newCount
                             sendJSON DidChangeCount { subscriptionId, count = newCount }
+                            writeIORef countRef (Just newCount)
 
-                let subscribe = PGListener.subscribeJSON (ChangeNotifications.channelName tableNameRLS) callback pgListener
-                let unsubscribe subscription = PGListener.unsubscribe subscription pgListener
+                let retryRefresh delay = do
+                        result <- Exception.tryAny refreshCount
+                        case result of
+                            Right () -> pure ()
+                            Left exception -> do
+                                ?modelContext.logger (toLogStr ("DataSync count refresh failed: " <> displayException exception))
+                                Concurrent.threadDelay delay
+                                retryRefresh (min 5_000_000 (delay * 2))
 
-                Exception.bracket subscribe unsubscribe \channelSubscription -> do
-                    sendJSON DidCreateCountSubscription { subscriptionId, requestId, count }
+                let refreshWorker = forever do
+                        MVar.takeMVar refreshSignal
+                        MVar.readMVar initialReady
+                        retryRefresh 50_000
 
-                    MVar.takeMVar close
+                let signalRefresh = void (MVar.tryPutMVar refreshSignal ())
+                let subscribe = subscribeToInvalidationChannels pgListener subscriptionChannels signalRefresh
+                let unsubscribe = unsubscribeAll pgListener
 
-            handleMessage getRLSColumns DeleteDataSubscription { requestId, subscriptionId } = do
-                DataSyncReady { subscriptions } <- getState
-                case HashMap.lookup subscriptionId subscriptions of
-                    Just closeSignalMVar -> do
-                        -- Cancel table watcher
-                        MVar.putMVar closeSignalMVar ()
+                let reserveSubscription = do
+                        atomicModifyIORef' ?subscriptionClosedSignals \signals ->
+                            (HashMap.insert subscriptionId closed signals, ())
+                        reserved <- atomicModifyIORef' ?state \state ->
+                            if HashMap.size state.subscriptions >= maxSubscriptionsPerConnection
+                                then (state, False)
+                                else (state |> modify #subscriptions (HashMap.insert subscriptionId close), True)
+                        unless reserved do
+                            atomicModifyIORef' ?subscriptionClosedSignals \signals ->
+                                (HashMap.delete subscriptionId signals, ())
+                            Exception.throwIO (userError ("You've reached the subscriptions limit of " <> cs (tshow maxSubscriptionsPerConnection) <> " subscriptions"))
 
-                        atomicModifyIORef'' ?state (\state -> state |> modify #subscriptions (HashMap.delete subscriptionId))
+                let releaseSubscription = do
+                        wasStillRegistered <- atomicModifyIORef' ?state \state ->
+                            let wasRegistered = HashMap.member subscriptionId state.subscriptions
+                            in (state |> modify #subscriptions (HashMap.delete subscriptionId), wasRegistered)
+                        void (MVar.tryPutMVar closed ())
+                        when wasStillRegistered do
+                            atomicModifyIORef' ?subscriptionClosedSignals \signals ->
+                                (HashMap.delete subscriptionId signals, ())
+
+                Exception.bracket_
+                    reserveSubscription
+                    releaseSubscription
+                    (Exception.bracket subscribe unsubscribe \_channelSubscriptions ->
+                        Exception.bracket (async refreshWorker) cancel \_refreshWorker ->
+                            Exception.finally
+                                (do
+                                    isListening <- PGListener.waitUntilListeningTo 10_000_000 subscriptionChannels pgListener
+                                    unless isListening do
+                                        Exception.throwIO (userError "Timed out waiting for PostgreSQL LISTEN while creating CountSubscription")
+
+                                    count :: Int <- sqlQueryScalarWithRLS hasqlPool countStmt
+                                    sendJSON DidCreateCountSubscription { subscriptionId, requestId, count }
+                                    writeIORef countRef (Just count)
+                                    MVar.putMVar initialReady ()
+                                    MVar.takeMVar close
+                                )
+                                (void (MVar.tryPutMVar initialReady ()))
+                    )
+
+            handleMessage _getRLSColumns _protocolVersion DeleteDataSubscription { requestId, subscriptionId } = do
+                closeSignal <- atomicModifyIORef' ?state \state ->
+                    let signal = HashMap.lookup subscriptionId state.subscriptions
+                    in (state |> modify #subscriptions (HashMap.delete subscriptionId), signal)
+                case closeSignal of
+                    Just close -> do
+                        closedSignals <- readIORef ?subscriptionClosedSignals
+                        closed <- case HashMap.lookup subscriptionId closedSignals of
+                            Just signal -> pure signal
+                            Nothing -> Exception.throwIO (userError "DataSubscription lifecycle completion signal is missing")
+
+                        void (MVar.tryPutMVar close ())
+                        MVar.readMVar closed
+                        atomicModifyIORef' ?subscriptionClosedSignals \signals ->
+                            (HashMap.delete subscriptionId signals, ())
 
                         sendJSON DidDeleteDataSubscription { subscriptionId, requestId }
                     Nothing -> sendJSON DataSyncError { requestId, errorMessage = "Failed to delete DataSubscription, could not find DataSubscription with id " <> tshow subscriptionId }
 
-            handleMessage getRLSColumns CreateRecordMessage { table, record, requestId, transactionId }  = do
+            handleMessage getRLSColumns _protocolVersion CreateRecordMessage { table, record, requestId, transactionId }  = do
                 ensureRLSEnabled table
 
                 columnTypes <- columnTypeLookup table
@@ -316,7 +448,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 pure ()
 
-            handleMessage getRLSColumns CreateRecordsMessage { table, records, requestId, transactionId }  = do
+            handleMessage getRLSColumns _protocolVersion CreateRecordsMessage { table, records, requestId, transactionId }  = do
                 ensureRLSEnabled table
 
                 columnTypes <- columnTypeLookup table
@@ -341,7 +473,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                         pure ()
 
-            handleMessage getRLSColumns UpdateRecordMessage { table, id, patch, requestId, transactionId } = do
+            handleMessage getRLSColumns _protocolVersion UpdateRecordMessage { table, id, patch, requestId, transactionId } = do
                 ensureRLSEnabled table
 
                 columnTypes <- columnTypeLookup table
@@ -359,7 +491,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 pure ()
 
-            handleMessage getRLSColumns UpdateRecordsMessage { table, ids, patch, requestId, transactionId } = do
+            handleMessage getRLSColumns _protocolVersion UpdateRecordsMessage { table, ids, patch, requestId, transactionId } = do
                 ensureRLSEnabled table
 
                 columnTypes <- columnTypeLookup table
@@ -375,7 +507,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 pure ()
 
-            handleMessage getRLSColumns DeleteRecordMessage { table, id, requestId, transactionId } = do
+            handleMessage getRLSColumns _protocolVersion DeleteRecordMessage { table, id, requestId, transactionId } = do
                 ensureRLSEnabled table
 
                 let deleteSnippet = Snippet.sql ("DELETE FROM " <> quoteIdentifier table <> " WHERE id = ") <> uuidParam id
@@ -384,7 +516,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 sendJSON DidDeleteRecord { requestId }
 
-            handleMessage getRLSColumns DeleteRecordsMessage { table, ids, requestId, transactionId } = do
+            handleMessage getRLSColumns _protocolVersion DeleteRecordsMessage { table, ids, requestId, transactionId } = do
                 ensureRLSEnabled table
 
                 let inList = mconcat $ List.intersperse (Snippet.sql ", ") (map uuidParam ids)
@@ -393,7 +525,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 sendJSON DidDeleteRecords { requestId }
 
-            handleMessage getRLSColumns StartTransaction { requestId } = do
+            handleMessage getRLSColumns _protocolVersion StartTransaction { requestId } = do
                 ensureBelowTransactionLimit
 
                 transactionId <- UUID.nextRandom
@@ -419,7 +551,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                     atomicModifyIORef'' ?state (\state -> state |> modify #transactions (HashMap.delete transactionId))
 
-            handleMessage getRLSColumns RollbackTransaction { requestId, id } = do
+            handleMessage getRLSColumns _protocolVersion RollbackTransaction { requestId, id } = do
                 DataSyncTransaction { id, close, connection } <- findTransactionById id
 
                 runSessionOnConnection connection (Session.script "ROLLBACK")
@@ -427,7 +559,7 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 sendJSON DidRollbackTransaction { requestId, transactionId = id }
 
-            handleMessage getRLSColumns CommitTransaction { requestId, id } = do
+            handleMessage getRLSColumns _protocolVersion CommitTransaction { requestId, id } = do
                 DataSyncTransaction { id, close, connection } <- findTransactionById id
 
                 runSessionOnConnection connection (Session.script "COMMIT")
@@ -435,7 +567,30 @@ buildMessageHandler hasqlPool ensureRLSEnabled installTableChangeTriggers sendJS
 
                 sendJSON DidCommitTransaction { requestId, transactionId = id }
 
-            handleMessage _getRLSColumns otherwise = handleCustomMessage sendJSON otherwise
+            handleMessage _getRLSColumns _protocolVersion otherwise = handleCustomMessage sendJSON otherwise
+
+-- | Register all relation invalidation channels as one exception-safe resource.
+-- Async exceptions are restored while each PGListener subscription is created,
+-- then masked again before its handle is added to the cleanup list.
+subscribeToInvalidationChannels :: PGListener.PGListener -> Set.Set ByteString -> IO () -> IO [PGListener.Subscription]
+subscribeToInvalidationChannels pgListener channels signalRefresh = Exception.mask \restore -> do
+    acquiredRef <- newIORef []
+    let cleanup = readIORef acquiredRef >>= unsubscribeAll pgListener
+    let acquire (isFirst, channel) = do
+            let reconnectCallback = if isFirst then signalRefresh else pure ()
+            subscription <- restore
+                (PGListener.subscribeWithReconnect channel (const signalRefresh) reconnectCallback pgListener)
+            modifyIORef' acquiredRef (subscription :)
+            pure subscription
+    let channelList = Set.toList channels
+    let markedChannels = zip (True : repeat False) channelList
+    mapM acquire markedChannels `Exception.onException` cleanup
+
+unsubscribeAll :: PGListener.PGListener -> [PGListener.Subscription] -> IO ()
+unsubscribeAll _pgListener [] = pure ()
+unsubscribeAll pgListener (subscription : remaining) =
+    PGListener.unsubscribe subscription pgListener
+        `Exception.finally` unsubscribeAll pgListener remaining
 
 changesToValue :: Renamer -> [ChangeNotifications.Change] -> (Maybe Value, Maybe Value)
 changesToValue renamer changes = (maybeObject replacePairs, maybeObject appendPairs)

--- a/ihp-datasync/IHP/DataSync/Types.hs
+++ b/ihp-datasync/IHP/DataSync/Types.hs
@@ -32,6 +32,8 @@ data DataSyncResponse
     | DataSyncError { requestId :: !Int, errorMessage :: !Text }
     | FailedToDecodeMessageError { errorMessage :: !Text }
     | DidCreateDataSubscription { requestId :: !Int, subscriptionId :: !UUID, result :: ![[Field]] }
+    | DidCreateDataSubscriptionV2 { requestId :: !Int, subscriptionId :: !UUID, revision :: !Int, result :: ![[Field]] }
+    | DidReplaceDataSubscription { subscriptionId :: !UUID, revision :: !Int, result :: ![[Field]] }
     | DidCreateCountSubscription { requestId :: !Int, subscriptionId :: !UUID, count :: !Int }
     | DidDeleteDataSubscription { requestId :: !Int, subscriptionId :: !UUID }
     | DidInsert { subscriptionId :: !UUID, record :: ![Field] }

--- a/ihp-datasync/Test/DataSync/ChangeNotifications.hs
+++ b/ihp-datasync/Test/DataSync/ChangeNotifications.hs
@@ -3,7 +3,7 @@ module DataSync.ChangeNotifications where
 import Test.Hspec
 import IHP.Prelude
 import Data.Aeson
-import IHP.DataSync.ChangeNotifications (Change(..), makeCachedInstallTableChangeTriggers, installTableChangeTriggers)
+import IHP.DataSync.ChangeNotifications (Change(..), InvalidationPlan(..), makeCachedInstallTableChangeTriggers, makeCachedInstallGlobalInvalidationTriggers, makeInstallInvalidationPlan, resolveInvalidationPlan, installTableChangeTriggers, installGlobalInvalidationTriggers)
 import IHP.DataSync.ControllerImpl (changesToValue)
 import IHP.DataSync.DynamicQueryCompiler (Renamer(..))
 import IHP.DataSync.DynamicQuery (ConditionExpression(..), ConditionOperator(..), FunctionCall(..), conditionColumns)
@@ -154,6 +154,130 @@ tests = do
             it "returns empty set for LiteralExpression" do
                 let condition = LiteralExpression (String "hello")
                 conditionColumns condition `shouldBe` Set.empty
+
+        describe "global invalidation trigger" do
+            it "installs and fires on a relation without an id column" do
+                withDB \connStr -> do
+                    Exception.bracket (makePool connStr) Hasql.Pool.release \pool -> do
+                        tableUuid <- UUID.nextRandom
+                        let tableName = "test_idless_" <> Text.replace "-" "_" (UUID.toText tableUuid)
+                        execSQL pool (cs ("CREATE TABLE " <> tableName <> " (user_id UUID NOT NULL, resource_id UUID NOT NULL)"))
+
+                        installGlobalInvalidationTriggers pool
+                        triggerCount <- queryGlobalInvalidationTriggerCount pool tableName
+                        triggerCount `shouldBe` 1
+
+                        -- A row-level trigger would fail here by referencing NEW.id.
+                        -- The global trigger is statement-level and payload-free.
+                        userId <- UUID.nextRandom
+                        resourceId <- UUID.nextRandom
+                        execSQL pool (cs ("INSERT INTO " <> tableName <> " (user_id, resource_id) VALUES ('" <> UUID.toText userId <> "', '" <> UUID.toText resourceId <> "')"))
+
+            it "reconciles new relations outside the search path" do
+                withDB \connStr -> do
+                    Exception.bracket (makePool connStr) Hasql.Pool.release \pool -> do
+                        install <- makeCachedInstallGlobalInvalidationTriggers pool
+                        install
+
+                        execSQL pool "CREATE SCHEMA auth"
+                        execSQL pool "CREATE TABLE auth.memberships (user_id UUID NOT NULL, resource_id UUID NOT NULL)"
+
+                        -- The fingerprint must invalidate the prior successful
+                        -- reconciliation even on a long-lived controller/pool.
+                        install
+                        queryGlobalInvalidationTriggerCount pool "auth.memberships"
+                            `shouldReturn` 1
+
+            it "serializes first installs across controllers without exhausting the pool" do
+                withDB \connStr -> do
+                    Exception.bracket (makePoolWithTimeout 2 1 connStr) Hasql.Pool.release \pool -> do
+                        execSQL pool "CREATE TABLE global_install_lock_test (value TEXT NOT NULL)"
+                        lockPool <- makePoolN 1 connStr
+                        execSQL lockPool "BEGIN; INSERT INTO global_install_lock_test (value) VALUES ('lock holder')"
+
+                        installers <- replicateM 100 (makeCachedInstallGlobalInvalidationTriggers pool)
+                        installsAsync <- async
+                            (Exception.try (mapConcurrently_ id installers) :: IO (Either Exception.SomeException ()))
+
+                        -- Keep CREATE TRIGGER blocked beyond the pool acquisition
+                        -- timeout. Only the elected Haskell-side installer may own
+                        -- a pool connection while all other callers wait.
+                        threadDelay 1_200_000
+                        Hasql.Pool.release lockPool
+
+                        result <- wait installsAsync
+                        case result of
+                            Left exception -> expectationFailure
+                                ("Concurrent global trigger installation failed: " <> displayException exception)
+                            Right () -> pure ()
+
+            it "rejects a same-name trigger wired to the wrong function" do
+                withDB \connStr -> do
+                    Exception.bracket (makePool connStr) Hasql.Pool.release \pool -> do
+                        execSQL pool "CREATE TABLE conflicting_global_trigger (value TEXT NOT NULL)"
+                        execSQL pool "CREATE FUNCTION conflicting_global_trigger_fn() RETURNS TRIGGER AS $$ BEGIN RETURN NULL; END $$ LANGUAGE plpgsql"
+                        execSQL pool "CREATE TRIGGER ihp_datasync_invalidate AFTER INSERT ON conflicting_global_trigger FOR EACH STATEMENT EXECUTE PROCEDURE conflicting_global_trigger_fn()"
+
+                        result <- Exception.try (installGlobalInvalidationTriggers pool)
+                            :: IO (Either Exception.SomeException ())
+                        case result of
+                            Left exception -> displayException exception
+                                `shouldContain` "Incompatible pre-existing trigger"
+                            Right () -> expectationFailure "Accepted incompatible same-name invalidation trigger"
+
+            it "rejects a replica-only invalidation trigger" do
+                withDB \connStr -> do
+                    Exception.bracket (makePool connStr) Hasql.Pool.release \pool -> do
+                        execSQL pool "CREATE TABLE replica_only_trigger (id UUID NOT NULL)"
+                        execSQL pool "ALTER TABLE replica_only_trigger ENABLE ROW LEVEL SECURITY"
+                        execSQL pool "CREATE POLICY replica_only_trigger_policy ON replica_only_trigger USING (true)"
+
+                        installPlan <- makeInstallInvalidationPlan pool
+                        initialPlan <- resolveInvalidationPlan pool (TableWithRLS "replica_only_trigger")
+                        installPlan initialPlan
+                        execSQL pool "ALTER TABLE replica_only_trigger ENABLE REPLICA TRIGGER ihp_datasync_invalidate"
+
+                        replicaOnlyPlan <- resolveInvalidationPlan pool (TableWithRLS "replica_only_trigger")
+                        replicaOnlyPlan.missingRelationOids `shouldSatisfy` (not . null)
+                        result <- Exception.try (installPlan replicaOnlyPlan)
+                            :: IO (Either Exception.SomeException ())
+                        case result of
+                            Left exception -> displayException exception
+                                `shouldContain` "Incompatible pre-existing trigger"
+                            Right () -> expectationFailure "Accepted a trigger that does not fire for normal writes"
+
+            it "rejects relations excluded by the trigger installer namespace rules" do
+                withDB \connStr -> do
+                    Exception.bracket (makePool connStr) Hasql.Pool.release \pool -> do
+                        result <- Exception.try
+                            (resolveInvalidationPlan pool (TableWithRLS "pg_catalog.pg_authid"))
+                            :: IO (Either Exception.SomeException InvalidationPlan)
+                        case result of
+                            Left exception -> displayException exception
+                                `shouldContain` "cannot install a safe invalidation trigger"
+                            Right _ -> expectationFailure "Accepted a pg_catalog relation that the installer skips"
+
+            it "recreates a dropped function and skips an already complete exact plan" do
+                withDB \connStr -> do
+                    Exception.bracket (makePool connStr) Hasql.Pool.release \pool -> do
+                        execSQL pool "CREATE TABLE exact_reconcile_test (id UUID NOT NULL)"
+                        execSQL pool "ALTER TABLE exact_reconcile_test ENABLE ROW LEVEL SECURITY"
+                        execSQL pool "CREATE POLICY exact_reconcile_policy ON exact_reconcile_test USING (true)"
+
+                        installPlan <- makeInstallInvalidationPlan pool
+                        firstPlan <- resolveInvalidationPlan pool (TableWithRLS "exact_reconcile_test")
+                        installPlan firstPlan
+
+                        execSQL pool "DROP FUNCTION public.ihp_datasync_notify_invalidation() CASCADE"
+                        missingPlan <- resolveInvalidationPlan pool (TableWithRLS "exact_reconcile_test")
+                        missingPlan.missingRelationOids `shouldSatisfy` (not . null)
+                        installPlan missingPlan
+
+                        completePlan <- resolveInvalidationPlan pool (TableWithRLS "exact_reconcile_test")
+                        completePlan.missingRelationOids `shouldBe` []
+                        installPlan completePlan
+                        queryGlobalInvalidationTriggerCount pool "exact_reconcile_test"
+                            `shouldReturn` 1
 
         -- https://github.com/digitallyinduced/ihp/issues/2467
         describe "concurrent trigger installation" do
@@ -316,6 +440,14 @@ queryTriggerCount :: Hasql.Pool.Pool -> Text -> IO Int
 queryTriggerCount pool tableName = do
     let session = Session.statement (cs tableName) $ Statement.preparable
             "SELECT count(*)::int FROM pg_trigger WHERE tgrelid = $1::regclass AND tgname LIKE 'did_%'"
+            (Encoders.param (Encoders.nonNullable Encoders.text))
+            (Decoders.singleRow (Decoders.column (Decoders.nonNullable (fromIntegral <$> Decoders.int4))))
+    runSession pool session
+
+queryGlobalInvalidationTriggerCount :: Hasql.Pool.Pool -> Text -> IO Int
+queryGlobalInvalidationTriggerCount pool tableName = do
+    let session = Session.statement (cs tableName) $ Statement.preparable
+            "SELECT count(*)::int FROM pg_trigger WHERE tgrelid = $1::regclass AND tgname = 'ihp_datasync_invalidate'"
             (Encoders.param (Encoders.nonNullable Encoders.text))
             (Decoders.singleRow (Decoders.column (Decoders.nonNullable (fromIntegral <$> Decoders.int4))))
     runSession pool session

--- a/ihp-datasync/Test/DataSync/DataSyncIntegrationSpec.hs
+++ b/ihp-datasync/Test/DataSync/DataSyncIntegrationSpec.hs
@@ -8,11 +8,11 @@ import qualified Hasql.Pool.Config as Hasql.Pool.Config
 import qualified Hasql.Connection.Settings as HasqlSettings
 import qualified Hasql.Session as Session
 import IHP.DataSync.Hasql (runSession)
-import IHP.DataSync.ControllerImpl (runDataSyncController)
+import IHP.DataSync.ControllerImpl (runDataSyncController, decodeDataSyncMessageEnvelope)
 import IHP.DataSync.Types
 import IHP.DataSync.DynamicQuery (Field(..))
 import IHP.DataSync.DynamicQueryCompiler (camelCaseRenamer)
-import IHP.DataSync.RowLevelSecurity (makeCachedEnsureRLSEnabled)
+import IHP.DataSync.RowLevelSecurity (TableWithRLS(..), makeCachedEnsureRLSEnabled)
 import qualified IHP.DataSync.ChangeNotifications as ChangeNotifications
 import IHP.RequestVault (pgListenerVaultKey, frameworkConfigVaultKey)
 import IHP.LoginSupport.Types (HasNewSessionUrl(..), CurrentUserRecord, currentUserVaultKey)
@@ -27,11 +27,13 @@ import qualified Data.Vault.Lazy as Vault
 import qualified Data.UUID.V4 as UUID
 import qualified Data.UUID as UUID
 import qualified Data.Text as Text
+import qualified Data.Set as Set
 import qualified Control.Exception as Exception
 import System.Environment (lookupEnv)
 import Network.Wai (defaultRequest, vault)
 import Data.Aeson (Value(..), object, (.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as AesonKeyMap
 import Control.Concurrent.STM
 import Control.Concurrent (threadDelay)
 
@@ -114,8 +116,17 @@ setupTestSchema pool = do
     execSQL pool "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
     execSQL pool "CREATE TABLE test_users (id UUID PRIMARY KEY DEFAULT gen_random_uuid())"
     execSQL pool "CREATE TABLE messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), user_id UUID NOT NULL, body TEXT NOT NULL)"
+    execSQL pool "CREATE TABLE idless_resources (owner_id UUID NOT NULL, body TEXT NOT NULL)"
+    execSQL pool "CREATE TABLE unrelated_events (body TEXT NOT NULL)"
+    -- Deliberately has no id column. Writes here can change message visibility
+    -- through the EXISTS policy and must use the global statement trigger.
+    execSQL pool "CREATE TABLE message_memberships (user_id UUID NOT NULL, message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE, PRIMARY KEY (user_id, message_id))"
+    execSQL pool "CREATE OR REPLACE FUNCTION public.ihp_user_id() RETURNS UUID AS $$ SELECT NULLIF(current_setting('rls.ihp_user_id'), '')::uuid $$ LANGUAGE SQL STABLE"
     execSQL pool "ALTER TABLE messages ENABLE ROW LEVEL SECURITY"
-    execSQL pool "CREATE POLICY messages_policy ON messages USING (user_id = current_setting('rls.ihp_user_id')::uuid)"
+    execSQL pool "CREATE POLICY messages_policy ON messages USING (user_id = public.ihp_user_id())"
+    execSQL pool "CREATE POLICY messages_membership_policy ON messages USING (EXISTS (SELECT 1 FROM message_memberships WHERE message_memberships.message_id = messages.id AND message_memberships.user_id = public.ihp_user_id()))"
+    execSQL pool "ALTER TABLE idless_resources ENABLE ROW LEVEL SECURITY"
+    execSQL pool "CREATE POLICY idless_resources_policy ON idless_resources USING (owner_id = public.ihp_user_id())"
     -- Create the authenticated role and grant permissions
     execSQL pool "DO $$ BEGIN CREATE ROLE ihp_authenticated NOLOGIN; EXCEPTION WHEN duplicate_object THEN null; END $$"
     execSQL pool "GRANT USAGE ON SCHEMA public TO ihp_authenticated"
@@ -242,8 +253,43 @@ encodeDeleteRecord table recordId requestId transactionId = cs $ Aeson.encode $ 
 
 -- | Encode a CreateDataSubscription as JSON
 encodeCreateDataSubscription :: Text -> Int -> ByteString
-encodeCreateDataSubscription table requestId = cs $ Aeson.encode $ object
+encodeCreateDataSubscription table requestId = encodeCreateDataSubscriptionQueryWithProtocol Nothing requestId $ object
+    [ "table" .= table
+    , "selectedColumns" .= object ["tag" .= ("SelectAll" :: Text)]
+    , "whereCondition" .= Null
+    , "orderByClause" .= ([] :: [Value])
+    , "distinctOnColumn" .= Null
+    , "limit" .= Null
+    , "offset" .= Null
+    ]
+
+encodeCreateDataSubscriptionV2 :: Text -> Int -> ByteString
+encodeCreateDataSubscriptionV2 table requestId = encodeCreateDataSubscriptionQueryWithProtocol (Just 1) requestId $ object
+    [ "table" .= table
+    , "selectedColumns" .= object ["tag" .= ("SelectAll" :: Text)]
+    , "whereCondition" .= Null
+    , "orderByClause" .= ([] :: [Value])
+    , "distinctOnColumn" .= Null
+    , "limit" .= Null
+    , "offset" .= Null
+    ]
+
+encodeCreateDataSubscriptionQuery :: Int -> Value -> ByteString
+encodeCreateDataSubscriptionQuery = encodeCreateDataSubscriptionQueryWithProtocol Nothing
+
+encodeCreateDataSubscriptionQueryV2 :: Int -> Value -> ByteString
+encodeCreateDataSubscriptionQueryV2 = encodeCreateDataSubscriptionQueryWithProtocol (Just 1)
+
+encodeCreateDataSubscriptionQueryWithProtocol :: Maybe Int -> Int -> Value -> ByteString
+encodeCreateDataSubscriptionQueryWithProtocol protocolVersion requestId query = cs $ Aeson.encode $ object $
     [ "tag" .= ("CreateDataSubscription" :: Text)
+    , "query" .= query
+    , "requestId" .= requestId
+    ] <> maybe [] (\version -> ["protocolVersion" .= version]) protocolVersion
+
+encodeCreateCountSubscription :: Text -> Int -> ByteString
+encodeCreateCountSubscription table requestId = cs $ Aeson.encode $ object
+    [ "tag" .= ("CreateCountSubscription" :: Text)
     , "query" .= object
         [ "table" .= table
         , "selectedColumns" .= object ["tag" .= ("SelectAll" :: Text)]
@@ -293,8 +339,45 @@ findField name fields = case filter (\f -> f.fieldName == name) fields of
     (f:_) -> Just f.fieldValue
     [] -> Nothing
 
+eventSubscriptionId :: DataSyncResponse -> Maybe UUID
+eventSubscriptionId DidDelete { subscriptionId } = Just subscriptionId
+eventSubscriptionId DidInsert { subscriptionId } = Just subscriptionId
+eventSubscriptionId DidUpdate { subscriptionId } = Just subscriptionId
+eventSubscriptionId _ = Nothing
+
 tests :: Spec
 tests = do
+    describe "DataSync protocol envelope" do
+        it "keeps the legacy Haskell constructor while detecting snapshot capability" do
+            case decodeDataSyncMessageEnvelope (encodeCreateDataSubscription "messages" 1) of
+                Right (Nothing, CreateDataSubscription { requestId }) -> requestId `shouldBe` 1
+                _ -> expectationFailure "Expected legacy CreateDataSubscription envelope"
+
+            case decodeDataSyncMessageEnvelope (encodeCreateDataSubscriptionV2 "messages" 2) of
+                Right (Just protocolVersion, CreateDataSubscription { requestId }) -> do
+                    protocolVersion `shouldBe` 1
+                    requestId `shouldBe` 2
+                _ -> expectationFailure "Expected snapshot-capable CreateDataSubscription envelope"
+
+        it "preserves the legacy create response and uses an explicit V2 response" do
+            subscriptionId <- UUID.nextRandom
+            case Aeson.toJSON DidCreateDataSubscription
+                    { requestId = 1
+                    , subscriptionId
+                    , result = []
+                    } of
+                Object fields -> AesonKeyMap.lookup "revision" fields `shouldBe` Nothing
+                _ -> expectationFailure "Expected object response"
+
+            case Aeson.toJSON DidCreateDataSubscriptionV2
+                    { requestId = 2
+                    , subscriptionId
+                    , revision = 0
+                    , result = []
+                    } of
+                Object fields -> AesonKeyMap.lookup "revision" fields `shouldBe` Just (Number 0)
+                _ -> expectationFailure "Expected object response"
+
     describe "IHP.DataSync Integration" do
         describe "DataSyncQuery" do
             it "returns rows from a table with RLS" do
@@ -444,9 +527,535 @@ tests = do
                                             requestId `shouldBe` 9
                                             deletedId `shouldBe` subscriptionId
                                         _ -> expectationFailure "Expected DidDeleteDataSubscription"
+
+                                    -- The delete acknowledgement is a lifecycle barrier:
+                                    -- no callback may send after it.
+                                    insertedId <- UUID.nextRandom
+                                    execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText insertedId <> "', '" <> UUID.toText userId <> "', 'After delete')"))
+                                    afterDelete <- race (threadDelay 300_000) recv
+                                    case afterDelete of
+                                        Left () -> pure ()
+                                        Right _ -> expectationFailure "Expected no subscription message after delete acknowledgement"
                                 DataSyncError { errorMessage } ->
                                     expectationFailure (cs $ "Unexpected error: " <> errorMessage)
                                 _ -> expectationFailure "Expected DidCreateDataSubscription"
+
+            it "keeps legacy clients on RLS-derived delta messages" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, messageId) <- insertTestData pool
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            -- No protocolVersion: the old response constructor and old
+                            -- delta tags remain wire-compatible.
+                            send (encodeCreateDataSubscription "messages" 90)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateDataSubscription { subscriptionId, result } -> do
+                                    length result `shouldBe` 1
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected legacy DidCreateDataSubscription" >> error "unreachable"
+
+                            execSQL pool (cs ("UPDATE messages SET body = 'Legacy safe' WHERE id = '" <> UUID.toText messageId <> "'"))
+
+                            cleared <- recv
+                            case cleared of
+                                DidDelete { subscriptionId = deletedSubscriptionId, id } -> do
+                                    deletedSubscriptionId `shouldBe` subscriptionId
+                                    id `shouldBe` messageId
+                                _ -> expectationFailure "Expected RLS-derived legacy delete"
+
+                            reinserted <- recv
+                            case reinserted of
+                                DidInsert { subscriptionId = insertedSubscriptionId, record } -> do
+                                    insertedSubscriptionId `shouldBe` subscriptionId
+                                    findField "id" record `shouldBe` Just (String (UUID.toText messageId))
+                                    findField "body" record `shouldBe` Just (String "Legacy safe")
+                                _ -> expectationFailure "Expected RLS-derived legacy insert"
+
+            it "invalidates V2 snapshots when an id-less RLS membership table grants and revokes access" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, ownMessageId) <- insertTestData pool
+                        otherUserId <- UUID.nextRandom
+                        sharedMessageId <- UUID.nextRandom
+                        execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText sharedMessageId <> "', '" <> UUID.toText otherUserId <> "', 'Shared')"))
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionV2 "messages" 93)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateDataSubscriptionV2 { subscriptionId, result } -> do
+                                    length result `shouldBe` 1
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected DidCreateDataSubscriptionV2" >> error "unreachable"
+
+                            execSQL pool (cs ("INSERT INTO message_memberships (user_id, message_id) VALUES ('" <> UUID.toText userId <> "', '" <> UUID.toText sharedMessageId <> "')"))
+                            granted <- recv
+                            case granted of
+                                DidReplaceDataSubscription { subscriptionId = replacedId, revision, result } -> do
+                                    replacedId `shouldBe` subscriptionId
+                                    revision `shouldBe` 1
+                                    Set.fromList (mapMaybe (findField "id") result) `shouldBe`
+                                        Set.fromList [String (UUID.toText ownMessageId), String (UUID.toText sharedMessageId)]
+                                _ -> expectationFailure "Expected replacement after membership grant"
+
+                            execSQL pool (cs ("DELETE FROM message_memberships WHERE user_id = '" <> UUID.toText userId <> "' AND message_id = '" <> UUID.toText sharedMessageId <> "'"))
+                            revoked <- recv
+                            case revoked of
+                                DidReplaceDataSubscription { revision, result } -> do
+                                    revision `shouldBe` 2
+                                    length result `shouldBe` 1
+                                    map (findField "id") result `shouldNotContain` [Just (String (UUID.toText sharedMessageId))]
+                                _ -> expectationFailure "Expected replacement after membership revoke"
+
+            it "subscribes only to direct RLS relation dependencies" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, _) <- insertTestData pool
+                        otherUserId <- UUID.nextRandom
+                        sharedMessageId <- UUID.nextRandom
+                        execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText sharedMessageId <> "', '" <> UUID.toText otherUserId <> "', 'Scoped shared')"))
+
+                        channels <- ChangeNotifications.invalidationChannelsForTable pool (TableWithRLS "messages")
+                        Set.size channels `shouldBe` 2 -- messages + message_memberships
+                        Set.member ChangeNotifications.globalInvalidationChannel channels `shouldBe` False
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionV2 "messages" 102)
+                            _ <- recv
+
+                            -- unrelated_events has its own relation channel, so
+                            -- this write cannot wake/requery the messages worker.
+                            execSQL pool "INSERT INTO unrelated_events (body) VALUES ('unrelated')"
+                            unrelatedResponse <- race (threadDelay 300_000) recv
+                            case unrelatedResponse of
+                                Left () -> pure ()
+                                Right _ -> expectationFailure "Unrelated relation woke messages subscription"
+
+                            execSQL pool (cs ("INSERT INTO message_memberships (user_id, message_id) VALUES ('" <> UUID.toText userId <> "', '" <> UUID.toText sharedMessageId <> "')"))
+                            membershipResponse <- recv
+                            case membershipResponse of
+                                DidReplaceDataSubscription { result } ->
+                                    mapMaybe (findField "id") result `shouldContain`
+                                        [String (UUID.toText sharedMessageId)]
+                                _ -> expectationFailure "Membership dependency did not refresh subscription"
+
+            it "uses global fallback for an opaque replacement of ihp_user_id" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, _) <- insertTestData pool
+                        execSQL pool "CREATE OR REPLACE FUNCTION public.ihp_user_id() RETURNS UUID AS $$ SELECT CASE WHEN EXISTS (SELECT 1 FROM unrelated_events) THEN NULLIF(current_setting('rls.ihp_user_id'), '')::uuid ELSE NULL::uuid END $$ LANGUAGE SQL STABLE"
+
+                        channels <- ChangeNotifications.invalidationChannelsForTable pool (TableWithRLS "messages")
+                        Set.member ChangeNotifications.globalInvalidationChannel channels `shouldBe` True
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionV2 "messages" 103)
+                            created <- recv
+                            case created of
+                                DidCreateDataSubscriptionV2 { result } -> length result `shouldBe` 0
+                                _ -> expectationFailure "Expected opaque-policy subscription"
+
+                            execSQL pool "INSERT INTO unrelated_events (body) VALUES ('unlock visibility')"
+                            refreshed <- recv
+                            case refreshed of
+                                DidReplaceDataSubscription { result } -> length result `shouldBe` 1
+                                _ -> expectationFailure "Opaque policy global fallback did not refresh"
+
+            it "invalidates a parent subscription after direct partition-child DML" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, _) <- insertTestData pool
+                        execSQL pool "CREATE TABLE partitioned_messages (id UUID NOT NULL, user_id UUID NOT NULL, body TEXT NOT NULL, bucket INT NOT NULL) PARTITION BY LIST (bucket)"
+                        execSQL pool "CREATE TABLE partitioned_messages_one PARTITION OF partitioned_messages FOR VALUES IN (1)"
+                        execSQL pool "ALTER TABLE partitioned_messages ENABLE ROW LEVEL SECURITY"
+                        execSQL pool "CREATE POLICY partitioned_messages_policy ON partitioned_messages USING (user_id = public.ihp_user_id())"
+                        execSQL pool "GRANT ALL PRIVILEGES ON partitioned_messages, partitioned_messages_one TO ihp_authenticated"
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionV2 "partitioned_messages" 104)
+                            created <- recv
+                            case created of
+                                DidCreateDataSubscriptionV2 { result } -> length result `shouldBe` 0
+                                _ -> expectationFailure "Expected partition-parent subscription"
+
+                            insertedId <- UUID.nextRandom
+                            execSQL pool (cs ("INSERT INTO partitioned_messages_one (id, user_id, body, bucket) VALUES ('" <> UUID.toText insertedId <> "', '" <> UUID.toText userId <> "', 'Child write', 1)"))
+                            refreshed <- recv
+                            case refreshed of
+                                DidReplaceDataSubscription { result } ->
+                                    map (findField "id") result `shouldBe` [Just (String (UUID.toText insertedId))]
+                                _ -> expectationFailure "Direct partition-child write did not invalidate parent"
+
+            it "invalidates count subscriptions through an id-less RLS membership table" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, _) <- insertTestData pool
+                        otherUserId <- UUID.nextRandom
+                        sharedMessageId <- UUID.nextRandom
+                        execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText sharedMessageId <> "', '" <> UUID.toText otherUserId <> "', 'Shared count')"))
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateCountSubscription "messages" 94)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateCountSubscription { subscriptionId, count } -> do
+                                    count `shouldBe` 1
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected DidCreateCountSubscription" >> error "unreachable"
+
+                            execSQL pool (cs ("INSERT INTO message_memberships (user_id, message_id) VALUES ('" <> UUID.toText userId <> "', '" <> UUID.toText sharedMessageId <> "')"))
+                            granted <- recv
+                            case granted of
+                                DidChangeCount { subscriptionId = changedSubscriptionId, count } -> do
+                                    changedSubscriptionId `shouldBe` subscriptionId
+                                    count `shouldBe` 2
+                                _ -> expectationFailure "Expected count after membership grant"
+
+                            execSQL pool (cs ("DELETE FROM message_memberships WHERE user_id = '" <> UUID.toText userId <> "' AND message_id = '" <> UUID.toText sharedMessageId <> "'"))
+                            revoked <- recv
+                            case revoked of
+                                DidChangeCount { subscriptionId = changedSubscriptionId, count } -> do
+                                    changedSubscriptionId `shouldBe` subscriptionId
+                                    count `shouldBe` 1
+                                _ -> expectationFailure "Expected count after membership revoke"
+
+            it "keeps legacy RLS membership invalidations snapshot-safe" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, ownMessageId) <- insertTestData pool
+                        otherUserId <- UUID.nextRandom
+                        sharedMessageId <- UUID.nextRandom
+                        execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText sharedMessageId <> "', '" <> UUID.toText otherUserId <> "', 'Legacy shared')"))
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscription "messages" 95)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateDataSubscription { subscriptionId } -> pure subscriptionId
+                                _ -> expectationFailure "Expected legacy subscription" >> error "unreachable"
+
+                            execSQL pool (cs ("INSERT INTO message_memberships (user_id, message_id) VALUES ('" <> UUID.toText userId <> "', '" <> UUID.toText sharedMessageId <> "')"))
+                            grantEvents <- sequence [recv, recv, recv, recv]
+                            let grantedDeletes = Set.fromList [id | DidDelete { id } <- grantEvents]
+                            let grantedInserts = Set.fromList [value | DidInsert { record } <- grantEvents, Just value <- [findField "id" record]]
+                            grantedDeletes `shouldBe` Set.fromList [ownMessageId, sharedMessageId]
+                            grantedInserts `shouldBe` Set.fromList [String (UUID.toText ownMessageId), String (UUID.toText sharedMessageId)]
+                            all (\event -> eventSubscriptionId event == Just subscriptionId) grantEvents `shouldBe` True
+
+                            execSQL pool (cs ("DELETE FROM message_memberships WHERE user_id = '" <> UUID.toText userId <> "' AND message_id = '" <> UUID.toText sharedMessageId <> "'"))
+                            revokeEvents <- sequence [recv, recv, recv]
+                            let revokedDeletes = Set.fromList [id | DidDelete { id } <- revokeEvents]
+                            let revokedInserts = [record | DidInsert { record } <- revokeEvents]
+                            revokedDeletes `shouldBe` Set.fromList [ownMessageId, sharedMessageId]
+                            map (findField "id") revokedInserts `shouldBe` [Just (String (UUID.toText ownMessageId))]
+
+            it "rejects legacy projections without id while V2 projections remain authoritative" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, messageId) <- insertTestData pool
+                        let projectedQuery = object
+                                [ "table" .= ("messages" :: Text)
+                                , "selectedColumns" .= object
+                                    [ "tag" .= ("SelectSpecific" :: Text)
+                                    , "contents" .= ["body" :: Text]
+                                    ]
+                                , "whereCondition" .= Null
+                                , "orderByClause" .= ([] :: [Value])
+                                , "distinctOnColumn" .= Null
+                                , "limit" .= Null
+                                , "offset" .= Null
+                                ]
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionQuery 96 projectedQuery)
+                            legacyResponse <- recv
+                            case legacyResponse of
+                                DataSyncError { errorMessage } ->
+                                    errorMessage `shouldSatisfy` Text.isInfixOf "require the id column"
+                                _ -> expectationFailure "Expected explicit legacy projection error"
+
+                            send (encodeCreateDataSubscriptionQueryV2 97 projectedQuery)
+                            created <- recv
+                            case created of
+                                DidCreateDataSubscriptionV2 { result } -> do
+                                    map (findField "body") result `shouldBe` [Just (String "Hello")]
+                                    map (findField "id") result `shouldBe` [Nothing]
+                                _ -> expectationFailure "Expected V2 projected subscription"
+
+                            execSQL pool (cs ("UPDATE messages SET body = 'Projected update' WHERE id = '" <> UUID.toText messageId <> "'"))
+                            replaced <- recv
+                            case replaced of
+                                DidReplaceDataSubscription { revision, result } -> do
+                                    revision `shouldBe` 1
+                                    map (findField "body") result `shouldBe` [Just (String "Projected update")]
+                                    map (findField "id") result `shouldBe` [Nothing]
+                                _ -> expectationFailure "Expected projected replacement"
+
+            it "supports V2 and count subscriptions on id-less tables without installing legacy row triggers" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, _) <- insertTestData pool
+                        execSQL pool (cs ("INSERT INTO idless_resources (owner_id, body) VALUES ('" <> UUID.toText userId <> "', 'First')"))
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscription "idless_resources" 98)
+                            legacyResponse <- recv
+                            case legacyResponse of
+                                DataSyncError { errorMessage } ->
+                                    errorMessage `shouldSatisfy` Text.isInfixOf "require the id column"
+                                _ -> expectationFailure "Expected legacy id-less table rejection"
+
+                            send (encodeCreateDataSubscriptionV2 "idless_resources" 99)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateDataSubscriptionV2 { subscriptionId, result } -> do
+                                    map (findField "body") result `shouldBe` [Just (String "First")]
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected id-less V2 subscription" >> error "unreachable"
+
+                            -- This UPDATE would fail inside notify_did_change_* if
+                            -- the id-dependent legacy trigger had been installed.
+                            execSQL pool "UPDATE idless_resources SET body = 'Updated'"
+                            replaced <- recv
+                            case replaced of
+                                DidReplaceDataSubscription { result } ->
+                                    map (findField "body") result `shouldBe` [Just (String "Updated")]
+                                _ -> expectationFailure "Expected id-less V2 replacement"
+
+                            send (encodeDeleteDataSubscription subscriptionId 100)
+                            _ <- recv
+                            pure ()
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateCountSubscription "idless_resources" 101)
+                            created <- recv
+                            case created of
+                                DidCreateCountSubscription { count } -> count `shouldBe` 1
+                                _ -> expectationFailure "Expected id-less count subscription"
+
+                            execSQL pool (cs ("INSERT INTO idless_resources (owner_id, body) VALUES ('" <> UUID.toText userId <> "', 'Second')"))
+                            changed <- recv
+                            case changed of
+                                DidChangeCount { count } -> count `shouldBe` 2
+                                _ -> expectationFailure "Expected id-less count refresh"
+
+            it "replaces the complete RLS-filtered snapshot with monotonic revisions" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, _) <- insertTestData pool
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionV2 "messages" 10)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateDataSubscriptionV2 { subscriptionId, revision, result } -> do
+                                    revision `shouldBe` 0
+                                    length result `shouldBe` 1
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected DidCreateDataSubscriptionV2" >> error "unreachable"
+
+                            insertedId <- UUID.nextRandom
+                            execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText insertedId <> "', '" <> UUID.toText userId <> "', 'Second')"))
+
+                            replacement <- recv
+                            case replacement of
+                                DidReplaceDataSubscription { subscriptionId = replacedId, revision, result } -> do
+                                    replacedId `shouldBe` subscriptionId
+                                    revision `shouldBe` 1
+                                    length result `shouldBe` 2
+                                _ -> expectationFailure "Expected DidReplaceDataSubscription"
+
+                            execSQL pool (cs ("UPDATE messages SET body = 'Updated second' WHERE id = '" <> UUID.toText insertedId <> "'"))
+
+                            replacement2 <- recv
+                            case replacement2 of
+                                DidReplaceDataSubscription { revision, result } -> do
+                                    revision `shouldBe` 2
+                                    let updatedRows = filter (\row -> findField "id" row == Just (String (UUID.toText insertedId))) result
+                                    map (findField "body") updatedRows `shouldBe` [Just (String "Updated second")]
+                                _ -> expectationFailure "Expected second DidReplaceDataSubscription"
+
+            it "does not emit a replacement for an RLS-hidden change" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, messageId) <- insertTestData pool
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionV2 "messages" 11)
+                            created <- recv
+                            case created of
+                                DidCreateDataSubscriptionV2 { revision, result } -> do
+                                    revision `shouldBe` 0
+                                    length result `shouldBe` 1
+                                _ -> expectationFailure "Expected DidCreateDataSubscriptionV2"
+
+                            otherUserId <- UUID.nextRandom
+                            hiddenMessageId <- UUID.nextRandom
+                            execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText hiddenMessageId <> "', '" <> UUID.toText otherUserId <> "', 'Hidden')"))
+
+                            possibleResponse <- race (threadDelay 500_000) recv
+                            case possibleResponse of
+                                Left () -> pure ()
+                                Right _ -> expectationFailure "Expected no response for an RLS-hidden insert"
+
+                            -- A subsequent visible change must still be revision 1. This
+                            -- both proves the listener remains live and that the hidden
+                            -- notification did not consume a revision.
+                            execSQL pool (cs ("UPDATE messages SET body = 'Visible update' WHERE id = '" <> UUID.toText messageId <> "'"))
+                            visibleReplacement <- recv
+                            case visibleReplacement of
+                                DidReplaceDataSubscription { revision, result } -> do
+                                    revision `shouldBe` 1
+                                    map (findField "body") result `shouldBe` [Just (String "Visible update")]
+                                _ -> expectationFailure "Expected DidReplaceDataSubscription for the visible update"
+
+            it "replaces a filtered snapshot when an unwatched row enters the query" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, messageId) <- insertTestData pool
+
+                        let filteredQuery = object
+                                [ "table" .= ("messages" :: Text)
+                                , "selectedColumns" .= object ["tag" .= ("SelectAll" :: Text)]
+                                , "whereCondition" .= object
+                                    [ "tag" .= ("InfixOperatorExpression" :: Text)
+                                    , "left" .= object
+                                        [ "tag" .= ("ColumnExpression" :: Text)
+                                        , "field" .= ("body" :: Text)
+                                        ]
+                                    , "op" .= ("OpEqual" :: Text)
+                                    , "right" .= object
+                                        [ "tag" .= ("LiteralExpression" :: Text)
+                                        , "value" .= ("Matches" :: Text)
+                                        ]
+                                    ]
+                                , "orderByClause" .= ([] :: [Value])
+                                , "distinctOnColumn" .= Null
+                                , "limit" .= Null
+                                , "offset" .= Null
+                                ]
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionQueryV2 12 filteredQuery)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateDataSubscriptionV2 { subscriptionId, revision, result } -> do
+                                    revision `shouldBe` 0
+                                    length result `shouldBe` 0
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected DidCreateDataSubscriptionV2" >> error "unreachable"
+
+                            -- DidCreate is sent only after LISTEN is active, so this immediate
+                            -- update also exercises the former setup race.
+                            execSQL pool (cs ("UPDATE messages SET body = 'Matches' WHERE id = '" <> UUID.toText messageId <> "'"))
+                            entered <- recv
+                            case entered of
+                                DidReplaceDataSubscription { subscriptionId = replacedId, revision, result } -> do
+                                    replacedId `shouldBe` subscriptionId
+                                    revision `shouldBe` 1
+                                    map (findField "id") result `shouldBe` [Just (String (UUID.toText messageId))]
+                                _ -> expectationFailure "Expected row-entered replacement"
+
+                            execSQL pool (cs ("UPDATE messages SET body = 'No longer' WHERE id = '" <> UUID.toText messageId <> "'"))
+                            left <- recv
+                            case left of
+                                DidReplaceDataSubscription { revision, result } -> do
+                                    revision `shouldBe` 2
+                                    length result `shouldBe` 0
+                                _ -> expectationFailure "Expected row-left replacement"
+
+            it "replaces a limited ordered window when a row is displaced" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, messageId) <- insertTestData pool
+
+                        let limitedQuery = object
+                                [ "table" .= ("messages" :: Text)
+                                , "selectedColumns" .= object ["tag" .= ("SelectAll" :: Text)]
+                                , "whereCondition" .= Null
+                                , "orderByClause" .=
+                                    [ object
+                                        [ "orderByColumn" .= ("body" :: Text)
+                                        , "orderByDirection" .= ("Asc" :: Text)
+                                        ]
+                                    ]
+                                , "distinctOnColumn" .= Null
+                                , "limit" .= (1 :: Int)
+                                , "offset" .= Null
+                                ]
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateDataSubscriptionQueryV2 13 limitedQuery)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateDataSubscriptionV2 { subscriptionId, revision, result } -> do
+                                    revision `shouldBe` 0
+                                    map (findField "id") result `shouldBe` [Just (String (UUID.toText messageId))]
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected DidCreateDataSubscriptionV2" >> error "unreachable"
+
+                            insertedId <- UUID.nextRandom
+                            execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText insertedId <> "', '" <> UUID.toText userId <> "', 'A first')"))
+                            displaced <- recv
+                            case displaced of
+                                DidReplaceDataSubscription { subscriptionId = replacedId, revision, result } -> do
+                                    replacedId `shouldBe` subscriptionId
+                                    revision `shouldBe` 1
+                                    map (findField "id") result `shouldBe` [Just (String (UUID.toText insertedId))]
+                                _ -> expectationFailure "Expected limited-window replacement"
+
+            it "authoritatively refreshes and deletes a count subscription" do
+                withDB \connStr -> do
+                    withHasqlPool connStr \pool -> do
+                        setupTestSchema pool
+                        (userId, _) <- insertTestData pool
+
+                        withDataSyncController connStr userId \(send, recv, _) -> do
+                            send (encodeCreateCountSubscription "messages" 91)
+                            created <- recv
+                            subscriptionId <- case created of
+                                DidCreateCountSubscription { subscriptionId, count } -> do
+                                    count `shouldBe` 1
+                                    pure subscriptionId
+                                _ -> expectationFailure "Expected DidCreateCountSubscription" >> error "unreachable"
+
+                            insertedId <- UUID.nextRandom
+                            execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText insertedId <> "', '" <> UUID.toText userId <> "', 'Counted')"))
+                            changed <- recv
+                            case changed of
+                                DidChangeCount { subscriptionId = changedSubscriptionId, count } -> do
+                                    changedSubscriptionId `shouldBe` subscriptionId
+                                    count `shouldBe` 2
+                                _ -> expectationFailure "Expected DidChangeCount"
+
+                            send (encodeDeleteDataSubscription subscriptionId 92)
+                            deleted <- recv
+                            case deleted of
+                                DidDeleteDataSubscription { subscriptionId = deletedSubscriptionId } ->
+                                    deletedSubscriptionId `shouldBe` subscriptionId
+                                _ -> expectationFailure "Expected DidDeleteDataSubscription"
+
+                            anotherId <- UUID.nextRandom
+                            execSQL pool (cs ("INSERT INTO messages (id, user_id, body) VALUES ('" <> UUID.toText anotherId <> "', '" <> UUID.toText userId <> "', 'After count delete')"))
+                            afterDelete <- race (threadDelay 300_000) recv
+                            case afterDelete of
+                                Left () -> pure ()
+                                Right _ -> expectationFailure "Expected no count message after delete acknowledgement"
 
         describe "Transactions" do
             it "starts, uses, and commits a transaction" do

--- a/ihp-datasync/data/DataSync/.gitignore
+++ b/ihp-datasync/data/DataSync/.gitignore
@@ -7,3 +7,4 @@
 # Keep test files and config
 !*.test.js
 !jest.config.js
+!src/*.typetest.d.ts

--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -29,6 +29,16 @@ async function flushMicrotasks(rounds = 8) {
     }
 }
 
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
 describe('DataSubscription external store', () => {
     beforeEach(() => {
         DataSyncController.instance = null;
@@ -44,6 +54,53 @@ describe('DataSubscription external store', () => {
         expect(DataSyncController.instance).toBeNull();
         expect(direct.getSnapshot().status).toBe('idle');
         expect(stored.getSnapshot().status).toBe('idle');
+    });
+
+    test('the writable records facade mirrors its historical connected flags', () => {
+        const resource = new DataSubscription(query());
+
+        resource.records = [{ id: 'assigned' }];
+
+        expect(resource.getSnapshot()).toEqual({
+            data: [{ id: 'assigned' }],
+            status: 'live',
+            error: null,
+        });
+        expect(resource.isConnected).toBe(true);
+        expect(resource.isClosed).toBe(false);
+        resource.records = null;
+        expect(resource.getSnapshot()).toEqual({
+            data: null,
+            status: 'idle',
+            error: null,
+        });
+        expect(resource.isConnected).toBe(true);
+        expect(resource.isClosed).toBe(false);
+        const compatibilitySubscriber = jest.fn();
+        resource.subscribers.push(compatibilitySubscriber);
+        resource.records = null;
+        expect(compatibilitySubscriber).toHaveBeenCalledWith(null);
+        resource.subscribers.length = 0;
+        expect(DataSyncController.instance).toBeNull();
+    });
+
+    test('scheduleCloseIfNotUsed closes an inert resource in the next microtask', async () => {
+        const resource = new DataSubscription(query());
+        const onClose = jest.fn();
+        resource.onClose = onClose;
+        const initialResult = resource.createOnServerPromise.catch(error => error);
+
+        resource.scheduleCloseIfNotUsed();
+        expect(resource.getSnapshot().status).toBe('idle');
+        await flushMicrotasks();
+
+        expect(resource.getSnapshot().status).toBe('closed');
+        expect(resource.isClosed).toBe(true);
+        expect(onClose).toHaveBeenCalledTimes(1);
+        await expect(initialResult).resolves.toEqual(expect.objectContaining({
+            message: expect.stringContaining('became unused'),
+        }));
+        expect(DataSyncController.instance).toBeNull();
     });
 
     test('registry lookup is render-pure and snapshots the mutable query', () => {
@@ -380,6 +437,23 @@ describe('DataSubscription external store', () => {
             result: [{ id: 'next' }],
         });
         expect(externallyAdded).toHaveBeenCalledWith([{ id: 'next' }]);
+
+        resource.subscriptionId = 'compatibility-id';
+        resource.onMessage({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'compatibility-id',
+            revision: 2,
+            result: [{ id: 'routed-through-public-field' }],
+        });
+        expect(resource.records).toEqual([{ id: 'routed-through-public-field' }]);
+        expect(resource.subscriptionId).toBe('compatibility-id');
+        resource.onMessage({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'compatibility-id',
+            revision: 3,
+            result: [{ id: 'routed-again' }],
+        });
+        expect(resource.records).toEqual([{ id: 'routed-again' }]);
         release();
         await flushMicrotasks();
         expect(resource.getSnapshot().status).toBe('live');
@@ -423,6 +497,83 @@ describe('DataSubscription external store', () => {
             'CreateDataSubscription',
             'DeleteDataSubscription',
         ]);
+    });
+
+    test('manual create awaits recreates after disconnect and explicit close', async () => {
+        const controller = DataSyncController.getInstance();
+        const reconnectCreate = deferred();
+        const reopenedCreate = deferred();
+        let createNumber = 0;
+        controller.sendMessage = jest.fn(payload => {
+            if (payload.tag !== 'CreateDataSubscription') {
+                return Promise.resolve({});
+            }
+            createNumber++;
+            if (createNumber === 1) {
+                return Promise.resolve({
+                    tag: 'DidCreateDataSubscriptionV2',
+                    subscriptionId: 'manual-initial',
+                    revision: 0,
+                    result: [],
+                });
+            }
+            return createNumber === 2 ? reconnectCreate.promise : reopenedCreate.promise;
+        });
+        const resource = new DataSubscription(query());
+        await resource.createOnServer();
+
+        resource.onDataSyncClosed();
+        let reconnectSettled = false;
+        const reconnect = resource.createOnServer().then(() => {
+            reconnectSettled = true;
+        });
+        expect(createNumber).toBe(2);
+        expect(reconnectSettled).toBe(false);
+        reconnectCreate.resolve({
+            tag: 'DidCreateDataSubscriptionV2',
+            subscriptionId: 'manual-reconnected',
+            revision: 0,
+            result: [],
+        });
+        await reconnect;
+        expect(resource.subscriptionId).toBe('manual-reconnected');
+
+        await resource.close();
+        let reopenSettled = false;
+        const reopen = resource.createOnServer().then(() => {
+            reopenSettled = true;
+        });
+        expect(createNumber).toBe(3);
+        expect(reopenSettled).toBe(false);
+        reopenedCreate.resolve({
+            tag: 'DidCreateDataSubscriptionV2',
+            subscriptionId: 'manual-reopened',
+            revision: 0,
+            result: [],
+        });
+        await reopen;
+        expect(resource.subscriptionId).toBe('manual-reopened');
+        await resource.close();
+    });
+
+    test('the initial promise result cannot mutate the live records array', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? {
+                tag: 'DidCreateDataSubscriptionV2',
+                subscriptionId: 'initial-result-clone',
+                revision: 0,
+                result: [{ id: 'server-record' }],
+            }
+            : {});
+        const resource = new DataSubscription(query());
+
+        await resource.createOnServer();
+        const initialResult = await resource.createOnServerPromise;
+        initialResult.push({ id: 'caller-only' });
+
+        expect(resource.records).toEqual([{ id: 'server-record' }]);
+        await resource.close();
     });
 
     test('closing before the first response settles createOnServerPromise', async () => {
@@ -545,12 +696,21 @@ describe('DataSubscription external store', () => {
 
             jwt = 'render-user-b';
             const callback = jest.fn();
+            const snapshotObservations = [];
+            const releaseSnapshot = oldResource.subscribeSnapshot(() => {
+                snapshotObservations.push(oldResource.getSnapshot());
+            });
             const release = oldResource.subscribe(callback);
             const releaseAgain = oldResource.subscribe(() => {});
 
             expect(DataSyncController.instance).toBeNull();
             expect(oldResource.getRecords()).toBeNull();
             expect(oldResource.getSnapshot().status).toBe('closed');
+            expect(snapshotObservations).toEqual([{
+                data: null,
+                status: 'closed',
+                error: null,
+            }]);
             expect(callback).not.toHaveBeenCalled();
             expect(DataSubscriptionStore.queryMap.has(oldKey)).toBe(false);
             await expect(staleImperative.createOnServer()).rejects.toThrow('scope changed');
@@ -559,8 +719,46 @@ describe('DataSubscription external store', () => {
             const newResource = DataSubscriptionStore.get(resourceQuery);
             expect(newResource).not.toBe(oldResource);
             expect(newResource.getRecords()).toBeNull();
+            releaseSnapshot();
             release();
             releaseAgain();
+        } finally {
+            if (originalLocalStorage === undefined) delete globalThis.localStorage;
+            else globalThis.localStorage = originalLocalStorage;
+        }
+    });
+
+    test('the public receiveUpdate facade retires stale auth-scoped resources', async () => {
+        const originalLocalStorage = globalThis.localStorage;
+        let jwt = 'receive-user-a';
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? jwt : null };
+        try {
+            const controller = DataSyncController.getInstance();
+            controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+                ? {
+                    tag: 'DidCreateDataSubscriptionV2',
+                    subscriptionId: 'receive-old-scope',
+                    revision: 0,
+                    result: [{ id: 'old-visible' }],
+                }
+                : {});
+            const resource = new DataSubscription(query());
+            const release = resource.subscribe(() => {});
+            await flushMicrotasks();
+            expect(resource.records).toEqual([{ id: 'old-visible' }]);
+
+            jwt = 'receive-user-b';
+            resource.receiveUpdate({
+                tag: 'DidReplaceDataSubscription',
+                subscriptionId: 'receive-old-scope',
+                revision: 1,
+                result: [{ id: 'must-not-publish' }],
+            });
+
+            expect(resource.records).toBeNull();
+            expect(resource.getSnapshot().status).toBe('closed');
+            expect(resource.isConnected).toBe(false);
+            release();
         } finally {
             if (originalLocalStorage === undefined) delete globalThis.localStorage;
             else globalThis.localStorage = originalLocalStorage;
@@ -675,6 +873,48 @@ describe('DataSubscription external store', () => {
             result: [{ id: 'obsolete' }],
         });
         expect(resource.getRecords()).toEqual([{ id: 'snapshot-2' }]);
+        release();
+        await flushMicrotasks();
+    });
+
+    test('the public reconnect promise waits for the replacement subscription', async () => {
+        const controller = DataSyncController.getInstance();
+        let createNumber = 0;
+        let resolveReconnect;
+        controller.sendMessage = jest.fn(payload => {
+            if (payload.tag !== 'CreateDataSubscription') {
+                return Promise.resolve({});
+            }
+            createNumber++;
+            if (createNumber === 1) {
+                return Promise.resolve({
+                    subscriptionId: 'before-reconnect',
+                    result: [],
+                });
+            }
+            return new Promise(resolve => { resolveReconnect = resolve; });
+        });
+        const resource = new DataSubscription(query());
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        for (const listener of [...controller.eventListeners.close]) listener(null);
+        let reconnectSettled = false;
+        const reconnect = resource.onDataSyncReconnect().then(() => {
+            reconnectSettled = true;
+        });
+
+        expect(createNumber).toBe(2);
+        expect(reconnectSettled).toBe(false);
+        expect(resource.subscriptionId).toBeNull();
+        resolveReconnect({
+            subscriptionId: 'after-reconnect',
+            result: [],
+        });
+        await reconnect;
+        expect(reconnectSettled).toBe(true);
+        expect(resource.subscriptionId).toBe('after-reconnect');
+
         release();
         await flushMicrotasks();
     });

--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -296,7 +296,7 @@ describe('Optimistic CRUD coordination', () => {
         expect(subscription.records).toEqual([originalRecord]);
     });
 
-    test('does not refresh a limited query before an optimistic create reaches the server', async () => {
+    test('keeps a limited query exact until a post-create server refresh', async () => {
         const controller = DataSyncController.getInstance();
         const subscription = makeSubscription([
             { id: 'a', title: 'A' },
@@ -320,12 +320,17 @@ describe('Optimistic CRUD coordination', () => {
         await Promise.resolve();
         await Promise.resolve();
 
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b', 'c']);
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
+        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
         expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateRecordMessage']);
 
         resolveCreate({ tag: 'DidCreateRecord', record: { id: 'b', title: 'B' } });
         await create;
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
+
         subscription.onCreate({ id: 'b', title: 'B' });
+        await Promise.resolve();
+        await Promise.resolve();
 
         expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
         expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
@@ -334,7 +339,54 @@ describe('Optimistic CRUD coordination', () => {
         ]);
     });
 
-    test('restores the complete limited window when an optimistic create fails offline', async () => {
+    test('queues an exact refresh when a create event races an in-flight refresh', async () => {
+        const controller = DataSyncController.getInstance();
+        const subscription = makeSubscription([
+            { id: 'a', title: 'A' },
+            { id: 'c', title: 'C' },
+        ]);
+        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
+        subscription.query.limit = 2;
+        controller.dataSubscriptions.push(subscription);
+
+        let resolveFirstRefresh;
+        let refreshCount = 0;
+        controller.sendMessage = jest.fn(payload => {
+            if (payload.tag === 'CreateRecordMessage') {
+                return Promise.resolve({ tag: 'DidCreateRecord', record: payload.record });
+            }
+
+            refreshCount++;
+            if (refreshCount === 1) {
+                return new Promise(resolve => { resolveFirstRefresh = resolve; });
+            }
+            return Promise.resolve({
+                tag: 'DataSyncResult',
+                result: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
+            });
+        });
+
+        subscription.onDelete('c');
+        await createRecord('test', { id: 'b', title: 'B' });
+        subscription.onCreate({ id: 'b', title: 'B' });
+
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
+        expect(refreshCount).toBe(1);
+
+        resolveFirstRefresh({
+            tag: 'DataSyncResult',
+            result: [{ id: 'a', title: 'A' }, { id: 'd', title: 'D' }],
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(refreshCount).toBe(2);
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
+    });
+
+    test('leaves a limited query unchanged when a create fails offline', async () => {
         const controller = DataSyncController.getInstance();
         const subscription = makeSubscription([
             { id: 'a', title: 'A' },
@@ -355,7 +407,6 @@ describe('Optimistic CRUD coordination', () => {
             expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
             expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
                 'CreateRecordMessage',
-                'DataSyncQuery',
             ]);
         } finally {
             consoleError.mockRestore();
@@ -379,11 +430,59 @@ describe('Optimistic CRUD coordination', () => {
         });
 
         await updateRecord('test', 'a', { title: 'Z' });
+        expect(subscription.records).toEqual([
+            { id: 'a', title: 'A' },
+            { id: 'b', title: 'B' },
+        ]);
         expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['UpdateRecordMessage']);
 
         controller.sendMessage.mockClear();
         await deleteRecord('test', 'b');
+        expect(subscription.records).toEqual([
+            { id: 'a', title: 'A' },
+            { id: 'b', title: 'B' },
+        ]);
         expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['DeleteRecordMessage']);
+    });
+
+    test('reconciles an optimistic create with the canonical server record', async () => {
+        const controller = DataSyncController.getInstance();
+        const subscription = makeSubscription([]);
+        subscription.query.whereCondition = {
+            tag: 'InfixOperatorExpression',
+            left: { tag: 'ColumnExpression', field: 'status' },
+            op: 'OpEqual',
+            right: { tag: 'LiteralExpression', value: 'draft' },
+        };
+        controller.dataSubscriptions.push(subscription);
+        controller.sendMessage = jest.fn(async payload => ({
+            tag: 'DidCreateRecord',
+            record: { ...payload.record, status: 'published' },
+        }));
+
+        const result = await createRecord('test', { id: 'post', status: 'draft' });
+
+        expect(result).toEqual({ id: 'post', status: 'published' });
+        expect(subscription.records).toEqual([]);
+        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
+        expect(controller.optimisticCreatedPendingRecordIds).toEqual([]);
+    });
+
+    test('deduplicates a DidInsert arriving after canonical create reconciliation', async () => {
+        const controller = DataSyncController.getInstance();
+        const subscription = makeSubscription([]);
+        controller.dataSubscriptions.push(subscription);
+        const canonicalRecord = { id: 'post', title: 'Canonical title' };
+        controller.sendMessage = jest.fn(async () => ({
+            tag: 'DidCreateRecord',
+            record: canonicalRecord,
+        }));
+
+        await createRecord('test', { id: 'post', title: 'Optimistic title' });
+        subscription.onCreate(canonicalRecord);
+
+        expect(subscription.records).toEqual([canonicalRecord]);
+        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
     });
 });
 
@@ -406,12 +505,10 @@ describe('DataSubscription query semantics', () => {
         expect(subscription.records.map(record => record.id)).toEqual(['c', 'a', 'b']);
     });
 
-    test('enforces limit immediately and refreshes the exact server window', async () => {
+    test('keeps the old limited window until the exact server refresh resolves', async () => {
         const controller = DataSyncController.getInstance();
-        controller.sendMessage = jest.fn(async () => ({
-            tag: 'DataSyncResult',
-            result: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }]
-        }));
+        let resolveRefresh;
+        controller.sendMessage = jest.fn(() => new Promise(resolve => { resolveRefresh = resolve; }));
         const subscription = makeSubscription([
             { id: 'a', title: 'A' },
             { id: 'c', title: 'C' },
@@ -420,9 +517,45 @@ describe('DataSubscription query semantics', () => {
         subscription.query.limit = 2;
 
         subscription.onCreate({ id: 'b', title: 'B' });
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
-        await Promise.resolve();
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
         expect(controller.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ tag: 'DataSyncQuery' }));
+
+        resolveRefresh({
+            tag: 'DataSyncResult',
+            result: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
+    });
+
+    test('keeps projected DISTINCT results verbatim after refresh', async () => {
+        const controller = DataSyncController.getInstance();
+        let resolveRefresh;
+        controller.sendMessage = jest.fn(() => new Promise(resolve => { resolveRefresh = resolve; }));
+        const subscription = makeSubscription([
+            { id: 'a', title: 'A' },
+            { id: 'b', title: 'B' },
+        ]);
+        subscription.query.selectedColumns = { tag: 'SelectSpecific', contents: ['id', 'title'] };
+        subscription.query.distinctOnColumn = 'category';
+
+        subscription.onCreate({ id: 'c', title: 'C' });
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
+
+        resolveRefresh({
+            tag: 'DataSyncResult',
+            result: [
+                { id: 'a', title: 'A' },
+                { id: 'b', title: 'B' },
+                { id: 'c', title: 'C' },
+            ],
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b', 'c']);
     });
 
     test('subscription errors notify subscribers', async () => {

--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -1,75 +1,914 @@
-import { DataSubscription, DataSyncController, createRecord, updateRecord, deleteRecord } from './ihp-datasync.js';
-import { withTransaction } from './transaction.js';
+import {
+    DataSubscription,
+    DataSyncController,
+    initIHPBackend,
+    createRecord,
+    updateRecord,
+    deleteRecord,
+} from './ihp-datasync.js';
+import { DataSubscriptionStore, dataSubscriptionKey } from './data-subscription-store.js';
+import { Transaction, withTransaction } from './transaction.js';
 import { jest } from '@jest/globals';
 
-function makeSubscription(records) {
-    const query = {
-        table: 'test',
+function query(overrides = {}) {
+    return {
+        table: 'tasks',
         selectedColumns: { tag: 'SelectAll' },
         whereCondition: null,
         orderByClause: [],
         distinctOnColumn: null,
         limit: null,
         offset: null,
+        ...overrides,
     };
-    const sub = new DataSubscription(query);
-    sub.records = records;
-    sub.subscribers = [];
-    return sub;
 }
 
-describe('DataSubscription.onUpdate', () => {
-    test('applies appendSet normally', () => {
-        const sub = makeSubscription([{ id: '1', name: 'Foo' }]);
+async function flushMicrotasks(rounds = 8) {
+    for (let index = 0; index < rounds; index++) {
+        await Promise.resolve();
+    }
+}
 
-        sub.onUpdate('1', null, { name: 'Bar' });
-
-        expect(sub.records[0].name).toBe('FooBar');
+describe('DataSubscription external store', () => {
+    beforeEach(() => {
+        DataSyncController.instance = null;
+        DataSyncController.ihpBackendHost = null;
+        DataSubscriptionStore.queryMap.clear();
+        DataSubscriptionStore.cache.clear();
     });
 
-    test('skips appendSet for optimistically updated records', () => {
-        const sub = makeSubscription([{ id: '1', name: 'Anrufbeantworter' }]);
+    test('constructing and looking up resources does not create a controller', () => {
+        const direct = new DataSubscription(query());
+        const stored = DataSubscriptionStore.get(query({ table: 'stored_tasks' }));
 
-        // Simulate optimistic update
-        sub.onUpdate('1', { name: 'Anrufbeantworter123' }, null);
-        sub.optimisticUpdatedPendingRecordIds.add('1');
-
-        // Simulate DidUpdate arrival with appendSet
-        sub.onUpdate('1', null, { name: '123' });
-
-        expect(sub.records[0].name).toBe('Anrufbeantworter123');
+        expect(DataSyncController.instance).toBeNull();
+        expect(direct.getSnapshot().status).toBe('idle');
+        expect(stored.getSnapshot().status).toBe('idle');
     });
 
-    test('applies appendSet for other records even with pending optimistic updates', () => {
-        const sub = makeSubscription([
-            { id: '1', name: 'Anrufbeantworter' },
-            { id: '2', name: 'Hello' },
+    test('registry lookup is render-pure and snapshots the mutable query', () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn();
+        const mutableQuery = query();
+
+        const resource = DataSubscriptionStore.get(mutableQuery);
+        mutableQuery.limit = 1;
+
+        expect(controller.sendMessage).not.toHaveBeenCalled();
+        expect(resource.query.limit).toBeNull();
+        expect(resource.cache).toBeNull();
+        expect(resource.getSnapshot()).toBe(resource.getSnapshot());
+        expect(resource.getSnapshot()).toEqual({ data: null, status: 'idle', error: null });
+    });
+
+    test('equal queries share one create and delete only after the final release', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscription', subscriptionId: 'shared', revision: 0, result: [] }
+            : { tag: 'DidDeleteDataSubscription', subscriptionId: payload.subscriptionId });
+
+        const first = DataSubscriptionStore.get(query());
+        const second = DataSubscriptionStore.get(query());
+        expect(second).toBe(first);
+
+        const releaseFirst = first.subscribe(() => {});
+        const releaseSecond = second.subscribe(() => {});
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.filter(([payload]) => payload.tag === 'CreateDataSubscription')).toHaveLength(1);
+
+        releaseFirst();
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.filter(([payload]) => payload.tag === 'DeleteDataSubscription')).toHaveLength(0);
+
+        releaseSecond();
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.filter(([payload]) => payload.tag === 'DeleteDataSubscription')).toHaveLength(1);
+        expect(DataSubscriptionStore.queryMap.size).toBe(0);
+    });
+
+    test('a second imperative subscriber immediately receives the current shared snapshot', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'shared-current', revision: 0, result: [{ id: 'current' }] }
+            : {});
+        const resource = DataSubscriptionStore.get(query());
+        const releaseFirst = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        const secondSubscriber = jest.fn();
+        const releaseSecond = resource.subscribe(secondSubscriber);
+        expect(secondSubscriber).toHaveBeenCalledTimes(1);
+        expect(secondSubscriber).toHaveBeenCalledWith([{ id: 'current' }]);
+
+        releaseFirst();
+        releaseSecond();
+        await flushMicrotasks();
+    });
+
+    test('a first legacy subscriber gets server data but no synchronous lifecycle value', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'legacy-callback', revision: 0, result: [{ id: 'ready' }] }
+            : {});
+        const resource = new DataSubscription(query());
+        const callback = jest.fn();
+
+        const release = resource.subscribe(callback);
+        expect(callback).not.toHaveBeenCalled();
+        await flushMicrotasks();
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenLastCalledWith([{ id: 'ready' }]);
+
+        for (const listener of [...controller.eventListeners.close]) listener(null);
+        expect(callback).toHaveBeenCalledTimes(1);
+        release();
+        await flushMicrotasks();
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test('one throwing legacy subscriber cannot block another or prevent cleanup', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'throwing-listener', revision: 0, result: [{ id: 'safe' }] }
+            : {});
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const resource = new DataSubscription(query());
+        const throwing = jest.fn(() => { throw new Error('listener failed'); });
+        const observing = jest.fn();
+
+        const releaseThrowing = resource.subscribe(throwing);
+        const releaseObserving = resource.subscribe(observing);
+        await flushMicrotasks();
+
+        expect(throwing).toHaveBeenCalledWith([{ id: 'safe' }]);
+        expect(observing).toHaveBeenCalledWith([{ id: 'safe' }]);
+        expect(consoleError).toHaveBeenCalledWith(
+            'DataSubscription subscriber failed:',
+            expect.objectContaining({ message: 'listener failed' }),
+        );
+        expect(() => releaseThrowing()).not.toThrow();
+        expect(() => releaseObserving()).not.toThrow();
+        await flushMicrotasks();
+        expect(resource.getSnapshot().status).toBe('closed');
+        consoleError.mockRestore();
+    });
+
+    test('mutating the public query cannot alter create or refresh transport queries', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscription', subscriptionId: 'stable-query', result: [] }
+            : { result: [] });
+        const resource = new DataSubscription(query());
+        resource.query.limit = 1;
+        resource.query.orderByClause.push({ orderByColumn: 'createdAt', orderByDirection: 'Desc' });
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+        resource.onCreate({ id: 'invalidate' });
+        await flushMicrotasks();
+
+        const transportedQueries = controller.sendMessage.mock.calls
+            .filter(([payload]) => payload.query !== undefined)
+            .map(([payload]) => payload.query);
+        expect(transportedQueries).toHaveLength(2);
+        for (const transportedQuery of transportedQueries) {
+            expect(transportedQuery.limit).toBeNull();
+            expect(transportedQuery.orderByClause).toEqual([]);
+            expect(Object.isFrozen(transportedQuery)).toBe(true);
+        }
+        release();
+        await flushMicrotasks();
+    });
+
+    test('StrictMode release and retain in one turn reuses the server subscription', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscription', subscriptionId: 'strict', revision: 0, result: [] }
+            : { tag: 'DidDeleteDataSubscription', subscriptionId: payload.subscriptionId });
+        const resource = DataSubscriptionStore.get(query());
+
+        const firstRelease = resource.subscribe(() => {});
+        firstRelease();
+        const finalRelease = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateDataSubscription']);
+        finalRelease();
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
+            'CreateDataSubscription',
+            'DeleteDataSubscription',
         ]);
-
-        // Optimistic update only on record 1
-        sub.onUpdate('1', { name: 'Anrufbeantworter123' }, null);
-        sub.optimisticUpdatedPendingRecordIds.add('1');
-
-        // appendSet for record 2 should apply normally
-        sub.onUpdate('2', null, { name: ' World' });
-
-        expect(sub.records[1].name).toBe('Hello World');
     });
 
-    test('pending optimistic flag is cleared after processing', () => {
-        const sub = makeSubscription([{ id: '1', name: 'Anrufbeantworter' }]);
+    test('the same callback can be retained twice without under-counting', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { subscriptionId: 'duplicate-listener', revision: 0, result: [] }
+            : {});
+        const resource = new DataSubscription(query());
+        const callback = jest.fn();
 
-        // Simulate optimistic update
-        sub.onUpdate('1', { name: 'Anrufbeantworter123' }, null);
-        sub.optimisticUpdatedPendingRecordIds.add('1');
+        const releaseFirst = resource.subscribe(callback);
+        const releaseSecond = resource.subscribe(callback);
+        await flushMicrotasks();
+        releaseFirst();
+        await flushMicrotasks();
+        expect(resource.getSnapshot().status).toBe('live');
 
-        // First DidUpdate: appendSet skipped
-        sub.onUpdate('1', null, { name: '123' });
-        expect(sub.records[0].name).toBe('Anrufbeantworter123');
+        releaseSecond();
+        await flushMicrotasks();
+        expect(resource.getSnapshot().status).toBe('closed');
+    });
 
-        // Subsequent append should work normally (flag cleared)
-        sub.onUpdate('1', null, { name: '456' });
-        expect(sub.records[0].name).toBe('Anrufbeantworter123456');
+    test('a create response arriving after final release is deleted and cannot resurrect state', async () => {
+        const controller = DataSyncController.getInstance();
+        let resolveCreate;
+        controller.sendMessage = jest.fn(payload => {
+            if (payload.tag === 'CreateDataSubscription') {
+                return new Promise(resolve => { resolveCreate = resolve; });
+            }
+            return Promise.resolve({ tag: 'DidDeleteDataSubscription' });
+        });
+        const resource = new DataSubscription(query());
+
+        const release = resource.subscribe(() => {});
+        release();
+        await flushMicrotasks();
+        expect(resource.getSnapshot().status).toBe('closed');
+
+        resolveCreate({ subscriptionId: 'late', revision: 0, result: [{ id: 'ghost' }] });
+        await flushMicrotasks();
+
+        expect(resource.getRecords()).toBeNull();
+        expect(resource.subscriptionId).toBeNull();
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
+            'CreateDataSubscription',
+            'DeleteDataSubscription',
+        ]);
+    });
+
+    test('a render-held resource reopened after full release is evicted again', async () => {
+        const controller = DataSyncController.getInstance();
+        let createNumber = 0;
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? {
+                tag: 'DidCreateDataSubscriptionV2',
+                subscriptionId: `reopened-${++createNumber}`,
+                revision: 0,
+                result: [],
+            }
+            : { tag: 'DidDeleteDataSubscription', subscriptionId: payload.subscriptionId });
+
+        const resource = DataSubscriptionStore.get(query({ table: 'reopened_tasks' }));
+        const releaseFirst = resource.subscribe(() => {});
+        await flushMicrotasks();
+        releaseFirst();
+        await flushMicrotasks();
+        expect(DataSubscriptionStore.queryMap.size).toBe(0);
+
+        const releaseSecond = resource.subscribe(() => {});
+        await flushMicrotasks();
+        expect(DataSubscriptionStore.queryMap.size).toBe(1);
+        releaseSecond();
+        await flushMicrotasks();
+
+        expect(DataSubscriptionStore.queryMap.size).toBe(0);
+        expect(controller.sendMessage.mock.calls.filter(([payload]) =>
+            payload.tag === 'CreateDataSubscription')).toHaveLength(2);
+        expect(controller.sendMessage.mock.calls.filter(([payload]) =>
+            payload.tag === 'DeleteDataSubscription')).toHaveLength(2);
+    });
+
+    test('authoritative replacements preserve server ordering and ignore old revisions', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async () => ({
+            subscriptionId: 'revisions',
+            revision: 0,
+            result: [{ id: 'initial' }],
+        }));
+        const resource = new DataSubscription(query({ limit: 1 }));
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        const initialSnapshot = resource.getSnapshot();
+        expect(resource.getSnapshot()).toBe(initialSnapshot);
+        resource.receiveUpdate({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'revisions',
+            revision: 2,
+            result: [{ id: 'new', rank: 1 }, { id: 'displaced', rank: 2 }],
+        });
+        const latestSnapshot = resource.getSnapshot();
+        resource.receiveUpdate({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'revisions',
+            revision: 1,
+            result: [{ id: 'stale' }],
+        });
+
+        expect(resource.getSnapshot()).toBe(latestSnapshot);
+        expect(resource.getRecords()).toEqual([
+            { id: 'new', rank: 1 },
+            { id: 'displaced', rank: 2 },
+        ]);
+        expect(Object.isFrozen(resource.getRecords())).toBe(false);
+        resource.getRecords().push({ id: 'locally-mutable-for-api-compatibility' });
+        expect(resource.getRecords()).toHaveLength(3);
+        release();
+        await flushMicrotasks();
+    });
+
+    test('the V2 create acknowledgement enables snapshots without waiting for a replacement', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'v2', revision: 0, result: [] }
+            : {});
+        const resource = new DataSubscription(query());
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        resource.receiveUpdate({ tag: 'DidInsert', subscriptionId: 'v2', record: { id: 'ignored-delta' } });
+        await flushMicrotasks();
+
+        expect(controller.sendMessage.mock.calls[0][0]).toMatchObject({
+            tag: 'CreateDataSubscription',
+            protocolVersion: 1,
+        });
+        expect(controller.sendMessage.mock.calls.filter(([payload]) => payload.tag === 'DataSyncQuery')).toHaveLength(0);
+        release();
+        await flushMicrotasks();
+    });
+
+    test('the first replacement is authoritative even if its revision equals the legacy baseline', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async () => ({
+            tag: 'DidCreateDataSubscription',
+            subscriptionId: 'upgrade-on-replacement',
+            result: [{ id: 'baseline' }],
+        }));
+        const resource = new DataSubscription(query());
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        resource.receiveUpdate({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'upgrade-on-replacement',
+            revision: 0,
+            result: [{ id: 'replacement' }],
+        });
+        expect(resource.getRecords()).toEqual([{ id: 'replacement' }]);
+        release();
+        await flushMicrotasks();
+    });
+
+    test('public subscribers remains a live writable compatibility array', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'public-listeners', revision: 0, result: [] }
+            : {});
+        const resource = new DataSubscription(query());
+        const externallyAdded = jest.fn();
+        resource.subscribers.push(externallyAdded);
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+        externallyAdded.mockClear();
+
+        resource.receiveUpdate({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'public-listeners',
+            revision: 1,
+            result: [{ id: 'next' }],
+        });
+        expect(externallyAdded).toHaveBeenCalledWith([{ id: 'next' }]);
+        release();
+        await flushMicrotasks();
+        expect(resource.getSnapshot().status).toBe('live');
+        resource.subscribers.length = 0;
+        await resource.close();
+    });
+
+    test('imperative ownership transfers to the first ref-counted subscriber', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'imperative-transfer', revision: 0, result: [] }
+            : {});
+        const resource = new DataSubscription(query());
+
+        await resource.createOnServer();
+        await flushMicrotasks();
+        expect(resource.getSnapshot().status).toBe('live');
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateDataSubscription']);
+
+        const release = resource.subscribe(() => {});
+        release();
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
+            'CreateDataSubscription',
+            'DeleteDataSubscription',
+        ]);
+    });
+
+    test('a never-subscribed imperative resource remains owned until explicit close', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'imperative-close', revision: 0, result: [] }
+            : {});
+        const resource = new DataSubscription(query());
+
+        await resource.createOnServer();
+        await flushMicrotasks();
+        expect(controller.sendMessage).toHaveBeenCalledTimes(1);
+        await resource.close();
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
+            'CreateDataSubscription',
+            'DeleteDataSubscription',
+        ]);
+    });
+
+    test('closing before the first response settles createOnServerPromise', async () => {
+        const resource = new DataSubscription(query());
+        const initialCreate = resource.createOnServerPromise;
+
+        await resource.close();
+        await expect(initialCreate).rejects.toThrow('closed before its initial server snapshot arrived');
+    });
+
+    test('a render-held resource is never evicted and duplicated before its commit', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+            ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: `active-${payload.query.table}`, revision: 0, result: [] }
+            : {});
+        const releases = [];
+        for (let index = 0; index < 120; index++) {
+            releases.push(DataSubscriptionStore.get(query({ table: `active_${index}` })).subscribe(() => {}));
+        }
+        await flushMicrotasks();
+
+        const laterCommitted = DataSubscriptionStore.get(query({ table: 'later_committed' }));
+        expect(DataSubscriptionStore.get(query({ table: 'later_committed' }))).toBe(laterCommitted);
+        expect(DataSubscriptionStore.queryMap.has(
+            dataSubscriptionKey(query({ table: 'later_committed' })),
+        )).toBe(false);
+        for (let index = 0; index < 150; index++) {
+            DataSubscriptionStore.get(query({ table: `render_only_${index}` }));
+        }
+        expect(DataSubscriptionStore.get(query({ table: 'later_committed' }))).toBe(laterCommitted);
+
+        const releaseLater = laterCommitted.subscribe(() => {});
+        expect(DataSubscriptionStore.queryMap.has(
+            dataSubscriptionKey(query({ table: 'later_committed' })),
+        )).toBe(true);
+        const releaseShared = DataSubscriptionStore
+            .get(query({ table: 'later_committed' }))
+            .subscribe(() => {});
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.filter(([payload]) =>
+            payload.tag === 'CreateDataSubscription'
+            && payload.query.table === 'later_committed')).toHaveLength(1);
+
+        releaseLater();
+        releaseShared();
+        releases.forEach(release => release());
+        await flushMicrotasks();
+        DataSubscriptionStore.queryMap.clear();
+    });
+
+    test('JWT scope rotation is lazy until commit and closes the old resource and socket', async () => {
+        const originalLocalStorage = globalThis.localStorage;
+        let jwt = 'old-token';
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? jwt : null };
+        const prototypeSend = jest.spyOn(DataSyncController.prototype, 'sendMessage');
+        try {
+            const oldController = DataSyncController.getInstance();
+            oldController.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+                ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'old-scope', revision: 0, result: [{ id: 'old-secret' }] }
+                : {});
+            const oldSocket = { close: jest.fn(), onclose: null, onmessage: null };
+            oldController.connection = oldSocket;
+            const oldResource = DataSubscriptionStore.get(query());
+            const releaseOld = oldResource.subscribe(() => {});
+            await flushMicrotasks();
+            expect(oldResource.getRecords()).toEqual([{ id: 'old-secret' }]);
+
+            jwt = 'new-token';
+            const newResource = DataSubscriptionStore.get(query());
+            expect(newResource).not.toBe(oldResource);
+            expect(DataSyncController.instance).toBe(oldController);
+            expect(oldSocket.close).not.toHaveBeenCalled();
+
+            prototypeSend.mockImplementation(async payload => payload.tag === 'CreateDataSubscription'
+                ? { tag: 'DidCreateDataSubscriptionV2', subscriptionId: 'new-scope', revision: 0, result: [{ id: 'new-row' }] }
+                : {});
+            const releaseNew = newResource.subscribe(() => {});
+            await flushMicrotasks();
+
+            expect(DataSyncController.instance).not.toBe(oldController);
+            expect(oldController.retired).toBe(true);
+            expect(oldSocket.close).toHaveBeenCalledTimes(1);
+            expect(oldResource.getRecords()).toBeNull();
+            expect(oldResource.getSnapshot().status).toBe('closed');
+            expect(newResource.getRecords()).toEqual([{ id: 'new-row' }]);
+
+            oldController.onMessage({ data: JSON.stringify({
+                tag: 'DidReplaceDataSubscription',
+                subscriptionId: 'old-scope',
+                revision: 99,
+                result: [{ id: 'late-old-secret' }],
+            }) });
+            expect(oldResource.getRecords()).toBeNull();
+
+            releaseOld();
+            releaseNew();
+            await flushMicrotasks();
+        } finally {
+            prototypeSend.mockRestore();
+            if (originalLocalStorage === undefined) {
+                delete globalThis.localStorage;
+            } else {
+                globalThis.localStorage = originalLocalStorage;
+            }
+        }
+    });
+
+    test('a cached render-held resource cannot commit or expose cache in a new JWT scope', async () => {
+        const originalLocalStorage = globalThis.localStorage;
+        let jwt = 'render-user-a';
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? jwt : null };
+        try {
+            const resourceQuery = query({ table: 'private_tasks' });
+            const oldKey = dataSubscriptionKey(resourceQuery);
+            DataSubscriptionStore.cache.set(oldKey, [{ id: 'user-a-secret' }]);
+            const oldResource = DataSubscriptionStore.get(resourceQuery);
+            const staleImperative = DataSubscriptionStore.get(query({ table: 'imperative_private_tasks' }));
+            expect(oldResource.getRecords()).toEqual([{ id: 'user-a-secret' }]);
+            expect(DataSyncController.instance).toBeNull();
+
+            jwt = 'render-user-b';
+            const callback = jest.fn();
+            const release = oldResource.subscribe(callback);
+            const releaseAgain = oldResource.subscribe(() => {});
+
+            expect(DataSyncController.instance).toBeNull();
+            expect(oldResource.getRecords()).toBeNull();
+            expect(oldResource.getSnapshot().status).toBe('closed');
+            expect(callback).not.toHaveBeenCalled();
+            expect(DataSubscriptionStore.queryMap.has(oldKey)).toBe(false);
+            await expect(staleImperative.createOnServer()).rejects.toThrow('scope changed');
+            expect(DataSyncController.instance).toBeNull();
+
+            const newResource = DataSubscriptionStore.get(resourceQuery);
+            expect(newResource).not.toBe(oldResource);
+            expect(newResource.getRecords()).toBeNull();
+            release();
+            releaseAgain();
+        } finally {
+            if (originalLocalStorage === undefined) delete globalThis.localStorage;
+            else globalThis.localStorage = originalLocalStorage;
+        }
+    });
+
+    test('the JWT-scoped record cache remains bounded independently of the weak render registry', async () => {
+        const originalLocalStorage = globalThis.localStorage;
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? 'cache-user' : null };
+        try {
+            const controller = DataSyncController.getInstance();
+            controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateDataSubscription'
+                ? {
+                    tag: 'DidCreateDataSubscriptionV2',
+                    subscriptionId: `cache-${payload.query.table}`,
+                    revision: 0,
+                    result: [{ id: payload.query.table }],
+                }
+                : {});
+            const releases = [];
+            for (let index = 0; index < 105; index++) {
+                const resource = DataSubscriptionStore.get(query({ table: `cached_${index}` }));
+                releases.push(resource.subscribe(() => {}));
+            }
+            await flushMicrotasks();
+
+            expect(DataSubscriptionStore.cache.size).toBe(100);
+            for (let index = 0; index < 5; index++) {
+                expect(DataSubscriptionStore.cache.has(
+                    dataSubscriptionKey(query({ table: `cached_${index}` })),
+                )).toBe(false);
+            }
+            releases.forEach(release => release());
+            await flushMicrotasks();
+        } finally {
+            if (originalLocalStorage === undefined) delete globalThis.localStorage;
+            else globalThis.localStorage = originalLocalStorage;
+        }
+    });
+
+    test('reconfiguring the same backend keeps the transport while a changed backend retires it', () => {
+        DataSyncController.ihpBackendHost = 'https://api.example.test';
+        const controller = DataSyncController.getInstance();
+        const socket = { close: jest.fn(), onclose: null, onmessage: null };
+        controller.connection = socket;
+
+        initIHPBackend({ host: 'https://api.example.test' });
+        expect(DataSyncController.instance).toBe(controller);
+        expect(socket.close).not.toHaveBeenCalled();
+
+        initIHPBackend({ host: 'https://other.example.test' });
+        expect(socket.close).toHaveBeenCalledTimes(1);
+        expect(controller.retired).toBe(true);
+        expect(DataSyncController.instance).toBeNull();
+    });
+
+    test('connection errors are observable snapshot transitions', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn().mockRejectedValue(new Error('denied'));
+        const resource = new DataSubscription(query());
+        const before = resource.getSnapshot();
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        expect(resource.getSnapshot()).not.toBe(before);
+        expect(resource.getSnapshot().status).toBe('error');
+        expect(resource.getSnapshot().error).toEqual(expect.objectContaining({ message: expect.stringContaining('denied') }));
+        release();
+        await flushMicrotasks();
+    });
+
+    test('disconnect keeps the last snapshot and reconnect creates exactly once', async () => {
+        const controller = DataSyncController.getInstance();
+        let createNumber = 0;
+        controller.sendMessage = jest.fn(async payload => {
+            if (payload.tag === 'CreateDataSubscription') {
+                createNumber++;
+                return {
+                    subscriptionId: `subscription-${createNumber}`,
+                    revision: 0,
+                    result: [{ id: `snapshot-${createNumber}` }],
+                };
+            }
+            return {};
+        });
+        const resource = new DataSubscription(query());
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+        expect(resource.isClosed).toBe(false);
+        expect(resource.isConnected).toBe(true);
+
+        for (const listener of [...controller.eventListeners.close]) listener(null);
+        expect(resource.getSnapshot()).toEqual({
+            data: [{ id: 'snapshot-1' }],
+            status: 'reconnecting',
+            error: null,
+        });
+        expect(resource.isClosed).toBe(true);
+        expect(resource.isConnected).toBe(false);
+        for (const listener of [...controller.eventListeners.reconnect]) listener();
+        for (const listener of [...controller.eventListeners.reconnect]) listener();
+        await flushMicrotasks();
+
+        expect(createNumber).toBe(2);
+        expect(resource.getRecords()).toEqual([{ id: 'snapshot-2' }]);
+        expect(resource.isClosed).toBe(false);
+        expect(resource.isConnected).toBe(true);
+        resource.onMessage({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'subscription-1',
+            revision: 99,
+            result: [{ id: 'obsolete' }],
+        });
+        expect(resource.getRecords()).toEqual([{ id: 'snapshot-2' }]);
+        release();
+        await flushMicrotasks();
+    });
+
+    test('legacy delta messages coalesce exact server refreshes instead of mutating records', async () => {
+        const controller = DataSyncController.getInstance();
+        let resolveFirstRefresh;
+        let refreshCount = 0;
+        controller.sendMessage = jest.fn(payload => {
+            if (payload.tag === 'CreateDataSubscription') {
+                return Promise.resolve({ subscriptionId: 'legacy', result: [{ id: 'server-a' }] });
+            }
+            if (payload.tag === 'DataSyncQuery') {
+                refreshCount++;
+                if (refreshCount === 1) {
+                    return new Promise(resolve => { resolveFirstRefresh = resolve; });
+                }
+                return Promise.resolve({ result: [{ id: 'server-c' }] });
+            }
+            return Promise.resolve({});
+        });
+        const resource = new DataSubscription(query());
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        resource.receiveUpdate({ tag: 'DidInsert', subscriptionId: 'legacy', record: { id: 'client-b' } });
+        resource.receiveUpdate({ tag: 'DidDelete', subscriptionId: 'legacy', id: 'server-a' });
+        expect(resource.getRecords()).toEqual([{ id: 'server-a' }]);
+        expect(refreshCount).toBe(1);
+
+        resolveFirstRefresh({ result: [{ id: 'server-b' }] });
+        await flushMicrotasks();
+        expect(refreshCount).toBe(2);
+        expect(resource.getRecords()).toEqual([{ id: 'server-c' }]);
+        release();
+        await flushMicrotasks();
+    });
+
+    test('an in-flight legacy refresh cannot overwrite a newer revisioned replacement', async () => {
+        const controller = DataSyncController.getInstance();
+        let resolveRefresh;
+        controller.sendMessage = jest.fn(payload => {
+            if (payload.tag === 'CreateDataSubscription') {
+                return Promise.resolve({
+                    tag: 'DidCreateDataSubscription',
+                    subscriptionId: 'legacy-upgrade-race',
+                    result: [{ id: 'baseline' }],
+                });
+            }
+            if (payload.tag === 'DataSyncQuery') {
+                return new Promise(resolve => { resolveRefresh = resolve; });
+            }
+            return Promise.resolve({});
+        });
+        const resource = new DataSubscription(query());
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        resource.receiveUpdate({
+            tag: 'DidInsert',
+            subscriptionId: 'legacy-upgrade-race',
+            record: { id: 'invalidate' },
+        });
+        resource.receiveUpdate({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'legacy-upgrade-race',
+            revision: 1,
+            result: [{ id: 'authoritative' }],
+        });
+        resolveRefresh({ result: [{ id: 'stale-refetch' }] });
+        await flushMicrotasks();
+
+        expect(resource.getRecords()).toEqual([{ id: 'authoritative' }]);
+        release();
+        await flushMicrotasks();
+    });
+});
+
+describe('server-authoritative CRUD', () => {
+    beforeEach(() => {
+        DataSyncController.instance = null;
+    });
+
+    test('create, update and delete never mutate subscription snapshots locally', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => {
+            switch (payload.tag) {
+                case 'CreateDataSubscription':
+                    return { subscriptionId: 'crud', revision: 0, result: [{ id: 'old', title: 'Old' }] };
+                case 'CreateRecordMessage':
+                    return { record: payload.record };
+                case 'UpdateRecordMessage':
+                    return { record: { id: payload.id, ...payload.patch } };
+                default:
+                    return {};
+            }
+        });
+        const resource = new DataSubscription(query());
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+
+        await createRecord('tasks', { id: 'new', title: 'New' });
+        await updateRecord('tasks', 'old', { title: 'Changed' });
+        await deleteRecord('tasks', 'old');
+        expect(resource.getRecords()).toEqual([{ id: 'old', title: 'Old' }]);
+
+        resource.receiveUpdate({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'crud',
+            revision: 1,
+            result: [{ id: 'new', title: 'New' }],
+        });
+        expect(resource.getRecords()).toEqual([{ id: 'new', title: 'New' }]);
+        release();
+        await flushMicrotasks();
+    });
+
+    test('a child create waits for the parent create it references', async () => {
+        const controller = DataSyncController.getInstance();
+        let resolveParent;
+        const sentIds = [];
+        controller.sendMessage = jest.fn(payload => {
+            sentIds.push(payload.record.id);
+            if (payload.record.id === 'parent') {
+                return new Promise(resolve => { resolveParent = resolve; });
+            }
+            return Promise.resolve({ record: payload.record });
+        });
+
+        const parent = createRecord('parents', { id: 'parent', name: 'Parent' });
+        await flushMicrotasks(2);
+        const child = createRecord('children', { id: 'child', parentId: 'parent' });
+        await flushMicrotasks(2);
+        expect(sentIds).toEqual(['parent']);
+
+        resolveParent({ record: { id: 'parent', name: 'Parent' } });
+        await parent;
+        await child;
+        expect(sentIds).toEqual(['parent', 'child']);
+    });
+
+    test('a dependent delete is not sent after its pending create fails', async () => {
+        const controller = DataSyncController.getInstance();
+        let rejectCreate;
+        controller.sendMessage = jest.fn(payload => payload.tag === 'CreateRecordMessage'
+            ? new Promise((_resolve, reject) => { rejectCreate = reject; })
+            : Promise.resolve({}));
+
+        const createOutcome = createRecord('tasks', { id: 'ghost' }).catch(error => error);
+        await flushMicrotasks(2);
+        const deleteOutcome = deleteRecord('tasks', 'ghost').catch(error => error);
+        await flushMicrotasks(2);
+        rejectCreate(new Error('create failed'));
+        await Promise.all([createOutcome, deleteOutcome]);
+
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateRecordMessage']);
+    });
+});
+
+describe('transaction transport scope', () => {
+    beforeEach(() => {
+        DataSyncController.instance = null;
+        DataSyncController.ihpBackendHost = null;
+    });
+
+    test('CRUD and query operations never move a transaction id to a replacement auth scope', async () => {
+        const originalLocalStorage = globalThis.localStorage;
+        let jwt = 'transaction-user-a';
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? jwt : null };
+        try {
+            const controller = DataSyncController.getInstance();
+            const sentMessages = [];
+            const socket = {
+                onclose: null,
+                onmessage: null,
+                close: jest.fn(),
+                send: jest.fn(serialized => {
+                    const payload = JSON.parse(serialized);
+                    sentMessages.push(payload);
+                    if (payload.tag === 'StartTransaction') {
+                        queueMicrotask(() => controller.onMessage({ data: JSON.stringify({
+                            tag: 'DidStartTransaction',
+                            requestId: payload.requestId,
+                            transactionId: 'transaction-a',
+                        }) }));
+                    }
+                }),
+            };
+            controller.connection = socket;
+            const transaction = new Transaction();
+            await transaction.start();
+            const transactionQuery = transaction.query('tasks');
+            expect(() => transactionQuery.subscribe(() => {})).toThrow(
+                'subscriptions are not supported inside a transaction',
+            );
+
+            jwt = 'transaction-user-b';
+            const update = transaction.updateRecord('tasks', 'task-id', { title: 'forbidden' });
+            const fetch = transactionQuery.fetch();
+
+            await expect(update).rejects.toThrow('transport scope');
+            await expect(fetch).rejects.toThrow('transport scope');
+            expect(sentMessages.map(message => message.tag)).toEqual(['StartTransaction']);
+            expect(sentMessages.some(message => message.transactionId === 'transaction-a')).toBe(false);
+            expect(controller.retired).toBe(true);
+            expect(socket.close).toHaveBeenCalledTimes(1);
+            expect(DataSyncController.instance).toBeNull();
+        } finally {
+            if (originalLocalStorage === undefined) delete globalThis.localStorage;
+            else globalThis.localStorage = originalLocalStorage;
+        }
+    });
+
+    test('withTransaction preserves the callback error after transport close clears the id', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => {
+            if (payload.tag === 'StartTransaction') {
+                return { transactionId: 'transaction-to-close' };
+            }
+            throw new Error(`Unexpected ${payload.tag}`);
+        });
+        const callbackError = new Error('callback failed during auth handoff');
+
+        const outcome = withTransaction(async () => {
+            for (const listener of [...controller.eventListeners.close]) {
+                listener(null);
+            }
+            throw callbackError;
+        });
+
+        await expect(outcome).rejects.toBe(callbackError);
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
+            'StartTransaction',
+        ]);
     });
 });
 
@@ -84,34 +923,106 @@ describe('DataSyncController pending requests', () => {
         jest.useRealTimers();
     });
 
-    test('an unrelated push message does not clear request timeouts', async () => {
+    test('an unrelated push message cannot clear another request timeout', async () => {
         const controller = DataSyncController.getInstance();
         controller.connection = { send: jest.fn(), close: jest.fn() };
-
         const first = controller.sendMessage({ tag: 'FirstRequest' });
         const second = controller.sendMessage({ tag: 'SecondRequest' });
-        controller.onMessage({ data: JSON.stringify({ tag: 'DidInsert', subscriptionId: 'sub', record: { id: '1' } }) });
 
+        controller.onMessage({ data: JSON.stringify({
+            tag: 'DidReplaceDataSubscription',
+            subscriptionId: 'other',
+            revision: 1,
+            result: [],
+        }) });
         expect(controller.pendingRequests).toHaveLength(2);
-        expect(controller.pendingRequests.every(request => request.timeout !== null)).toBe(true);
 
         controller.onMessage({ data: JSON.stringify({ tag: 'DataSyncResult', requestId: 0, result: [] }) });
         await expect(first).resolves.toMatchObject({ requestId: 0 });
-        expect(controller.pendingRequests).toHaveLength(1);
         expect(controller.pendingRequests[0].timeout).not.toBeNull();
 
         controller.onClose(null);
         await expect(second).rejects.toThrow('closed before the server responded');
     });
 
-    test('a timed out request is rejected and removed', async () => {
+    test('sendMessage rejects and retires a controller captured by an old auth scope', async () => {
+        const originalLocalStorage = globalThis.localStorage;
+        let jwt = 'controller-user-a';
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? jwt : null };
+        try {
+            const controller = DataSyncController.getInstance();
+            const socket = {
+                send: jest.fn(),
+                close: jest.fn(),
+                onclose: null,
+                onmessage: null,
+            };
+            controller.connection = socket;
+            jwt = 'controller-user-b';
+
+            await expect(controller.sendMessage({ tag: 'MustNotSend' })).rejects.toThrow('transport scope');
+            expect(socket.send).not.toHaveBeenCalled();
+            expect(socket.close).toHaveBeenCalledTimes(1);
+            expect(controller.retired).toBe(true);
+            expect(DataSyncController.instance).toBeNull();
+        } finally {
+            if (originalLocalStorage === undefined) delete globalThis.localStorage;
+            else globalThis.localStorage = originalLocalStorage;
+        }
+    });
+
+    test('retirement blocks reentrant controller acquisition and deterministically leaves null', () => {
+        const controller = DataSyncController.getInstance();
+        const socket = { send: jest.fn(), close: jest.fn(), onclose: null, onmessage: null };
+        controller.connection = socket;
+        let reentrantError = null;
+        controller.addEventListener('close', () => {
+            try {
+                DataSyncController.getInstance();
+            } catch (error) {
+                reentrantError = error;
+            }
+        });
+        const instanceEvents = [];
+        const removeInstanceListener = DataSyncController.addInstanceListener(instance => {
+            instanceEvents.push(instance);
+        });
+
+        DataSyncController.retireCurrentTransport();
+
+        expect(reentrantError).toEqual(expect.objectContaining({
+            message: expect.stringContaining('while the current transport is being retired'),
+        }));
+        expect(instanceEvents).toEqual([null]);
+        expect(DataSyncController.instance).toBeNull();
+        expect(controller.retired).toBe(true);
+        expect(socket.close).toHaveBeenCalledTimes(1);
+        removeInstanceListener();
+    });
+
+    test('one throwing controller listener cannot stop later listeners', () => {
+        const controller = DataSyncController.getInstance();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const observer = jest.fn();
+        controller.addEventListener('message', () => { throw new Error('message listener failed'); });
+        controller.addEventListener('message', observer);
+
+        expect(() => controller.onMessage({ data: JSON.stringify({ tag: 'Push' }) })).not.toThrow();
+        expect(observer).toHaveBeenCalledWith({ tag: 'Push' });
+        expect(consoleError).toHaveBeenCalledWith(
+            'DataSync message listener failed:',
+            expect.objectContaining({ message: 'message listener failed' }),
+        );
+        consoleError.mockRestore();
+    });
+
+    test('a timed-out request is rejected and removed', async () => {
         const controller = DataSyncController.getInstance();
         controller.messageTimeout = 10;
         controller.connection = { send: jest.fn(), close: jest.fn() };
-
         const request = controller.sendMessage({ tag: 'SlowRequest' });
-        jest.advanceTimersByTime(10);
 
+        jest.advanceTimersByTime(10);
         await expect(request).rejects.toThrow('timed out after 10ms');
         expect(controller.pendingRequests).toHaveLength(0);
         expect(controller.connection.close).toHaveBeenCalledTimes(1);
@@ -125,6 +1036,7 @@ describe('DataSyncController pending requests', () => {
             constructor() {
                 queueMicrotask(() => this.onerror(new Event('error')));
             }
+            close() {}
         }
         class SuccessfulWebSocket {
             send = jest.fn();
@@ -153,21 +1065,12 @@ describe('DataSyncController pending requests', () => {
             await expect(successfulConnection).resolves.toBeInstanceOf(SuccessfulWebSocket);
             expect(controller.connection).toBeInstanceOf(SuccessfulWebSocket);
         } finally {
-            if (originalWebSocket === undefined) {
-                delete globalThis.WebSocket;
-            } else {
-                globalThis.WebSocket = originalWebSocket;
-            }
-            if (originalLocation === undefined) {
-                delete globalThis.location;
-            } else {
-                globalThis.location = originalLocation;
-            }
-            if (originalDocument === undefined) {
-                delete globalThis.document;
-            } else {
-                globalThis.document = originalDocument;
-            }
+            if (originalWebSocket === undefined) delete globalThis.WebSocket;
+            else globalThis.WebSocket = originalWebSocket;
+            if (originalLocation === undefined) delete globalThis.location;
+            else globalThis.location = originalLocation;
+            if (originalDocument === undefined) delete globalThis.document;
+            else globalThis.document = originalDocument;
         }
     });
 
@@ -201,573 +1104,12 @@ describe('DataSyncController pending requests', () => {
             expect(controller.pendingRequests).toHaveLength(0);
             expect(controller.outbox).toHaveLength(0);
         } finally {
-            if (originalWebSocket === undefined) {
-                delete globalThis.WebSocket;
-            } else {
-                globalThis.WebSocket = originalWebSocket;
-            }
-            if (originalLocation === undefined) {
-                delete globalThis.location;
-            } else {
-                globalThis.location = originalLocation;
-            }
-            if (originalDocument === undefined) {
-                delete globalThis.document;
-            } else {
-                globalThis.document = originalDocument;
-            }
+            if (originalWebSocket === undefined) delete globalThis.WebSocket;
+            else globalThis.WebSocket = originalWebSocket;
+            if (originalLocation === undefined) delete globalThis.location;
+            else globalThis.location = originalLocation;
+            if (originalDocument === undefined) delete globalThis.document;
+            else globalThis.document = originalDocument;
         }
-    });
-});
-
-describe('Optimistic CRUD coordination', () => {
-    beforeEach(() => {
-        DataSyncController.instance = null;
-    });
-
-    test('a child waits for the referenced parent create, not for its own response', async () => {
-        const controller = DataSyncController.getInstance();
-        let resolveParent;
-        const sentIds = [];
-        controller.sendMessage = jest.fn(payload => {
-            sentIds.push(payload.record.id);
-            if (payload.record.id === 'parent') {
-                return new Promise(resolve => { resolveParent = resolve; });
-            }
-            return Promise.resolve({ tag: 'DidCreateRecord', record: payload.record });
-        });
-
-        const parent = createRecord('parents', { id: 'parent', name: 'Parent' });
-        await Promise.resolve();
-        const child = createRecord('children', { id: 'child', parentId: 'parent' });
-        await Promise.resolve();
-
-        expect(sentIds).toEqual(['parent']);
-        resolveParent({ tag: 'DidCreateRecord', record: { id: 'parent', name: 'Parent' } });
-        await parent;
-        await child;
-
-        expect(sentIds).toEqual(['parent', 'child']);
-    });
-
-    test('deleting a failed optimistic create does not restore a ghost record', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([]);
-        controller.dataSubscriptions.push(subscription);
-        let rejectCreate;
-        controller.sendMessage = jest.fn(payload => {
-            if (payload.tag === 'CreateRecordMessage') {
-                return new Promise((_resolve, reject) => { rejectCreate = reject; });
-            }
-            return Promise.resolve({ tag: 'DidDeleteRecord' });
-        });
-
-        const createOutcome = createRecord('test', { id: 'ghost', title: 'Ghost' }).catch(error => error);
-        await Promise.resolve();
-        const deleteOutcome = deleteRecord('test', 'ghost').catch(error => error);
-        await Promise.resolve();
-
-        rejectCreate(new Error('create failed'));
-        await Promise.all([createOutcome, deleteOutcome]);
-
-        expect(subscription.records).toEqual([]);
-        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateRecordMessage']);
-    });
-
-    test('transaction rollback leaves subscriptions unchanged', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([]);
-        controller.dataSubscriptions.push(subscription);
-        controller.sendMessage = jest.fn(async payload => {
-            if (payload.tag === 'StartTransaction') {
-                return { tag: 'DidStartTransaction', transactionId: 'tx' };
-            }
-            if (payload.tag === 'CreateRecordMessage') {
-                return { tag: 'DidCreateRecord', record: payload.record };
-            }
-            return { tag: 'DidRollbackTransaction', transactionId: 'tx' };
-        });
-
-        await expect(withTransaction(async transaction => {
-            await transaction.createRecord('test', { id: 'ghost', title: 'Ghost' });
-            throw new Error('abort');
-        })).rejects.toThrow('abort');
-
-        expect(subscription.records).toEqual([]);
-        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
-    });
-
-    test('transactional updates and deletes are not applied optimistically', async () => {
-        const controller = DataSyncController.getInstance();
-        const originalRecord = { id: 'record', title: 'Original' };
-        const subscription = makeSubscription([originalRecord]);
-        controller.dataSubscriptions.push(subscription);
-        controller.sendMessage = jest.fn(async payload => {
-            switch (payload.tag) {
-                case 'StartTransaction': return { tag: 'DidStartTransaction', transactionId: 'tx' };
-                case 'UpdateRecordMessage': return { tag: 'DidUpdateRecord', record: { id: payload.id, ...payload.patch } };
-                case 'DeleteRecordMessage': return { tag: 'DidDeleteRecord' };
-                default: return { tag: 'DidRollbackTransaction', transactionId: 'tx' };
-            }
-        });
-
-        await expect(withTransaction(async transaction => {
-            await transaction.updateRecord('test', 'record', { title: 'Changed' });
-            await transaction.deleteRecord('test', 'record');
-            throw new Error('abort');
-        })).rejects.toThrow('abort');
-
-        expect(subscription.records).toEqual([originalRecord]);
-    });
-
-    test('keeps a limited query exact until a post-create server refresh', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([
-            { id: 'a', title: 'A' },
-            { id: 'c', title: 'C' },
-        ]);
-        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
-        subscription.query.limit = 2;
-        controller.dataSubscriptions.push(subscription);
-        let resolveCreate;
-        controller.sendMessage = jest.fn(payload => {
-            if (payload.tag === 'CreateRecordMessage') {
-                return new Promise(resolve => { resolveCreate = resolve; });
-            }
-            return Promise.resolve({ tag: 'DataSyncResult', result: [
-                { id: 'a', title: 'A' },
-                { id: 'b', title: 'B' },
-            ] });
-        });
-
-        const create = createRecord('test', { id: 'b', title: 'B' });
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
-        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
-        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateRecordMessage']);
-
-        resolveCreate({ tag: 'DidCreateRecord', record: { id: 'b', title: 'B' } });
-        await create;
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
-
-        subscription.onCreate({ id: 'b', title: 'B' });
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
-        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
-            'CreateRecordMessage',
-            'DataSyncQuery',
-        ]);
-    });
-
-    test('queues an exact refresh when a create event races an in-flight refresh', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([
-            { id: 'a', title: 'A' },
-            { id: 'c', title: 'C' },
-        ]);
-        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
-        subscription.query.limit = 2;
-        controller.dataSubscriptions.push(subscription);
-
-        let resolveFirstRefresh;
-        let refreshCount = 0;
-        controller.sendMessage = jest.fn(payload => {
-            if (payload.tag === 'CreateRecordMessage') {
-                return Promise.resolve({ tag: 'DidCreateRecord', record: payload.record });
-            }
-
-            refreshCount++;
-            if (refreshCount === 1) {
-                return new Promise(resolve => { resolveFirstRefresh = resolve; });
-            }
-            return Promise.resolve({
-                tag: 'DataSyncResult',
-                result: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
-            });
-        });
-
-        subscription.onDelete('c');
-        await createRecord('test', { id: 'b', title: 'B' });
-        subscription.onCreate({ id: 'b', title: 'B' });
-
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
-        expect(refreshCount).toBe(1);
-
-        resolveFirstRefresh({
-            tag: 'DataSyncResult',
-            result: [{ id: 'a', title: 'A' }, { id: 'd', title: 'D' }],
-        });
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(refreshCount).toBe(2);
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
-    });
-
-    test('leaves a limited query unchanged when a create fails offline', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([
-            { id: 'a', title: 'A' },
-            { id: 'c', title: 'C' },
-        ]);
-        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
-        subscription.query.limit = 2;
-        controller.dataSubscriptions.push(subscription);
-        controller.sendMessage = jest.fn(async payload => {
-            throw new Error(`${payload.tag} failed`);
-        });
-        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-        try {
-            await expect(createRecord('test', { id: 'b', title: 'B' })).rejects.toThrow('CreateRecordMessage failed');
-            await Promise.resolve();
-
-            expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
-            expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
-                'CreateRecordMessage',
-            ]);
-        } finally {
-            consoleError.mockRestore();
-        }
-    });
-
-    test('does not refresh limited queries before optimistic updates and deletes are sent', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([
-            { id: 'a', title: 'A' },
-            { id: 'b', title: 'B' },
-        ]);
-        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
-        subscription.query.limit = 2;
-        controller.dataSubscriptions.push(subscription);
-        controller.sendMessage = jest.fn(async payload => {
-            if (payload.tag === 'UpdateRecordMessage') {
-                return { tag: 'DidUpdateRecord', record: { id: payload.id, ...payload.patch } };
-            }
-            return { tag: 'DidDeleteRecord' };
-        });
-
-        await updateRecord('test', 'a', { title: 'Z' });
-        expect(subscription.records).toEqual([
-            { id: 'a', title: 'A' },
-            { id: 'b', title: 'B' },
-        ]);
-        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['UpdateRecordMessage']);
-
-        controller.sendMessage.mockClear();
-        await deleteRecord('test', 'b');
-        expect(subscription.records).toEqual([
-            { id: 'a', title: 'A' },
-            { id: 'b', title: 'B' },
-        ]);
-        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['DeleteRecordMessage']);
-    });
-
-    test('reconciles an optimistic create with the canonical server record', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([]);
-        subscription.query.whereCondition = {
-            tag: 'InfixOperatorExpression',
-            left: { tag: 'ColumnExpression', field: 'status' },
-            op: 'OpEqual',
-            right: { tag: 'LiteralExpression', value: 'draft' },
-        };
-        controller.dataSubscriptions.push(subscription);
-        controller.sendMessage = jest.fn(async payload => ({
-            tag: 'DidCreateRecord',
-            record: { ...payload.record, status: 'published' },
-        }));
-
-        const result = await createRecord('test', { id: 'post', status: 'draft' });
-
-        expect(result).toEqual({ id: 'post', status: 'published' });
-        expect(subscription.records).toEqual([]);
-        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
-        expect(controller.optimisticCreatedPendingRecordIds).toEqual([]);
-    });
-
-    test('deduplicates a DidInsert arriving after canonical create reconciliation', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([]);
-        controller.dataSubscriptions.push(subscription);
-        const canonicalRecord = { id: 'post', title: 'Canonical title' };
-        controller.sendMessage = jest.fn(async () => ({
-            tag: 'DidCreateRecord',
-            record: canonicalRecord,
-        }));
-
-        await createRecord('test', { id: 'post', title: 'Optimistic title' });
-        subscription.onCreate(canonicalRecord);
-
-        expect(subscription.records).toEqual([canonicalRecord]);
-        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
-    });
-
-    test('keeps selected-column subscriptions projected during creates and updates', async () => {
-        const controller = DataSyncController.getInstance();
-        const subscription = makeSubscription([]);
-        subscription.query.selectedColumns = { tag: 'SelectSpecific', contents: ['id', 'title'] };
-        controller.dataSubscriptions.push(subscription);
-        let resolveCreate;
-        controller.sendMessage = jest.fn(payload => new Promise(resolve => {
-            resolveCreate = () => resolve({
-                tag: 'DidCreateRecord',
-                record: { ...payload.record, secret: 'canonical secret' },
-            });
-        }));
-
-        const create = createRecord('test', { id: 'projected', title: 'Title', secret: 'optimistic secret' });
-        await Promise.resolve();
-        await Promise.resolve();
-        expect(subscription.records).toEqual([{ id: 'projected', title: 'Title' }]);
-
-        resolveCreate();
-        await create;
-        subscription.onCreate({ id: 'projected', title: 'Title' });
-        subscription.onUpdate('projected', { secret: 'updated secret' }, null);
-
-        expect(subscription.records).toEqual([{ id: 'projected', title: 'Title' }]);
-    });
-});
-
-describe('DataSubscription query semantics', () => {
-    beforeEach(() => {
-        DataSyncController.instance = null;
-    });
-
-    test('keeps records ordered after inserts and updates', () => {
-        const subscription = makeSubscription([
-            { id: 'a', title: 'A' },
-            { id: 'c', title: 'C' },
-        ]);
-        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
-
-        subscription.onCreate({ id: 'b', title: 'B' });
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b', 'c']);
-
-        subscription.onUpdate('c', { title: '0' }, null);
-        expect(subscription.records.map(record => record.id)).toEqual(['c', 'a', 'b']);
-    });
-
-    test('orders optimistic Date values against server ISO timestamps', () => {
-        const subscription = makeSubscription([
-            { id: 'old', createdAt: '2025-01-01T00:00:00.000Z' },
-        ]);
-        subscription.query.orderByClause = [{ orderByColumn: 'createdAt', orderByDirection: 'Desc' }];
-
-        subscription.onCreateOptimistic({ id: 'new', createdAt: new Date('2026-01-01T00:00:00.000Z') });
-
-        expect(subscription.records.map(record => record.id)).toEqual(['new', 'old']);
-    });
-
-    test('keeps the old limited window until the exact server refresh resolves', async () => {
-        const controller = DataSyncController.getInstance();
-        let resolveRefresh;
-        controller.sendMessage = jest.fn(() => new Promise(resolve => { resolveRefresh = resolve; }));
-        const subscription = makeSubscription([
-            { id: 'a', title: 'A' },
-            { id: 'c', title: 'C' },
-        ]);
-        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
-        subscription.query.limit = 2;
-
-        subscription.onCreate({ id: 'b', title: 'B' });
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'c']);
-        expect(controller.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ tag: 'DataSyncQuery' }));
-
-        resolveRefresh({
-            tag: 'DataSyncResult',
-            result: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
-        });
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
-    });
-
-    test('keeps projected DISTINCT results verbatim after refresh', async () => {
-        const controller = DataSyncController.getInstance();
-        let resolveRefresh;
-        controller.sendMessage = jest.fn(() => new Promise(resolve => { resolveRefresh = resolve; }));
-        const subscription = makeSubscription([
-            { id: 'a', title: 'A' },
-            { id: 'b', title: 'B' },
-        ]);
-        subscription.query.selectedColumns = { tag: 'SelectSpecific', contents: ['id', 'title'] };
-        subscription.query.distinctOnColumn = 'category';
-
-        subscription.onCreate({ id: 'c', title: 'C' });
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
-
-        resolveRefresh({
-            tag: 'DataSyncResult',
-            result: [
-                { id: 'a', title: 'A' },
-                { id: 'b', title: 'B' },
-                { id: 'c', title: 'C' },
-            ],
-        });
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b', 'c']);
-    });
-
-    test('subscription errors notify subscribers', async () => {
-        const controller = DataSyncController.getInstance();
-        controller.sendMessage = jest.fn().mockRejectedValue(new Error('denied'));
-        const subscription = makeSubscription([]);
-        const subscriber = jest.fn();
-        subscription.subscribers = [subscriber];
-        const createPromise = subscription.createOnServer();
-        const internalPromise = subscription.createOnServerPromise.catch(() => {});
-
-        await expect(createPromise).rejects.toThrow('denied while trying to subscribe');
-        await internalPromise;
-        expect(subscription.connectError).toBeInstanceOf(Error);
-        expect(subscriber).toHaveBeenCalled();
-    });
-});
-
-describe('DataSubscription disconnect cleanup', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
-        DataSyncController.instance = null;
-    });
-
-    afterEach(() => {
-        jest.clearAllTimers();
-        jest.useRealTimers();
-    });
-
-    test('removes an unused subscription locally after its socket was closed', async () => {
-        const controller = DataSyncController.getInstance();
-        const sub = makeSubscription([]);
-        sub.isClosed = true;
-        controller.dataSubscriptions.push(sub);
-
-        await sub.close();
-
-        expect(controller.dataSubscriptions).not.toContain(sub);
-        expect(sub.isConnected).toBe(false);
-    });
-
-    test('prunes an unused subscription after the React commit grace period', async () => {
-        const controller = DataSyncController.getInstance();
-        const sub = makeSubscription([]);
-        controller.dataSubscriptions.push(sub);
-
-        sub.onDataSyncClosed();
-
-        jest.advanceTimersByTime(999);
-        expect(controller.dataSubscriptions).toContain(sub);
-
-        jest.advanceTimersByTime(1);
-        await Promise.resolve();
-        expect(controller.dataSubscriptions).not.toContain(sub);
-    });
-
-    test('keeps a subscription when React commits before reconnect', () => {
-        const controller = DataSyncController.getInstance();
-        const sub = makeSubscription([]);
-        controller.dataSubscriptions.push(sub);
-
-        sub.onDataSyncClosed();
-        jest.advanceTimersByTime(100);
-        const unsubscribe = sub.subscribe(() => {});
-        jest.advanceTimersByTime(900);
-
-        expect(controller.dataSubscriptions).toContain(sub);
-        expect(sub.subscribers).toHaveLength(1);
-
-        unsubscribe();
-    });
-
-    test('notifies local stores only once when close is repeated', async () => {
-        const controller = DataSyncController.getInstance();
-        const sub = makeSubscription([]);
-        const replacement = makeSubscription([]);
-        const store = new Map([['test', sub]]);
-        let closeNotifications = 0;
-        sub.isClosed = true;
-        sub.onClose = () => {
-            closeNotifications++;
-            store.delete('test');
-        };
-        controller.dataSubscriptions.push(sub);
-
-        await sub.close();
-        store.set('test', replacement);
-        await sub.close();
-
-        expect(closeNotifications).toBe(1);
-        expect(store.get('test')).toBe(replacement);
-    });
-
-    test('deletes a reconnect response that arrives after the subscription was closed', async () => {
-        const controller = DataSyncController.getInstance();
-        const sub = makeSubscription([]);
-        const sentMessages = [];
-        let resolveCreateOnServer;
-        sub.isClosed = true;
-        controller.dataSubscriptions.push(sub);
-        controller.sendMessage = (message) => {
-            sentMessages.push(message);
-            if (message.tag === 'CreateDataSubscription') {
-                return new Promise(resolve => { resolveCreateOnServer = resolve; });
-            }
-            return Promise.resolve({});
-        };
-
-        const reconnect = sub.onDataSyncReconnect();
-        await sub.close();
-        resolveCreateOnServer({ subscriptionId: 'reconnected-id', result: [] });
-        await reconnect;
-
-        expect(sentMessages).toEqual([
-            { tag: 'CreateDataSubscription', query: sub.query },
-            { tag: 'DeleteDataSubscription', subscriptionId: 'reconnected-id' },
-        ]);
-        expect(controller.dataSubscriptions).not.toContain(sub);
-        expect(sub.isClosed).toBe(true);
-        expect(sub.isConnected).toBe(false);
-        expect(sub.subscriptionId).toBe(null);
-    });
-
-    test('does not close a subscription that becomes used while setup is pending', async () => {
-        const controller = DataSyncController.getInstance();
-        const sub = makeSubscription([]);
-        const sentMessages = [];
-        let resolveCreateOnServer;
-        controller.sendMessage = message => {
-            sentMessages.push(message);
-            if (message.tag === 'CreateDataSubscription') {
-                return new Promise(resolve => { resolveCreateOnServer = resolve; });
-            }
-            return Promise.resolve({ tag: 'DidDeleteDataSubscription' });
-        };
-
-        const setup = sub.createOnServer();
-        await Promise.resolve();
-        sub.closeIfNotUsed();
-        const unsubscribe = sub.subscribe(() => {});
-        resolveCreateOnServer({ subscriptionId: 'active-subscription', result: [] });
-        await setup;
-        await Promise.resolve();
-
-        expect(sentMessages).toEqual([
-            { tag: 'CreateDataSubscription', query: sub.query },
-        ]);
-        expect(sub.isClosed).toBe(false);
-        expect(sub.isConnected).toBe(true);
-        expect(controller.dataSubscriptions).toContain(sub);
-
-        unsubscribe();
     });
 });

--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -1,10 +1,12 @@
-import { DataSubscription, DataSyncController } from './ihp-datasync.js';
+import { DataSubscription, DataSyncController, createRecord } from './ihp-datasync.js';
+import { withTransaction } from './transaction.js';
 import { jest } from '@jest/globals';
 
 function makeSubscription(records) {
     const query = {
         table: 'test',
-        conditionExpression: [],
+        selectedColumns: { tag: 'SelectAll' },
+        whereCondition: null,
         orderByClause: [],
         distinctOnColumn: null,
         limit: null,
@@ -13,7 +15,6 @@ function makeSubscription(records) {
     const sub = new DataSubscription(query);
     sub.records = records;
     sub.subscribers = [];
-    sub.updateSubscribers = function () {};
     return sub;
 }
 
@@ -69,6 +70,236 @@ describe('DataSubscription.onUpdate', () => {
         // Subsequent append should work normally (flag cleared)
         sub.onUpdate('1', null, { name: '456' });
         expect(sub.records[0].name).toBe('Anrufbeantworter123456');
+    });
+});
+
+describe('DataSyncController pending requests', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        DataSyncController.instance = null;
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test('an unrelated push message does not clear request timeouts', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.connection = { send: jest.fn(), close: jest.fn() };
+
+        const first = controller.sendMessage({ tag: 'FirstRequest' });
+        const second = controller.sendMessage({ tag: 'SecondRequest' });
+        controller.onMessage({ data: JSON.stringify({ tag: 'DidInsert', subscriptionId: 'sub', record: { id: '1' } }) });
+
+        expect(controller.pendingRequests).toHaveLength(2);
+        expect(controller.pendingRequests.every(request => request.timeout !== null)).toBe(true);
+
+        controller.onMessage({ data: JSON.stringify({ tag: 'DataSyncResult', requestId: 0, result: [] }) });
+        await expect(first).resolves.toMatchObject({ requestId: 0 });
+        expect(controller.pendingRequests).toHaveLength(1);
+        expect(controller.pendingRequests[0].timeout).not.toBeNull();
+
+        controller.onClose(null);
+        await expect(second).rejects.toThrow('closed before the server responded');
+    });
+
+    test('a timed out request is rejected and removed', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.messageTimeout = 10;
+        controller.connection = { send: jest.fn(), close: jest.fn() };
+
+        const request = controller.sendMessage({ tag: 'SlowRequest' });
+        jest.advanceTimersByTime(10);
+
+        await expect(request).rejects.toThrow('timed out after 10ms');
+        expect(controller.pendingRequests).toHaveLength(0);
+        expect(controller.connection.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('clears a failed pending connection so a later call can reconnect', async () => {
+        const originalWebSocket = globalThis.WebSocket;
+        const originalLocation = globalThis.location;
+        const originalDocument = globalThis.document;
+        class FailingWebSocket {
+            constructor() {
+                queueMicrotask(() => this.onerror(new Event('error')));
+            }
+        }
+        class SuccessfulWebSocket {
+            send = jest.fn();
+            close = jest.fn();
+
+            constructor() {
+                queueMicrotask(() => this.onopen(new Event('open')));
+            }
+        }
+
+        try {
+            const controller = DataSyncController.getInstance();
+            controller.connectionRetryLimit = 1;
+            globalThis.location = { protocol: 'http:' };
+            globalThis.document = { location: { hostname: 'localhost', port: '8000' } };
+            globalThis.WebSocket = FailingWebSocket;
+
+            const failedConnection = controller.startConnection();
+            jest.runAllTicks();
+            await expect(failedConnection).rejects.toBeInstanceOf(Event);
+            expect(controller.pendingConnection).toBeNull();
+
+            globalThis.WebSocket = SuccessfulWebSocket;
+            const successfulConnection = controller.startConnection();
+            jest.runAllTicks();
+            await expect(successfulConnection).resolves.toBeInstanceOf(SuccessfulWebSocket);
+            expect(controller.connection).toBeInstanceOf(SuccessfulWebSocket);
+        } finally {
+            if (originalWebSocket === undefined) {
+                delete globalThis.WebSocket;
+            } else {
+                globalThis.WebSocket = originalWebSocket;
+            }
+            if (originalLocation === undefined) {
+                delete globalThis.location;
+            } else {
+                globalThis.location = originalLocation;
+            }
+            if (originalDocument === undefined) {
+                delete globalThis.document;
+            } else {
+                globalThis.document = originalDocument;
+            }
+        }
+    });
+});
+
+describe('Optimistic CRUD coordination', () => {
+    beforeEach(() => {
+        DataSyncController.instance = null;
+    });
+
+    test('a child waits for the referenced parent create, not for its own response', async () => {
+        const controller = DataSyncController.getInstance();
+        let resolveParent;
+        const sentIds = [];
+        controller.sendMessage = jest.fn(payload => {
+            sentIds.push(payload.record.id);
+            if (payload.record.id === 'parent') {
+                return new Promise(resolve => { resolveParent = resolve; });
+            }
+            return Promise.resolve({ tag: 'DidCreateRecord', record: payload.record });
+        });
+
+        const parent = createRecord('parents', { id: 'parent', name: 'Parent' });
+        await Promise.resolve();
+        const child = createRecord('children', { id: 'child', parentId: 'parent' });
+        await Promise.resolve();
+
+        expect(sentIds).toEqual(['parent']);
+        resolveParent({ tag: 'DidCreateRecord', record: { id: 'parent', name: 'Parent' } });
+        await parent;
+        await child;
+
+        expect(sentIds).toEqual(['parent', 'child']);
+    });
+
+    test('transaction rollback leaves subscriptions unchanged', async () => {
+        const controller = DataSyncController.getInstance();
+        const subscription = makeSubscription([]);
+        controller.dataSubscriptions.push(subscription);
+        controller.sendMessage = jest.fn(async payload => {
+            if (payload.tag === 'StartTransaction') {
+                return { tag: 'DidStartTransaction', transactionId: 'tx' };
+            }
+            if (payload.tag === 'CreateRecordMessage') {
+                return { tag: 'DidCreateRecord', record: payload.record };
+            }
+            return { tag: 'DidRollbackTransaction', transactionId: 'tx' };
+        });
+
+        await expect(withTransaction(async transaction => {
+            await transaction.createRecord('test', { id: 'ghost', title: 'Ghost' });
+            throw new Error('abort');
+        })).rejects.toThrow('abort');
+
+        expect(subscription.records).toEqual([]);
+        expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
+    });
+
+    test('transactional updates and deletes are not applied optimistically', async () => {
+        const controller = DataSyncController.getInstance();
+        const originalRecord = { id: 'record', title: 'Original' };
+        const subscription = makeSubscription([originalRecord]);
+        controller.dataSubscriptions.push(subscription);
+        controller.sendMessage = jest.fn(async payload => {
+            switch (payload.tag) {
+                case 'StartTransaction': return { tag: 'DidStartTransaction', transactionId: 'tx' };
+                case 'UpdateRecordMessage': return { tag: 'DidUpdateRecord', record: { id: payload.id, ...payload.patch } };
+                case 'DeleteRecordMessage': return { tag: 'DidDeleteRecord' };
+                default: return { tag: 'DidRollbackTransaction', transactionId: 'tx' };
+            }
+        });
+
+        await expect(withTransaction(async transaction => {
+            await transaction.updateRecord('test', 'record', { title: 'Changed' });
+            await transaction.deleteRecord('test', 'record');
+            throw new Error('abort');
+        })).rejects.toThrow('abort');
+
+        expect(subscription.records).toEqual([originalRecord]);
+    });
+});
+
+describe('DataSubscription query semantics', () => {
+    beforeEach(() => {
+        DataSyncController.instance = null;
+    });
+
+    test('keeps records ordered after inserts and updates', () => {
+        const subscription = makeSubscription([
+            { id: 'a', title: 'A' },
+            { id: 'c', title: 'C' },
+        ]);
+        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
+
+        subscription.onCreate({ id: 'b', title: 'B' });
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b', 'c']);
+
+        subscription.onUpdate('c', { title: '0' }, null);
+        expect(subscription.records.map(record => record.id)).toEqual(['c', 'a', 'b']);
+    });
+
+    test('enforces limit immediately and refreshes the exact server window', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async () => ({
+            tag: 'DataSyncResult',
+            result: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }]
+        }));
+        const subscription = makeSubscription([
+            { id: 'a', title: 'A' },
+            { id: 'c', title: 'C' },
+        ]);
+        subscription.query.orderByClause = [{ orderByColumn: 'title', orderByDirection: 'Asc' }];
+        subscription.query.limit = 2;
+
+        subscription.onCreate({ id: 'b', title: 'B' });
+        expect(subscription.records.map(record => record.id)).toEqual(['a', 'b']);
+        await Promise.resolve();
+        expect(controller.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ tag: 'DataSyncQuery' }));
+    });
+
+    test('subscription errors notify subscribers', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn().mockRejectedValue(new Error('denied'));
+        const subscription = makeSubscription([]);
+        const subscriber = jest.fn();
+        subscription.subscribers = [subscriber];
+        const createPromise = subscription.createOnServer();
+        const internalPromise = subscription.createOnServerPromise.catch(() => {});
+
+        await expect(createPromise).rejects.toThrow('denied while trying to subscribe');
+        await internalPromise;
+        expect(subscription.connectError).toBeInstanceOf(Error);
+        expect(subscriber).toHaveBeenCalled();
     });
 });
 

--- a/ihp-datasync/data/DataSync/ihp-datasync.test.js
+++ b/ihp-datasync/data/DataSync/ihp-datasync.test.js
@@ -250,6 +250,30 @@ describe('Optimistic CRUD coordination', () => {
         expect(sentIds).toEqual(['parent', 'child']);
     });
 
+    test('deleting a failed optimistic create does not restore a ghost record', async () => {
+        const controller = DataSyncController.getInstance();
+        const subscription = makeSubscription([]);
+        controller.dataSubscriptions.push(subscription);
+        let rejectCreate;
+        controller.sendMessage = jest.fn(payload => {
+            if (payload.tag === 'CreateRecordMessage') {
+                return new Promise((_resolve, reject) => { rejectCreate = reject; });
+            }
+            return Promise.resolve({ tag: 'DidDeleteRecord' });
+        });
+
+        const createOutcome = createRecord('test', { id: 'ghost', title: 'Ghost' }).catch(error => error);
+        await Promise.resolve();
+        const deleteOutcome = deleteRecord('test', 'ghost').catch(error => error);
+        await Promise.resolve();
+
+        rejectCreate(new Error('create failed'));
+        await Promise.all([createOutcome, deleteOutcome]);
+
+        expect(subscription.records).toEqual([]);
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateRecordMessage']);
+    });
+
     test('transaction rollback leaves subscriptions unchanged', async () => {
         const controller = DataSyncController.getInstance();
         const subscription = makeSubscription([]);
@@ -484,6 +508,32 @@ describe('Optimistic CRUD coordination', () => {
         expect(subscription.records).toEqual([canonicalRecord]);
         expect(subscription.optimisticCreatedPendingRecordIds).toEqual([]);
     });
+
+    test('keeps selected-column subscriptions projected during creates and updates', async () => {
+        const controller = DataSyncController.getInstance();
+        const subscription = makeSubscription([]);
+        subscription.query.selectedColumns = { tag: 'SelectSpecific', contents: ['id', 'title'] };
+        controller.dataSubscriptions.push(subscription);
+        let resolveCreate;
+        controller.sendMessage = jest.fn(payload => new Promise(resolve => {
+            resolveCreate = () => resolve({
+                tag: 'DidCreateRecord',
+                record: { ...payload.record, secret: 'canonical secret' },
+            });
+        }));
+
+        const create = createRecord('test', { id: 'projected', title: 'Title', secret: 'optimistic secret' });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(subscription.records).toEqual([{ id: 'projected', title: 'Title' }]);
+
+        resolveCreate();
+        await create;
+        subscription.onCreate({ id: 'projected', title: 'Title' });
+        subscription.onUpdate('projected', { secret: 'updated secret' }, null);
+
+        expect(subscription.records).toEqual([{ id: 'projected', title: 'Title' }]);
+    });
 });
 
 describe('DataSubscription query semantics', () => {
@@ -503,6 +553,17 @@ describe('DataSubscription query semantics', () => {
 
         subscription.onUpdate('c', { title: '0' }, null);
         expect(subscription.records.map(record => record.id)).toEqual(['c', 'a', 'b']);
+    });
+
+    test('orders optimistic Date values against server ISO timestamps', () => {
+        const subscription = makeSubscription([
+            { id: 'old', createdAt: '2025-01-01T00:00:00.000Z' },
+        ]);
+        subscription.query.orderByClause = [{ orderByColumn: 'createdAt', orderByDirection: 'Desc' }];
+
+        subscription.onCreateOptimistic({ id: 'new', createdAt: new Date('2026-01-01T00:00:00.000Z') });
+
+        expect(subscription.records.map(record => record.id)).toEqual(['new', 'old']);
     });
 
     test('keeps the old limited window until the exact server refresh resolves', async () => {
@@ -677,5 +738,36 @@ describe('DataSubscription disconnect cleanup', () => {
         expect(sub.isClosed).toBe(true);
         expect(sub.isConnected).toBe(false);
         expect(sub.subscriptionId).toBe(null);
+    });
+
+    test('does not close a subscription that becomes used while setup is pending', async () => {
+        const controller = DataSyncController.getInstance();
+        const sub = makeSubscription([]);
+        const sentMessages = [];
+        let resolveCreateOnServer;
+        controller.sendMessage = message => {
+            sentMessages.push(message);
+            if (message.tag === 'CreateDataSubscription') {
+                return new Promise(resolve => { resolveCreateOnServer = resolve; });
+            }
+            return Promise.resolve({ tag: 'DidDeleteDataSubscription' });
+        };
+
+        const setup = sub.createOnServer();
+        await Promise.resolve();
+        sub.closeIfNotUsed();
+        const unsubscribe = sub.subscribe(() => {});
+        resolveCreateOnServer({ subscriptionId: 'active-subscription', result: [] });
+        await setup;
+        await Promise.resolve();
+
+        expect(sentMessages).toEqual([
+            { tag: 'CreateDataSubscription', query: sub.query },
+        ]);
+        expect(sub.isClosed).toBe(false);
+        expect(sub.isConnected).toBe(true);
+        expect(controller.dataSubscriptions).toContain(sub);
+
+        unsubscribe();
     });
 });

--- a/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
+++ b/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
@@ -15,6 +15,7 @@ import {
     whereLessThanOrEqual,
     whereGreaterThan,
     whereGreaterThanOrEqual,
+    recordMatchesQuery,
 } from './ihp-querybuilder';
 
 const tags = {
@@ -64,6 +65,15 @@ const expression = {
 	}
     }
 }
+
+describe('recordMatchesQuery', () => {
+    it('skips unsupported full-text optimism instead of throwing', () => {
+        const fullTextQuery = query('posts').whereTextSearchStartsWith('body', 'hello').query;
+
+        expect(() => recordMatchesQuery(fullTextQuery, { id: '1', body: 'hello world' })).not.toThrow();
+        expect(recordMatchesQuery(fullTextQuery, { id: '1', body: 'hello world' })).toBe(false);
+    });
+});
 
 describe('Value Transformations and basic use', () => {
     const suite = ([fnName, extractor, operator, where]) => {

--- a/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
+++ b/ihp-datasync/data/DataSync/ihp-querybuilder.test.js
@@ -73,6 +73,25 @@ describe('recordMatchesQuery', () => {
         expect(() => recordMatchesQuery(fullTextQuery, { id: '1', body: 'hello world' })).not.toThrow();
         expect(recordMatchesQuery(fullTextQuery, { id: '1', body: 'hello world' })).toBe(false);
     });
+
+    it('uses PostgreSQL NULL semantics for comparisons', () => {
+        const notDraft = query('posts').whereNot('status', 'draft').query;
+        const olderThanOne = query('posts').whereLessThan('position', 1).query;
+
+        expect(recordMatchesQuery(notDraft, { id: '1', status: null })).toBe(false);
+        expect(recordMatchesQuery(notDraft, { id: '2', status: 'published' })).toBe(true);
+        expect(recordMatchesQuery(olderThanOne, { id: '3', position: null })).toBe(false);
+    });
+
+    it('matches the compiler rewrites for NULL equality and IN lists', () => {
+        const nullStatus = query('posts').where('status', null).query;
+        const selectedStatuses = query('posts').whereIn('status', ['draft', null]).query;
+
+        expect(recordMatchesQuery(nullStatus, { id: '1', status: null })).toBe(true);
+        expect(recordMatchesQuery(nullStatus, { id: '2', status: 'draft' })).toBe(false);
+        expect(recordMatchesQuery(selectedStatuses, { id: '3', status: null })).toBe(true);
+        expect(recordMatchesQuery(selectedStatuses, { id: '4', status: 'published' })).toBe(false);
+    });
 });
 
 describe('Value Transformations and basic use', () => {

--- a/ihp-datasync/data/DataSync/package.json
+++ b/ihp-datasync/data/DataSync/package.json
@@ -24,6 +24,9 @@
   "devDependencies": {
     "@types/react": "*",
     "jest": "^30.2.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-test-renderer": "18.3.1",
     "typescript": "^5.0.0"
   }
 }

--- a/ihp-datasync/data/DataSync/public-api-runtime-compat.test.js
+++ b/ihp-datasync/data/DataSync/public-api-runtime-compat.test.js
@@ -1,0 +1,193 @@
+import * as root from './index.js';
+import * as dataSyncEntrypoint from './ihp-datasync.js';
+import * as queryBuilderEntrypoint from './ihp-querybuilder.js';
+import * as transactionEntrypoint from './transaction.js';
+import * as reactEntrypoint from './react.js';
+import * as legacyReactEntrypoint from './ihp-datasync-react.js';
+import * as dataSubscriptionStoreEntrypoint from './data-subscription-store.js';
+import * as countSubscriptionEntrypoint from './count-subscription.js';
+
+function query(overrides = {}) {
+    return {
+        table: 'tasks',
+        selectedColumns: { tag: 'SelectAll' },
+        whereCondition: null,
+        orderByClause: [],
+        distinctOnColumn: null,
+        limit: null,
+        offset: null,
+        ...overrides,
+    };
+}
+
+let originalControllerInstance;
+let originalBackendHost;
+let originalDataSubscriptionQueryMap;
+let originalDataSubscriptionCache;
+let originalCountSubscriptionQueryMap;
+
+beforeEach(() => {
+    originalControllerInstance = root.DataSyncController.instance;
+    originalBackendHost = root.DataSyncController.ihpBackendHost;
+    originalDataSubscriptionQueryMap = dataSubscriptionStoreEntrypoint.DataSubscriptionStore.queryMap;
+    originalDataSubscriptionCache = dataSubscriptionStoreEntrypoint.DataSubscriptionStore.cache;
+    originalCountSubscriptionQueryMap = countSubscriptionEntrypoint.CountSubscriptionStore.queryMap;
+
+    root.DataSyncController.instance = null;
+    root.DataSyncController.ihpBackendHost = null;
+});
+
+afterEach(() => {
+    root.DataSyncController.instance = originalControllerInstance;
+    root.DataSyncController.ihpBackendHost = originalBackendHost;
+    dataSubscriptionStoreEntrypoint.DataSubscriptionStore.queryMap = originalDataSubscriptionQueryMap;
+    dataSubscriptionStoreEntrypoint.DataSubscriptionStore.cache = originalDataSubscriptionCache;
+    countSubscriptionEntrypoint.CountSubscriptionStore.queryMap = originalCountSubscriptionQueryMap;
+});
+
+describe('DataSync public runtime compatibility', () => {
+    test('root and documented deep entrypoints expose the same runtime values', () => {
+        expect(root.DataSyncController).toBe(dataSyncEntrypoint.DataSyncController);
+        expect(root.DataSubscription).toBe(dataSyncEntrypoint.DataSubscription);
+        expect(root.QueryBuilder).toBe(queryBuilderEntrypoint.QueryBuilder);
+        expect(root.ConditionBuilder).toBe(queryBuilderEntrypoint.ConditionBuilder);
+        expect(root.Transaction).toBe(transactionEntrypoint.Transaction);
+        expect(root.withTransaction).toBe(transactionEntrypoint.withTransaction);
+
+        expect(reactEntrypoint.DataSubscriptionStore)
+            .toBe(dataSubscriptionStoreEntrypoint.DataSubscriptionStore);
+        expect(reactEntrypoint.CountSubscription)
+            .toBe(countSubscriptionEntrypoint.CountSubscription);
+        expect(reactEntrypoint.CountSubscriptionStore)
+            .toBe(countSubscriptionEntrypoint.CountSubscriptionStore);
+        expect(legacyReactEntrypoint.AuthCompletedContext)
+            .toBe(reactEntrypoint.AuthCompletedContext);
+        expect(legacyReactEntrypoint.AuthCompletedProvider)
+            .toBe(reactEntrypoint.AuthCompletedProvider);
+        expect(legacyReactEntrypoint.useQuery).toBe(reactEntrypoint.useQuery);
+    });
+
+    test('public constructors retain instanceof and prototype method behaviour', () => {
+        const controller = new root.DataSyncController();
+        const subscription = new root.DataSubscription(query());
+        const countSubscription = new reactEntrypoint.CountSubscription(query());
+        const queryBuilder = new root.QueryBuilder('tasks');
+        const conditionBuilder = new root.ConditionBuilder();
+        const transaction = new root.Transaction();
+
+        expect(controller).toBeInstanceOf(root.DataSyncController);
+        expect(subscription).toBeInstanceOf(root.DataSubscription);
+        expect(countSubscription).toBeInstanceOf(reactEntrypoint.CountSubscription);
+        expect(queryBuilder).toBeInstanceOf(root.QueryBuilder);
+        expect(conditionBuilder).toBeInstanceOf(root.ConditionBuilder);
+        expect(transaction).toBeInstanceOf(root.Transaction);
+
+        expect(typeof root.DataSyncController.prototype.sendMessage).toBe('function');
+        expect(typeof root.DataSyncController.prototype.addEventListener).toBe('function');
+        expect(typeof root.DataSubscription.prototype.subscribe).toBe('function');
+        expect(typeof root.DataSubscription.prototype.createOnServer).toBe('function');
+        expect(typeof reactEntrypoint.CountSubscription.prototype.subscribe).toBe('function');
+        expect(typeof root.QueryBuilder.prototype.fetch).toBe('function');
+        expect(typeof root.QueryBuilder.prototype.subscribe).toBe('function');
+        expect(typeof root.ConditionBuilder.prototype.where).toBe('function');
+        expect(typeof root.Transaction.prototype.start).toBe('function');
+        expect(typeof root.Transaction.prototype.commit).toBe('function');
+
+        expect(Object.getOwnPropertyDescriptor(root.DataSubscription.prototype, 'records')?.get)
+            .toEqual(expect.any(Function));
+        expect(Object.getOwnPropertyDescriptor(root.DataSubscription.prototype, 'records')?.set)
+            .toEqual(expect.any(Function));
+        expect(Object.getOwnPropertyDescriptor(reactEntrypoint.CountSubscription.prototype, 'count')?.get)
+            .toEqual(expect.any(Function));
+        expect(Object.getOwnPropertyDescriptor(reactEntrypoint.CountSubscription.prototype, 'count')?.set)
+            .toEqual(expect.any(Function));
+    });
+
+    test('historically writable static and public fields remain writable', () => {
+        const controller = new root.DataSyncController();
+        const subscription = new root.DataSubscription(query());
+        const countSubscription = new reactEntrypoint.CountSubscription(query());
+        const queryBuilder = new root.QueryBuilder('tasks');
+        const transaction = new root.Transaction();
+
+        root.DataSyncController.instance = controller;
+        root.DataSyncController.ihpBackendHost = 'https://api.example.test';
+        expect(root.DataSyncController.instance).toBe(controller);
+        expect(root.DataSyncController.ihpBackendHost).toBe('https://api.example.test');
+
+        const socket = { send() {}, close() {} };
+        controller.connection = socket;
+        controller.dataSubscriptions = [subscription];
+        expect(controller.connection).toBe(socket);
+        expect(controller.dataSubscriptions).toEqual([subscription]);
+
+        const replacementQuery = query({ table: 'other_tasks' });
+        const subscriber = () => {};
+        const cache = new Map();
+        subscription.query = replacementQuery;
+        subscription.records = [{ id: 'task-1' }];
+        subscription.subscribers = [subscriber];
+        subscription.cache = cache;
+        subscription.subscriptionId = 'subscription-id';
+        expect(subscription.query).toBe(replacementQuery);
+        expect(subscription.records).toEqual([{ id: 'task-1' }]);
+        expect(subscription.subscribers).toEqual([subscriber]);
+        expect(subscription.cache).toBe(cache);
+        expect(subscription.subscriptionId).toBe('subscription-id');
+
+        const countSubscribers = new Set([subscriber]);
+        countSubscription.query = replacementQuery;
+        countSubscription.count = 3;
+        countSubscription.subscriptionId = 'count-subscription-id';
+        countSubscription.subscribers = countSubscribers;
+        expect(countSubscription.query).toBe(replacementQuery);
+        expect(countSubscription.count).toBe(3);
+        expect(countSubscription.subscriptionId).toBe('count-subscription-id');
+        expect(countSubscription.subscribers).toBe(countSubscribers);
+
+        queryBuilder.query = replacementQuery;
+        queryBuilder.transactionId = 'query-transaction-id';
+        transaction.transactionId = 'transaction-id';
+        transaction.dataSyncController = controller;
+        expect(queryBuilder.query).toBe(replacementQuery);
+        expect(queryBuilder.transactionId).toBe('query-transaction-id');
+        expect(transaction.transactionId).toBe('transaction-id');
+        expect(transaction.dataSyncController).toBe(controller);
+    });
+
+    test('public stores retain their Map-shaped inspection and replacement surfaces', () => {
+        const dataStore = dataSubscriptionStoreEntrypoint.DataSubscriptionStore;
+        const countStore = countSubscriptionEntrypoint.CountSubscriptionStore;
+        const replacementQueryMap = new Map();
+        const replacementCache = new Map();
+        const replacementCountQueryMap = new Map();
+
+        dataStore.queryMap = replacementQueryMap;
+        dataStore.cache = replacementCache;
+        expect(dataStore.queryMap).toBe(replacementQueryMap);
+        expect(dataStore.cache).toBe(replacementCache);
+        expect(dataStore.queryMap).toBeInstanceOf(Map);
+        expect(dataStore.cache).toBeInstanceOf(Map);
+
+        countStore.queryMap = replacementCountQueryMap;
+        expect(countStore.queryMap).toBe(replacementCountQueryMap);
+        expect(countStore.queryMap).toBeInstanceOf(Map);
+
+        const key = '__public_runtime_compatibility__';
+        const hadPreviousValue = countStore.queryMap.has(key);
+        const previousValue = countStore.queryMap.get(key);
+        const countSubscription = new reactEntrypoint.CountSubscription(query());
+        try {
+            countStore.queryMap.set(key, countSubscription);
+            expect(countStore.queryMap.get(key)).toBe(countSubscription);
+            expect(countStore.queryMap.delete(key)).toBe(true);
+            expect(countStore.queryMap.has(key)).toBe(false);
+        } finally {
+            if (hadPreviousValue) {
+                countStore.queryMap.set(key, previousValue);
+            } else {
+                countStore.queryMap.delete(key);
+            }
+        }
+    });
+});

--- a/ihp-datasync/data/DataSync/react.integration.test.js
+++ b/ihp-datasync/data/DataSync/react.integration.test.js
@@ -1,0 +1,462 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { renderToString } from 'react-dom/server';
+import { jest } from '@jest/globals';
+
+import { CountSubscriptionStore } from './count-subscription.js';
+import { DataSubscriptionStore, dataSubscriptionKey } from './data-subscription-store.js';
+import { DataSyncController } from './ihp-datasync.js';
+import { query } from './ihp-querybuilder.js';
+import {
+    AuthCompletedContext,
+    AuthCompletedProvider,
+    useCount,
+    useIsConnected,
+    useQuery,
+} from './react.js';
+
+async function flushMicrotasks(rounds = 12) {
+    for (let index = 0; index < rounds; index++) {
+        await Promise.resolve();
+    }
+}
+
+function installServerDouble({ queryResult = [{ id: 'task-1' }], count = 1 } = {}) {
+    const controller = DataSyncController.getInstance();
+    controller.sendMessage = jest.fn(async payload => {
+        switch (payload.tag) {
+            case 'CreateDataSubscription':
+                return {
+                    tag: 'DidCreateDataSubscription',
+                    subscriptionId: 'query-subscription',
+                    revision: 0,
+                    result: queryResult,
+                };
+            case 'CreateCountSubscription':
+                return {
+                    tag: 'DidCreateCountSubscription',
+                    subscriptionId: 'count-subscription',
+                    count,
+                };
+            case 'DeleteDataSubscription':
+                return { tag: 'DidDeleteDataSubscription' };
+            default:
+                throw new Error(`Unexpected test request: ${String(payload.tag)}`);
+        }
+    });
+    return controller;
+}
+
+function requestTags(controller) {
+    return controller.sendMessage.mock.calls.map(([payload]) => payload.tag);
+}
+
+describe('React 18 DataSync adapter integration', () => {
+    beforeEach(() => {
+        DataSyncController.instance = null;
+        DataSubscriptionStore.queryMap.clear();
+        DataSubscriptionStore.cache.clear();
+        CountSubscriptionStore.queryMap.clear();
+        jest.restoreAllMocks();
+    });
+
+    test('StrictMode shares useQuery/useCount resources and cleans each up once', async () => {
+        const controller = installServerDouble({ count: 7 });
+
+        function QueryProbe() {
+            const records = useQuery(query('tasks'));
+            return React.createElement('span', null, records === null ? 'loading' : records.length);
+        }
+
+        function CountProbe() {
+            const count = useCount(query('tasks'));
+            return React.createElement('span', null, count === null ? 'loading' : count);
+        }
+
+        const strictTree = React.createElement(
+            React.StrictMode,
+            null,
+            React.createElement(QueryProbe),
+            React.createElement(QueryProbe),
+            React.createElement(CountProbe),
+            React.createElement(CountProbe),
+        );
+        let renderer;
+        await act(async () => {
+            renderer = TestRenderer.create(strictTree);
+            await flushMicrotasks();
+        });
+
+        expect(requestTags(controller)).toEqual([
+            'CreateDataSubscription',
+            'CreateCountSubscription',
+        ]);
+        expect(DataSubscriptionStore.queryMap.size).toBe(1);
+        expect(CountSubscriptionStore.queryMap.size).toBe(1);
+
+        // react-test-renderer does not replay effects itself. Reproduce React
+        // 18's development-only release/retain cycle in one commit window.
+        await act(async () => {
+            renderer.unmount();
+            renderer = TestRenderer.create(strictTree);
+            await flushMicrotasks();
+        });
+        expect(requestTags(controller)).toEqual([
+            'CreateDataSubscription',
+            'CreateCountSubscription',
+        ]);
+
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+
+        expect(requestTags(controller)).toEqual([
+            'CreateDataSubscription',
+            'CreateCountSubscription',
+            'DeleteDataSubscription',
+            'DeleteDataSubscription',
+        ]);
+        expect(DataSubscriptionStore.queryMap.size).toBe(0);
+        expect(CountSubscriptionStore.queryMap.size).toBe(0);
+    });
+
+    test('auth false -> true -> false gates both query and count transport work', async () => {
+        const requests = [];
+        const sendMessage = jest.spyOn(DataSyncController.prototype, 'sendMessage').mockImplementation(async payload => {
+            requests.push(payload);
+            if (payload.tag === 'CreateDataSubscription') {
+                return {
+                    tag: 'DidCreateDataSubscriptionV2',
+                    subscriptionId: 'query-auth-scope',
+                    revision: 0,
+                    result: [{ id: 'task-1' }],
+                };
+            }
+            if (payload.tag === 'CreateCountSubscription') {
+                return { tag: 'DidCreateCountSubscription', subscriptionId: 'count-auth-scope', count: 3 };
+            }
+            return { tag: 'DidDeleteDataSubscription' };
+        });
+        const preAuthController = DataSyncController.getInstance();
+        const preAuthSocket = { close: jest.fn(), onclose: null, onmessage: null };
+        preAuthController.connection = preAuthSocket;
+
+        function Probe() {
+            const records = useQuery(query('tasks'));
+            const count = useCount(query('tasks'));
+            return React.createElement('span', null, `${records?.length ?? 'null'}:${count ?? 'null'}`);
+        }
+
+        const tree = authCompleted => React.createElement(
+            AuthCompletedContext.Provider,
+            { value: authCompleted },
+            React.createElement(Probe),
+        );
+
+        let renderer;
+        await act(async () => {
+            renderer = TestRenderer.create(tree(false));
+            await flushMicrotasks();
+        });
+        expect(requests).toEqual([]);
+        expect(preAuthSocket.close).toHaveBeenCalledTimes(1);
+        expect(preAuthController.retired).toBe(true);
+        expect(DataSyncController.instance).toBeNull();
+        expect(DataSubscriptionStore.queryMap.size).toBe(0);
+        expect(CountSubscriptionStore.queryMap.size).toBe(0);
+        expect(renderer.toJSON().children).toEqual(['null:null']);
+
+        await act(async () => {
+            renderer.update(tree(true));
+            await flushMicrotasks();
+        });
+        expect(requests.map(payload => payload.tag)).toEqual([
+            'CreateDataSubscription',
+            'CreateCountSubscription',
+        ]);
+        const authenticatedController = DataSyncController.instance;
+        expect(authenticatedController).not.toBe(preAuthController);
+        expect(renderer.toJSON().children).toEqual(['1:3']);
+
+        const authenticatedSocket = { close: jest.fn(), onclose: null, onmessage: null };
+        authenticatedController.connection = authenticatedSocket;
+
+        await act(async () => {
+            renderer.update(tree(false));
+            await flushMicrotasks();
+        });
+        expect(requests.map(payload => payload.tag)).toEqual([
+            'CreateDataSubscription',
+            'CreateCountSubscription',
+        ]);
+        expect(authenticatedSocket.close).toHaveBeenCalledTimes(1);
+        expect(authenticatedController.retired).toBe(true);
+        expect(DataSyncController.instance).toBeNull();
+        expect(renderer.toJSON().children).toEqual(['null:null']);
+
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+        sendMessage.mockRestore();
+    });
+
+    test('a cookie session handoff with no mounted query hooks creates a fresh transport for user B', async () => {
+        const controllerA = installServerDouble({ queryResult: [{ id: 'user-a-task' }] });
+        const socketA = { close: jest.fn(), onclose: null, onmessage: null };
+        controllerA.connection = socketA;
+
+        function Probe() {
+            const records = useQuery(query('tasks'));
+            return React.createElement('span', null, records?.[0]?.id ?? 'loading');
+        }
+
+        const authenticatedTree = React.createElement(
+            AuthCompletedProvider,
+            { value: true },
+            React.createElement(Probe),
+        );
+        let renderer;
+        await act(async () => {
+            renderer = TestRenderer.create(authenticatedTree);
+            await flushMicrotasks();
+        });
+        expect(renderer.toJSON().children).toEqual(['user-a-task']);
+        const resourceA = DataSubscriptionStore.get(query('tasks').query);
+
+        // User A's entire application tree goes away before the session cookie
+        // changes, so there are deliberately no query hooks left to perform the
+        // reset on behalf of the auth layer.
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+
+        await act(async () => {
+            renderer = TestRenderer.create(
+                React.createElement(AuthCompletedProvider, { value: false }),
+            );
+            await flushMicrotasks();
+        });
+        expect(socketA.close).toHaveBeenCalledTimes(1);
+        expect(controllerA.retired).toBe(true);
+        expect(DataSyncController.instance).toBeNull();
+
+        const resourceB = DataSubscriptionStore.get(query('tasks').query);
+        expect(resourceB).not.toBe(resourceA);
+        expect(DataSyncController.instance).toBeNull();
+
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+
+        const controllerB = installServerDouble({ queryResult: [{ id: 'user-b-task' }] });
+        expect(controllerB).not.toBe(controllerA);
+        await act(async () => {
+            renderer = TestRenderer.create(authenticatedTree);
+            await flushMicrotasks();
+        });
+
+        expect(renderer.toJSON().children).toEqual(['user-b-task']);
+        expect(requestTags(controllerB)).toEqual(['CreateDataSubscription']);
+
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+    });
+
+    test('a JWT change in the render-to-commit gap discards the old cache and resolves the current resource', async () => {
+        const originalLocalStorage = globalThis.localStorage;
+        let jwt = 'render-a';
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? jwt : null };
+        const queryBuilder = query('private_tasks');
+        DataSubscriptionStore.cache.set(dataSubscriptionKey(queryBuilder.query), [{ id: 'user-a-secret' }]);
+        const requests = [];
+        const sendMessage = jest.spyOn(DataSyncController.prototype, 'sendMessage').mockImplementation(async payload => {
+            requests.push(payload);
+            if (payload.tag === 'CreateDataSubscription') {
+                return {
+                    tag: 'DidCreateDataSubscriptionV2',
+                    subscriptionId: 'render-b-subscription',
+                    revision: 0,
+                    result: [{ id: 'user-b-row' }],
+                };
+            }
+            return { tag: 'DidDeleteDataSubscription' };
+        });
+        let switchScopeAfterFirstRender = true;
+
+        function Probe() {
+            const records = useQuery(query('private_tasks'));
+            if (switchScopeAfterFirstRender) {
+                switchScopeAfterFirstRender = false;
+                jwt = 'render-b';
+            }
+            return React.createElement('span', null, records?.[0]?.id ?? 'loading');
+        }
+
+        let renderer;
+        try {
+            await act(async () => {
+                renderer = TestRenderer.create(React.createElement(Probe));
+                await flushMicrotasks();
+            });
+
+            expect(renderer.toJSON().children).toEqual(['user-b-row']);
+            expect(requests.filter(payload => payload.tag === 'CreateDataSubscription')).toHaveLength(1);
+            expect(DataSubscriptionStore.queryMap.size).toBe(1);
+            await act(async () => {
+                renderer.unmount();
+                await flushMicrotasks();
+            });
+        } finally {
+            sendMessage.mockRestore();
+            if (originalLocalStorage === undefined) delete globalThis.localStorage;
+            else globalThis.localStorage = originalLocalStorage;
+        }
+    });
+
+    test('SSR returns null/false snapshots without starting a socket', () => {
+        const previousWebSocket = globalThis.WebSocket;
+        const webSocketConstructor = jest.fn(() => {
+            throw new Error('SSR must not construct a WebSocket');
+        });
+        globalThis.WebSocket = webSocketConstructor;
+
+        function Probe() {
+            const records = useQuery(query('tasks'));
+            const count = useCount(query('tasks'));
+            const isConnected = useIsConnected();
+            return React.createElement(
+                'span',
+                null,
+                `${records === null}:${count === null}:${isConnected}`,
+            );
+        }
+
+        try {
+            expect(renderToString(React.createElement(Probe))).toContain('true:true:false');
+            expect(DataSyncController.instance).toBeNull();
+            expect(DataSubscriptionStore.queryMap.size).toBe(0);
+            expect(CountSubscriptionStore.queryMap.size).toBe(0);
+            expect(webSocketConstructor).not.toHaveBeenCalled();
+        } finally {
+            globalThis.WebSocket = previousWebSocket;
+        }
+    });
+
+    test('a create failure reaches the nearest React ErrorBoundary', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn().mockRejectedValue(new Error('row policy denied'));
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        class ErrorBoundary extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = { error: null };
+            }
+
+            static getDerivedStateFromError(error) {
+                return { error };
+            }
+
+            render() {
+                return this.state.error === null
+                    ? this.props.children
+                    : React.createElement('span', null, this.state.error.message);
+            }
+        }
+
+        function Probe() {
+            useQuery(query('private_tasks'));
+            return React.createElement('span', null, 'no error');
+        }
+
+        let renderer;
+        await act(async () => {
+            renderer = TestRenderer.create(
+                React.createElement(ErrorBoundary, null, React.createElement(Probe)),
+            );
+            await flushMicrotasks();
+        });
+
+        expect(renderer.toJSON().children[0]).toContain('row policy denied');
+        expect(requestTags(controller)).toEqual(['CreateDataSubscription']);
+        expect(consoleError).toHaveBeenCalled();
+
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+    });
+
+    test('rerendering an equivalent query key does not resubscribe', async () => {
+        const controller = installServerDouble();
+
+        function Probe({ rerender }) {
+            const records = useQuery(query('tasks'));
+            return React.createElement('span', null, `${rerender}:${records?.length ?? 'null'}`);
+        }
+
+        let renderer;
+        await act(async () => {
+            renderer = TestRenderer.create(React.createElement(Probe, { rerender: 0 }));
+            await flushMicrotasks();
+        });
+
+        await act(async () => {
+            renderer.update(React.createElement(Probe, { rerender: 1 }));
+            await flushMicrotasks();
+        });
+
+        expect(requestTags(controller)).toEqual(['CreateDataSubscription']);
+        expect(DataSubscriptionStore.queryMap.size).toBe(1);
+        expect(DataSubscriptionStore.queryMap.values().next().value.getSnapshot().status).toBe('live');
+
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+    });
+
+    test('useIsConnected observes a connection opened in the render-to-subscribe gap', async () => {
+        const controller = DataSyncController.getInstance();
+        const originalAddEventListener = controller.addEventListener.bind(controller);
+        const observedSnapshots = [];
+        let openWasDropped = false;
+
+        controller.addEventListener = jest.fn((event, callback) => {
+            if (event === 'open' && controller.connection === null) {
+                controller.connection = {};
+                openWasDropped = controller.eventListeners.open.length === 0;
+            }
+            originalAddEventListener(event, callback);
+        });
+
+        function Probe() {
+            const isConnected = useIsConnected();
+            observedSnapshots.push(isConnected);
+            return React.createElement('span', null, String(isConnected));
+        }
+
+        let renderer;
+        await act(async () => {
+            renderer = TestRenderer.create(React.createElement(Probe));
+            await flushMicrotasks();
+        });
+
+        expect(openWasDropped).toBe(true);
+        expect(observedSnapshots[0]).toBe(false);
+        expect(observedSnapshots.at(-1)).toBe(true);
+        expect(renderer.toJSON().children).toEqual(['true']);
+
+        await act(async () => {
+            renderer.unmount();
+            await flushMicrotasks();
+        });
+        controller.connection = null;
+    });
+});

--- a/ihp-datasync/data/DataSync/react.test.js
+++ b/ihp-datasync/data/DataSync/react.test.js
@@ -1,0 +1,84 @@
+import { CountSubscription } from './count-subscription.js';
+import { DataSyncController } from './ihp-datasync.js';
+import { jest } from '@jest/globals';
+
+const countQuery = {
+    table: 'tasks',
+    selectedColumns: { tag: 'SelectAll' },
+    whereCondition: null,
+    orderByClause: [],
+    distinctOnColumn: null,
+    limit: null,
+    offset: null,
+};
+
+describe('CountSubscription', () => {
+    beforeEach(() => {
+        DataSyncController.instance = null;
+    });
+
+    test('recreates its server subscription after a reconnect', async () => {
+        const controller = DataSyncController.getInstance();
+        let createCount = 0;
+        controller.sendMessage = jest.fn(async payload => {
+            if (payload.tag === 'CreateCountSubscription') {
+                createCount++;
+                return {
+                    tag: 'DidCreateCountSubscription',
+                    subscriptionId: `count-${createCount}`,
+                    count: createCount * 10,
+                };
+            }
+            return { tag: 'DidDeleteDataSubscription', subscriptionId: payload.subscriptionId };
+        });
+
+        const subscription = new CountSubscription(countQuery);
+        const onStoreChange = jest.fn();
+        const unsubscribe = subscription.subscribe(onStoreChange);
+        await Promise.resolve();
+
+        expect(subscription.getCount()).toBe(10);
+        expect(subscription.subscriptionId).toBe('count-1');
+
+        for (const listener of controller.eventListeners.close) {
+            listener(null);
+        }
+        expect(subscription.getCount()).toBeNull();
+
+        for (const listener of controller.eventListeners.reconnect) {
+            listener();
+        }
+        await Promise.resolve();
+
+        expect(subscription.getCount()).toBe(20);
+        expect(subscription.subscriptionId).toBe('count-2');
+        expect(controller.sendMessage).toHaveBeenCalledTimes(2);
+
+        unsubscribe();
+        await Promise.resolve();
+    });
+
+    test('ignores messages for an obsolete subscription id', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async () => ({
+            tag: 'DidCreateCountSubscription',
+            subscriptionId: 'current',
+            count: 1,
+        }));
+        const subscription = new CountSubscription(countQuery);
+        const unsubscribe = subscription.subscribe(() => {});
+        await Promise.resolve();
+
+        for (const listener of controller.eventListeners.message) {
+            listener({ tag: 'DidChangeCount', subscriptionId: 'obsolete', count: 99 });
+        }
+        expect(subscription.getCount()).toBe(1);
+
+        for (const listener of controller.eventListeners.message) {
+            listener({ tag: 'DidChangeCount', subscriptionId: 'current', count: 2 });
+        }
+        expect(subscription.getCount()).toBe(2);
+
+        unsubscribe();
+    });
+});

--- a/ihp-datasync/data/DataSync/react.test.js
+++ b/ihp-datasync/data/DataSync/react.test.js
@@ -1,4 +1,5 @@
-import { CountSubscription } from './count-subscription.js';
+import { CountSubscription, CountSubscriptionStore } from './count-subscription.js';
+import { dataSubscriptionKey } from './data-subscription-store.js';
 import { DataSyncController } from './ihp-datasync.js';
 import { jest } from '@jest/globals';
 
@@ -12,73 +13,272 @@ const countQuery = {
     offset: null,
 };
 
-describe('CountSubscription', () => {
+async function flushMicrotasks(rounds = 8) {
+    for (let index = 0; index < rounds; index++) {
+        await Promise.resolve();
+    }
+}
+
+describe('CountSubscription external store', () => {
     beforeEach(() => {
         DataSyncController.instance = null;
+        CountSubscriptionStore.queryMap.clear();
     });
 
-    test('recreates its server subscription after a reconnect', async () => {
+    test('constructing and looking up count resources does not create a controller', () => {
+        const direct = new CountSubscription(countQuery);
+        const stored = CountSubscriptionStore.get({ ...countQuery, table: 'other_tasks' });
+
+        expect(DataSyncController.instance).toBeNull();
+        expect(direct.getSnapshot().status).toBe('idle');
+        expect(stored.getSnapshot().status).toBe('idle');
+    });
+
+    test('lookup is inert and equal queries share one resource', () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn();
+
+        const first = CountSubscriptionStore.get(countQuery);
+        const second = CountSubscriptionStore.get({ ...countQuery });
+
+        expect(first).toBe(second);
+        expect(controller.sendMessage).not.toHaveBeenCalled();
+        expect(first.getSnapshot()).toBe(first.getSnapshot());
+    });
+
+    test('mutating the public count query cannot alter the transport query', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateCountSubscription'
+            ? { subscriptionId: 'stable-count-query', count: 0 }
+            : {});
+        const resource = new CountSubscription(countQuery);
+        resource.query.limit = 1;
+        resource.query.orderByClause.push({ orderByColumn: 'createdAt', orderByDirection: 'Desc' });
+
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+        const transportedQuery = controller.sendMessage.mock.calls[0][0].query;
+        expect(transportedQuery.limit).toBeNull();
+        expect(transportedQuery.orderByClause).toEqual([]);
+        expect(Object.isFrozen(transportedQuery)).toBe(true);
+
+        release();
+        await flushMicrotasks();
+    });
+
+    test('StrictMode-style release and retain creates once and final release deletes once', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateCountSubscription'
+            ? { subscriptionId: 'count', count: 4 }
+            : {});
+        const resource = CountSubscriptionStore.get(countQuery);
+
+        const firstRelease = resource.subscribe(() => {});
+        firstRelease();
+        const finalRelease = resource.subscribe(() => {});
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual(['CreateCountSubscription']);
+
+        finalRelease();
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
+            'CreateCountSubscription',
+            'DeleteDataSubscription',
+        ]);
+        expect(CountSubscriptionStore.queryMap.size).toBe(0);
+    });
+
+    test('clears the count while reconnecting and recreates exactly once', async () => {
         const controller = DataSyncController.getInstance();
         let createCount = 0;
         controller.sendMessage = jest.fn(async payload => {
             if (payload.tag === 'CreateCountSubscription') {
                 createCount++;
-                return {
-                    tag: 'DidCreateCountSubscription',
-                    subscriptionId: `count-${createCount}`,
-                    count: createCount * 10,
-                };
+                return { subscriptionId: `count-${createCount}`, count: createCount * 10 };
             }
-            return { tag: 'DidDeleteDataSubscription', subscriptionId: payload.subscriptionId };
+            return {};
         });
+        const resource = new CountSubscription(countQuery);
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+        expect(resource.getCount()).toBe(10);
 
-        const subscription = new CountSubscription(countQuery);
-        const onStoreChange = jest.fn();
-        const unsubscribe = subscription.subscribe(onStoreChange);
-        await Promise.resolve();
+        for (const listener of [...controller.eventListeners.close]) listener(null);
+        expect(resource.getCount()).toBeNull();
+        expect(resource.getSnapshot().status).toBe('reconnecting');
 
-        expect(subscription.getCount()).toBe(10);
-        expect(subscription.subscriptionId).toBe('count-1');
+        for (const listener of [...controller.eventListeners.reconnect]) listener();
+        for (const listener of [...controller.eventListeners.reconnect]) listener();
+        await flushMicrotasks();
+        expect(createCount).toBe(2);
+        expect(resource.getCount()).toBe(20);
 
-        for (const listener of controller.eventListeners.close) {
-            listener(null);
+        for (const listener of [...controller.eventListeners.message]) {
+            listener({ tag: 'DidChangeCount', subscriptionId: 'count-1', count: 99 });
         }
-        expect(subscription.getCount()).toBeNull();
-
-        for (const listener of controller.eventListeners.reconnect) {
-            listener();
-        }
-        await Promise.resolve();
-
-        expect(subscription.getCount()).toBe(20);
-        expect(subscription.subscriptionId).toBe('count-2');
-        expect(controller.sendMessage).toHaveBeenCalledTimes(2);
-
-        unsubscribe();
-        await Promise.resolve();
+        expect(resource.getCount()).toBe(20);
+        release();
+        await flushMicrotasks();
     });
 
-    test('ignores messages for an obsolete subscription id', async () => {
+    test('legacy count subscribers are isolated and observe data/disconnect, not CONNECT', async () => {
         const controller = DataSyncController.getInstance();
-        controller.sendMessage = jest.fn(async () => ({
-            tag: 'DidCreateCountSubscription',
-            subscriptionId: 'current',
-            count: 1,
-        }));
-        const subscription = new CountSubscription(countQuery);
-        const unsubscribe = subscription.subscribe(() => {});
-        await Promise.resolve();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateCountSubscription'
+            ? { subscriptionId: 'isolated-count', count: 4 }
+            : {});
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const resource = new CountSubscription(countQuery);
+        const throwing = jest.fn(() => { throw new Error('count listener failed'); });
+        const observing = jest.fn();
 
-        for (const listener of controller.eventListeners.message) {
-            listener({ tag: 'DidChangeCount', subscriptionId: 'obsolete', count: 99 });
+        const releaseThrowing = resource.subscribe(throwing);
+        const releaseObserving = resource.subscribe(observing);
+        expect(throwing).not.toHaveBeenCalled();
+        expect(observing).not.toHaveBeenCalled();
+        await flushMicrotasks();
+        expect(throwing).toHaveBeenCalledTimes(1);
+        expect(observing).toHaveBeenCalledTimes(1);
+
+        for (const listener of [...controller.eventListeners.close]) listener(null);
+        expect(resource.getCount()).toBeNull();
+        expect(throwing).toHaveBeenCalledTimes(2);
+        expect(observing).toHaveBeenCalledTimes(2);
+        expect(consoleError).toHaveBeenCalledWith(
+            'CountSubscription subscriber failed:',
+            expect.objectContaining({ message: 'count listener failed' }),
+        );
+
+        expect(() => releaseThrowing()).not.toThrow();
+        expect(() => releaseObserving()).not.toThrow();
+        await flushMicrotasks();
+        consoleError.mockRestore();
+    });
+
+    test('deletes a late create response after the last subscriber leaves', async () => {
+        const controller = DataSyncController.getInstance();
+        let resolveCreate;
+        controller.sendMessage = jest.fn(payload => payload.tag === 'CreateCountSubscription'
+            ? new Promise(resolve => { resolveCreate = resolve; })
+            : Promise.resolve({}));
+        const resource = new CountSubscription(countQuery);
+
+        const release = resource.subscribe(() => {});
+        release();
+        await flushMicrotasks();
+        resolveCreate({ subscriptionId: 'late-count', count: 42 });
+        await flushMicrotasks();
+
+        expect(resource.getCount()).toBeNull();
+        expect(controller.sendMessage.mock.calls.map(([payload]) => payload.tag)).toEqual([
+            'CreateCountSubscription',
+            'DeleteDataSubscription',
+        ]);
+    });
+
+    test('creation errors become observable snapshot state', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn().mockRejectedValue(new Error('count denied'));
+        const resource = new CountSubscription(countQuery);
+
+        const release = resource.subscribe(() => {});
+        await flushMicrotasks();
+        expect(resource.getSnapshot().status).toBe('error');
+        expect(resource.getSnapshot().error?.message).toBe('count denied');
+        release();
+        await flushMicrotasks();
+    });
+
+    test('public subscribers remains a live Set while duplicate retains are counted separately', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateCountSubscription'
+            ? { subscriptionId: 'public-count-listeners', count: 1 }
+            : {});
+        const resource = new CountSubscription(countQuery);
+        const callback = jest.fn();
+        const external = jest.fn();
+        resource.subscribers.add(external);
+        const releaseFirst = resource.subscribe(callback);
+        const releaseSecond = resource.subscribe(callback);
+        await flushMicrotasks();
+
+        releaseFirst();
+        expect(resource.subscribers.has(callback)).toBe(true);
+        for (const listener of [...controller.eventListeners.message]) {
+            listener({ tag: 'DidChangeCount', subscriptionId: 'public-count-listeners', count: 2 });
         }
-        expect(subscription.getCount()).toBe(1);
+        expect(callback).toHaveBeenCalled();
+        expect(external).toHaveBeenCalled();
 
-        for (const listener of controller.eventListeners.message) {
-            listener({ tag: 'DidChangeCount', subscriptionId: 'current', count: 2 });
+        releaseSecond();
+        await flushMicrotasks();
+        expect(resource.subscribers.has(callback)).toBe(false);
+        expect(resource.getSnapshot().status).toBe('live');
+        resource.subscribers.delete(external);
+        await resource.close();
+    });
+
+    test('a render-held count resource is never evicted and duplicated before its commit', async () => {
+        const controller = DataSyncController.getInstance();
+        controller.sendMessage = jest.fn(async payload => payload.tag === 'CreateCountSubscription'
+            ? { subscriptionId: `count-${payload.query.table}`, count: 0 }
+            : {});
+        const releases = [];
+        for (let index = 0; index < 120; index++) {
+            releases.push(CountSubscriptionStore.get({ ...countQuery, table: `active_count_${index}` }).subscribe(() => {}));
         }
-        expect(subscription.getCount()).toBe(2);
+        await flushMicrotasks();
 
-        unsubscribe();
+        const laterCommitted = CountSubscriptionStore.get({ ...countQuery, table: 'later_count' });
+        expect(CountSubscriptionStore.get({ ...countQuery, table: 'later_count' })).toBe(laterCommitted);
+        expect(CountSubscriptionStore.queryMap.has(
+            `count:${dataSubscriptionKey({ ...countQuery, table: 'later_count' })}`,
+        )).toBe(false);
+        for (let index = 0; index < 150; index++) {
+            CountSubscriptionStore.get({ ...countQuery, table: `idle_count_${index}` });
+        }
+
+        expect(CountSubscriptionStore.get({ ...countQuery, table: 'later_count' })).toBe(laterCommitted);
+        const releaseLater = laterCommitted.subscribe(() => {});
+        expect(CountSubscriptionStore.queryMap.has(
+            `count:${dataSubscriptionKey({ ...countQuery, table: 'later_count' })}`,
+        )).toBe(true);
+        const releaseShared = CountSubscriptionStore
+            .get({ ...countQuery, table: 'later_count' })
+            .subscribe(() => {});
+        await flushMicrotasks();
+        expect(controller.sendMessage.mock.calls.filter(([payload]) =>
+            payload.tag === 'CreateCountSubscription'
+            && payload.query.table === 'later_count')).toHaveLength(1);
+
+        releaseLater();
+        releaseShared();
+        releases.forEach(release => release());
+        await flushMicrotasks();
+        CountSubscriptionStore.queryMap.clear();
+    });
+
+    test('a render-held count resource cannot commit in a different JWT scope', () => {
+        const originalLocalStorage = globalThis.localStorage;
+        let jwt = 'count-user-a';
+        globalThis.localStorage = { getItem: key => key === 'ihp_jwt' ? jwt : null };
+        try {
+            const oldResource = CountSubscriptionStore.get(countQuery);
+            expect(DataSyncController.instance).toBeNull();
+
+            jwt = 'count-user-b';
+            const callback = jest.fn();
+            const release = oldResource.subscribe(callback);
+
+            expect(DataSyncController.instance).toBeNull();
+            expect(oldResource.getCount()).toBeNull();
+            expect(oldResource.getSnapshot().status).toBe('closed');
+            expect(callback).not.toHaveBeenCalled();
+            const newResource = CountSubscriptionStore.get(countQuery);
+            expect(newResource).not.toBe(oldResource);
+            release();
+        } finally {
+            if (originalLocalStorage === undefined) delete globalThis.localStorage;
+            else globalThis.localStorage = originalLocalStorage;
+        }
     });
 });

--- a/ihp-datasync/data/DataSync/resource-registry.test.js
+++ b/ihp-datasync/data/DataSync/resource-registry.test.js
@@ -1,0 +1,126 @@
+import { createResourceRegistry } from './resource-registry.js';
+
+function createTestRegistry() {
+    let creationCount = 0;
+    const registry = createResourceRegistry({
+        key: input => input.key,
+        create: (input, lifecycle) => ({
+            creation: ++creationCount,
+            input,
+            lifecycle,
+        }),
+    });
+
+    return {
+        registry,
+        creationCount: () => creationCount,
+    };
+}
+
+describe('createResourceRegistry', () => {
+    test('get-or-create is inert and canonicalizes equal keys while pending', () => {
+        const { registry, creationCount } = createTestRegistry();
+
+        const first = registry.getOrCreate({ key: 'tasks', render: 1 });
+        const second = registry.getOrCreate({ key: 'tasks', render: 2 });
+
+        expect(second).toBe(first);
+        expect(first.input).toEqual({ key: 'tasks', render: 1 });
+        expect(creationCount()).toBe(1);
+        expect(registry.active.size).toBe(0);
+    });
+
+    test('retain promotes a pending resource into the exposed active Map', () => {
+        const { registry, creationCount } = createTestRegistry();
+        const resource = registry.getOrCreate({ key: 'tasks' });
+
+        resource.lifecycle.retain(resource);
+
+        expect(registry.active).toBeInstanceOf(Map);
+        expect(registry.active.get('tasks')).toBe(resource);
+        expect(registry.getOrCreate({ key: 'tasks' })).toBe(resource);
+        expect(creationCount()).toBe(1);
+    });
+
+    test('close removes the current pending and active value', () => {
+        const { registry, creationCount } = createTestRegistry();
+        const resource = registry.getOrCreate({ key: 'tasks' });
+        resource.lifecycle.retain(resource);
+
+        resource.lifecycle.close(resource);
+        const replacement = registry.getOrCreate({ key: 'tasks' });
+
+        expect(registry.active.has('tasks')).toBe(false);
+        expect(replacement).not.toBe(resource);
+        expect(creationCount()).toBe(2);
+    });
+
+    test('a stale close cannot evict a newer active value for the same key', () => {
+        const { registry, creationCount } = createTestRegistry();
+        const stale = registry.getOrCreate({ key: 'tasks', generation: 1 });
+        stale.lifecycle.retain(stale);
+
+        registry.clear();
+        const current = registry.getOrCreate({ key: 'tasks', generation: 2 });
+        current.lifecycle.retain(current);
+        stale.lifecycle.close(stale);
+
+        expect(registry.active.get('tasks')).toBe(current);
+        expect(registry.getOrCreate({ key: 'tasks' })).toBe(current);
+        expect(creationCount()).toBe(2);
+    });
+
+    test('clearing the exposed active Map also resets weak pending values', () => {
+        const { registry, creationCount } = createTestRegistry();
+        const pending = registry.getOrCreate({ key: 'tasks' });
+        expect(registry.active.size).toBe(0);
+
+        registry.active.clear();
+        const replacement = registry.getOrCreate({ key: 'tasks' });
+
+        expect(replacement).not.toBe(pending);
+        expect(creationCount()).toBe(2);
+    });
+
+    test('replacing the active compatibility Map resets pending values', () => {
+        const { registry, creationCount } = createTestRegistry();
+        const pending = registry.getOrCreate({ key: 'tasks' });
+        const replacementMap = new Map();
+
+        registry.replaceActive(replacementMap);
+        const replacement = registry.getOrCreate({ key: 'tasks' });
+
+        expect(registry.active).toBe(replacementMap);
+        expect(replacement).not.toBe(pending);
+        expect(creationCount()).toBe(2);
+    });
+
+    test('clear still resets pending values after replacing the active Map', () => {
+        const { registry, creationCount } = createTestRegistry();
+        const replacementMap = new Map();
+        registry.replaceActive(replacementMap);
+        const pending = registry.getOrCreate({ key: 'tasks' });
+
+        registry.active.clear();
+        const replacement = registry.getOrCreate({ key: 'tasks' });
+
+        expect(registry.active).toBe(replacementMap);
+        expect(replacement).not.toBe(pending);
+        expect(creationCount()).toBe(2);
+    });
+
+    test('accepts a frozen compatibility Map without trying to replace its methods', () => {
+        const { registry, creationCount } = createTestRegistry();
+        const replacementMap = Object.freeze(new Map());
+
+        expect(() => registry.replaceActive(replacementMap)).not.toThrow();
+        expect(registry.active).toBe(replacementMap);
+        const pending = registry.getOrCreate({ key: 'tasks' });
+        expect(pending).toEqual(expect.objectContaining({
+            input: { key: 'tasks' },
+        }));
+        registry.clear();
+        expect(registry.getOrCreate({ key: 'tasks' })).not.toBe(pending);
+        expect(creationCount()).toBe(2);
+    });
+});

--- a/ihp-datasync/data/DataSync/src/controller-subscription-transport.ts
+++ b/ihp-datasync/data/DataSync/src/controller-subscription-transport.ts
@@ -1,0 +1,52 @@
+import type { DataSyncController } from './ihp-datasync.js';
+import type {
+    SubscriptionTransport,
+    SubscriptionTransportEvent,
+} from './subscription-resource.js';
+import type { ServerMessage } from './types.js';
+
+/** Adapts the existing public controller class to the functional transport port. */
+export function createControllerSubscriptionTransport(
+    controller: DataSyncController,
+    scopeKey: string,
+): SubscriptionTransport {
+    return Object.freeze({
+        scopeKey,
+        request: message => controller.sendMessage(message),
+        isCurrent: () => controller.isBoundToTransportScope(scopeKey),
+        subscribe(listener: (event: SubscriptionTransportEvent) => void): () => void {
+            const onMessage = (message: ServerMessage): void => {
+                listener({ type: 'message', message });
+            };
+            const onClose = (event: unknown): void => {
+                listener({
+                    type: 'closed',
+                    scopeChanged: isTransportScopeChange(event),
+                });
+            };
+            const onReconnect = (): void => {
+                listener({ type: 'reconnected' });
+            };
+            controller.addEventListener('message', onMessage);
+            controller.addEventListener('close', onClose);
+            controller.addEventListener('reconnect', onReconnect);
+            let subscribed = true;
+            return () => {
+                if (!subscribed) {
+                    return;
+                }
+                subscribed = false;
+                controller.removeEventListener('message', onMessage);
+                controller.removeEventListener('close', onClose);
+                controller.removeEventListener('reconnect', onReconnect);
+            };
+        },
+    });
+}
+
+export function isTransportScopeChange(event: unknown): boolean {
+    return typeof event === 'object'
+        && event !== null
+        && 'type' in event
+        && (event as { type?: unknown }).type === 'transport-scope-changed';
+}

--- a/ihp-datasync/data/DataSync/src/count-subscription-protocol.ts
+++ b/ihp-datasync/data/DataSync/src/count-subscription-protocol.ts
@@ -1,0 +1,44 @@
+import type { SubscriptionProtocol } from './subscription-resource.js';
+import type { DynamicSQLQuery, UUID } from './types.js';
+
+/** Wire adapter for the count subscription protocol. */
+export function createCountSubscriptionProtocol(
+    serverQuery: DynamicSQLQuery,
+): SubscriptionProtocol<number> {
+    return Object.freeze({
+        async create(transport) {
+            const response = await transport.request({
+                tag: 'CreateCountSubscription',
+                query: serverQuery,
+            });
+            return {
+                subscriptionId: response.subscriptionId as UUID,
+                value: response.count as number,
+                mode: 'legacy',
+                revision: 0,
+            };
+        },
+        async delete(transport, subscriptionId) {
+            await transport.request({ tag: 'DeleteDataSubscription', subscriptionId });
+        },
+        isRelevantMessage(message, state) {
+            return state.phase.tag === 'live'
+                && message.subscriptionId === state.phase.subscriptionId;
+        },
+        decodeMessage(message, state) {
+            if (
+                message.tag !== 'DidChangeCount'
+                || state.phase.tag !== 'live'
+                || message.subscriptionId !== state.phase.subscriptionId
+            ) {
+                return null;
+            }
+            return {
+                type: 'SERVER_VALUE',
+                generation: state.generation,
+                subscriptionId: state.phase.subscriptionId,
+                value: message.count as number,
+            };
+        },
+    });
+}

--- a/ihp-datasync/data/DataSync/src/count-subscription.ts
+++ b/ihp-datasync/data/DataSync/src/count-subscription.ts
@@ -1,130 +1,438 @@
 import { DataSyncController } from './ihp-datasync.js';
-import type { DynamicSQLQuery, ServerMessage } from './types.js';
+import { dataSubscriptionKey } from './data-subscription-store.js';
+import { WeakValueMap } from './weak-value-map.js';
+import {
+    initialResourceSnapshot,
+    reduceResourceSnapshot,
+    type ResourceSnapshot,
+    type ResourceSnapshotAction,
+} from './subscription-reducer.js';
+import type { DynamicSQLQuery, ServerMessage, UUID } from './types.js';
 
-/** Maintains the server-side subscription used by the React useCount hook. */
+class ResettableMap<K, V> extends Map<K, V> {
+    constructor(private readonly resetPendingEntries: () => void) {
+        super();
+    }
+
+    override clear(): void {
+        super.clear();
+        this.resetPendingEntries();
+    }
+}
+
+/** Server-backed count resource used by the React hook and non-React callers. */
 export class CountSubscription {
     query: DynamicSQLQuery;
-    count: number | null;
-    subscriptionId: string | null;
-    subscribers: Set<() => void>;
-    private controller: DataSyncController;
-    private isStarted: boolean;
-    private generation: number;
+    subscriptionId: UUID | null = null;
+    onClose: () => void = () => {};
+    onStoreClose: () => void = () => {};
+    /** @internal Promotes a render-only weak registry entry on first retain. */
+    onStoreRetain: () => void = () => {};
+    subscribers = new Set<() => void>();
 
-    constructor(query: DynamicSQLQuery) {
-        this.query = query;
-        this.count = null;
-        this.subscriptionId = null;
-        this.subscribers = new Set();
-        this.controller = DataSyncController.getInstance();
-        this.isStarted = false;
-        this.generation = 0;
+    private controller: DataSyncController | null = null;
+    private readonly serverQuery: DynamicSQLQuery;
+    private readonly expectedTransportScopeKey: string;
+    private snapshot: ResourceSnapshot<number> = initialResourceSnapshot();
+    private readonly subscriberEntries = new Map<number, () => void>();
+    private readonly snapshotSubscriberEntries = new Map<number, () => void>();
+    private nextSubscriberId = 0;
+    private nextSnapshotSubscriberId = 0;
+    private generation = 0;
+    private started = false;
+    private listenersAttached = false;
+    private disposalToken = 0;
+    private startPromise: Promise<void> | null = null;
 
+    constructor(
+        query: DynamicSQLQuery,
+        expectedTransportScopeKey: string = DataSyncController.currentTransportScopeKey(),
+    ) {
+        this.query = JSON.parse(JSON.stringify(query)) as DynamicSQLQuery;
+        this.serverQuery = deepFreeze(JSON.parse(JSON.stringify(query)) as DynamicSQLQuery);
+        this.expectedTransportScopeKey = expectedTransportScopeKey;
         this.subscribe = this.subscribe.bind(this);
+        this.subscribeSnapshot = this.subscribeSnapshot.bind(this);
         this.getCount = this.getCount.bind(this);
+        this.getSnapshot = this.getSnapshot.bind(this);
+        this.getServerSnapshot = this.getServerSnapshot.bind(this);
         this.onMessage = this.onMessage.bind(this);
         this.onDataSyncClosed = this.onDataSyncClosed.bind(this);
         this.onDataSyncReconnect = this.onDataSyncReconnect.bind(this);
     }
 
-    subscribe(callback: () => void): () => void {
-        this.subscribers.add(callback);
-        if (!this.isStarted) {
-            this.start();
-        }
+    get count(): number | null {
+        return this.snapshot.data;
+    }
 
-        return () => {
-            this.subscribers.delete(callback);
-            if (this.subscribers.size === 0) {
-                this.stop();
-            }
-        };
+    set count(count: number | null) {
+        if (count === null) {
+            this.snapshot = initialResourceSnapshot();
+            this.notifySubscribers();
+            this.notifySnapshotSubscribers();
+        } else {
+            this.dispatch({ type: 'SNAPSHOT', data: count });
+        }
+    }
+
+    get connectError(): Error | null {
+        return this.snapshot.error;
+    }
+
+    getSnapshot(): ResourceSnapshot<number> {
+        return this.snapshot;
+    }
+
+    getServerSnapshot(): ResourceSnapshot<number> {
+        return initialResourceSnapshot();
     }
 
     getCount(): number | null {
-        return this.count;
+        return this.snapshot.data;
     }
 
-    private start(): void {
-        this.isStarted = true;
-        this.controller.addEventListener('message', this.onMessage);
-        this.controller.addEventListener('close', this.onDataSyncClosed);
-        this.controller.addEventListener('reconnect', this.onDataSyncReconnect);
-        void this.createOnServer();
-    }
-
-    private stop(): void {
-        if (!this.isStarted) {
-            return;
+    subscribe(callback: () => void): () => void {
+        this.retainInStore();
+        const shouldStart = this.trackedSubscriberCount() === 0;
+        const id = this.nextSubscriberId++;
+        this.subscriberEntries.set(id, callback);
+        this.subscribers.add(callback);
+        this.disposalToken++;
+        if (shouldStart) {
+            void this.start(false).catch(() => {
+                // The immutable snapshot carries the error to the consumer.
+            });
         }
 
-        this.isStarted = false;
-        this.generation++;
-        const subscriptionId = this.subscriptionId;
-        this.subscriptionId = null;
-        this.controller.removeEventListener('message', this.onMessage);
-        this.controller.removeEventListener('close', this.onDataSyncClosed);
-        this.controller.removeEventListener('reconnect', this.onDataSyncReconnect);
-
-        if (subscriptionId !== null) {
-            void this.deleteOnServer(subscriptionId);
-        }
+        let subscribed = true;
+        return () => {
+            if (!subscribed) {
+                return;
+            }
+            subscribed = false;
+            this.subscriberEntries.delete(id);
+            if (!Array.from(this.subscriberEntries.values()).includes(callback)) {
+                this.subscribers.delete(callback);
+            }
+            this.scheduleStop();
+        };
     }
 
-    private async createOnServer(): Promise<void> {
+    /** Internal external-store subscription; observes lifecycle and error changes. */
+    subscribeSnapshot(callback: () => void): () => void {
+        this.retainInStore();
+        const shouldStart = this.trackedSubscriberCount() === 0;
+        const id = this.nextSnapshotSubscriberId++;
+        this.snapshotSubscriberEntries.set(id, callback);
+        this.disposalToken++;
+        if (shouldStart) {
+            void this.start(false).catch(() => {
+                // The immutable snapshot carries the error to the consumer.
+            });
+        }
+
+        let subscribed = true;
+        return () => {
+            if (!subscribed) {
+                return;
+            }
+            subscribed = false;
+            this.snapshotSubscriberEntries.delete(id);
+            this.scheduleStop();
+        };
+    }
+
+    async close(): Promise<void> {
+        this.subscriberEntries.clear();
+        this.snapshotSubscriberEntries.clear();
+        this.subscribers.clear();
+        this.disposalToken++;
+        await this.stop();
+    }
+
+    private start(reconnect: boolean): Promise<void> {
+        this.disposalToken++;
+        if (this.startPromise !== null) {
+            return this.startPromise;
+        }
+        if (this.started && this.subscriptionId !== null) {
+            return Promise.resolve();
+        }
+
+        if (!this.hasExpectedTransportScope()) {
+            this.closeForTransportScopeChange();
+            return Promise.resolve();
+        }
+
+        const controller = DataSyncController.getInstance();
+        if (!controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
+            this.closeForTransportScopeChange();
+            return Promise.resolve();
+        }
+        this.attachListeners(controller);
+        this.started = true;
         const generation = ++this.generation;
-        try {
-            const response = await this.controller.sendMessage({ tag: 'CreateCountSubscription', query: this.query });
-            const subscriptionId = response.subscriptionId as string;
+        this.dispatch({ type: 'CONNECT', reconnect });
+        const startPromise = this.createOnServer(generation, controller);
+        this.startPromise = startPromise;
+        void startPromise.finally(() => {
+            if (this.startPromise === startPromise) {
+                this.startPromise = null;
+            }
+        }).catch(() => {});
+        return startPromise;
+    }
 
-            if (!this.isStarted || generation !== this.generation) {
-                await this.deleteOnServer(subscriptionId);
+    private async createOnServer(generation: number, controller: DataSyncController): Promise<void> {
+        try {
+            const response = await controller.sendMessage({
+                tag: 'CreateCountSubscription',
+                query: this.serverQuery,
+            });
+            const subscriptionId = response.subscriptionId as UUID;
+            if (!this.started
+                || generation !== this.generation
+                || this.controller !== controller
+                || !this.hasExpectedTransportScope()
+                || !controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
+                if (!this.hasExpectedTransportScope()) {
+                    this.closeForTransportScopeChange();
+                }
+                await this.deleteOnServer(controller, subscriptionId);
                 return;
             }
 
             this.subscriptionId = subscriptionId;
-            this.count = response.count as number;
-            this.notifySubscribers();
-        } catch (error) {
-            if (this.isStarted && generation === this.generation) {
-                console.error('useCount: Failed to create count subscription', error);
+            this.dispatch({ type: 'SNAPSHOT', data: response.count as number });
+        } catch (unknownError) {
+            if (!this.started || generation !== this.generation || this.controller !== controller) {
+                return;
             }
+            const error = unknownError instanceof Error ? unknownError : new Error(String(unknownError));
+            this.dispatch({ type: 'FAIL', error });
+            throw error;
         }
     }
 
-    private async deleteOnServer(subscriptionId: string): Promise<void> {
-        try {
-            await this.controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
-        } catch (error) {
-            if (this.controller.connection !== null) {
-                console.error('useCount: Failed to delete count subscription', error);
-            }
+    private attachListeners(controller: DataSyncController): void {
+        if (this.listenersAttached && this.controller === controller) {
+            return;
         }
+        this.detachListeners();
+        this.controller = controller;
+        this.listenersAttached = true;
+        controller.addEventListener('message', this.onMessage);
+        controller.addEventListener('close', this.onDataSyncClosed);
+        controller.addEventListener('reconnect', this.onDataSyncReconnect);
+    }
+
+    private detachListeners(): void {
+        const controller = this.controller;
+        if (controller === null) {
+            this.listenersAttached = false;
+            return;
+        }
+        if (this.listenersAttached) {
+            this.listenersAttached = false;
+            controller.removeEventListener('message', this.onMessage);
+            controller.removeEventListener('close', this.onDataSyncClosed);
+            controller.removeEventListener('reconnect', this.onDataSyncReconnect);
+        }
+        this.controller = null;
     }
 
     private onMessage(message: ServerMessage): void {
+        if (!this.hasExpectedTransportScope()
+            || this.controller?.isBoundToTransportScope(this.expectedTransportScopeKey) !== true) {
+            this.closeForTransportScopeChange();
+            return;
+        }
         if (message.tag === 'DidChangeCount' && message.subscriptionId === this.subscriptionId) {
-            this.count = message.count as number;
+            this.dispatch({ type: 'SNAPSHOT', data: message.count as number });
+        }
+    }
+
+    private onDataSyncClosed(event: unknown = null): void {
+        if (!this.started) {
+            return;
+        }
+        if (isTransportScopeChange(event)) {
+            this.closeForTransportScopeChange();
+            return;
+        }
+        this.generation++;
+        this.subscriptionId = null;
+        this.startPromise = null;
+        this.dispatch({ type: 'DISCONNECT', clearData: true });
+    }
+
+    private onDataSyncReconnect(): void {
+        if (!this.started || this.startPromise !== null || this.subscriptionId !== null) {
+            return;
+        }
+        void this.start(true).catch(() => {
+            // The immutable snapshot carries the error to the consumer.
+        });
+    }
+
+    private scheduleStop(): void {
+        const token = ++this.disposalToken;
+        queueMicrotask(() => {
+            if (token === this.disposalToken
+                && this.subscribers.size === 0
+                && this.snapshotSubscriberEntries.size === 0) {
+                void this.stop();
+            }
+        });
+    }
+
+    private async stop(): Promise<void> {
+        if (!this.started && this.snapshot.status === 'closed') {
+            return;
+        }
+        this.started = false;
+        this.generation++;
+        this.startPromise = null;
+        const subscriptionId = this.subscriptionId;
+        const controller = this.controller;
+        this.subscriptionId = null;
+        this.detachListeners();
+        this.dispatch({ type: 'CLOSE' });
+        this.notifyClose();
+        if (subscriptionId !== null && controller !== null) {
+            await this.deleteOnServer(controller, subscriptionId);
+        }
+    }
+
+    private async deleteOnServer(controller: DataSyncController, subscriptionId: UUID): Promise<void> {
+        try {
+            await controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
+        } catch (error) {
+            if (!controller.retired && controller.connection !== null) {
+                console.error('Failed to delete a stale CountSubscription:', error);
+            }
+        }
+    }
+
+    private closeForTransportScopeChange(): void {
+        this.started = false;
+        this.generation++;
+        this.subscriptionId = null;
+        this.startPromise = null;
+        this.detachListeners();
+        this.snapshot = initialResourceSnapshot();
+        this.dispatch({ type: 'CLOSE' });
+        this.notifyClose();
+    }
+
+    private dispatch(action: ResourceSnapshotAction<number>): void {
+        const nextSnapshot = reduceResourceSnapshot(this.snapshot, action);
+        if (nextSnapshot === this.snapshot) {
+            return;
+        }
+        this.snapshot = nextSnapshot;
+        this.notifySnapshotSubscribers();
+        if (action.type === 'SNAPSHOT' || action.type === 'DISCONNECT') {
             this.notifySubscribers();
         }
     }
 
-    private onDataSyncClosed(): void {
-        this.generation++;
-        this.subscriptionId = null;
-        this.count = null;
-        this.notifySubscribers();
+    private trackedSubscriberCount(): number {
+        return this.subscriberEntries.size + this.snapshotSubscriberEntries.size;
     }
 
-    private onDataSyncReconnect(): void {
-        if (this.isStarted) {
-            void this.createOnServer();
+    private retainInStore(): void {
+        try {
+            this.onStoreRetain();
+        } catch (error) {
+            console.error('CountSubscription store-retain listener failed:', error);
+        }
+    }
+
+    private notifySnapshotSubscribers(): void {
+        for (const subscriber of Array.from(this.snapshotSubscriberEntries.values())) {
+            try {
+                subscriber();
+            } catch (error) {
+                console.error('CountSubscription snapshot subscriber failed:', error);
+            }
         }
     }
 
     private notifySubscribers(): void {
-        for (const subscriber of this.subscribers) {
-            subscriber();
+        for (const subscriber of Array.from(this.subscribers)) {
+            try {
+                subscriber();
+            } catch (error) {
+                console.error('CountSubscription subscriber failed:', error);
+            }
         }
     }
+
+    private notifyClose(): void {
+        try {
+            this.onStoreClose();
+        } catch (error) {
+            console.error('CountSubscription store-close listener failed:', error);
+        }
+        try {
+            this.onClose();
+        } catch (error) {
+            console.error('CountSubscription close listener failed:', error);
+        }
+    }
+
+    private hasExpectedTransportScope(): boolean {
+        return this.expectedTransportScopeKey === DataSyncController.currentTransportScopeKey();
+    }
+}
+
+export class CountSubscriptionStore {
+    private static readonly pendingQueryMap = new WeakValueMap<string, CountSubscription>();
+    static readonly queryMap = new ResettableMap<string, CountSubscription>(() => {
+        CountSubscriptionStore.pendingQueryMap.clear();
+    });
+
+    static get(query: DynamicSQLQuery): CountSubscription {
+        const key = `count:${dataSubscriptionKey(query)}`;
+        const existing = this.queryMap.get(key);
+        if (existing !== undefined) {
+            return existing;
+        }
+        const pending = this.pendingQueryMap.get(key);
+        if (pending !== undefined) {
+            return pending;
+        }
+
+        const expectedTransportScopeKey = DataSyncController.currentTransportScopeKey();
+        const subscription = new CountSubscription(query, expectedTransportScopeKey);
+        subscription.onStoreRetain = () => {
+            this.queryMap.set(key, subscription);
+        };
+        subscription.onStoreClose = () => {
+            if (this.queryMap.get(key) === subscription) {
+                this.queryMap.delete(key);
+            }
+            this.pendingQueryMap.delete(key, subscription);
+        };
+        this.pendingQueryMap.set(key, subscription);
+        return subscription;
+    }
+}
+
+function isTransportScopeChange(event: unknown): boolean {
+    return typeof event === 'object'
+        && event !== null
+        && 'type' in event
+        && (event as { type?: unknown }).type === 'transport-scope-changed';
+}
+
+function deepFreeze<T>(value: T): T {
+    if (typeof value !== 'object' || value === null || Object.isFrozen(value)) {
+        return value;
+    }
+    for (const nestedValue of Object.values(value as Record<string, unknown>)) {
+        deepFreeze(nestedValue);
+    }
+    return Object.freeze(value);
 }

--- a/ihp-datasync/data/DataSync/src/count-subscription.ts
+++ b/ihp-datasync/data/DataSync/src/count-subscription.ts
@@ -1,0 +1,130 @@
+import { DataSyncController } from './ihp-datasync.js';
+import type { DynamicSQLQuery, ServerMessage } from './types.js';
+
+/** Maintains the server-side subscription used by the React useCount hook. */
+export class CountSubscription {
+    query: DynamicSQLQuery;
+    count: number | null;
+    subscriptionId: string | null;
+    subscribers: Set<() => void>;
+    private controller: DataSyncController;
+    private isStarted: boolean;
+    private generation: number;
+
+    constructor(query: DynamicSQLQuery) {
+        this.query = query;
+        this.count = null;
+        this.subscriptionId = null;
+        this.subscribers = new Set();
+        this.controller = DataSyncController.getInstance();
+        this.isStarted = false;
+        this.generation = 0;
+
+        this.subscribe = this.subscribe.bind(this);
+        this.getCount = this.getCount.bind(this);
+        this.onMessage = this.onMessage.bind(this);
+        this.onDataSyncClosed = this.onDataSyncClosed.bind(this);
+        this.onDataSyncReconnect = this.onDataSyncReconnect.bind(this);
+    }
+
+    subscribe(callback: () => void): () => void {
+        this.subscribers.add(callback);
+        if (!this.isStarted) {
+            this.start();
+        }
+
+        return () => {
+            this.subscribers.delete(callback);
+            if (this.subscribers.size === 0) {
+                this.stop();
+            }
+        };
+    }
+
+    getCount(): number | null {
+        return this.count;
+    }
+
+    private start(): void {
+        this.isStarted = true;
+        this.controller.addEventListener('message', this.onMessage);
+        this.controller.addEventListener('close', this.onDataSyncClosed);
+        this.controller.addEventListener('reconnect', this.onDataSyncReconnect);
+        void this.createOnServer();
+    }
+
+    private stop(): void {
+        if (!this.isStarted) {
+            return;
+        }
+
+        this.isStarted = false;
+        this.generation++;
+        const subscriptionId = this.subscriptionId;
+        this.subscriptionId = null;
+        this.controller.removeEventListener('message', this.onMessage);
+        this.controller.removeEventListener('close', this.onDataSyncClosed);
+        this.controller.removeEventListener('reconnect', this.onDataSyncReconnect);
+
+        if (subscriptionId !== null) {
+            void this.deleteOnServer(subscriptionId);
+        }
+    }
+
+    private async createOnServer(): Promise<void> {
+        const generation = ++this.generation;
+        try {
+            const response = await this.controller.sendMessage({ tag: 'CreateCountSubscription', query: this.query });
+            const subscriptionId = response.subscriptionId as string;
+
+            if (!this.isStarted || generation !== this.generation) {
+                await this.deleteOnServer(subscriptionId);
+                return;
+            }
+
+            this.subscriptionId = subscriptionId;
+            this.count = response.count as number;
+            this.notifySubscribers();
+        } catch (error) {
+            if (this.isStarted && generation === this.generation) {
+                console.error('useCount: Failed to create count subscription', error);
+            }
+        }
+    }
+
+    private async deleteOnServer(subscriptionId: string): Promise<void> {
+        try {
+            await this.controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
+        } catch (error) {
+            if (this.controller.connection !== null) {
+                console.error('useCount: Failed to delete count subscription', error);
+            }
+        }
+    }
+
+    private onMessage(message: ServerMessage): void {
+        if (message.tag === 'DidChangeCount' && message.subscriptionId === this.subscriptionId) {
+            this.count = message.count as number;
+            this.notifySubscribers();
+        }
+    }
+
+    private onDataSyncClosed(): void {
+        this.generation++;
+        this.subscriptionId = null;
+        this.count = null;
+        this.notifySubscribers();
+    }
+
+    private onDataSyncReconnect(): void {
+        if (this.isStarted) {
+            void this.createOnServer();
+        }
+    }
+
+    private notifySubscribers(): void {
+        for (const subscriber of this.subscribers) {
+            subscriber();
+        }
+    }
+}

--- a/ihp-datasync/data/DataSync/src/count-subscription.ts
+++ b/ihp-datasync/data/DataSync/src/count-subscription.ts
@@ -1,24 +1,12 @@
 import { DataSyncController } from './ihp-datasync.js';
-import { dataSubscriptionKey } from './data-subscription-store.js';
-import { WeakValueMap } from './weak-value-map.js';
-import {
-    initialResourceSnapshot,
-    reduceResourceSnapshot,
-    type ResourceSnapshot,
-    type ResourceSnapshotAction,
-} from './subscription-reducer.js';
+import { createControllerSubscriptionTransport, isTransportScopeChange } from './controller-subscription-transport.js';
+import { createCountSubscriptionProtocol } from './count-subscription-protocol.js';
+import { countResourceKeyForScope } from './resource-key.js';
+import { createResourceRegistry } from './resource-registry.js';
+import { countSubscriptionPolicy, type SubscriptionPublication } from './subscription-machine.js';
+import { createSubscriptionResource, type SubscriptionResource } from './subscription-resource.js';
+import { initialResourceSnapshot, type ResourceSnapshot } from './subscription-reducer.js';
 import type { DynamicSQLQuery, ServerMessage, UUID } from './types.js';
-
-class ResettableMap<K, V> extends Map<K, V> {
-    constructor(private readonly resetPendingEntries: () => void) {
-        super();
-    }
-
-    override clear(): void {
-        super.clear();
-        this.resetPendingEntries();
-    }
-}
 
 /** Server-backed count resource used by the React hook and non-React callers. */
 export class CountSubscription {
@@ -30,19 +18,13 @@ export class CountSubscription {
     onStoreRetain: () => void = () => {};
     subscribers = new Set<() => void>();
 
-    private controller: DataSyncController | null = null;
     private readonly serverQuery: DynamicSQLQuery;
     private readonly expectedTransportScopeKey: string;
-    private snapshot: ResourceSnapshot<number> = initialResourceSnapshot();
+    private readonly resource: SubscriptionResource<number>;
     private readonly subscriberEntries = new Map<number, () => void>();
     private readonly snapshotSubscriberEntries = new Map<number, () => void>();
     private nextSubscriberId = 0;
     private nextSnapshotSubscriberId = 0;
-    private generation = 0;
-    private started = false;
-    private listenersAttached = false;
-    private disposalToken = 0;
-    private startPromise: Promise<void> | null = null;
 
     constructor(
         query: DynamicSQLQuery,
@@ -59,28 +41,45 @@ export class CountSubscription {
         this.onMessage = this.onMessage.bind(this);
         this.onDataSyncClosed = this.onDataSyncClosed.bind(this);
         this.onDataSyncReconnect = this.onDataSyncReconnect.bind(this);
+        this.resource = createSubscriptionResource<number>(
+            createCountSubscriptionProtocol(this.serverQuery),
+            {
+                expectedScopeKey: this.expectedTransportScopeKey,
+                currentScopeKey: () => DataSyncController.currentTransportScopeKey(),
+                acquireTransport: () => {
+                    const controller = DataSyncController.getInstance();
+                    return createControllerSubscriptionTransport(
+                        controller,
+                        this.expectedTransportScopeKey,
+                    );
+                },
+                policy: countSubscriptionPolicy,
+                onState: state => {
+                    this.subscriptionId = state.phase.tag === 'live'
+                        ? state.phase.subscriptionId
+                        : null;
+                },
+                publish: publication => this.publish(publication),
+                evict: () => this.notifyClose(),
+                reportError: (message, error) => console.error(message, error),
+            },
+        );
     }
 
     get count(): number | null {
-        return this.snapshot.data;
+        return this.resource.getSnapshot().data;
     }
 
     set count(count: number | null) {
-        if (count === null) {
-            this.snapshot = initialResourceSnapshot();
-            this.notifySubscribers();
-            this.notifySnapshotSubscribers();
-        } else {
-            this.dispatch({ type: 'SNAPSHOT', data: count });
-        }
+        this.resource.dispatchCompatibilityValue(count);
     }
 
     get connectError(): Error | null {
-        return this.snapshot.error;
+        return this.resource.getSnapshot().error;
     }
 
     getSnapshot(): ResourceSnapshot<number> {
-        return this.snapshot;
+        return this.resource.getSnapshot();
     }
 
     getServerSnapshot(): ResourceSnapshot<number> {
@@ -88,21 +87,15 @@ export class CountSubscription {
     }
 
     getCount(): number | null {
-        return this.snapshot.data;
+        return this.resource.getSnapshot().data;
     }
 
     subscribe(callback: () => void): () => void {
         this.retainInStore();
-        const shouldStart = this.trackedSubscriberCount() === 0;
         const id = this.nextSubscriberId++;
         this.subscriberEntries.set(id, callback);
         this.subscribers.add(callback);
-        this.disposalToken++;
-        if (shouldStart) {
-            void this.start(false).catch(() => {
-                // The immutable snapshot carries the error to the consumer.
-            });
-        }
+        this.updateDemand(false);
 
         let subscribed = true;
         return () => {
@@ -114,22 +107,16 @@ export class CountSubscription {
             if (!Array.from(this.subscriberEntries.values()).includes(callback)) {
                 this.subscribers.delete(callback);
             }
-            this.scheduleStop();
+            this.updateDemand(false);
         };
     }
 
     /** Internal external-store subscription; observes lifecycle and error changes. */
     subscribeSnapshot(callback: () => void): () => void {
         this.retainInStore();
-        const shouldStart = this.trackedSubscriberCount() === 0;
         const id = this.nextSnapshotSubscriberId++;
         this.snapshotSubscriberEntries.set(id, callback);
-        this.disposalToken++;
-        if (shouldStart) {
-            void this.start(false).catch(() => {
-                // The immutable snapshot carries the error to the consumer.
-            });
-        }
+        this.updateDemand(false);
 
         let subscribed = true;
         return () => {
@@ -138,7 +125,7 @@ export class CountSubscription {
             }
             subscribed = false;
             this.snapshotSubscriberEntries.delete(id);
-            this.scheduleStop();
+            this.updateDemand(false);
         };
     }
 
@@ -146,199 +133,35 @@ export class CountSubscription {
         this.subscriberEntries.clear();
         this.snapshotSubscriberEntries.clear();
         this.subscribers.clear();
-        this.disposalToken++;
-        await this.stop();
-    }
-
-    private start(reconnect: boolean): Promise<void> {
-        this.disposalToken++;
-        if (this.startPromise !== null) {
-            return this.startPromise;
-        }
-        if (this.started && this.subscriptionId !== null) {
-            return Promise.resolve();
-        }
-
-        if (!this.hasExpectedTransportScope()) {
-            this.closeForTransportScopeChange();
-            return Promise.resolve();
-        }
-
-        const controller = DataSyncController.getInstance();
-        if (!controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
-            this.closeForTransportScopeChange();
-            return Promise.resolve();
-        }
-        this.attachListeners(controller);
-        this.started = true;
-        const generation = ++this.generation;
-        this.dispatch({ type: 'CONNECT', reconnect });
-        const startPromise = this.createOnServer(generation, controller);
-        this.startPromise = startPromise;
-        void startPromise.finally(() => {
-            if (this.startPromise === startPromise) {
-                this.startPromise = null;
-            }
-        }).catch(() => {});
-        return startPromise;
-    }
-
-    private async createOnServer(generation: number, controller: DataSyncController): Promise<void> {
-        try {
-            const response = await controller.sendMessage({
-                tag: 'CreateCountSubscription',
-                query: this.serverQuery,
-            });
-            const subscriptionId = response.subscriptionId as UUID;
-            if (!this.started
-                || generation !== this.generation
-                || this.controller !== controller
-                || !this.hasExpectedTransportScope()
-                || !controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
-                if (!this.hasExpectedTransportScope()) {
-                    this.closeForTransportScopeChange();
-                }
-                await this.deleteOnServer(controller, subscriptionId);
-                return;
-            }
-
-            this.subscriptionId = subscriptionId;
-            this.dispatch({ type: 'SNAPSHOT', data: response.count as number });
-        } catch (unknownError) {
-            if (!this.started || generation !== this.generation || this.controller !== controller) {
-                return;
-            }
-            const error = unknownError instanceof Error ? unknownError : new Error(String(unknownError));
-            this.dispatch({ type: 'FAIL', error });
-            throw error;
-        }
-    }
-
-    private attachListeners(controller: DataSyncController): void {
-        if (this.listenersAttached && this.controller === controller) {
-            return;
-        }
-        this.detachListeners();
-        this.controller = controller;
-        this.listenersAttached = true;
-        controller.addEventListener('message', this.onMessage);
-        controller.addEventListener('close', this.onDataSyncClosed);
-        controller.addEventListener('reconnect', this.onDataSyncReconnect);
-    }
-
-    private detachListeners(): void {
-        const controller = this.controller;
-        if (controller === null) {
-            this.listenersAttached = false;
-            return;
-        }
-        if (this.listenersAttached) {
-            this.listenersAttached = false;
-            controller.removeEventListener('message', this.onMessage);
-            controller.removeEventListener('close', this.onDataSyncClosed);
-            controller.removeEventListener('reconnect', this.onDataSyncReconnect);
-        }
-        this.controller = null;
+        await this.resource.close();
     }
 
     private onMessage(message: ServerMessage): void {
-        if (!this.hasExpectedTransportScope()
-            || this.controller?.isBoundToTransportScope(this.expectedTransportScopeKey) !== true) {
-            this.closeForTransportScopeChange();
-            return;
-        }
-        if (message.tag === 'DidChangeCount' && message.subscriptionId === this.subscriptionId) {
-            this.dispatch({ type: 'SNAPSHOT', data: message.count as number });
-        }
+        this.resource.receiveMessage(message);
     }
 
     private onDataSyncClosed(event: unknown = null): void {
-        if (!this.started) {
-            return;
-        }
-        if (isTransportScopeChange(event)) {
-            this.closeForTransportScopeChange();
-            return;
-        }
-        this.generation++;
-        this.subscriptionId = null;
-        this.startPromise = null;
-        this.dispatch({ type: 'DISCONNECT', clearData: true });
+        this.resource.transportClosed(isTransportScopeChange(event));
     }
 
     private onDataSyncReconnect(): void {
-        if (!this.started || this.startPromise !== null || this.subscriptionId !== null) {
-            return;
-        }
-        void this.start(true).catch(() => {
-            // The immutable snapshot carries the error to the consumer.
-        });
+        void this.resource.transportReconnected();
     }
 
-    private scheduleStop(): void {
-        const token = ++this.disposalToken;
-        queueMicrotask(() => {
-            if (token === this.disposalToken
-                && this.subscribers.size === 0
-                && this.snapshotSubscriberEntries.size === 0) {
-                void this.stop();
-            }
-        });
-    }
-
-    private async stop(): Promise<void> {
-        if (!this.started && this.snapshot.status === 'closed') {
-            return;
-        }
-        this.started = false;
-        this.generation++;
-        this.startPromise = null;
-        const subscriptionId = this.subscriptionId;
-        const controller = this.controller;
-        this.subscriptionId = null;
-        this.detachListeners();
-        this.dispatch({ type: 'CLOSE' });
-        this.notifyClose();
-        if (subscriptionId !== null && controller !== null) {
-            await this.deleteOnServer(controller, subscriptionId);
-        }
-    }
-
-    private async deleteOnServer(controller: DataSyncController, subscriptionId: UUID): Promise<void> {
-        try {
-            await controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
-        } catch (error) {
-            if (!controller.retired && controller.connection !== null) {
-                console.error('Failed to delete a stale CountSubscription:', error);
+    private updateDemand(imperative: boolean): void {
+        const trackedCallbacks = new Set(this.subscriberEntries.values());
+        let externalSubscribers = 0;
+        for (const subscriber of this.subscribers) {
+            if (!trackedCallbacks.has(subscriber)) {
+                externalSubscribers++;
             }
         }
-    }
-
-    private closeForTransportScopeChange(): void {
-        this.started = false;
-        this.generation++;
-        this.subscriptionId = null;
-        this.startPromise = null;
-        this.detachListeners();
-        this.snapshot = initialResourceSnapshot();
-        this.dispatch({ type: 'CLOSE' });
-        this.notifyClose();
-    }
-
-    private dispatch(action: ResourceSnapshotAction<number>): void {
-        const nextSnapshot = reduceResourceSnapshot(this.snapshot, action);
-        if (nextSnapshot === this.snapshot) {
-            return;
-        }
-        this.snapshot = nextSnapshot;
-        this.notifySnapshotSubscribers();
-        if (action.type === 'SNAPSHOT' || action.type === 'DISCONNECT') {
-            this.notifySubscribers();
-        }
-    }
-
-    private trackedSubscriberCount(): number {
-        return this.subscriberEntries.size + this.snapshotSubscriberEntries.size;
+        this.resource.updateDemand(
+            this.subscriberEntries.size
+                + this.snapshotSubscriberEntries.size
+                + externalSubscribers,
+            imperative,
+        );
     }
 
     private retainInStore(): void {
@@ -356,6 +179,15 @@ export class CountSubscription {
             } catch (error) {
                 console.error('CountSubscription snapshot subscriber failed:', error);
             }
+        }
+    }
+
+    private publish(publication: SubscriptionPublication): void {
+        if (publication === 'snapshot' || publication === 'both') {
+            this.notifySnapshotSubscribers();
+        }
+        if (publication === 'legacy' || publication === 'both') {
+            this.notifySubscribers();
         }
     }
 
@@ -381,50 +213,46 @@ export class CountSubscription {
             console.error('CountSubscription close listener failed:', error);
         }
     }
-
-    private hasExpectedTransportScope(): boolean {
-        return this.expectedTransportScopeKey === DataSyncController.currentTransportScopeKey();
-    }
 }
+
+type CountSubscriptionRegistryInput = Readonly<{
+    key: string;
+    query: DynamicSQLQuery;
+    scope: string;
+}>;
+
+const countSubscriptionRegistry = createResourceRegistry<
+    CountSubscriptionRegistryInput,
+    string,
+    CountSubscription
+>({
+    key: input => input.key,
+    create: (input, lifecycle) => {
+        const subscription = new CountSubscription(input.query, input.scope);
+        subscription.onStoreRetain = () => lifecycle.retain(subscription);
+        subscription.onStoreClose = () => lifecycle.close(subscription);
+        return subscription;
+    },
+});
 
 export class CountSubscriptionStore {
-    private static readonly pendingQueryMap = new WeakValueMap<string, CountSubscription>();
-    static readonly queryMap = new ResettableMap<string, CountSubscription>(() => {
-        CountSubscriptionStore.pendingQueryMap.clear();
-    });
+    static get queryMap(): Map<string, CountSubscription> {
+        return countSubscriptionRegistry.active;
+    }
+
+    static set queryMap(next: Map<string, CountSubscription>) {
+        countSubscriptionRegistry.replaceActive(next);
+    }
 
     static get(query: DynamicSQLQuery): CountSubscription {
-        const key = `count:${dataSubscriptionKey(query)}`;
-        const existing = this.queryMap.get(key);
-        if (existing !== undefined) {
-            return existing;
-        }
-        const pending = this.pendingQueryMap.get(key);
-        if (pending !== undefined) {
-            return pending;
-        }
-
         const expectedTransportScopeKey = DataSyncController.currentTransportScopeKey();
-        const subscription = new CountSubscription(query, expectedTransportScopeKey);
-        subscription.onStoreRetain = () => {
-            this.queryMap.set(key, subscription);
-        };
-        subscription.onStoreClose = () => {
-            if (this.queryMap.get(key) === subscription) {
-                this.queryMap.delete(key);
-            }
-            this.pendingQueryMap.delete(key, subscription);
-        };
-        this.pendingQueryMap.set(key, subscription);
-        return subscription;
+        const key = countResourceKeyForScope(expectedTransportScopeKey, query);
+        return countSubscriptionRegistry.getOrCreate({
+            key,
+            query,
+            scope: expectedTransportScopeKey,
+        });
     }
-}
-
-function isTransportScopeChange(event: unknown): boolean {
-    return typeof event === 'object'
-        && event !== null
-        && 'type' in event
-        && (event as { type?: unknown }).type === 'transport-scope-changed';
 }
 
 function deepFreeze<T>(value: T): T {

--- a/ihp-datasync/data/DataSync/src/data-subscription-protocol.ts
+++ b/ihp-datasync/data/DataSync/src/data-subscription-protocol.ts
@@ -1,0 +1,93 @@
+import type { SubscriptionEvent, SubscriptionState } from './subscription-machine.js';
+import type { SubscriptionProtocol } from './subscription-resource.js';
+import type { DataRecord, DynamicSQLQuery, ServerMessage, UUID } from './types.js';
+
+/** Wire adapter for revisioned row snapshots and legacy invalidations. */
+export function createDataSubscriptionProtocol(
+    serverQuery: DynamicSQLQuery,
+): SubscriptionProtocol<DataRecord[]> {
+    return Object.freeze({
+        async create(transport) {
+            const response = await transport.request({
+                tag: 'CreateDataSubscription',
+                query: serverQuery,
+                protocolVersion: 1,
+            });
+            const snapshotMode = response.tag === 'DidCreateDataSubscriptionV2';
+            return {
+                subscriptionId: response.subscriptionId as UUID,
+                value: cloneDataRecords(response.result as DataRecord[]),
+                mode: snapshotMode ? 'snapshot' : 'legacy',
+                revision: snapshotMode && typeof response.revision === 'number'
+                    ? response.revision
+                    : 0,
+            };
+        },
+        async delete(transport, subscriptionId) {
+            await transport.request({ tag: 'DeleteDataSubscription', subscriptionId });
+        },
+        async refresh(transport) {
+            const response = await transport.request({
+                tag: 'DataSyncQuery',
+                query: serverQuery,
+                transactionId: null,
+            });
+            return cloneDataRecords(response.result as DataRecord[]);
+        },
+        isRelevantMessage(message, state) {
+            return state.phase.tag === 'live'
+                && message.subscriptionId === state.phase.subscriptionId;
+        },
+        decodeMessage: decodeDataSubscriptionMessage,
+        createError(unknownError) {
+            const error = unknownError instanceof Error
+                ? unknownError
+                : new Error(String(unknownError));
+            return new Error(
+                error.message
+                + ' while trying to subscribe to:\n'
+                + JSON.stringify(serverQuery, null, 4),
+            );
+        },
+    });
+}
+
+export function decodeDataSubscriptionMessage(
+    message: ServerMessage,
+    state: SubscriptionState<DataRecord[]>,
+): SubscriptionEvent<DataRecord[]> | null {
+    if (
+        state.phase.tag !== 'live'
+        || message.subscriptionId !== state.phase.subscriptionId
+    ) {
+        return null;
+    }
+    if (message.tag === 'DidReplaceDataSubscription') {
+        return {
+            type: 'SERVER_SNAPSHOT',
+            generation: state.generation,
+            subscriptionId: state.phase.subscriptionId,
+            value: cloneDataRecords(message.result as DataRecord[]),
+            revision: typeof message.revision === 'number'
+                ? message.revision
+                : state.phase.revision + 1,
+        };
+    }
+    if (
+        state.phase.mode === 'legacy'
+        && (message.tag === 'DidInsert'
+            || message.tag === 'DidUpdate'
+            || message.tag === 'DidDelete')
+    ) {
+        return {
+            type: 'LEGACY_INVALIDATED',
+            generation: state.generation,
+            subscriptionId: state.phase.subscriptionId,
+        };
+    }
+    return null;
+}
+
+export function cloneDataRecords(records: DataRecord[]): DataRecord[] {
+    return records.map(record => ({ ...record })) as DataRecord[];
+}

--- a/ihp-datasync/data/DataSync/src/data-subscription-store.ts
+++ b/ihp-datasync/data/DataSync/src/data-subscription-store.ts
@@ -1,0 +1,94 @@
+import { DataSubscription, DataSyncController } from './ihp-datasync.js';
+import { WeakValueMap } from './weak-value-map.js';
+import type { DataRecord, DataSubscriptionOptions, DynamicSQLQuery } from './types.js';
+
+class ResettableMap<K, V> extends Map<K, V> {
+    constructor(private readonly resetPendingEntries: () => void) {
+        super();
+    }
+
+    override clear(): void {
+        super.clear();
+        this.resetPendingEntries();
+    }
+}
+
+/**
+ * React-independent registry for shared query resources.
+ *
+ * Looking up a resource is deliberately inert. The first committed subscriber
+ * starts the transport, so abandoned React renders cannot open WebSockets.
+ */
+export class DataSubscriptionStore {
+    private static readonly pendingQueryMap = new WeakValueMap<string, DataSubscription>();
+    // Keep the historical public `Map` type so downstream code can replace
+    // this test/debug registry without depending on the internal reset hook.
+    static queryMap: Map<string, DataSubscription> = new ResettableMap<string, DataSubscription>(() => {
+        DataSubscriptionStore.pendingQueryMap.clear();
+    });
+    static cache = new Map<string, DataRecord[]>();
+
+    static get(
+        query: DynamicSQLQuery,
+        options: DataSubscriptionOptions | null = null,
+    ): DataSubscription {
+        const scope = backendScope();
+        const key = dataSubscriptionKeyForScope(scope, query, options);
+        const existingSubscription = this.queryMap.get(key);
+        if (existingSubscription !== undefined) {
+            return existingSubscription;
+        }
+        const pendingSubscription = this.pendingQueryMap.get(key);
+        if (pendingSubscription !== undefined) {
+            return pendingSubscription;
+        }
+
+        // A session-cookie user id is intentionally invisible to JavaScript, so
+        // it cannot be part of a safe cache key. Cache only JWT-scoped sessions;
+        // otherwise a logout/login could briefly expose the previous user's rows.
+        const scopedCache = currentJWT() === null ? null : this.cache;
+        const subscription = new DataSubscription(query, options, scopedCache, key, scope);
+        subscription.onStoreRetain = () => {
+            this.queryMap.set(key, subscription);
+        };
+        subscription.onStoreClose = () => {
+            if (this.queryMap.get(key) === subscription) {
+                this.queryMap.delete(key);
+            }
+            this.pendingQueryMap.delete(key, subscription);
+        };
+        this.pendingQueryMap.set(key, subscription);
+        return subscription;
+    }
+}
+
+export function dataSubscriptionKey(
+    query: DynamicSQLQuery,
+    options: DataSubscriptionOptions | null = null,
+): string {
+    return dataSubscriptionKeyForScope(backendScope(), query, options);
+}
+
+function dataSubscriptionKeyForScope(
+    scope: string,
+    query: DynamicSQLQuery,
+    options: DataSubscriptionOptions | null,
+): string {
+    return JSON.stringify([scope, query, options]);
+}
+
+function backendScope(): string {
+    return DataSyncController.currentTransportScopeKey();
+}
+
+function currentJWT(): string | null {
+    let jwt: string | null = null;
+    try {
+        if (typeof localStorage !== 'undefined') {
+            jwt = localStorage.getItem('ihp_jwt');
+        }
+    } catch (_error) {
+        // localStorage may be unavailable in SSR or privacy-restricted contexts.
+    }
+    return jwt;
+}

--- a/ihp-datasync/data/DataSync/src/data-subscription-store.ts
+++ b/ihp-datasync/data/DataSync/src/data-subscription-store.ts
@@ -1,17 +1,35 @@
 import { DataSubscription, DataSyncController } from './ihp-datasync.js';
-import { WeakValueMap } from './weak-value-map.js';
+import { dataResourceKeyForScope } from './resource-key.js';
+import { createResourceRegistry } from './resource-registry.js';
 import type { DataRecord, DataSubscriptionOptions, DynamicSQLQuery } from './types.js';
 
-class ResettableMap<K, V> extends Map<K, V> {
-    constructor(private readonly resetPendingEntries: () => void) {
-        super();
-    }
+type DataSubscriptionRegistryInput = Readonly<{
+    key: string;
+    scope: string;
+    query: DynamicSQLQuery;
+    options: DataSubscriptionOptions | null;
+    cache: Map<string, DataRecord[]> | null;
+}>;
 
-    override clear(): void {
-        super.clear();
-        this.resetPendingEntries();
-    }
-}
+const dataSubscriptionRegistry = createResourceRegistry<
+    DataSubscriptionRegistryInput,
+    string,
+    DataSubscription
+>({
+    key: input => input.key,
+    create: (input, lifecycle) => {
+        const subscription = new DataSubscription(
+            input.query,
+            input.options,
+            input.cache,
+            input.key,
+            input.scope,
+        );
+        subscription.onStoreRetain = () => lifecycle.retain(subscription);
+        subscription.onStoreClose = () => lifecycle.close(subscription);
+        return subscription;
+    },
+});
 
 /**
  * React-independent registry for shared query resources.
@@ -20,45 +38,35 @@ class ResettableMap<K, V> extends Map<K, V> {
  * starts the transport, so abandoned React renders cannot open WebSockets.
  */
 export class DataSubscriptionStore {
-    private static readonly pendingQueryMap = new WeakValueMap<string, DataSubscription>();
-    // Keep the historical public `Map` type so downstream code can replace
-    // this test/debug registry without depending on the internal reset hook.
-    static queryMap: Map<string, DataSubscription> = new ResettableMap<string, DataSubscription>(() => {
-        DataSubscriptionStore.pendingQueryMap.clear();
-    });
     static cache = new Map<string, DataRecord[]>();
+
+    // Keep the historical writable Map surface while the functional registry
+    // owns canonical pending and active values internally.
+    static get queryMap(): Map<string, DataSubscription> {
+        return dataSubscriptionRegistry.active;
+    }
+
+    static set queryMap(next: Map<string, DataSubscription>) {
+        dataSubscriptionRegistry.replaceActive(next);
+    }
 
     static get(
         query: DynamicSQLQuery,
         options: DataSubscriptionOptions | null = null,
     ): DataSubscription {
         const scope = backendScope();
-        const key = dataSubscriptionKeyForScope(scope, query, options);
-        const existingSubscription = this.queryMap.get(key);
-        if (existingSubscription !== undefined) {
-            return existingSubscription;
-        }
-        const pendingSubscription = this.pendingQueryMap.get(key);
-        if (pendingSubscription !== undefined) {
-            return pendingSubscription;
-        }
-
+        const key = dataResourceKeyForScope(scope, query, options);
         // A session-cookie user id is intentionally invisible to JavaScript, so
         // it cannot be part of a safe cache key. Cache only JWT-scoped sessions;
         // otherwise a logout/login could briefly expose the previous user's rows.
         const scopedCache = currentJWT() === null ? null : this.cache;
-        const subscription = new DataSubscription(query, options, scopedCache, key, scope);
-        subscription.onStoreRetain = () => {
-            this.queryMap.set(key, subscription);
-        };
-        subscription.onStoreClose = () => {
-            if (this.queryMap.get(key) === subscription) {
-                this.queryMap.delete(key);
-            }
-            this.pendingQueryMap.delete(key, subscription);
-        };
-        this.pendingQueryMap.set(key, subscription);
-        return subscription;
+        return dataSubscriptionRegistry.getOrCreate({
+            key,
+            scope,
+            query,
+            options,
+            cache: scopedCache,
+        });
     }
 }
 
@@ -66,15 +74,7 @@ export function dataSubscriptionKey(
     query: DynamicSQLQuery,
     options: DataSubscriptionOptions | null = null,
 ): string {
-    return dataSubscriptionKeyForScope(backendScope(), query, options);
-}
-
-function dataSubscriptionKeyForScope(
-    scope: string,
-    query: DynamicSQLQuery,
-    options: DataSubscriptionOptions | null,
-): string {
-    return JSON.stringify([scope, query, options]);
+    return dataResourceKeyForScope(backendScope(), query, options);
 }
 
 function backendScope(): string {

--- a/ihp-datasync/data/DataSync/src/ihp-datasync-react.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync-react.ts
@@ -1,1 +1,2 @@
-export { useQuery } from './react.js';
+export { AuthCompletedContext, AuthCompletedProvider, useQuery } from './react.js';
+export type { AuthCompletedProviderProps } from './react.js';

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -632,11 +632,13 @@ class DataSubscription {
             return;
         }
 
+        const projectedChangeSet = changeSet === null ? null : this.projectFields(changeSet);
+        const projectedAppendSet = appendSet === null ? null : this.projectFields(appendSet);
         this.records = this.normalizeRecords(this.records!.map(record => {
             if (record.id === id) {
-                const updated = Object.assign({}, record, changeSet);
-                if (appendSet && !wasOptimisticallyUpdated) {
-                    for (const [key, value] of Object.entries(appendSet)) {
+                const updated = Object.assign({}, record, projectedChangeSet);
+                if (projectedAppendSet && !wasOptimisticallyUpdated) {
+                    for (const [key, value] of Object.entries(projectedAppendSet)) {
                         (updated as Record<string, unknown>)[key] = (typeof updated[key] === 'string' ? updated[key] : '') + String(value);
                     }
                 }
@@ -658,6 +660,7 @@ class DataSubscription {
         }
 
         const shouldAppend = this.newRecordBehaviour === APPEND_NEW_RECORD;
+        const projectedRecord = this.projectFields(newRecord) as DataRecord;
 
         const newRecordId = newRecord.id;
         const optimisticIndex = this.optimisticCreatedPendingRecordIds.indexOf(newRecordId);
@@ -668,14 +671,14 @@ class DataSubscription {
             }
             // The create response and DidInsert notification can both contain
             // the same record. Reconcile by id instead of appending twice.
-            this.onUpdate(newRecordId, newRecord, null, isOptimistic);
+            this.onUpdate(newRecordId, projectedRecord, null, isOptimistic);
             return;
         }
 
         if (isOptimistic && optimisticIndex === -1) {
             this.optimisticCreatedPendingRecordIds.push(newRecordId);
         }
-        const records = shouldAppend ? [...this.records!, newRecord] : [newRecord, ...this.records!];
+        const records = shouldAppend ? [...this.records!, projectedRecord] : [projectedRecord, ...this.records!];
         this.records = this.normalizeRecords(records);
 
         this.updateSubscribers();
@@ -771,6 +774,20 @@ class DataSubscription {
         return normalized;
     }
 
+    private projectFields<T extends Record<string, unknown>>(fields: T): T {
+        if (this.query.selectedColumns.tag === 'SelectAll') {
+            return fields;
+        }
+
+        const projected: Record<string, unknown> = {};
+        for (const column of this.query.selectedColumns.contents) {
+            if (Object.prototype.hasOwnProperty.call(fields, column)) {
+                projected[column] = fields[column];
+            }
+        }
+        return projected as T;
+    }
+
     supportsOptimisticUpdates(): boolean {
         const selectedColumns = this.query.selectedColumns;
         const hasUnprojectedOrderColumn = selectedColumns.tag === 'SelectSpecific'
@@ -837,7 +854,29 @@ class DataSubscription {
             return;
         }
 
-        this.close();
+        void this.closeWhenUnused();
+    }
+
+    private async closeWhenUnused(): Promise<void> {
+        if (!this.isClosed && !this.isConnected) {
+            try {
+                await this.createOnServerPromise;
+            } catch (_error) {
+                // close() handles failed setup and removes the local subscription.
+            }
+        }
+
+        // A React commit can subscribe while setup is still pending. Recheck
+        // after the await so that the earlier cleanup request is cancellable.
+        if (this.subscribers.length > 0) {
+            return;
+        }
+
+        try {
+            await this.close();
+        } catch (error) {
+            console.error('Failed to close an unused DataSubscription:', error);
+        }
     }
 
     onClose(): void {
@@ -857,8 +896,19 @@ function compareQueryValues(left: unknown, right: unknown): number {
         return -1;
     }
 
-    const normalizedLeft = left instanceof Date ? left.getTime() : left;
-    const normalizedRight = right instanceof Date ? right.getTime() : right;
+    let normalizedLeft = left instanceof Date ? left.getTime() : left;
+    let normalizedRight = right instanceof Date ? right.getTime() : right;
+    if (left instanceof Date || right instanceof Date) {
+        const leftTimestamp = toTimestamp(left);
+        const rightTimestamp = toTimestamp(right);
+        if (leftTimestamp !== null && rightTimestamp !== null) {
+            normalizedLeft = leftTimestamp;
+            normalizedRight = rightTimestamp;
+        }
+    }
+    if (Object.is(normalizedLeft, normalizedRight)) {
+        return 0;
+    }
     if ((typeof normalizedLeft === 'number' && typeof normalizedRight === 'number')
         || (typeof normalizedLeft === 'string' && typeof normalizedRight === 'string')
         || (typeof normalizedLeft === 'boolean' && typeof normalizedRight === 'boolean')) {
@@ -868,6 +918,17 @@ function compareQueryValues(left: unknown, right: unknown): number {
     const leftText = String(normalizedLeft);
     const rightText = String(normalizedRight);
     return leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
+}
+
+function toTimestamp(value: unknown): number | null {
+    const timestamp = value instanceof Date
+        ? value.getTime()
+        : typeof value === 'string'
+            ? Date.parse(value)
+            : typeof value === 'number'
+                ? value
+                : NaN;
+    return Number.isFinite(timestamp) ? timestamp : null;
 }
 
 function initIHPBackend({ host }: { host: string }): void {
@@ -976,11 +1037,12 @@ export async function deleteRecord<T extends TableName>(table: T, id: UUID, opti
     const transactionId = options.transactionId ?? null;
     const request = { tag: 'DeleteRecordMessage', table, id, transactionId };
 
-    const undoOptimisticDeleteRecord = transactionId === null
-        ? deleteRecordOptimistic(table, id)
-        : () => {};
+    let undoOptimisticDeleteRecord = () => {};
     try {
         await waitPendingCreation(table, id);
+        if (transactionId === null) {
+            undoOptimisticDeleteRecord = deleteRecordOptimistic(table, id);
+        }
         await DataSyncController.getInstance().sendMessage(request);
 
         return;

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -21,6 +21,17 @@ type EventListeners = {
     [K in DataSyncEventType]: DataSyncEventMap[K][];
 };
 
+type OutboxMessage = {
+    requestId: number;
+    payload: string;
+};
+
+type PendingOptimisticCreate = {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (reason: Error) => void;
+};
+
 class DataSyncController {
     static instance: DataSyncController | null = null;
     static ihpBackendHost: string | null = null;
@@ -52,13 +63,15 @@ class DataSyncController {
     requestIdCounter: number;
     receivedFirstResponse: boolean;
     eventListeners: EventListeners;
-    outbox: string[];
+    outbox: OutboxMessage[];
     reconnectTimeout: ReturnType<typeof setTimeout> | null;
-    pendingRequestTimeout: ReturnType<typeof setTimeout> | null;
     dataSubscriptions: DataSubscription[];
     optimisticCreatedPendingRecordIds: UUID[];
+    pendingOptimisticCreates: Map<UUID, PendingOptimisticCreate>;
     optimisticCreatedNeedsCreatedAtField: Set<string>;
     messageTimeout: number;
+    connectionRetryLimit: number;
+    connectionRetryMaxDelayExponent: number;
     pendingConnection: Promise<WebSocket> | null;
 
     constructor() {
@@ -75,11 +88,13 @@ class DataSyncController {
 
         this.outbox = [];
         this.reconnectTimeout = null;
-        this.pendingRequestTimeout = null;
         this.dataSubscriptions = [];
         this.optimisticCreatedPendingRecordIds = [];
+        this.pendingOptimisticCreates = new Map();
         this.optimisticCreatedNeedsCreatedAtField = new Set();
         this.messageTimeout = 5000;
+        this.connectionRetryLimit = 32;
+        this.connectionRetryMaxDelayExponent = 6;
         this.pendingConnection = null;
     }
 
@@ -92,51 +107,58 @@ class DataSyncController {
             return await this.pendingConnection;
         }
 
-        const connect = (): Promise<WebSocket> => new Promise((resolve, reject) => {
-            const socket = new WebSocket(DataSyncController.getWSUrl());
+        let pendingConnection!: Promise<WebSocket>;
+        pendingConnection = (async () => {
+            const connect = (): Promise<{ socket: WebSocket; event: Event }> => new Promise((resolve, reject) => {
+                const socket = new WebSocket(DataSyncController.getWSUrl());
 
-            socket.onopen = (event) => {
-                socket.onclose = this.onClose.bind(this);
-                socket.onmessage = this.onMessage.bind(this);
+                socket.onopen = (event) => {
+                    this.connection = socket;
+                    socket.onclose = (closeEvent) => this.onClose(closeEvent, socket);
+                    socket.onmessage = this.onMessage.bind(this);
+                    resolve({ socket, event });
+                };
 
-                resolve(socket);
-
-                for (const listener of this.eventListeners.open) {
-                    listener(event);
-                }
-            };
-
-            socket.onerror = (event) => reject(event);
-        });
-        const wait = (timeout: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, timeout));
-
-        const MAX_RETRIES = 32;
-        const MAX_DELAY_EXPONENT = 6; // 2 ^ 6 ~> 1 min
-
-        for (let i = 0; i < MAX_RETRIES; i++) {
-            this.pendingConnection = connect();
-
+                socket.onerror = (event) => reject(event);
+            });
+            const wait = (timeout: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, timeout));
             try {
-                const socket = await this.pendingConnection;
-                this.pendingConnection = null;
-                this.connection = socket;
+                for (let i = 0; i < this.connectionRetryLimit; i++) {
+                    try {
+                        const { socket, event } = await connect();
+                        if (this.connection !== socket) {
+                            throw new Error('DataSync WebSocket closed while the connection was opening');
+                        }
+                        this.flushOutbox(socket);
 
-                // Flush outbox
-                for (let j = 0; j < this.outbox.length; j++) {
-                    this.connection.send(this.outbox[j]);
+                        for (const listener of this.eventListeners.open) {
+                            try {
+                                listener(event);
+                            } catch (error) {
+                                console.error('DataSync open listener failed:', error);
+                            }
+                        }
+
+                        return socket;
+                    } catch (error) {
+                        if (i === this.connectionRetryLimit - 1) {
+                            throw error;
+                        }
+                        const time = Math.pow(2, Math.min(i, this.connectionRetryMaxDelayExponent));
+                        console.log('Retrying in ', time, 'secs');
+                        await wait(time * 1000);
+                    }
                 }
 
-                this.outbox = [];
-
-                return this.connection;
-            } catch (error) {
-                const time = Math.pow(2, Math.min(i, MAX_DELAY_EXPONENT)); // 2, 4, 8, 16, 32, ...
-                console.log('Retrying in ', time, 'secs');
-                await wait(time * 1000);
+                throw new Error('Unable to connect to the DataSync Websocket');
+            } finally {
+                if (this.pendingConnection === pendingConnection) {
+                    this.pendingConnection = null;
+                }
             }
-        }
-
-        throw new Error('Unable to connect to the DataSync Websocket');
+        })();
+        this.pendingConnection = pendingConnection;
+        return await pendingConnection;
     }
 
     onMessage(event: MessageEvent): void {
@@ -144,18 +166,8 @@ class DataSyncController {
         const requestId = payload.requestId;
         const request = this.pendingRequests.find(request => request.requestId === requestId);
 
-        if (request !== undefined) {
-            this.pendingRequests.splice(this.pendingRequests.indexOf(request), 1);
-        }
-
-        this.receivedFirstResponse = true;
-
-        if (this.pendingRequestTimeout) {
-            clearTimeout(this.pendingRequestTimeout);
-            this.pendingRequestTimeout = null;
-        }
-
         if (request) {
+            this.removePendingRequest(request);
             const { resolve, reject } = request;
 
             if (payload.tag === 'DataSyncError') {
@@ -169,11 +181,17 @@ class DataSyncController {
             }
         }
 
+        this.receivedFirstResponse = true;
         this.eventListeners.message.slice(0).forEach(callback => callback(payload));
     }
 
-    onClose(_event: CloseEvent | null): void {
+    onClose(_event: CloseEvent | null, closedSocket: WebSocket | null = null): void {
+        if (closedSocket !== null && this.connection !== closedSocket) {
+            return;
+        }
+
         this.connection = null;
+        this.rejectSentPendingRequests(new Error('DataSync WebSocket closed before the server responded'));
 
         for (const listener of this.eventListeners.close) {
             listener(_event);
@@ -185,23 +203,77 @@ class DataSyncController {
     async sendMessage(payload: Record<string, unknown>): Promise<ServerMessage> {
         return new Promise((resolve, reject) => {
             payload.requestId = this.requestIdCounter++;
-            this.pendingRequests.push({ requestId: payload.requestId as number, resolve: resolve as (value: unknown) => void, reject });
+            const requestId = payload.requestId as number;
+            const pendingRequest: PendingRequest = { requestId, resolve, reject, timeout: null, sent: false };
+            const outboxMessage = { requestId, payload: JSON.stringify(payload) };
+            this.pendingRequests.push(pendingRequest);
 
             if (this.connection === null) {
-                this.outbox.push(JSON.stringify(payload));
+                this.outbox.push(outboxMessage);
 
-                const isFirstMessage = this.requestIdCounter === 1;
-                if (isFirstMessage) {
-                    this.startConnection();
+                if (this.reconnectTimeout === null) {
+                    void this.startConnection().catch((error: unknown) => {
+                        this.rejectPendingRequest(requestId, new Error(`Unable to connect to the DataSync WebSocket: ${String(error)}`));
+                    });
                 }
             } else {
-                this.connection.send(JSON.stringify(payload));
-
-                if (!this.pendingRequestTimeout) {
-                    this.pendingRequestTimeout = setTimeout(this.onPendingRequestTimeout.bind(this), this.messageTimeout);
-                }
+                this.sendPendingRequest(this.connection, outboxMessage);
             }
         });
+    }
+
+    private flushOutbox(connection: WebSocket): void {
+        const queuedMessages = this.outbox;
+        this.outbox = [];
+        for (const message of queuedMessages) {
+            this.sendPendingRequest(connection, message);
+        }
+    }
+
+    private sendPendingRequest(connection: WebSocket, message: OutboxMessage): void {
+        const request = this.pendingRequests.find(({ requestId }) => requestId === message.requestId);
+        if (!request) {
+            return;
+        }
+
+        try {
+            connection.send(message.payload);
+            request.sent = true;
+            request.timeout = setTimeout(() => this.onPendingRequestTimeout(request.requestId), this.messageTimeout);
+        } catch (error) {
+            this.rejectPendingRequest(request.requestId, error);
+        }
+    }
+
+    private removePendingRequest(request: PendingRequest): void {
+        if (request.timeout !== null) {
+            clearTimeout(request.timeout);
+        }
+        const index = this.pendingRequests.indexOf(request);
+        if (index !== -1) {
+            this.pendingRequests.splice(index, 1);
+        }
+        const outboxIndex = this.outbox.findIndex(({ requestId }) => requestId === request.requestId);
+        if (outboxIndex !== -1) {
+            this.outbox.splice(outboxIndex, 1);
+        }
+    }
+
+    private rejectPendingRequest(requestId: number, reason: unknown): void {
+        const request = this.pendingRequests.find(request => request.requestId === requestId);
+        if (!request) {
+            return;
+        }
+        this.removePendingRequest(request);
+        request.reject(reason);
+    }
+
+    private rejectSentPendingRequests(reason: Error): void {
+        for (const request of this.pendingRequests.slice()) {
+            if (request.sent) {
+                this.rejectPendingRequest(request.requestId, reason);
+            }
+        }
     }
 
     addEventListener<E extends DataSyncEventType>(event: E, callback: DataSyncEventMap[E]): void {
@@ -225,12 +297,17 @@ class DataSyncController {
             clearTimeout(this.reconnectTimeout);
         }
         this.reconnectTimeout = setTimeout(async () => {
+            this.reconnectTimeout = null;
             try {
                 console.log('Trying to reconnect DataSync ...');
                 await this.startConnection();
 
                 for (const listener of this.eventListeners.reconnect) {
-                    listener();
+                    try {
+                        listener();
+                    } catch (error) {
+                        console.error('DataSync reconnect listener failed:', error);
+                    }
                 }
             } catch (error) {
                 console.error('DataSync reconnection failed:', error);
@@ -248,11 +325,16 @@ class DataSyncController {
         }
     }
 
-    onPendingRequestTimeout(): void {
+    onPendingRequestTimeout(requestId: number): void {
+        const request = this.pendingRequests.find(request => request.requestId === requestId);
+        if (!request) {
+            return;
+        }
+
+        this.rejectPendingRequest(requestId, new Error(`DataSync request ${requestId} timed out after ${this.messageTimeout}ms`));
         if (this.connection) {
             console.log('Pending request timed out, closing WebSocket');
             this.connection.close();
-            this.onClose(null);
         }
     }
 }
@@ -274,6 +356,8 @@ class DataSubscription {
     optimisticUpdatedPendingRecordIds: Set<UUID>;
     private closeNotificationSent: boolean;
     private closeIfNotUsedTimeout: ReturnType<typeof setTimeout> | null;
+    private refreshPromise: Promise<void> | null;
+    private refreshRequested: boolean;
 
     constructor(query: DynamicSQLQuery, options: DataSubscriptionOptions | null = null, cache: Map<string, DataRecord[]> | null = null) {
         if (typeof query !== "object" || !('table' in query)) {
@@ -283,6 +367,10 @@ class DataSubscription {
         this.createOnServerPromise = new Promise((resolve, reject) => {
             this.resolveCreateOnServer = resolve;
             this.rejectCreateOnServer = reject;
+        });
+        void this.createOnServerPromise.catch(() => {
+            // close() observes the same promise when it needs to wait for setup;
+            // most subscriptions never need that path, so avoid an unhandled rejection.
         });
 
         this.isClosed = false;
@@ -316,6 +404,8 @@ class DataSubscription {
         this.optimisticUpdatedPendingRecordIds = new Set();
         this.closeNotificationSent = false;
         this.closeIfNotUsedTimeout = null;
+        this.refreshPromise = null;
+        this.refreshRequested = false;
     }
 
     detectNewRecordBehaviour(): number {
@@ -356,7 +446,8 @@ class DataSubscription {
 
             this.isConnected = true;
             this.isClosed = false;
-            this.records = result;
+            this.connectError = null;
+            this.records = this.normalizeRecords(result);
 
             this.resolveCreateOnServer(result);
             this.updateSubscribers();
@@ -364,8 +455,10 @@ class DataSubscription {
             dataSyncController.learnOptimisticShapeFromResult(this.query.table, result);
         } catch (e) {
             const error = e as Error;
+            this.isConnected = false;
             this.connectError = new Error(error.message + ' while trying to subscribe to:\n' + JSON.stringify(this.query, null, 4));
             this.rejectCreateOnServer(this.connectError);
+            this.notifySubscribers();
             throw this.connectError;
         }
     }
@@ -406,7 +499,14 @@ class DataSubscription {
 
         // We cannot close the DataSubscription when the subscriptionId is not assigned
         if (!this.isClosed && !this.isConnected) {
-            await this.createOnServerPromise;
+            try {
+                await this.createOnServerPromise;
+            } catch (_error) {
+                this.isClosed = true;
+                this.notifyClose();
+                this.detachFromDataSyncController(dataSyncController);
+                return;
+            }
             return this.close();
         }
 
@@ -453,12 +553,14 @@ class DataSubscription {
         this.scheduleCloseIfNotUsed();
     }
 
-    async onDataSyncReconnect(): Promise<void> {
-        await this.createOnServer();
+    onDataSyncReconnect(): void {
+        void this.createOnServer().catch(() => {
+            // createOnServer stores the error and notifies React subscribers.
+        });
     }
 
     onUpdate(id: UUID, changeSet: Record<string, unknown> | null, appendSet: Record<string, unknown> | null): void {
-        this.records = this.records!.map(record => {
+        this.records = this.normalizeRecords(this.records!.map(record => {
             if (record.id === id) {
                 const updated = Object.assign({}, record, changeSet);
                 if (appendSet && !this.optimisticUpdatedPendingRecordIds.has(id)) {
@@ -470,10 +572,11 @@ class DataSubscription {
             }
 
             return record;
-        });
+        }));
 
         this.optimisticUpdatedPendingRecordIds.delete(id);
         this.updateSubscribers();
+        this.refreshAfterComplexMutation();
     }
 
     onCreate(newRecord: DataRecord): void {
@@ -484,11 +587,14 @@ class DataSubscription {
         if (isOptimisticallyCreatedAlready) {
             this.onUpdate(newRecordId, newRecord, null);
             this.optimisticCreatedPendingRecordIds.splice(this.optimisticCreatedPendingRecordIds.indexOf(newRecordId), 1);
+            return;
         } else {
-            this.records = shouldAppend ? [...this.records!, newRecord] : [newRecord, ...this.records!];
+            const records = shouldAppend ? [...this.records!, newRecord] : [newRecord, ...this.records!];
+            this.records = this.normalizeRecords(records);
         }
 
         this.updateSubscribers();
+        this.refreshAfterComplexMutation();
     }
 
     onCreateOptimistic(newRecord: DataRecord): void {
@@ -502,7 +608,12 @@ class DataSubscription {
 
     onDelete(id: UUID): void {
         this.records = this.records!.filter(record => record.id !== id);
+        const optimisticIndex = this.optimisticCreatedPendingRecordIds.indexOf(id);
+        if (optimisticIndex !== -1) {
+            this.optimisticCreatedPendingRecordIds.splice(optimisticIndex, 1);
+        }
         this.updateSubscribers();
+        this.refreshAfterComplexMutation();
     }
 
     subscribe(callback: (records: DataRecord[] | null) => void): () => void {
@@ -537,11 +648,96 @@ class DataSubscription {
     }
 
     updateSubscribers(): void {
-        if (this.cache) {
-            this.cache.set(JSON.stringify(this.query), this.records!);
+        if (this.cache && this.records !== null) {
+            this.cache.set(JSON.stringify(this.query), this.records);
         }
+        this.notifySubscribers();
+    }
+
+    private notifySubscribers(): void {
         for (const subscriber of this.subscribers) {
             subscriber(this.records);
+        }
+    }
+
+    private normalizeRecords(records: DataRecord[]): DataRecord[] {
+        let normalized = [...records];
+        const sortableClauses = this.query.orderByClause.filter(clause => 'orderByColumn' in clause);
+
+        if (sortableClauses.length > 0) {
+            normalized.sort((left, right) => {
+                for (const clause of sortableClauses) {
+                    const comparison = compareQueryValues(left[clause.orderByColumn], right[clause.orderByColumn]);
+                    if (comparison !== 0) {
+                        return clause.orderByDirection === 'Desc' ? -comparison : comparison;
+                    }
+                }
+                return 0;
+            });
+        }
+
+        if (this.query.distinctOnColumn !== null) {
+            const seen = new Set<unknown>();
+            normalized = normalized.filter(record => {
+                const value = record[this.query.distinctOnColumn!];
+                if (seen.has(value)) {
+                    return false;
+                }
+                seen.add(value);
+                return true;
+            });
+        }
+
+        if (this.query.limit !== null && this.query.limit >= 0) {
+            normalized = normalized.slice(0, this.query.limit);
+        }
+
+        return normalized;
+    }
+
+    private refreshAfterComplexMutation(): void {
+        const selectedColumns = this.query.selectedColumns;
+        const hasUnprojectedOrderColumn = selectedColumns.tag === 'SelectSpecific'
+            && this.query.orderByClause.some(clause => 'orderByColumn' in clause
+                && !selectedColumns.contents.includes(clause.orderByColumn));
+        const requiresRefresh = this.query.limit !== null
+            || this.query.offset !== null
+            || this.query.distinctOnColumn !== null
+            || this.query.orderByClause.some(clause => 'tag' in clause && clause.tag === 'OrderByTSRank')
+            || hasUnprojectedOrderColumn;
+        if (!requiresRefresh || this.isClosed) {
+            return;
+        }
+
+        this.refreshRequested = true;
+        if (this.refreshPromise !== null) {
+            return;
+        }
+
+        this.refreshPromise = this.refreshRecordsFromServer();
+    }
+
+    private async refreshRecordsFromServer(): Promise<void> {
+        this.refreshRequested = false;
+        try {
+            const response = await DataSyncController.getInstance().sendMessage({
+                tag: 'DataSyncQuery',
+                query: this.query,
+                transactionId: null
+            });
+            if (!this.isClosed) {
+                this.records = this.normalizeRecords(response.result as DataRecord[]);
+                this.updateSubscribers();
+            }
+        } catch (error) {
+            if (!this.isClosed) {
+                console.error('Failed to refresh a complex DataSubscription:', error);
+            }
+        } finally {
+            this.refreshPromise = null;
+            if (this.refreshRequested) {
+                this.refreshAfterComplexMutation();
+            }
         }
     }
 
@@ -566,6 +762,31 @@ class DataSubscription {
     }
 }
 
+function compareQueryValues(left: unknown, right: unknown): number {
+    if (Object.is(left, right)) {
+        return 0;
+    }
+    // PostgreSQL's default is NULLS LAST for ASC and NULLS FIRST for DESC.
+    if (left === null || left === undefined) {
+        return 1;
+    }
+    if (right === null || right === undefined) {
+        return -1;
+    }
+
+    const normalizedLeft = left instanceof Date ? left.getTime() : left;
+    const normalizedRight = right instanceof Date ? right.getTime() : right;
+    if ((typeof normalizedLeft === 'number' && typeof normalizedRight === 'number')
+        || (typeof normalizedLeft === 'string' && typeof normalizedRight === 'string')
+        || (typeof normalizedLeft === 'boolean' && typeof normalizedRight === 'boolean')) {
+        return normalizedLeft < normalizedRight ? -1 : 1;
+    }
+
+    const leftText = String(normalizedLeft);
+    const rightText = String(normalizedRight);
+    return leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
+}
+
 function initIHPBackend({ host }: { host: string }): void {
     if (typeof host !== "string" || (!host.startsWith("http://") && !host.startsWith("https://"))) {
         throw new Error("IHP Backend host url needs to start with \"http://\" or \"https://\", you passed \"" + host + "\"");
@@ -584,18 +805,25 @@ export async function createRecord<T extends TableName>(table: T, record: NewRec
         throw new Error(`Record needs to be an object, you passed ${JSON.stringify(record)} in a call to createRecord(${JSON.stringify(table)}, ${JSON.stringify(record, null, 4)})`);
     }
 
-    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const transactionId = options.transactionId ?? null;
     const request = { tag: 'CreateRecordMessage', table, record, transactionId };
+    const shouldUpdateOptimistically = transactionId === null;
 
     try {
-        createOptimisticRecord(table, record);
+        if (shouldUpdateOptimistically) {
+            createOptimisticRecord(table, record);
+        }
         await waitPendingChanges(table, record);
 
         const response = await DataSyncController.getInstance().sendMessage(request);
-        markCreateOptimisticRecordFinished(record);
+        if (shouldUpdateOptimistically) {
+            markCreateOptimisticRecordFinished(record);
+        }
         return response.record as IHPRecord<T>;
     } catch (e) {
-        undoCreateOptimisticRecord(table, record);
+        if (shouldUpdateOptimistically) {
+            undoCreateOptimisticRecord(table, record, e as Error);
+        }
 
         throw new Error(`${(e as Error).message} while calling:\n\ncreateRecord(${JSON.stringify(table)}, ${JSON.stringify(record, null, 4)})`);
     }
@@ -612,10 +840,12 @@ export async function updateRecord<T extends TableName>(table: T, id: UUID, patc
         throw new Error(`Patch needs to be an object, you passed ${JSON.stringify(patch)} in a call to updateRecord(${JSON.stringify(table)}, ${JSON.stringify(id)}, ${JSON.stringify(patch, null, 4)})`);
     }
 
-    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const transactionId = options.transactionId ?? null;
     const request = { tag: 'UpdateRecordMessage', table, id, patch, transactionId };
 
-    const undoUpdateRecordOptimistic = updateRecordOptimistic(table, id, patch);
+    const undoUpdateRecordOptimistic = transactionId === null
+        ? updateRecordOptimistic(table, id, patch)
+        : () => {};
 
     try {
         await waitPendingCreation(table, id);
@@ -640,7 +870,7 @@ export async function updateRecords<T extends TableName>(table: T, ids: UUID[], 
         throw new Error(`Patch needs to be an object, you passed ${JSON.stringify(patch)} in a call to updateRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)}, ${JSON.stringify(patch, null, 4)})`);
     }
 
-    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const transactionId = options.transactionId ?? null;
     const request = { tag: 'UpdateRecordsMessage', table, ids, patch, transactionId };
 
     try {
@@ -660,10 +890,12 @@ export async function deleteRecord<T extends TableName>(table: T, id: UUID, opti
         throw new Error(`ID needs to be an UUID, you passed ${JSON.stringify(id)} in a call to deleteRecord(${JSON.stringify(table)}, ${JSON.stringify(id)})`);
     }
 
-    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const transactionId = options.transactionId ?? null;
     const request = { tag: 'DeleteRecordMessage', table, id, transactionId };
 
-    const undoOptimisticDeleteRecord = deleteRecordOptimistic(table, id);
+    const undoOptimisticDeleteRecord = transactionId === null
+        ? deleteRecordOptimistic(table, id)
+        : () => {};
     try {
         await waitPendingCreation(table, id);
         await DataSyncController.getInstance().sendMessage(request);
@@ -683,7 +915,7 @@ export async function deleteRecords<T extends TableName>(table: T, ids: UUID[], 
         throw new Error(`IDs needs to be an array, you passed ${JSON.stringify(ids)} in a call to deleteRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)})`);
     }
 
-    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const transactionId = options.transactionId ?? null;
     const request = { tag: 'DeleteRecordsMessage', table, ids, transactionId };
 
     try {
@@ -703,7 +935,7 @@ export async function createRecords<T extends TableName>(table: T, records: NewR
         throw new Error(`Records need to be an array, you passed ${JSON.stringify(records)} in a call to createRecords(${JSON.stringify(table)}, ${JSON.stringify(records, null, 4)})`);
     }
 
-    const transactionId = 'transactionId' in options ? options.transactionId : null;
+    const transactionId = options.transactionId ?? null;
     const request = { tag: 'CreateRecordsMessage', table, records, transactionId };
 
     try {
@@ -722,6 +954,7 @@ function createOptimisticRecord<T extends TableName>(table: T, record: NewRecord
     if (record.id == null) {
         record.id = randomUUID();
     }
+    registerPendingOptimisticCreate(record.id);
 
     // Optimistically set createdAt if the table has this field (dynamic check)
     const rec = record as Record<string, unknown>;
@@ -741,6 +974,24 @@ function createOptimisticRecord<T extends TableName>(table: T, record: NewRecord
     }
 
     dataSyncController.optimisticCreatedPendingRecordIds.push(record.id!);
+}
+
+function registerPendingOptimisticCreate(id: UUID): void {
+    const dataSyncController = DataSyncController.getInstance();
+    if (dataSyncController.pendingOptimisticCreates.has(id)) {
+        return;
+    }
+
+    let resolve!: () => void;
+    let reject!: (reason: Error) => void;
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    // A create often has no dependent operation. Mark the rejection as handled
+    // while still keeping the original promise rejectable for actual dependants.
+    void promise.catch(() => {});
+    dataSyncController.pendingOptimisticCreates.set(id, { promise, resolve, reject });
 }
 
 function randomUUID(): UUID {
@@ -764,24 +1015,37 @@ function randomUUID(): UUID {
     }
 }
 
-function undoCreateOptimisticRecord<T extends TableName>(table: T, record: NewRecord<T>): void {
+function undoCreateOptimisticRecord<T extends TableName>(table: T, record: NewRecord<T>, reason: Error): void {
     const dataSyncController = DataSyncController.getInstance();
     for (const dataSubscription of dataSyncController.dataSubscriptions) {
         if (dataSubscription.query.table !== table) {
+            continue;
+        }
+        if (!dataSubscription.optimisticCreatedPendingRecordIds.includes(record.id!)) {
             continue;
         }
 
         dataSubscription.onDelete(record.id!);
     }
 
-    markCreateOptimisticRecordFinished(record);
+    markCreateOptimisticRecordFinished(record, reason);
 }
 
-function markCreateOptimisticRecordFinished<T extends TableName>(record: NewRecord<T>): void {
+function markCreateOptimisticRecordFinished<T extends TableName>(record: NewRecord<T>, error: Error | null = null): void {
     const dataSyncController = DataSyncController.getInstance();
     const index = dataSyncController.optimisticCreatedPendingRecordIds.indexOf(record.id!);
     if (index !== -1) {
         dataSyncController.optimisticCreatedPendingRecordIds.splice(index, 1);
+    }
+
+    const pendingCreate = dataSyncController.pendingOptimisticCreates.get(record.id!);
+    if (pendingCreate) {
+        dataSyncController.pendingOptimisticCreates.delete(record.id!);
+        if (error) {
+            pendingCreate.reject(error);
+        } else {
+            pendingCreate.resolve();
+        }
     }
 }
 
@@ -868,49 +1132,33 @@ function deleteRecordOptimistic<T extends TableName>(table: T, id: UUID): () => 
     };
 }
 
-function doesRecordReferencePendingOptimisticRecord<T extends TableName>(record: NewRecord<T> | Partial<NewRecord<T>>): boolean {
+function pendingOptimisticCreatesReferencedBy<T extends TableName>(record: NewRecord<T> | Partial<NewRecord<T>>): Promise<void>[] {
     const dataSyncController = DataSyncController.getInstance();
-    const optimisticIds = dataSyncController.optimisticCreatedPendingRecordIds;
     const rec = record as Record<string, unknown>;
+    const pendingCreates = new Set<Promise<void>>();
 
     for (const attribute in rec) {
         if (attribute === 'id') {
             continue; // The current record's id is always optimistic
         }
-        if (optimisticIds.indexOf(rec[attribute] as UUID) !== -1) {
-            return true;
+        const pendingCreate = dataSyncController.pendingOptimisticCreates.get(rec[attribute] as UUID);
+        if (pendingCreate) {
+            pendingCreates.add(pendingCreate.promise);
         }
     }
 
-    return false;
+    return Array.from(pendingCreates);
 }
 
 async function waitPendingChanges<T extends TableName>(_table: T, record: NewRecord<T> | Partial<NewRecord<T>>): Promise<void> {
-    if (doesRecordReferencePendingOptimisticRecord(record)) {
-        return waitForMessageMatching(message => message.tag === 'DidCreateRecord' && (message as ServerMessage).record != null && ((message as ServerMessage).record as DataRecord).id === record.id!);
-    }
+    await Promise.all(pendingOptimisticCreatesReferencedBy(record));
 }
 
 async function waitPendingCreation<T extends TableName>(_table: T, id: UUID): Promise<void> {
-    const optimisticIds = DataSyncController.getInstance().optimisticCreatedPendingRecordIds;
-    if (optimisticIds.indexOf(id) !== -1) {
-        return waitForMessageMatching(message => message.tag === 'DidCreateRecord' && (message as ServerMessage).record != null && ((message as ServerMessage).record as DataRecord).id === id);
+    const pendingCreate = DataSyncController.getInstance().pendingOptimisticCreates.get(id);
+    if (pendingCreate) {
+        await pendingCreate.promise;
     }
-}
-
-function waitForMessageMatching(condition: (message: ServerMessage) => boolean): Promise<void> {
-    const dataSyncController = DataSyncController.getInstance();
-
-    return new Promise((resolve) => {
-        const callback = (payload: ServerMessage) => {
-            if (condition(payload)) {
-                dataSyncController.removeEventListener('message', callback);
-                resolve();
-            }
-        };
-
-        dataSyncController.addEventListener('message', callback);
-    });
 }
 
 export { DataSyncController, DataSubscription, initIHPBackend, NewRecordBehaviour };

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -1,9 +1,16 @@
 import {
     initialResourceSnapshot,
-    reduceResourceSnapshot,
     type ResourceSnapshot,
-    type ResourceSnapshotAction,
 } from './subscription-reducer.js';
+import { createControllerSubscriptionTransport } from './controller-subscription-transport.js';
+import { cloneDataRecords, createDataSubscriptionProtocol } from './data-subscription-protocol.js';
+import {
+    rowSubscriptionPolicy,
+    type SubscriptionEvent,
+    type SubscriptionPublication,
+    type SubscriptionState,
+} from './subscription-machine.js';
+import { createSubscriptionResource, type SubscriptionResource } from './subscription-resource.js';
 import type {
     DynamicSQLQuery,
     DataRecord,
@@ -658,9 +665,9 @@ class DataSubscription {
     subscriptionId: UUID | null = null;
     createOnServerPromise: Promise<DataRecord[]>;
     /** @deprecated Prefer createOnServerPromise; retained for source compatibility. */
-    resolveCreateOnServer!: (value: DataRecord[]) => void;
+    resolveCreateOnServer: (value: DataRecord[]) => void;
     /** @deprecated Prefer createOnServerPromise; retained for source compatibility. */
-    rejectCreateOnServer!: (reason: Error) => void;
+    rejectCreateOnServer: (reason: Error) => void;
     onClose: () => void = () => {};
     onStoreClose: () => void = () => {};
     /** @internal Promotes a render-only weak registry entry on first retain. */
@@ -674,30 +681,18 @@ class DataSubscription {
     /** @deprecated Optimistic mutation is disabled; retained empty for compatibility. */
     optimisticUpdatedPendingRecordIds: Set<UUID> = new Set();
 
-    private controller: DataSyncController | null = null;
     private readonly serverQuery: DynamicSQLQuery;
     private readonly expectedTransportScopeKey: string;
     private readonly scopedCache: Map<string, DataRecord[]> | null;
     private readonly cacheKey: string;
-    private snapshot: ResourceSnapshot<DataRecord[]>;
+    private readonly resource: SubscriptionResource<DataRecord[]>;
     private readonly subscriberEntries = new Map<number, (records: DataRecord[] | null) => void>();
     private readonly snapshotSubscriberEntries = new Map<number, () => void>();
     private nextSubscriberId = 0;
     private nextSnapshotSubscriberId = 0;
-    private generation = 0;
-    private lastRevision = -1;
-    private started = false;
-    private listenersAttached = false;
-    private closeNotificationSent = false;
-    private disposalToken = 0;
-    private startPromise: Promise<void> | null = null;
-    private refreshPromise: Promise<void> | null = null;
-    private refreshRequested = false;
-    private supportsAuthoritativeSnapshots = false;
-    private initialCreateSettled = false;
     private imperativelyOwned = false;
-    private resolveInitialCreate!: (records: DataRecord[]) => void;
-    private rejectInitialCreate!: (error: Error) => void;
+    private closeNotificationSent = false;
+    private compatibilityController: DataSyncController | null = null;
 
     constructor(
         query: DynamicSQLQuery,
@@ -710,27 +705,54 @@ class DataSubscription {
             throw new Error("Query passed to `new DataSubscription(..)` doesn't look like a query object. If you're using the `query()` functions to construct the object, pass the `.query` property, like this: `new DataSubscription(query('my_table').orderBy('createdAt').query)`");
         }
 
-        // QueryBuilder is mutable. A live subscription must never change when a
-        // component reuses and mutates the builder after this point.
         this.query = cloneQuery(query);
         this.serverQuery = deepFreeze(cloneQuery(query));
         this.expectedTransportScopeKey = expectedTransportScopeKey;
         this.scopedCache = cache;
         this.cache = cache;
         this.cacheKey = cacheKey;
-        const cachedRecords = cache?.get(cacheKey);
-        this.snapshot = initialResourceSnapshot(
-            cachedRecords?.map(record => ({ ...record })) as DataRecord[] | undefined,
-        );
-        this.createOnServerPromise = new Promise((resolve, reject) => {
-            this.resolveInitialCreate = resolve;
-            this.rejectInitialCreate = reject;
-        });
-        this.resolveCreateOnServer = records => this.resolveInitialCreateOnce(records);
-        this.rejectCreateOnServer = error => this.rejectInitialCreateOnce(error);
-        void this.createOnServerPromise.catch(() => {});
         this.newRecordBehaviour = options?.newRecordBehaviour ?? this.detectNewRecordBehaviour();
 
+        const cachedRecords = cache?.get(cacheKey);
+        this.resource = createSubscriptionResource<DataRecord[]>(
+            createDataSubscriptionProtocol(this.serverQuery),
+            {
+                expectedScopeKey: this.expectedTransportScopeKey,
+                currentScopeKey: () => DataSyncController.currentTransportScopeKey(),
+                acquireTransport: () => {
+                    const controller = DataSyncController.getInstance();
+                    this.attachCompatibilityController(controller);
+                    return createControllerSubscriptionTransport(
+                        controller,
+                        this.expectedTransportScopeKey,
+                    );
+                },
+                policy: rowSubscriptionPolicy,
+                initialData: cachedRecords === undefined ? null : cloneDataRecords(cachedRecords),
+                cloneInitialResult: cloneDataRecords,
+                writeCache: records => this.writeCache(records),
+                onState: (state, event) => this.mirrorState(state, event),
+                publish: publication => this.publish(publication),
+                evict: () => {
+                    this.detachCompatibilityController();
+                    this.notifyClose();
+                },
+                reportError: (message, error) => {
+                    if (
+                        message === 'Failed to delete a stale subscription:'
+                        && (this.compatibilityController?.retired === true
+                            || this.compatibilityController?.connection === null)
+                    ) {
+                        return;
+                    }
+                    console.error(message, error);
+                },
+            },
+        );
+
+        this.createOnServerPromise = this.resource.initialResult;
+        this.resolveCreateOnServer = records => this.resource.resolveInitial(records);
+        this.rejectCreateOnServer = error => this.resource.rejectInitial(error);
         this.subscribe = this.subscribe.bind(this);
         this.subscribeSnapshot = this.subscribeSnapshot.bind(this);
         this.getRecords = this.getRecords.bind(this);
@@ -742,22 +764,18 @@ class DataSubscription {
     }
 
     get records(): DataRecord[] | null {
-        return this.snapshot.data;
+        return this.resource.getSnapshot().data;
     }
 
     /** @deprecated Query snapshots are server-owned; assigning is retained for compatibility only. */
     set records(records: DataRecord[] | null) {
-        if (records === null) {
-            this.snapshot = initialResourceSnapshot();
-            this.notifySubscribers();
-            this.notifySnapshotSubscribers();
-        } else {
-            this.applyServerSnapshot(records, this.lastRevision + 1);
-        }
+        this.resource.dispatchCompatibilityValue(
+            records === null ? null : cloneDataRecords(records),
+        );
     }
 
     getSnapshot(): ResourceSnapshot<DataRecord[]> {
-        return this.snapshot;
+        return this.resource.getSnapshot();
     }
 
     getServerSnapshot(): ResourceSnapshot<DataRecord[]> {
@@ -765,29 +783,20 @@ class DataSubscription {
     }
 
     getRecords(): DataRecord[] | null {
-        return this.snapshot.data;
+        return this.resource.getSnapshot().data;
     }
 
     subscribe(callback: (records: DataRecord[] | null) => void): () => void {
-        // The first ref-counted consumer takes ownership from the imperative
-        // API. Its final release can then close the server resource normally.
         this.imperativelyOwned = false;
         this.retainInStore();
-        const shouldStart = this.trackedSubscriberCount() === 0;
         const subscriberId = this.nextSubscriberId++;
         this.subscriberEntries.set(subscriberId, callback);
         this.subscribers.push(callback);
-        this.disposalToken++;
-        if (shouldStart) {
-            void this.start(false).catch(() => {
-                // The error is part of the immutable snapshot and is surfaced by React.
-            });
-        }
-        // Do not synchronously expose CONNECT/null lifecycle changes through
-        // the legacy record callback. A later subscriber to an already-live
-        // shared resource still receives its current server value immediately.
-        if (this.snapshot.status === 'live' && this.snapshot.data !== null) {
-            this.callSubscriber(callback, this.snapshot.data);
+        this.updateDemand();
+
+        const snapshot = this.resource.getSnapshot();
+        if (snapshot.status === 'live' && snapshot.data !== null) {
+            this.callSubscriber(callback, snapshot.data);
         }
 
         let subscribed = true;
@@ -797,8 +806,6 @@ class DataSubscription {
             }
             subscribed = false;
             this.subscriberEntries.delete(subscriberId);
-            // subscribe() appends, so remove from the end to avoid consuming a
-            // matching callback that legacy code inserted directly beforehand.
             const publicIndex = this.subscribers.lastIndexOf(callback);
             if (publicIndex !== -1) {
                 this.subscribers.splice(publicIndex, 1);
@@ -811,15 +818,9 @@ class DataSubscription {
     subscribeSnapshot(callback: () => void): () => void {
         this.imperativelyOwned = false;
         this.retainInStore();
-        const shouldStart = this.trackedSubscriberCount() === 0;
         const subscriberId = this.nextSnapshotSubscriberId++;
         this.snapshotSubscriberEntries.set(subscriberId, callback);
-        this.disposalToken++;
-        if (shouldStart) {
-            void this.start(false).catch(() => {
-                // The error is part of the immutable snapshot and is surfaced by React.
-            });
-        }
+        this.updateDemand();
 
         let subscribed = true;
         return () => {
@@ -835,268 +836,44 @@ class DataSubscription {
     /** Starts a manually managed subscription. React and QueryBuilder do not need this. */
     async createOnServer(): Promise<void> {
         this.retainInStore();
-        if (this.trackedSubscriberCount() === 0) {
+        if (this.subscriberDemand() === 0) {
             this.imperativelyOwned = true;
         }
-        await this.start(false);
-        // Scope-change and explicit-close paths settle the same public promise;
-        // imperative callers must not observe a successful create when the
-        // server resource was discarded before its first snapshot.
+        this.updateDemand();
+        await this.resource.ensureCreated();
         await this.createOnServerPromise;
     }
 
-    private start(reconnect: boolean): Promise<void> {
-        this.disposalToken++;
-        if (this.startPromise !== null) {
-            return this.startPromise;
-        }
-        if (this.started && this.subscriptionId !== null) {
-            return Promise.resolve();
-        }
-
-        if (!this.hasExpectedTransportScope()) {
-            this.closeForTransportScopeChange('before the subscription could commit');
-            return Promise.resolve();
-        }
-
-        const controller = DataSyncController.getInstance();
-        if (!controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
-            this.closeForTransportScopeChange('before the subscription could acquire its controller');
-            return Promise.resolve();
-        }
-        // A render may retain an object that was fully released between render
-        // and commit. Reopening is supported, and its next final release must
-        // notify the store again instead of leaving a closed registry entry.
-        this.closeNotificationSent = false;
-        this.attachControllerListeners(controller);
-        this.started = true;
-        const generation = ++this.generation;
-        this.lastRevision = -1;
-        this.supportsAuthoritativeSnapshots = false;
-        this.dispatch({ type: 'CONNECT', reconnect });
-
-        const startPromise = this.createServerSubscription(generation, controller);
-        this.startPromise = startPromise;
-        void startPromise.finally(() => {
-            if (this.startPromise === startPromise) {
-                this.startPromise = null;
-            }
-        }).catch(() => {});
-        return startPromise;
-    }
-
-    private async createServerSubscription(generation: number, controller: DataSyncController): Promise<void> {
-        try {
-            const response = await controller.sendMessage({
-                tag: 'CreateDataSubscription',
-                query: this.serverQuery,
-                protocolVersion: 1,
-            });
-            const subscriptionId = response.subscriptionId as UUID;
-
-            if (!this.started
-                || generation !== this.generation
-                || this.controller !== controller
-                || !this.hasExpectedTransportScope()
-                || !controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
-                if (!this.hasExpectedTransportScope()) {
-                    this.closeForTransportScopeChange('while the subscription was being created');
-                }
-                await this.deleteStaleDataSubscription(controller, subscriptionId);
-                return;
-            }
-
-            this.subscriptionId = subscriptionId;
-            this.supportsAuthoritativeSnapshots = response.tag === 'DidCreateDataSubscriptionV2';
-            const result = response.result as DataRecord[];
-            // The V2 tag explicitly acknowledges snapshot support. An old
-            // DidCreate response remains delta-compatible even when that server
-            // silently ignored the protocolVersion request field.
-            const initialRevision = this.supportsAuthoritativeSnapshots && typeof response.revision === 'number'
-                ? response.revision
-                : 0;
-            this.applyServerSnapshot(result, initialRevision);
-            this.resolveInitialCreateOnce(result);
-        } catch (unknownError) {
-            if (!this.started || generation !== this.generation || this.controller !== controller) {
-                return;
-            }
-
-            const error = unknownError instanceof Error ? unknownError : new Error(String(unknownError));
-            const connectionError = new Error(error.message + ' while trying to subscribe to:\n' + JSON.stringify(this.serverQuery, null, 4));
-            this.dispatch({ type: 'FAIL', error: connectionError });
-            this.rejectInitialCreateOnce(connectionError);
-            throw connectionError;
-        }
-    }
-
-    private attachControllerListeners(controller: DataSyncController): void {
-        if (this.listenersAttached && this.controller === controller) {
-            return;
-        }
-        this.detachControllerListeners();
-        this.controller = controller;
-        this.listenersAttached = true;
-        controller.addEventListener('message', this.onMessage);
-        controller.addEventListener('close', this.onDataSyncClosed);
-        controller.addEventListener('reconnect', this.onDataSyncReconnect);
-        if (!controller.dataSubscriptions.includes(this)) {
-            controller.dataSubscriptions.push(this);
-        }
-    }
-
-    private detachControllerListeners(): void {
-        const controller = this.controller;
-        if (controller === null) {
-            this.listenersAttached = false;
-            return;
-        }
-        if (this.listenersAttached) {
-            controller.removeEventListener('message', this.onMessage);
-            controller.removeEventListener('close', this.onDataSyncClosed);
-            controller.removeEventListener('reconnect', this.onDataSyncReconnect);
-            this.listenersAttached = false;
-        }
-        const index = controller.dataSubscriptions.indexOf(this);
-        if (index !== -1) {
-            controller.dataSubscriptions.splice(index, 1);
-        }
-        this.controller = null;
-    }
-
     onMessage(message: ServerMessage): void {
-        if (!this.started || message.subscriptionId !== this.subscriptionId) {
+        if (
+            this.resource.getState().phase.tag !== 'live'
+            || message.subscriptionId !== this.subscriptionId
+        ) {
             return;
         }
         this.receiveUpdate(message);
     }
 
     receiveUpdate(message: ServerMessage): void {
-        if (!this.hasExpectedTransportScope()) {
-            this.closeForTransportScopeChange('before a server update was applied');
-            return;
-        }
         if (message.tag === 'DidReplaceDataSubscription') {
-            const isFirstReplacement = !this.supportsAuthoritativeSnapshots;
-            this.supportsAuthoritativeSnapshots = true;
-            const revision = typeof message.revision === 'number'
-                ? message.revision
-                : this.lastRevision + 1;
-            if (isFirstReplacement && revision <= this.lastRevision) {
-                this.lastRevision = revision - 1;
-            }
-            this.applyServerSnapshot(message.result as DataRecord[], revision);
-            return;
-        }
-
-        // Compatibility with older servers: delta messages are invalidations,
-        // never instructions to emulate PostgreSQL query semantics in the browser.
-        if (!this.supportsAuthoritativeSnapshots
-            && (message.tag === 'DidInsert' || message.tag === 'DidUpdate' || message.tag === 'DidDelete')) {
-            this.requestAuthoritativeRefresh();
-        }
-    }
-
-    private applyServerSnapshot(records: DataRecord[], revision: number): void {
-        if (revision <= this.lastRevision) {
-            return;
-        }
-        this.lastRevision = revision;
-        // Keep the public mutable `DataRecord[]` contract. The snapshot wrapper
-        // is immutable, while callers remain free to use normal array methods.
-        const snapshotRecords = records.map(record => ({ ...record })) as DataRecord[];
-        if (this.scopedCache !== null
-            && this.hasExpectedTransportScope()
-            && this.controller?.isBoundToTransportScope(this.expectedTransportScopeKey) === true) {
-            this.scopedCache.delete(this.cacheKey);
-            this.scopedCache.set(
-                this.cacheKey,
-                snapshotRecords.map(record => ({ ...record })) as DataRecord[],
+            this.resource.dispatchCompatibilitySnapshot(
+                cloneDataRecords(message.result as DataRecord[]),
+                typeof message.revision === 'number' ? message.revision : undefined,
             );
-            trimOldestMapEntries(this.scopedCache, 100);
-        }
-        this.dispatch({ type: 'SNAPSHOT', data: snapshotRecords });
-    }
-
-    private requestAuthoritativeRefresh(): void {
-        if (!this.started) {
             return;
         }
-        this.refreshRequested = true;
-        if (this.refreshPromise !== null) {
-            return;
+        if (message.tag === 'DidInsert' || message.tag === 'DidUpdate' || message.tag === 'DidDelete') {
+            this.resource.invalidateLegacy();
         }
-        const generation = this.generation;
-        const refreshPromise = this.refreshUntilClean(generation);
-        this.refreshPromise = refreshPromise;
-        void refreshPromise.finally(() => {
-            if (this.refreshPromise === refreshPromise) {
-                this.refreshPromise = null;
-            }
-        }).catch(() => {});
-    }
-
-    private async refreshUntilClean(generation: number): Promise<void> {
-        do {
-            this.refreshRequested = false;
-            if (this.supportsAuthoritativeSnapshots) {
-                return;
-            }
-            try {
-                const controller = this.controller;
-                if (controller === null
-                    || !this.hasExpectedTransportScope()
-                    || !controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
-                    if (!this.hasExpectedTransportScope()) {
-                        this.closeForTransportScopeChange('before a legacy refresh was sent');
-                    }
-                    return;
-                }
-                const response = await controller.sendMessage({
-                    tag: 'DataSyncQuery',
-                    query: this.serverQuery,
-                    transactionId: null,
-                });
-                // A replacement received while this legacy refetch was in
-                // flight upgrades the resource to revisioned snapshots. The
-                // unrevisioned query response can then be older and must not
-                // overwrite that authoritative replacement.
-                if (this.started
-                    && generation === this.generation
-                    && !this.supportsAuthoritativeSnapshots) {
-                    this.applyServerSnapshot(response.result as DataRecord[], this.lastRevision + 1);
-                }
-            } catch (error) {
-                if (this.started && generation === this.generation) {
-                    console.error('Failed to refresh a legacy DataSubscription:', error);
-                }
-            }
-        } while (this.refreshRequested && this.started && generation === this.generation);
     }
 
     onDataSyncClosed(event: unknown = null): void {
-        if (!this.started) {
-            return;
-        }
-        if (isTransportScopeChange(event)) {
-            this.closeForTransportScopeChange('because the controller transport changed');
-            return;
-        }
-        this.generation++;
-        this.subscriptionId = null;
-        this.lastRevision = -1;
-        this.startPromise = null;
-        this.refreshPromise = null;
-        this.refreshRequested = false;
-        this.dispatch({ type: 'DISCONNECT' });
+        this.resource.transportClosed(isTransportScopeChange(event));
     }
 
     async onDataSyncReconnect(): Promise<void> {
-        if (!this.started || this.startPromise !== null || this.subscriptionId !== null) {
-            return;
-        }
-        await this.start(true).catch(() => {
-            // The failure is observable through getSnapshot().
+        await this.resource.transportReconnected().catch(() => {
+            // The failed snapshot remains observable to external-store readers.
         });
     }
 
@@ -1107,12 +884,12 @@ class DataSubscription {
         _appendSet: Record<string, unknown> | null,
         _isOptimistic = false,
     ): void {
-        this.requestAuthoritativeRefresh();
+        this.resource.invalidateLegacy();
     }
 
     /** @deprecated Delta mutation now triggers an exact server refresh. */
     onCreate(_newRecord: DataRecord, _isOptimistic = false): void {
-        this.requestAuthoritativeRefresh();
+        this.resource.invalidateLegacy();
     }
 
     /** @deprecated Optimistic mutation is disabled and triggers an exact refresh. */
@@ -1120,12 +897,12 @@ class DataSubscription {
         if (!('id' in newRecord)) {
             throw new Error('Requires the record to have an id');
         }
-        this.requestAuthoritativeRefresh();
+        this.resource.invalidateLegacy();
     }
 
     /** @deprecated Delta mutation now triggers an exact server refresh. */
     onDelete(_id: UUID, _isOptimistic = false): void {
-        this.requestAuthoritativeRefresh();
+        this.resource.invalidateLegacy();
     }
 
     /** @deprecated Optimistic updates are intentionally disabled. */
@@ -1139,21 +916,18 @@ class DataSubscription {
     }
 
     scheduleCloseIfNotUsed(): void {
-        const token = ++this.disposalToken;
-        queueMicrotask(() => {
-            if (token === this.disposalToken) {
-                this.closeIfNotUsed();
-            }
-        });
+        const previousDemand = this.resource.getState().demand;
+        this.updateDemand();
+        if (previousDemand.subscribers === 0 && !previousDemand.imperative) {
+            this.resource.scheduleCloseIfUnused();
+        }
     }
 
     closeIfNotUsed(): void {
-        if (this.subscribers.length !== 0
-            || this.snapshotSubscriberEntries.size !== 0
-            || this.imperativelyOwned) {
+        if (this.subscriberDemand() !== 0 || this.imperativelyOwned) {
             return;
         }
-        void this.stop().catch(error => {
+        void this.resource.close().catch(error => {
             console.error('Failed to close an unused DataSubscription:', error);
         });
     }
@@ -1163,30 +937,148 @@ class DataSubscription {
         this.subscriberEntries.clear();
         this.snapshotSubscriberEntries.clear();
         this.subscribers.length = 0;
-        this.disposalToken++;
-        await this.stop();
+        await this.resource.close();
     }
 
-    private async stop(): Promise<void> {
-        if (!this.started && this.snapshot.status === 'closed') {
+    /** @deprecated Server snapshots make local record placement irrelevant. */
+    detectNewRecordBehaviour(): number {
+        const firstOrderBy = this.query.orderByClause[0];
+        return firstOrderBy
+            && 'orderByColumn' in firstOrderBy
+            && firstOrderBy.orderByColumn === 'createdAt'
+            && firstOrderBy.orderByDirection === 'Desc'
+            ? PREPEND_NEW_RECORD
+            : APPEND_NEW_RECORD;
+    }
+
+    private mirrorState(
+        state: SubscriptionState<DataRecord[]>,
+        event: SubscriptionEvent<DataRecord[]>,
+    ): void {
+        if (event.type === 'COMPAT_VALUE_SET') {
+            if (event.value !== null) {
+                this.isClosed = false;
+                this.isConnected = true;
+                this.connectError = null;
+            }
             return;
         }
+        if (state.phase.tag !== 'live') {
+            this.subscriptionId = null;
+        } else if (event.type === 'CREATE_SUCCEEDED') {
+            this.subscriptionId = state.phase.subscriptionId;
+        }
+        this.connectError = state.snapshot.error;
+        switch (state.phase.tag) {
+            case 'idle':
+                this.isConnected = false;
+                break;
+            case 'creating':
+                this.closeNotificationSent = false;
+                this.isConnected = false;
+                if (!state.phase.reconnect) {
+                    this.isClosed = false;
+                }
+                break;
+            case 'live':
+                this.isClosed = false;
+                this.isConnected = true;
+                break;
+            case 'offline':
+            case 'closed':
+                this.isClosed = true;
+                this.isConnected = false;
+                break;
+            case 'failed':
+                this.isConnected = false;
+                break;
+        }
+    }
 
-        this.started = false;
-        this.generation++;
-        this.startPromise = null;
-        this.refreshPromise = null;
-        this.refreshRequested = false;
-        const subscriptionId = this.subscriptionId;
-        const controller = this.controller;
-        this.subscriptionId = null;
-        this.detachControllerListeners();
-        this.dispatch({ type: 'CLOSE' });
-        this.rejectInitialCreateOnce(new Error('DataSubscription closed before its initial server snapshot arrived'));
-        this.notifyClose();
+    private writeCache(records: DataRecord[]): void {
+        if (this.scopedCache === null) {
+            return;
+        }
+        this.scopedCache.delete(this.cacheKey);
+        this.scopedCache.set(this.cacheKey, cloneDataRecords(records));
+        trimOldestMapEntries(this.scopedCache, 100);
+    }
 
-        if (subscriptionId !== null && controller !== null) {
-            await this.deleteStaleDataSubscription(controller, subscriptionId);
+    private updateDemand(): void {
+        this.resource.updateDemand(this.subscriberDemand(), this.imperativelyOwned);
+    }
+
+    private subscriberDemand(): number {
+        return this.subscribers.length + this.snapshotSubscriberEntries.size;
+    }
+
+    private retainInStore(): void {
+        if (this.expectedTransportScopeKey !== DataSyncController.currentTransportScopeKey()) {
+            return;
+        }
+        try {
+            this.onStoreRetain();
+        } catch (error) {
+            console.error('DataSubscription store-retain listener failed:', error);
+        }
+    }
+
+    private attachCompatibilityController(controller: DataSyncController): void {
+        if (this.compatibilityController === controller) {
+            return;
+        }
+        this.detachCompatibilityController();
+        this.compatibilityController = controller;
+        if (!controller.dataSubscriptions.includes(this)) {
+            controller.dataSubscriptions.push(this);
+        }
+    }
+
+    private detachCompatibilityController(): void {
+        const controller = this.compatibilityController;
+        this.compatibilityController = null;
+        if (controller === null) {
+            return;
+        }
+        const index = controller.dataSubscriptions.indexOf(this);
+        if (index !== -1) {
+            controller.dataSubscriptions.splice(index, 1);
+        }
+    }
+
+    private publish(publication: SubscriptionPublication): void {
+        if (publication === 'snapshot' || publication === 'both') {
+            this.notifySnapshotSubscribers();
+        }
+        if (publication === 'legacy' || publication === 'both') {
+            this.notifySubscribers();
+        }
+    }
+
+    private notifySnapshotSubscribers(): void {
+        for (const subscriber of Array.from(this.snapshotSubscriberEntries.values())) {
+            try {
+                subscriber();
+            } catch (error) {
+                console.error('DataSubscription snapshot subscriber failed:', error);
+            }
+        }
+    }
+
+    private notifySubscribers(): void {
+        for (const subscriber of this.subscribers.slice()) {
+            this.callSubscriber(subscriber, this.resource.getSnapshot().data);
+        }
+    }
+
+    private callSubscriber(
+        subscriber: (records: DataRecord[] | null) => void,
+        records: DataRecord[] | null,
+    ): void {
+        try {
+            subscriber(records);
+        } catch (error) {
+            console.error('DataSubscription subscriber failed:', error);
         }
     }
 
@@ -1205,151 +1097,6 @@ class DataSubscription {
         } catch (error) {
             console.error('DataSubscription close listener failed:', error);
         }
-    }
-
-    private async deleteStaleDataSubscription(controller: DataSyncController, subscriptionId: UUID): Promise<void> {
-        try {
-            await controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
-        } catch (error) {
-            if (!controller.retired && controller.connection !== null) {
-                console.error('Failed to delete a stale DataSubscription:', error);
-            }
-        }
-    }
-
-    private closeForTransportScopeChange(reason: string): void {
-        if (!this.started && this.snapshot.status === 'closed' && this.closeNotificationSent) {
-            return;
-        }
-        this.imperativelyOwned = false;
-        this.started = false;
-        this.generation++;
-        this.subscriptionId = null;
-        this.lastRevision = -1;
-        this.startPromise = null;
-        this.refreshPromise = null;
-        this.refreshRequested = false;
-        this.supportsAuthoritativeSnapshots = false;
-        this.detachControllerListeners();
-        this.snapshot = initialResourceSnapshot();
-        this.dispatch({ type: 'CLOSE' });
-        this.rejectInitialCreateOnce(new Error(`DataSubscription closed because its authentication/backend scope changed ${reason}`));
-        this.notifyClose();
-    }
-
-    private hasExpectedTransportScope(): boolean {
-        return this.expectedTransportScopeKey === DataSyncController.currentTransportScopeKey();
-    }
-
-    private resolveInitialCreateOnce(records: DataRecord[]): void {
-        if (this.initialCreateSettled) {
-            return;
-        }
-        this.initialCreateSettled = true;
-        this.resolveInitialCreate(records);
-    }
-
-    private rejectInitialCreateOnce(error: Error): void {
-        if (this.initialCreateSettled) {
-            return;
-        }
-        this.initialCreateSettled = true;
-        this.rejectInitialCreate(error);
-    }
-
-    private dispatch(action: ResourceSnapshotAction<DataRecord[]>): void {
-        const nextSnapshot = reduceResourceSnapshot(this.snapshot, action);
-        if (nextSnapshot === this.snapshot) {
-            return;
-        }
-        this.snapshot = nextSnapshot;
-        switch (action.type) {
-            case 'CONNECT':
-                this.isConnected = false;
-                if (!action.reconnect) {
-                    this.isClosed = false;
-                }
-                this.connectError = null;
-                break;
-            case 'SNAPSHOT':
-                this.isClosed = false;
-                this.isConnected = true;
-                this.connectError = null;
-                break;
-            case 'DISCONNECT':
-                this.isClosed = true;
-                this.isConnected = false;
-                break;
-            case 'FAIL':
-                this.isConnected = false;
-                this.connectError = action.error;
-                break;
-            case 'CLOSE':
-                this.isClosed = true;
-                this.isConnected = false;
-                this.connectError = null;
-                break;
-        }
-        this.notifySnapshotSubscribers();
-        if (action.type === 'SNAPSHOT' || action.type === 'FAIL') {
-            this.notifySubscribers();
-        }
-    }
-
-    private trackedSubscriberCount(): number {
-        return this.subscriberEntries.size + this.snapshotSubscriberEntries.size;
-    }
-
-    private retainInStore(): void {
-        // Never promote a stale render handle back into the active registry.
-        // Its commit-time snapshot check will make React resolve a resource for
-        // the current scope instead.
-        if (!this.hasExpectedTransportScope()) {
-            return;
-        }
-        try {
-            this.onStoreRetain();
-        } catch (error) {
-            console.error('DataSubscription store-retain listener failed:', error);
-        }
-    }
-
-    private notifySnapshotSubscribers(): void {
-        for (const subscriber of Array.from(this.snapshotSubscriberEntries.values())) {
-            try {
-                subscriber();
-            } catch (error) {
-                console.error('DataSubscription snapshot subscriber failed:', error);
-            }
-        }
-    }
-
-    private notifySubscribers(): void {
-        for (const subscriber of this.subscribers.slice()) {
-            this.callSubscriber(subscriber, this.snapshot.data);
-        }
-    }
-
-    private callSubscriber(
-        subscriber: (records: DataRecord[] | null) => void,
-        records: DataRecord[] | null,
-    ): void {
-        try {
-            subscriber(records);
-        } catch (error) {
-            console.error('DataSubscription subscriber failed:', error);
-        }
-    }
-
-    /** @deprecated Server snapshots make local record placement irrelevant. */
-    detectNewRecordBehaviour(): number {
-        const firstOrderBy = this.query.orderByClause[0];
-        return firstOrderBy
-            && 'orderByColumn' in firstOrderBy
-            && firstOrderBy.orderByColumn === 'createdAt'
-            && firstOrderBy.orderByDirection === 'Desc'
-            ? PREPEND_NEW_RECORD
-            : APPEND_NEW_RECORD;
     }
 }
 

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -491,7 +491,10 @@ class DataSubscription {
             this.isConnected = true;
             this.isClosed = false;
             this.connectError = null;
-            this.records = this.normalizeRecords(result);
+            // The server result already has the exact projection, ordering and
+            // window requested by the query. Reapplying parts of the query in
+            // the browser can corrupt projected DISTINCT/ORDER BY results.
+            this.records = result;
 
             this.resolveCreateOnServer(result);
             this.updateSubscribers();
@@ -622,6 +625,13 @@ class DataSubscription {
             this.optimisticUpdatedPendingRecordIds.delete(id);
         }
 
+        if (!this.supportsOptimisticUpdates()) {
+            if (!isOptimistic) {
+                this.refreshAfterComplexMutation();
+            }
+            return;
+        }
+
         this.records = this.normalizeRecords(this.records!.map(record => {
             if (record.id === id) {
                 const updated = Object.assign({}, record, changeSet);
@@ -634,35 +644,41 @@ class DataSubscription {
             }
 
             return record;
-        }), this.hasPendingOptimisticChanges());
+        }));
 
         this.updateSubscribers();
-        if (!isOptimistic) {
-            this.refreshAfterComplexMutation();
-        }
     }
 
     onCreate(newRecord: DataRecord, isOptimistic = false): void {
+        if (!this.supportsOptimisticUpdates()) {
+            if (!isOptimistic) {
+                this.refreshAfterComplexMutation();
+            }
+            return;
+        }
+
         const shouldAppend = this.newRecordBehaviour === APPEND_NEW_RECORD;
 
         const newRecordId = newRecord.id;
-        const isOptimisticallyCreatedAlready = this.optimisticCreatedPendingRecordIds.indexOf(newRecordId) !== -1;
-        if (isOptimisticallyCreatedAlready && !isOptimistic) {
-            this.optimisticCreatedPendingRecordIds.splice(this.optimisticCreatedPendingRecordIds.indexOf(newRecordId), 1);
-            this.onUpdate(newRecordId, newRecord, null);
-            return;
-        } else {
-            if (isOptimistic) {
-                this.optimisticCreatedPendingRecordIds.push(newRecordId);
+        const optimisticIndex = this.optimisticCreatedPendingRecordIds.indexOf(newRecordId);
+        const existingRecord = this.records!.find(record => record.id === newRecordId);
+        if (existingRecord) {
+            if (!isOptimistic && optimisticIndex !== -1) {
+                this.optimisticCreatedPendingRecordIds.splice(optimisticIndex, 1);
             }
-            const records = shouldAppend ? [...this.records!, newRecord] : [newRecord, ...this.records!];
-            this.records = this.normalizeRecords(records, this.hasPendingOptimisticChanges());
+            // The create response and DidInsert notification can both contain
+            // the same record. Reconcile by id instead of appending twice.
+            this.onUpdate(newRecordId, newRecord, null, isOptimistic);
+            return;
         }
 
-        this.updateSubscribers();
-        if (!isOptimistic) {
-            this.refreshAfterComplexMutation();
+        if (isOptimistic && optimisticIndex === -1) {
+            this.optimisticCreatedPendingRecordIds.push(newRecordId);
         }
+        const records = shouldAppend ? [...this.records!, newRecord] : [newRecord, ...this.records!];
+        this.records = this.normalizeRecords(records);
+
+        this.updateSubscribers();
     }
 
     onCreateOptimistic(newRecord: DataRecord): void {
@@ -680,14 +696,16 @@ class DataSubscription {
                 this.optimisticCreatedPendingRecordIds.splice(optimisticIndex, 1);
             }
         }
-        this.records = this.normalizeRecords(
-            this.records!.filter(record => record.id !== id),
-            this.hasPendingOptimisticChanges()
-        );
-        this.updateSubscribers();
-        if (!isOptimistic) {
-            this.refreshAfterComplexMutation();
+
+        if (!this.supportsOptimisticUpdates()) {
+            if (!isOptimistic) {
+                this.refreshAfterComplexMutation();
+            }
+            return;
         }
+
+        this.records = this.normalizeRecords(this.records!.filter(record => record.id !== id));
+        this.updateSubscribers();
     }
 
     subscribe(callback: (records: DataRecord[] | null) => void): () => void {
@@ -734,12 +752,7 @@ class DataSubscription {
         }
     }
 
-    private hasPendingOptimisticChanges(): boolean {
-        return this.optimisticCreatedPendingRecordIds.length > 0
-            || this.optimisticUpdatedPendingRecordIds.size > 0;
-    }
-
-    private normalizeRecords(records: DataRecord[], preserveCompleteSet = false): DataRecord[] {
+    private normalizeRecords(records: DataRecord[]): DataRecord[] {
         let normalized = [...records];
         const sortableClauses = this.query.orderByClause.filter(clause => 'orderByColumn' in clause);
 
@@ -755,36 +768,24 @@ class DataSubscription {
             });
         }
 
-        if (!preserveCompleteSet && this.query.distinctOnColumn !== null) {
-            const seen = new Set<unknown>();
-            normalized = normalized.filter(record => {
-                const value = record[this.query.distinctOnColumn!];
-                if (seen.has(value)) {
-                    return false;
-                }
-                seen.add(value);
-                return true;
-            });
-        }
-
-        if (!preserveCompleteSet && this.query.limit !== null && this.query.limit >= 0) {
-            normalized = normalized.slice(0, this.query.limit);
-        }
-
         return normalized;
     }
 
-    private refreshAfterComplexMutation(): void {
+    supportsOptimisticUpdates(): boolean {
         const selectedColumns = this.query.selectedColumns;
         const hasUnprojectedOrderColumn = selectedColumns.tag === 'SelectSpecific'
             && this.query.orderByClause.some(clause => 'orderByColumn' in clause
                 && !selectedColumns.contents.includes(clause.orderByColumn));
-        const requiresRefresh = this.query.limit !== null
-            || this.query.offset !== null
-            || this.query.distinctOnColumn !== null
-            || this.query.orderByClause.some(clause => 'tag' in clause && clause.tag === 'OrderByTSRank')
-            || hasUnprojectedOrderColumn;
-        if (!requiresRefresh || this.isClosed) {
+
+        return this.query.limit === null
+            && this.query.offset === null
+            && this.query.distinctOnColumn === null
+            && !this.query.orderByClause.some(clause => 'tag' in clause && clause.tag === 'OrderByTSRank')
+            && !hasUnprojectedOrderColumn;
+    }
+
+    private refreshAfterComplexMutation(): void {
+        if (this.supportsOptimisticUpdates() || this.isClosed) {
             return;
         }
 
@@ -805,7 +806,10 @@ class DataSubscription {
                 transactionId: null
             });
             if (!this.isClosed) {
-                this.records = this.normalizeRecords(response.result as DataRecord[]);
+                // DataSyncQuery returns the authoritative query window. Keep it
+                // verbatim so projected DISTINCT/ORDER BY columns are not read
+                // as undefined and collapsed locally.
+                this.records = response.result as DataRecord[];
                 this.updateSubscribers();
             }
         } catch (error) {
@@ -896,7 +900,7 @@ export async function createRecord<T extends TableName>(table: T, record: NewRec
 
         const response = await DataSyncController.getInstance().sendMessage(request);
         if (shouldUpdateOptimistically) {
-            markCreateOptimisticRecordFinished(record);
+            markCreateOptimisticRecordFinished(table, record, null, response.record as DataRecord);
         }
         return response.record as IHPRecord<T>;
     } catch (e) {
@@ -1045,6 +1049,9 @@ function createOptimisticRecord<T extends TableName>(table: T, record: NewRecord
         if (dataSubscription.query.table !== table) {
             continue;
         }
+        if (!dataSubscription.supportsOptimisticUpdates()) {
+            continue;
+        }
         if (!recordMatchesQuery(dataSubscription.query, rec as DataRecord)) {
             continue;
         }
@@ -1107,11 +1114,27 @@ function undoCreateOptimisticRecord<T extends TableName>(table: T, record: NewRe
         dataSubscription.onDelete(record.id!);
     }
 
-    markCreateOptimisticRecordFinished(record, reason);
+    markCreateOptimisticRecordFinished(table, record, reason);
 }
 
-function markCreateOptimisticRecordFinished<T extends TableName>(record: NewRecord<T>, error: Error | null = null): void {
+function markCreateOptimisticRecordFinished<T extends TableName>(table: T, record: NewRecord<T>, error: Error | null = null, canonicalRecord: DataRecord | null = null): void {
     const dataSyncController = DataSyncController.getInstance();
+
+    if (!error && canonicalRecord) {
+        for (const dataSubscription of dataSyncController.dataSubscriptions) {
+            if (dataSubscription.query.table !== table
+                || !dataSubscription.optimisticCreatedPendingRecordIds.includes(record.id!)) {
+                continue;
+            }
+
+            if (recordMatchesQuery(dataSubscription.query, canonicalRecord)) {
+                dataSubscription.onCreate(canonicalRecord);
+            } else {
+                dataSubscription.onDelete(record.id!);
+            }
+        }
+    }
+
     const index = dataSyncController.optimisticCreatedPendingRecordIds.indexOf(record.id!);
     if (index !== -1) {
         dataSyncController.optimisticCreatedPendingRecordIds.splice(index, 1);
@@ -1134,6 +1157,9 @@ function updateRecordOptimistic<T extends TableName>(table: T, id: UUID, patch: 
     const rollbackOperations: (() => void)[] = [];
     for (const dataSubscription of dataSyncController.dataSubscriptions) {
         if (dataSubscription.query.table !== table) {
+            continue;
+        }
+        if (!dataSubscription.supportsOptimisticUpdates()) {
             continue;
         }
 
@@ -1194,6 +1220,9 @@ function deleteRecordOptimistic<T extends TableName>(table: T, id: UUID): () => 
     const undoOperations: (() => void)[] = [];
     for (const dataSubscription of dataSyncController.dataSubscriptions) {
         if (dataSubscription.query.table !== table) {
+            continue;
+        }
+        if (!dataSubscription.supportsOptimisticUpdates()) {
             continue;
         }
 

--- a/ihp-datasync/data/DataSync/src/ihp-datasync.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-datasync.ts
@@ -1,4 +1,9 @@
-import { recordMatchesQuery } from './ihp-querybuilder.js';
+import {
+    initialResourceSnapshot,
+    reduceResourceSnapshot,
+    type ResourceSnapshot,
+    type ResourceSnapshotAction,
+} from './subscription-reducer.js';
 import type {
     DynamicSQLQuery,
     DataRecord,
@@ -15,8 +20,6 @@ import type {
 } from './types.js';
 import { APPEND_NEW_RECORD, PREPEND_NEW_RECORD, NewRecordBehaviour } from './types.js';
 
-const UNUSED_SUBSCRIPTION_CLOSE_DELAY = 1000;
-
 type EventListeners = {
     [K in DataSyncEventType]: DataSyncEventMap[K][];
 };
@@ -26,31 +29,158 @@ type OutboxMessage = {
     payload: string;
 };
 
-type PendingOptimisticCreate = {
+type PendingCreate = {
     promise: Promise<void>;
     resolve: () => void;
     reject: (reason: Error) => void;
 };
 
+type TransportScope = Readonly<{
+    backendHost: string | null;
+    jwt: string | null;
+    origin: string;
+    key: string;
+}>;
+
+const transportScopeChanged = Object.freeze({ type: 'transport-scope-changed' });
+
+function isTransportScopeChange(event: unknown): boolean {
+    return event === transportScopeChanged;
+}
+
 class DataSyncController {
     static instance: DataSyncController | null = null;
     static ihpBackendHost: string | null = null;
+    private static readonly instanceListeners = new Set<(controller: DataSyncController | null) => void>();
+    private static retiringCurrentTransport = false;
+    private static authSessionGeneration = 0;
 
     static getInstance(): DataSyncController {
-        if (!DataSyncController.instance) {
-            DataSyncController.instance = new DataSyncController();
+        if (DataSyncController.retiringCurrentTransport) {
+            throw new Error('Cannot acquire a DataSync controller while the current transport is being retired');
+        }
+        const scope = DataSyncController.currentTransportScope();
+        const current = DataSyncController.instance;
+        if (current === null || current.transportScope.key !== scope.key || current.retired) {
+            const next = new DataSyncController(scope);
+            DataSyncController.instance = next;
+            if (current !== null) {
+                current.retire();
+            }
+            DataSyncController.notifyInstanceListeners(next);
         }
 
-        return DataSyncController.instance;
+        return DataSyncController.instance!;
+    }
+
+    /** Returns the controller only if it belongs to the current auth/backend scope. */
+    static peekInstance(): DataSyncController | null {
+        const current = DataSyncController.instance;
+        if (current === null || current.retired) {
+            return null;
+        }
+        return current.transportScope.key === DataSyncController.currentTransportScope().key
+            ? current
+            : null;
+    }
+
+    static addInstanceListener(listener: (controller: DataSyncController | null) => void): () => void {
+        DataSyncController.instanceListeners.add(listener);
+        return () => DataSyncController.instanceListeners.delete(listener);
+    }
+
+    static currentTransportScopeKey(): string {
+        return DataSyncController.currentTransportScope().key;
+    }
+
+    /**
+     * Invalidates all DataSync resources belonging to the previous auth
+     * session and closes its transport. Call this after replacing or clearing
+     * a cookie-authenticated session, before rendering the next user's tree.
+     *
+     * Cookie contents (especially HttpOnly cookies) are intentionally opaque
+     * to JavaScript, so this explicit boundary is required even when the
+     * backend host and JWT have not changed.
+     */
+    static authSessionDidChange(): void {
+        DataSyncController.authSessionGeneration++;
+        DataSyncController.retireCurrentTransport();
+    }
+
+    /**
+     * Retires the current cookie/JWT transport without creating a replacement.
+     * Intended for explicit auth/config transitions in a commit or event phase.
+     */
+    static retireCurrentTransport(): void {
+        if (DataSyncController.retiringCurrentTransport || DataSyncController.instance === null) {
+            return;
+        }
+        DataSyncController.retiringCurrentTransport = true;
+        try {
+            const current = DataSyncController.instance;
+            DataSyncController.instance = null;
+            current?.retire();
+            // Notify while acquisition is still blocked. A re-entrant listener
+            // cannot install a replacement that would survive an auth reset.
+            DataSyncController.notifyInstanceListeners(null);
+            DataSyncController.instance = null;
+        } finally {
+            DataSyncController.retiringCurrentTransport = false;
+        }
+    }
+
+    private static notifyInstanceListeners(controller: DataSyncController | null): void {
+        for (const listener of Array.from(DataSyncController.instanceListeners)) {
+            try {
+                listener(controller);
+            } catch (error) {
+                console.error('DataSync controller instance listener failed:', error);
+            }
+        }
+    }
+
+    private static currentTransportScope(): TransportScope {
+        let jwt: string | null = null;
+        try {
+            if (typeof localStorage !== 'undefined') {
+                jwt = localStorage.getItem('ihp_jwt');
+            }
+        } catch (_error) {
+            // localStorage can be unavailable during SSR or in privacy modes.
+        }
+
+        let origin = 'same-origin';
+        try {
+            if (typeof location !== 'undefined' && typeof location.origin === 'string') {
+                origin = location.origin;
+            }
+        } catch (_error) {
+            // Keep the stable SSR fallback.
+        }
+
+        const backendHost = DataSyncController.ihpBackendHost;
+        return {
+            backendHost,
+            jwt,
+            origin,
+            key: JSON.stringify([
+                backendHost ?? origin,
+                jwt,
+                DataSyncController.authSessionGeneration,
+            ]),
+        };
     }
 
     static getWSUrl(): string {
-        if (DataSyncController.ihpBackendHost) {
-            const jwt = localStorage.getItem('ihp_jwt');
-            const host = DataSyncController.ihpBackendHost
+        return DataSyncController.webSocketUrl(DataSyncController.currentTransportScope());
+    }
+
+    private static webSocketUrl(scope: TransportScope): string {
+        if (scope.backendHost) {
+            const host = scope.backendHost
                 .replace('https://', 'wss://')
                 .replace('http://', 'ws://');
-            return host + '/DataSyncController' + (jwt !== null ? '?access_token=' + encodeURIComponent(jwt) : '');
+            return host + '/DataSyncController' + (scope.jwt !== null ? '?access_token=' + encodeURIComponent(scope.jwt) : '');
         }
 
         const socketProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -66,16 +196,24 @@ class DataSyncController {
     outbox: OutboxMessage[];
     reconnectTimeout: ReturnType<typeof setTimeout> | null;
     dataSubscriptions: DataSubscription[];
+    pendingCreates: Map<UUID, PendingCreate>;
+    /** @deprecated Optimistic updates are disabled; retained as an empty compatibility field. */
     optimisticCreatedPendingRecordIds: UUID[];
-    pendingOptimisticCreates: Map<UUID, PendingOptimisticCreate>;
+    /** @deprecated Alias for pendingCreates. */
+    pendingOptimisticCreates: Map<UUID, PendingCreate>;
+    /** @deprecated Optimistic shape inference is disabled. */
     optimisticCreatedNeedsCreatedAtField: Set<string>;
     messageTimeout: number;
     connectionAttemptTimeout: number;
     connectionRetryLimit: number;
     connectionRetryMaxDelayExponent: number;
     pendingConnection: Promise<WebSocket> | null;
+    private readonly transportScope: TransportScope;
+    retired: boolean;
+    private readonly connectionAttemptAborters = new Set<(reason: Error) => void>();
 
-    constructor() {
+    constructor(scope: TransportScope = DataSyncController.currentTransportScope()) {
+        this.transportScope = scope;
         this.pendingRequests = [];
         this.connection = null;
         this.requestIdCounter = 0;
@@ -90,17 +228,43 @@ class DataSyncController {
         this.outbox = [];
         this.reconnectTimeout = null;
         this.dataSubscriptions = [];
+        this.pendingCreates = new Map();
         this.optimisticCreatedPendingRecordIds = [];
-        this.pendingOptimisticCreates = new Map();
+        this.pendingOptimisticCreates = this.pendingCreates;
         this.optimisticCreatedNeedsCreatedAtField = new Set();
         this.messageTimeout = 5000;
         this.connectionAttemptTimeout = 5000;
         this.connectionRetryLimit = 32;
         this.connectionRetryMaxDelayExponent = 6;
         this.pendingConnection = null;
+        this.retired = false;
+    }
+
+    isBoundToTransportScope(scopeKey: string): boolean {
+        return !this.retired && this.transportScope.key === scopeKey;
+    }
+
+    hasCurrentTransportScope(): boolean {
+        return this.isBoundToTransportScope(DataSyncController.currentTransportScope().key);
+    }
+
+    private rejectScopeMismatch(): Error {
+        const error = new Error('DataSync controller transport scope no longer matches the current authentication/backend scope');
+        if (DataSyncController.instance === this) {
+            DataSyncController.retireCurrentTransport();
+        } else {
+            this.retire();
+        }
+        return error;
     }
 
     async startConnection(): Promise<WebSocket> {
+        if (!this.hasCurrentTransportScope()) {
+            throw this.rejectScopeMismatch();
+        }
+        if (this.retired) {
+            throw new Error('DataSync controller transport scope is no longer active');
+        }
         if (this.connection) {
             return this.connection;
         }
@@ -112,7 +276,7 @@ class DataSyncController {
         let pendingConnection!: Promise<WebSocket>;
         pendingConnection = (async () => {
             const connect = (): Promise<{ socket: WebSocket; event: Event }> => new Promise((resolve, reject) => {
-                const socket = new WebSocket(DataSyncController.getWSUrl());
+                const socket = new WebSocket(DataSyncController.webSocketUrl(this.transportScope));
                 let settled = false;
 
                 const clearHandlers = () => {
@@ -133,21 +297,29 @@ class DataSyncController {
                     }
                     settled = true;
                     clearTimeout(attemptTimeout);
+                    this.connectionAttemptAborters.delete(abort);
                     clearHandlers();
                     closeSocket();
                     reject(error);
                 };
+                const abort = (reason: Error) => fail(reason);
                 const attemptTimeout = setTimeout(() => {
                     fail(new Error(`DataSync WebSocket connection attempt timed out after ${this.connectionAttemptTimeout}ms`));
                 }, this.connectionAttemptTimeout);
+                this.connectionAttemptAborters.add(abort);
 
                 socket.onopen = (event) => {
-                    if (settled) {
+                    if (settled || this.retired || !this.hasCurrentTransportScope()) {
+                        if (!settled && !this.retired) {
+                            fail(this.rejectScopeMismatch());
+                            return;
+                        }
                         closeSocket();
                         return;
                     }
                     settled = true;
                     clearTimeout(attemptTimeout);
+                    this.connectionAttemptAborters.delete(abort);
                     this.connection = socket;
                     socket.onclose = (closeEvent) => this.onClose(closeEvent, socket);
                     socket.onmessage = this.onMessage.bind(this);
@@ -160,14 +332,22 @@ class DataSyncController {
             const wait = (timeout: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, timeout));
             try {
                 for (let i = 0; i < this.connectionRetryLimit; i++) {
+                    if (this.retired) {
+                        throw new Error('DataSync controller transport scope is no longer active');
+                    }
                     try {
                         const { socket, event } = await connect();
                         if (this.connection !== socket) {
                             throw new Error('DataSync WebSocket closed while the connection was opening');
                         }
                         this.flushOutbox(socket);
+                        if (this.retired
+                            || !this.hasCurrentTransportScope()
+                            || this.connection !== socket) {
+                            throw new Error('DataSync WebSocket became obsolete before it could be used');
+                        }
 
-                        for (const listener of this.eventListeners.open) {
+                        for (const listener of this.eventListeners.open.slice()) {
                             try {
                                 listener(event);
                             } catch (error) {
@@ -177,6 +357,9 @@ class DataSyncController {
 
                         return socket;
                     } catch (error) {
+                        if (this.retired) {
+                            throw error;
+                        }
                         if (i === this.connectionRetryLimit - 1) {
                             throw error;
                         }
@@ -198,6 +381,13 @@ class DataSyncController {
     }
 
     onMessage(event: MessageEvent): void {
+        if (!this.hasCurrentTransportScope()) {
+            this.rejectScopeMismatch();
+            return;
+        }
+        if (this.retired) {
+            return;
+        }
         const payload: ServerMessage = JSON.parse(event.data as string);
         const requestId = payload.requestId;
         const request = this.pendingRequests.find(request => request.requestId === requestId);
@@ -218,10 +408,19 @@ class DataSyncController {
         }
 
         this.receivedFirstResponse = true;
-        this.eventListeners.message.slice(0).forEach(callback => callback(payload));
+        for (const callback of this.eventListeners.message.slice()) {
+            try {
+                callback(payload);
+            } catch (error) {
+                console.error('DataSync message listener failed:', error);
+            }
+        }
     }
 
     onClose(_event: CloseEvent | null, closedSocket: WebSocket | null = null): void {
+        if (this.retired) {
+            return;
+        }
         if (closedSocket !== null && this.connection !== closedSocket) {
             return;
         }
@@ -229,14 +428,26 @@ class DataSyncController {
         this.connection = null;
         this.rejectSentPendingRequests(new Error('DataSync WebSocket closed before the server responded'));
 
-        for (const listener of this.eventListeners.close) {
-            listener(_event);
+        for (const listener of this.eventListeners.close.slice()) {
+            try {
+                listener(_event);
+            } catch (error) {
+                console.error('DataSync close listener failed:', error);
+            }
         }
 
-        this.retryToReconnect();
+        if (!this.retired) {
+            this.retryToReconnect();
+        }
     }
 
     async sendMessage(payload: Record<string, unknown>): Promise<ServerMessage> {
+        if (!this.hasCurrentTransportScope()) {
+            throw this.rejectScopeMismatch();
+        }
+        if (this.retired) {
+            throw new Error('DataSync controller transport scope is no longer active');
+        }
         return new Promise((resolve, reject) => {
             payload.requestId = this.requestIdCounter++;
             const requestId = payload.requestId as number;
@@ -269,6 +480,24 @@ class DataSyncController {
     private sendPendingRequest(connection: WebSocket, message: OutboxMessage): void {
         const request = this.pendingRequests.find(({ requestId }) => requestId === message.requestId);
         if (!request) {
+            return;
+        }
+        if (this.retired) {
+            this.rejectPendingRequest(
+                request.requestId,
+                new Error('DataSync controller transport scope is no longer active'),
+            );
+            return;
+        }
+        if (!this.hasCurrentTransportScope()) {
+            this.rejectPendingRequest(request.requestId, this.rejectScopeMismatch());
+            return;
+        }
+        if (connection !== this.connection) {
+            this.rejectPendingRequest(
+                request.requestId,
+                new Error('DataSync WebSocket closed before the request could be sent'),
+            );
             return;
         }
 
@@ -312,6 +541,55 @@ class DataSyncController {
         }
     }
 
+    private rejectAllPendingRequests(reason: Error): void {
+        for (const request of this.pendingRequests.slice()) {
+            this.rejectPendingRequest(request.requestId, reason);
+        }
+        this.outbox = [];
+    }
+
+    private retire(): void {
+        if (this.retired) {
+            return;
+        }
+        this.retired = true;
+        if (this.reconnectTimeout !== null) {
+            clearTimeout(this.reconnectTimeout);
+            this.reconnectTimeout = null;
+        }
+
+        const reason = new Error('DataSync transport scope changed');
+        for (const abort of Array.from(this.connectionAttemptAborters)) {
+            abort(reason);
+        }
+        this.connectionAttemptAborters.clear();
+        this.rejectAllPendingRequests(reason);
+        for (const pendingCreate of this.pendingCreates.values()) {
+            pendingCreate.reject(reason);
+        }
+        this.pendingCreates.clear();
+
+        const connection = this.connection;
+        this.connection = null;
+        if (connection !== null) {
+            connection.onmessage = null;
+            connection.onclose = null;
+            try {
+                connection.close();
+            } catch (_error) {
+                // Test doubles and already closed sockets need no further work.
+            }
+        }
+
+        for (const listener of this.eventListeners.close.slice()) {
+            try {
+                listener(transportScopeChanged);
+            } catch (error) {
+                console.error('DataSync close listener failed during transport rotation:', error);
+            }
+        }
+    }
+
     addEventListener<E extends DataSyncEventType>(event: E, callback: DataSyncEventMap[E]): void {
         (this.eventListeners[event] as DataSyncEventMap[E][]).push(callback);
     }
@@ -325,7 +603,7 @@ class DataSyncController {
     }
 
     retryToReconnect(): void {
-        if (this.connection) {
+        if (this.connection || this.retired) {
             return;
         }
 
@@ -334,11 +612,14 @@ class DataSyncController {
         }
         this.reconnectTimeout = setTimeout(async () => {
             this.reconnectTimeout = null;
+            if (this.retired) {
+                return;
+            }
             try {
                 console.log('Trying to reconnect DataSync ...');
                 await this.startConnection();
 
-                for (const listener of this.eventListeners.reconnect) {
+                for (const listener of this.eventListeners.reconnect.slice()) {
                     try {
                         listener();
                     } catch (error) {
@@ -352,14 +633,8 @@ class DataSyncController {
         }, 1000);
     }
 
-    learnOptimisticShapeFromResult(table: string, result: DataRecord[]): void {
-        if (result.length > 0) {
-            const hasCreatedAtField = 'createdAt' in result[0];
-            if (hasCreatedAtField) {
-                this.optimisticCreatedNeedsCreatedAtField.add(table);
-            }
-        }
-    }
+    /** @deprecated Server snapshots replaced optimistic shape inference. */
+    learnOptimisticShapeFromResult(_table: string, _result: DataRecord[]): void {}
 
     onPendingRequestTimeout(requestId: number): void {
         const request = this.pendingRequests.find(request => request.requestId === requestId);
@@ -377,558 +652,729 @@ class DataSyncController {
 
 class DataSubscription {
     query: DynamicSQLQuery;
-    createOnServerPromise: Promise<DataRecord[]>;
-    resolveCreateOnServer!: (value: DataRecord[]) => void;
-    rejectCreateOnServer!: (reason: Error) => void;
-    isClosed: boolean;
-    isConnected: boolean;
-    connectError: Error | null;
-    subscriptionId: UUID | null;
-    subscribers: Array<(records: DataRecord[] | null) => void>;
-    records: DataRecord[] | null;
     cache: Map<string, DataRecord[]> | null;
+    /** @deprecated Server snapshots make client-side insertion placement a no-op. */
     newRecordBehaviour: number;
-    optimisticCreatedPendingRecordIds: UUID[];
-    optimisticUpdatedPendingRecordIds: Set<UUID>;
-    private closeNotificationSent: boolean;
-    private closeIfNotUsedTimeout: ReturnType<typeof setTimeout> | null;
-    private refreshPromise: Promise<void> | null;
-    private refreshRequested: boolean;
-    private createOnServerGeneration: number;
+    subscriptionId: UUID | null = null;
+    createOnServerPromise: Promise<DataRecord[]>;
+    /** @deprecated Prefer createOnServerPromise; retained for source compatibility. */
+    resolveCreateOnServer!: (value: DataRecord[]) => void;
+    /** @deprecated Prefer createOnServerPromise; retained for source compatibility. */
+    rejectCreateOnServer!: (reason: Error) => void;
+    onClose: () => void = () => {};
+    onStoreClose: () => void = () => {};
+    /** @internal Promotes a render-only weak registry entry on first retain. */
+    onStoreRetain: () => void = () => {};
+    subscribers: Array<(records: DataRecord[] | null) => void> = [];
+    isClosed = false;
+    isConnected = false;
+    connectError: Error | null = null;
+    /** @deprecated Optimistic mutation is disabled; retained empty for compatibility. */
+    optimisticCreatedPendingRecordIds: UUID[] = [];
+    /** @deprecated Optimistic mutation is disabled; retained empty for compatibility. */
+    optimisticUpdatedPendingRecordIds: Set<UUID> = new Set();
 
-    constructor(query: DynamicSQLQuery, options: DataSubscriptionOptions | null = null, cache: Map<string, DataRecord[]> | null = null) {
-        if (typeof query !== "object" || !('table' in query)) {
-            throw new Error("Query passed to `new DataSubscription(..)` doesn't look like a query object. If you're using the `query()` functions to costruct the object, make sure you pass the `.query` property, like this: `new DataSubscription(query('my_table').orderBy('createdAt').query)`");
+    private controller: DataSyncController | null = null;
+    private readonly serverQuery: DynamicSQLQuery;
+    private readonly expectedTransportScopeKey: string;
+    private readonly scopedCache: Map<string, DataRecord[]> | null;
+    private readonly cacheKey: string;
+    private snapshot: ResourceSnapshot<DataRecord[]>;
+    private readonly subscriberEntries = new Map<number, (records: DataRecord[] | null) => void>();
+    private readonly snapshotSubscriberEntries = new Map<number, () => void>();
+    private nextSubscriberId = 0;
+    private nextSnapshotSubscriberId = 0;
+    private generation = 0;
+    private lastRevision = -1;
+    private started = false;
+    private listenersAttached = false;
+    private closeNotificationSent = false;
+    private disposalToken = 0;
+    private startPromise: Promise<void> | null = null;
+    private refreshPromise: Promise<void> | null = null;
+    private refreshRequested = false;
+    private supportsAuthoritativeSnapshots = false;
+    private initialCreateSettled = false;
+    private imperativelyOwned = false;
+    private resolveInitialCreate!: (records: DataRecord[]) => void;
+    private rejectInitialCreate!: (error: Error) => void;
+
+    constructor(
+        query: DynamicSQLQuery,
+        options: DataSubscriptionOptions | null = null,
+        cache: Map<string, DataRecord[]> | null = null,
+        cacheKey: string = JSON.stringify(query),
+        expectedTransportScopeKey: string = DataSyncController.currentTransportScopeKey(),
+    ) {
+        if (typeof query !== 'object' || query === null || !('table' in query)) {
+            throw new Error("Query passed to `new DataSubscription(..)` doesn't look like a query object. If you're using the `query()` functions to construct the object, pass the `.query` property, like this: `new DataSubscription(query('my_table').orderBy('createdAt').query)`");
         }
-        this.query = query;
-        this.createOnServerPromise = new Promise((resolve, reject) => {
-            this.resolveCreateOnServer = resolve;
-            this.rejectCreateOnServer = reject;
-        });
-        void this.createOnServerPromise.catch(() => {
-            // close() observes the same promise when it needs to wait for setup;
-            // most subscriptions never need that path, so avoid an unhandled rejection.
-        });
 
-        this.isClosed = false;
-        this.isConnected = false;
-        this.connectError = null;
-        this.subscriptionId = null;
-        this.subscribers = [];
-
-        if (cache) {
-            const cacheResults = cache.get(JSON.stringify(query));
-            if (cacheResults !== undefined) {
-                this.records = cacheResults;
-            } else {
-                this.records = null;
-            }
-        } else {
-            this.records = null;
-        }
+        // QueryBuilder is mutable. A live subscription must never change when a
+        // component reuses and mutates the builder after this point.
+        this.query = cloneQuery(query);
+        this.serverQuery = deepFreeze(cloneQuery(query));
+        this.expectedTransportScopeKey = expectedTransportScopeKey;
+        this.scopedCache = cache;
         this.cache = cache;
+        this.cacheKey = cacheKey;
+        const cachedRecords = cache?.get(cacheKey);
+        this.snapshot = initialResourceSnapshot(
+            cachedRecords?.map(record => ({ ...record })) as DataRecord[] | undefined,
+        );
+        this.createOnServerPromise = new Promise((resolve, reject) => {
+            this.resolveInitialCreate = resolve;
+            this.rejectInitialCreate = reject;
+        });
+        this.resolveCreateOnServer = records => this.resolveInitialCreateOnce(records);
+        this.rejectCreateOnServer = error => this.rejectInitialCreateOnce(error);
+        void this.createOnServerPromise.catch(() => {});
+        this.newRecordBehaviour = options?.newRecordBehaviour ?? this.detectNewRecordBehaviour();
 
-        this.getRecords = this.getRecords.bind(this);
         this.subscribe = this.subscribe.bind(this);
+        this.subscribeSnapshot = this.subscribeSnapshot.bind(this);
+        this.getRecords = this.getRecords.bind(this);
+        this.getSnapshot = this.getSnapshot.bind(this);
+        this.getServerSnapshot = this.getServerSnapshot.bind(this);
+        this.onMessage = this.onMessage.bind(this);
         this.onDataSyncClosed = this.onDataSyncClosed.bind(this);
         this.onDataSyncReconnect = this.onDataSyncReconnect.bind(this);
-        this.onMessage = this.onMessage.bind(this);
-
-        // When a new record is inserted, do we put it at the end or at the beginning?
-        this.newRecordBehaviour = (options && 'newRecordBehaviour' in options) ? options.newRecordBehaviour! : this.detectNewRecordBehaviour();
-
-        this.optimisticCreatedPendingRecordIds = [];
-        this.optimisticUpdatedPendingRecordIds = new Set();
-        this.closeNotificationSent = false;
-        this.closeIfNotUsedTimeout = null;
-        this.refreshPromise = null;
-        this.refreshRequested = false;
-        this.createOnServerGeneration = 0;
     }
 
-    detectNewRecordBehaviour(): number {
-        // If the query is ordered by the createdAt column, and the latest is at the top
-        // we want to prepend new record
-        const firstOrderBy = this.query.orderByClause[0];
-        const isOrderByCreatedAtDesc = this.query.orderByClause.length > 0
-            && firstOrderBy
-            && 'orderByColumn' in firstOrderBy
-            && firstOrderBy.orderByColumn === 'createdAt'
-            && firstOrderBy.orderByDirection === 'Desc';
+    get records(): DataRecord[] | null {
+        return this.snapshot.data;
+    }
 
-        if (isOrderByCreatedAtDesc) {
-            return PREPEND_NEW_RECORD;
+    /** @deprecated Query snapshots are server-owned; assigning is retained for compatibility only. */
+    set records(records: DataRecord[] | null) {
+        if (records === null) {
+            this.snapshot = initialResourceSnapshot();
+            this.notifySubscribers();
+            this.notifySnapshotSubscribers();
+        } else {
+            this.applyServerSnapshot(records, this.lastRevision + 1);
+        }
+    }
+
+    getSnapshot(): ResourceSnapshot<DataRecord[]> {
+        return this.snapshot;
+    }
+
+    getServerSnapshot(): ResourceSnapshot<DataRecord[]> {
+        return initialResourceSnapshot();
+    }
+
+    getRecords(): DataRecord[] | null {
+        return this.snapshot.data;
+    }
+
+    subscribe(callback: (records: DataRecord[] | null) => void): () => void {
+        // The first ref-counted consumer takes ownership from the imperative
+        // API. Its final release can then close the server resource normally.
+        this.imperativelyOwned = false;
+        this.retainInStore();
+        const shouldStart = this.trackedSubscriberCount() === 0;
+        const subscriberId = this.nextSubscriberId++;
+        this.subscriberEntries.set(subscriberId, callback);
+        this.subscribers.push(callback);
+        this.disposalToken++;
+        if (shouldStart) {
+            void this.start(false).catch(() => {
+                // The error is part of the immutable snapshot and is surfaced by React.
+            });
+        }
+        // Do not synchronously expose CONNECT/null lifecycle changes through
+        // the legacy record callback. A later subscriber to an already-live
+        // shared resource still receives its current server value immediately.
+        if (this.snapshot.status === 'live' && this.snapshot.data !== null) {
+            this.callSubscriber(callback, this.snapshot.data);
         }
 
-        return APPEND_NEW_RECORD;
+        let subscribed = true;
+        return () => {
+            if (!subscribed) {
+                return;
+            }
+            subscribed = false;
+            this.subscriberEntries.delete(subscriberId);
+            // subscribe() appends, so remove from the end to avoid consuming a
+            // matching callback that legacy code inserted directly beforehand.
+            const publicIndex = this.subscribers.lastIndexOf(callback);
+            if (publicIndex !== -1) {
+                this.subscribers.splice(publicIndex, 1);
+            }
+            this.scheduleCloseIfNotUsed();
+        };
     }
 
-    async createOnServer(): Promise<void> {
-        const dataSyncController = DataSyncController.getInstance();
-        const createOnServerGeneration = this.createOnServerGeneration;
-        try {
-            const response = await dataSyncController.sendMessage({ tag: 'CreateDataSubscription', query: this.query });
-            const subscriptionId = response.subscriptionId as UUID;
-            const result = response.result as DataRecord[];
+    /** Internal external-store subscription; observes every snapshot identity change. */
+    subscribeSnapshot(callback: () => void): () => void {
+        this.imperativelyOwned = false;
+        this.retainInStore();
+        const shouldStart = this.trackedSubscriberCount() === 0;
+        const subscriberId = this.nextSnapshotSubscriberId++;
+        this.snapshotSubscriberEntries.set(subscriberId, callback);
+        this.disposalToken++;
+        if (shouldStart) {
+            void this.start(false).catch(() => {
+                // The error is part of the immutable snapshot and is surfaced by React.
+            });
+        }
 
-            if (createOnServerGeneration !== this.createOnServerGeneration) {
-                await this.deleteStaleDataSubscription(dataSyncController, subscriptionId);
+        let subscribed = true;
+        return () => {
+            if (!subscribed) {
+                return;
+            }
+            subscribed = false;
+            this.snapshotSubscriberEntries.delete(subscriberId);
+            this.scheduleCloseIfNotUsed();
+        };
+    }
+
+    /** Starts a manually managed subscription. React and QueryBuilder do not need this. */
+    async createOnServer(): Promise<void> {
+        this.retainInStore();
+        if (this.trackedSubscriberCount() === 0) {
+            this.imperativelyOwned = true;
+        }
+        await this.start(false);
+        // Scope-change and explicit-close paths settle the same public promise;
+        // imperative callers must not observe a successful create when the
+        // server resource was discarded before its first snapshot.
+        await this.createOnServerPromise;
+    }
+
+    private start(reconnect: boolean): Promise<void> {
+        this.disposalToken++;
+        if (this.startPromise !== null) {
+            return this.startPromise;
+        }
+        if (this.started && this.subscriptionId !== null) {
+            return Promise.resolve();
+        }
+
+        if (!this.hasExpectedTransportScope()) {
+            this.closeForTransportScopeChange('before the subscription could commit');
+            return Promise.resolve();
+        }
+
+        const controller = DataSyncController.getInstance();
+        if (!controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
+            this.closeForTransportScopeChange('before the subscription could acquire its controller');
+            return Promise.resolve();
+        }
+        // A render may retain an object that was fully released between render
+        // and commit. Reopening is supported, and its next final release must
+        // notify the store again instead of leaving a closed registry entry.
+        this.closeNotificationSent = false;
+        this.attachControllerListeners(controller);
+        this.started = true;
+        const generation = ++this.generation;
+        this.lastRevision = -1;
+        this.supportsAuthoritativeSnapshots = false;
+        this.dispatch({ type: 'CONNECT', reconnect });
+
+        const startPromise = this.createServerSubscription(generation, controller);
+        this.startPromise = startPromise;
+        void startPromise.finally(() => {
+            if (this.startPromise === startPromise) {
+                this.startPromise = null;
+            }
+        }).catch(() => {});
+        return startPromise;
+    }
+
+    private async createServerSubscription(generation: number, controller: DataSyncController): Promise<void> {
+        try {
+            const response = await controller.sendMessage({
+                tag: 'CreateDataSubscription',
+                query: this.serverQuery,
+                protocolVersion: 1,
+            });
+            const subscriptionId = response.subscriptionId as UUID;
+
+            if (!this.started
+                || generation !== this.generation
+                || this.controller !== controller
+                || !this.hasExpectedTransportScope()
+                || !controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
+                if (!this.hasExpectedTransportScope()) {
+                    this.closeForTransportScopeChange('while the subscription was being created');
+                }
+                await this.deleteStaleDataSubscription(controller, subscriptionId);
                 return;
             }
 
             this.subscriptionId = subscriptionId;
-
-            // This condition ensure that the event listeners are only installed on first
-            // run. This function could be called multiple times (e.g. a second time on internet reconnect).
-            // In those cases we already did register the event listener.
-            if (this.isClosed === false) {
-                dataSyncController.addEventListener('message', this.onMessage);
-                dataSyncController.addEventListener('close', this.onDataSyncClosed);
-                dataSyncController.addEventListener('reconnect', this.onDataSyncReconnect);
-                dataSyncController.dataSubscriptions.push(this);
+            this.supportsAuthoritativeSnapshots = response.tag === 'DidCreateDataSubscriptionV2';
+            const result = response.result as DataRecord[];
+            // The V2 tag explicitly acknowledges snapshot support. An old
+            // DidCreate response remains delta-compatible even when that server
+            // silently ignored the protocolVersion request field.
+            const initialRevision = this.supportsAuthoritativeSnapshots && typeof response.revision === 'number'
+                ? response.revision
+                : 0;
+            this.applyServerSnapshot(result, initialRevision);
+            this.resolveInitialCreateOnce(result);
+        } catch (unknownError) {
+            if (!this.started || generation !== this.generation || this.controller !== controller) {
+                return;
             }
 
-            this.isConnected = true;
-            this.isClosed = false;
-            this.connectError = null;
-            // The server result already has the exact projection, ordering and
-            // window requested by the query. Reapplying parts of the query in
-            // the browser can corrupt projected DISTINCT/ORDER BY results.
-            this.records = result;
-
-            this.resolveCreateOnServer(result);
-            this.updateSubscribers();
-
-            dataSyncController.learnOptimisticShapeFromResult(this.query.table, result);
-        } catch (e) {
-            const error = e as Error;
-            this.isConnected = false;
-            this.connectError = new Error(error.message + ' while trying to subscribe to:\n' + JSON.stringify(this.query, null, 4));
-            this.rejectCreateOnServer(this.connectError);
-            this.notifySubscribers();
-            throw this.connectError;
+            const error = unknownError instanceof Error ? unknownError : new Error(String(unknownError));
+            const connectionError = new Error(error.message + ' while trying to subscribe to:\n' + JSON.stringify(this.serverQuery, null, 4));
+            this.dispatch({ type: 'FAIL', error: connectionError });
+            this.rejectInitialCreateOnce(connectionError);
+            throw connectionError;
         }
+    }
+
+    private attachControllerListeners(controller: DataSyncController): void {
+        if (this.listenersAttached && this.controller === controller) {
+            return;
+        }
+        this.detachControllerListeners();
+        this.controller = controller;
+        this.listenersAttached = true;
+        controller.addEventListener('message', this.onMessage);
+        controller.addEventListener('close', this.onDataSyncClosed);
+        controller.addEventListener('reconnect', this.onDataSyncReconnect);
+        if (!controller.dataSubscriptions.includes(this)) {
+            controller.dataSubscriptions.push(this);
+        }
+    }
+
+    private detachControllerListeners(): void {
+        const controller = this.controller;
+        if (controller === null) {
+            this.listenersAttached = false;
+            return;
+        }
+        if (this.listenersAttached) {
+            controller.removeEventListener('message', this.onMessage);
+            controller.removeEventListener('close', this.onDataSyncClosed);
+            controller.removeEventListener('reconnect', this.onDataSyncReconnect);
+            this.listenersAttached = false;
+        }
+        const index = controller.dataSubscriptions.indexOf(this);
+        if (index !== -1) {
+            controller.dataSubscriptions.splice(index, 1);
+        }
+        this.controller = null;
     }
 
     onMessage(message: ServerMessage): void {
-        if (this.isClosed) {
+        if (!this.started || message.subscriptionId !== this.subscriptionId) {
             return;
         }
-        if (message.subscriptionId === this.subscriptionId) {
-            this.receiveUpdate(message);
-        }
+        this.receiveUpdate(message);
     }
 
     receiveUpdate(message: ServerMessage): void {
-        const tag = message.tag;
-        if (tag === 'DidUpdate') {
-            this.onUpdate(message.id as UUID, message.changeSet as Record<string, unknown> | null, message.appendSet as Record<string, unknown> | null);
-        } else if (tag === 'DidInsert') {
-            this.onCreate(message.record as DataRecord);
-        } else if (tag === 'DidDelete') {
-            this.onDelete(message.id as UUID);
+        if (!this.hasExpectedTransportScope()) {
+            this.closeForTransportScopeChange('before a server update was applied');
+            return;
         }
-    }
-
-    async close(): Promise<void> {
-        const dataSyncController = DataSyncController.getInstance();
-        this.cancelScheduledCloseIfNotUsed();
-
-        if (this.isClosed) {
-            this.createOnServerGeneration++;
-            // A dropped WebSocket marks every subscription as closed. There is
-            // no server-side subscription left to delete, but an unused React
-            // subscription still needs to be removed from the local store and
-            // reconnect list.
-            this.notifyClose();
-            this.detachFromDataSyncController(dataSyncController);
+        if (message.tag === 'DidReplaceDataSubscription') {
+            const isFirstReplacement = !this.supportsAuthoritativeSnapshots;
+            this.supportsAuthoritativeSnapshots = true;
+            const revision = typeof message.revision === 'number'
+                ? message.revision
+                : this.lastRevision + 1;
+            if (isFirstReplacement && revision <= this.lastRevision) {
+                this.lastRevision = revision - 1;
+            }
+            this.applyServerSnapshot(message.result as DataRecord[], revision);
             return;
         }
 
-        // We cannot close the DataSubscription when the subscriptionId is not assigned
-        if (!this.isClosed && !this.isConnected) {
-            try {
-                await this.createOnServerPromise;
-            } catch (_error) {
-                this.isClosed = true;
-                this.notifyClose();
-                this.detachFromDataSyncController(dataSyncController);
-                return;
-            }
-            return this.close();
-        }
-
-        // Set isClosed early as we need to prevent a second close() from triggering another DeleteDataSubscription message
-        // also we don't want to receive any further messages, and onMessage will not process if isClosed == true
-        this.createOnServerGeneration++;
-        this.isClosed = true;
-        this.notifyClose();
-
-        try {
-            await dataSyncController.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId: this.subscriptionId });
-        } finally {
-            this.detachFromDataSyncController(dataSyncController);
+        // Compatibility with older servers: delta messages are invalidations,
+        // never instructions to emulate PostgreSQL query semantics in the browser.
+        if (!this.supportsAuthoritativeSnapshots
+            && (message.tag === 'DidInsert' || message.tag === 'DidUpdate' || message.tag === 'DidDelete')) {
+            this.requestAuthoritativeRefresh();
         }
     }
 
-    private detachFromDataSyncController(dataSyncController: DataSyncController): void {
-        dataSyncController.removeEventListener('message', this.onMessage);
-        dataSyncController.removeEventListener('close', this.onDataSyncClosed);
-        dataSyncController.removeEventListener('reconnect', this.onDataSyncReconnect);
-        const index = dataSyncController.dataSubscriptions.indexOf(this);
-        if (index !== -1) {
-            dataSyncController.dataSubscriptions.splice(index, 1);
+    private applyServerSnapshot(records: DataRecord[], revision: number): void {
+        if (revision <= this.lastRevision) {
+            return;
+        }
+        this.lastRevision = revision;
+        // Keep the public mutable `DataRecord[]` contract. The snapshot wrapper
+        // is immutable, while callers remain free to use normal array methods.
+        const snapshotRecords = records.map(record => ({ ...record })) as DataRecord[];
+        if (this.scopedCache !== null
+            && this.hasExpectedTransportScope()
+            && this.controller?.isBoundToTransportScope(this.expectedTransportScopeKey) === true) {
+            this.scopedCache.delete(this.cacheKey);
+            this.scopedCache.set(
+                this.cacheKey,
+                snapshotRecords.map(record => ({ ...record })) as DataRecord[],
+            );
+            trimOldestMapEntries(this.scopedCache, 100);
+        }
+        this.dispatch({ type: 'SNAPSHOT', data: snapshotRecords });
+    }
+
+    private requestAuthoritativeRefresh(): void {
+        if (!this.started) {
+            return;
+        }
+        this.refreshRequested = true;
+        if (this.refreshPromise !== null) {
+            return;
+        }
+        const generation = this.generation;
+        const refreshPromise = this.refreshUntilClean(generation);
+        this.refreshPromise = refreshPromise;
+        void refreshPromise.finally(() => {
+            if (this.refreshPromise === refreshPromise) {
+                this.refreshPromise = null;
+            }
+        }).catch(() => {});
+    }
+
+    private async refreshUntilClean(generation: number): Promise<void> {
+        do {
+            this.refreshRequested = false;
+            if (this.supportsAuthoritativeSnapshots) {
+                return;
+            }
+            try {
+                const controller = this.controller;
+                if (controller === null
+                    || !this.hasExpectedTransportScope()
+                    || !controller.isBoundToTransportScope(this.expectedTransportScopeKey)) {
+                    if (!this.hasExpectedTransportScope()) {
+                        this.closeForTransportScopeChange('before a legacy refresh was sent');
+                    }
+                    return;
+                }
+                const response = await controller.sendMessage({
+                    tag: 'DataSyncQuery',
+                    query: this.serverQuery,
+                    transactionId: null,
+                });
+                // A replacement received while this legacy refetch was in
+                // flight upgrades the resource to revisioned snapshots. The
+                // unrevisioned query response can then be older and must not
+                // overwrite that authoritative replacement.
+                if (this.started
+                    && generation === this.generation
+                    && !this.supportsAuthoritativeSnapshots) {
+                    this.applyServerSnapshot(response.result as DataRecord[], this.lastRevision + 1);
+                }
+            } catch (error) {
+                if (this.started && generation === this.generation) {
+                    console.error('Failed to refresh a legacy DataSubscription:', error);
+                }
+            }
+        } while (this.refreshRequested && this.started && generation === this.generation);
+    }
+
+    onDataSyncClosed(event: unknown = null): void {
+        if (!this.started) {
+            return;
+        }
+        if (isTransportScopeChange(event)) {
+            this.closeForTransportScopeChange('because the controller transport changed');
+            return;
+        }
+        this.generation++;
+        this.subscriptionId = null;
+        this.lastRevision = -1;
+        this.startPromise = null;
+        this.refreshPromise = null;
+        this.refreshRequested = false;
+        this.dispatch({ type: 'DISCONNECT' });
+    }
+
+    async onDataSyncReconnect(): Promise<void> {
+        if (!this.started || this.startPromise !== null || this.subscriptionId !== null) {
+            return;
+        }
+        await this.start(true).catch(() => {
+            // The failure is observable through getSnapshot().
+        });
+    }
+
+    /** @deprecated Delta mutation now triggers an exact server refresh. */
+    onUpdate(
+        _id: UUID,
+        _changeSet: Record<string, unknown> | null,
+        _appendSet: Record<string, unknown> | null,
+        _isOptimistic = false,
+    ): void {
+        this.requestAuthoritativeRefresh();
+    }
+
+    /** @deprecated Delta mutation now triggers an exact server refresh. */
+    onCreate(_newRecord: DataRecord, _isOptimistic = false): void {
+        this.requestAuthoritativeRefresh();
+    }
+
+    /** @deprecated Optimistic mutation is disabled and triggers an exact refresh. */
+    onCreateOptimistic(newRecord: DataRecord): void {
+        if (!('id' in newRecord)) {
+            throw new Error('Requires the record to have an id');
+        }
+        this.requestAuthoritativeRefresh();
+    }
+
+    /** @deprecated Delta mutation now triggers an exact server refresh. */
+    onDelete(_id: UUID, _isOptimistic = false): void {
+        this.requestAuthoritativeRefresh();
+    }
+
+    /** @deprecated Optimistic updates are intentionally disabled. */
+    supportsOptimisticUpdates(): boolean {
+        return false;
+    }
+
+    /** @deprecated Snapshots notify automatically; retained for compatibility. */
+    updateSubscribers(): void {
+        this.notifySubscribers();
+    }
+
+    scheduleCloseIfNotUsed(): void {
+        const token = ++this.disposalToken;
+        queueMicrotask(() => {
+            if (token === this.disposalToken) {
+                this.closeIfNotUsed();
+            }
+        });
+    }
+
+    closeIfNotUsed(): void {
+        if (this.subscribers.length !== 0
+            || this.snapshotSubscriberEntries.size !== 0
+            || this.imperativelyOwned) {
+            return;
+        }
+        void this.stop().catch(error => {
+            console.error('Failed to close an unused DataSubscription:', error);
+        });
+    }
+
+    async close(): Promise<void> {
+        this.imperativelyOwned = false;
+        this.subscriberEntries.clear();
+        this.snapshotSubscriberEntries.clear();
+        this.subscribers.length = 0;
+        this.disposalToken++;
+        await this.stop();
+    }
+
+    private async stop(): Promise<void> {
+        if (!this.started && this.snapshot.status === 'closed') {
+            return;
         }
 
-        this.isConnected = false;
+        this.started = false;
+        this.generation++;
+        this.startPromise = null;
+        this.refreshPromise = null;
+        this.refreshRequested = false;
+        const subscriptionId = this.subscriptionId;
+        const controller = this.controller;
+        this.subscriptionId = null;
+        this.detachControllerListeners();
+        this.dispatch({ type: 'CLOSE' });
+        this.rejectInitialCreateOnce(new Error('DataSubscription closed before its initial server snapshot arrived'));
+        this.notifyClose();
+
+        if (subscriptionId !== null && controller !== null) {
+            await this.deleteStaleDataSubscription(controller, subscriptionId);
+        }
     }
 
     private notifyClose(): void {
         if (this.closeNotificationSent) {
             return;
         }
-
         this.closeNotificationSent = true;
-        this.onClose();
-    }
-
-    private async deleteStaleDataSubscription(dataSyncController: DataSyncController, subscriptionId: UUID): Promise<void> {
         try {
-            await dataSyncController.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
+            this.onStoreClose();
         } catch (error) {
-            console.error('Failed to delete a DataSubscription created after it was closed:', error);
+            console.error('DataSubscription store-close listener failed:', error);
         }
-    }
-
-    onDataSyncClosed(): void {
-        this.createOnServerGeneration++;
-        this.isClosed = true;
-        this.isConnected = false;
-
-        // The controller reconnects after one second. This timeout is registered
-        // before the reconnect timeout, so unused subscriptions are pruned first.
-        // A React commit that subscribes in the meantime cancels the cleanup.
-        this.scheduleCloseIfNotUsed();
-    }
-
-    async onDataSyncReconnect(): Promise<void> {
         try {
-            await this.createOnServer();
-        } catch (_error) {
-            // createOnServer stores the error and notifies React subscribers.
+            this.onClose();
+        } catch (error) {
+            console.error('DataSubscription close listener failed:', error);
         }
     }
 
-    onUpdate(id: UUID, changeSet: Record<string, unknown> | null, appendSet: Record<string, unknown> | null, isOptimistic = false): void {
-        const wasOptimisticallyUpdated = this.optimisticUpdatedPendingRecordIds.has(id);
-        if (!isOptimistic) {
-            this.optimisticUpdatedPendingRecordIds.delete(id);
-        }
-
-        if (!this.supportsOptimisticUpdates()) {
-            if (!isOptimistic) {
-                this.refreshAfterComplexMutation();
+    private async deleteStaleDataSubscription(controller: DataSyncController, subscriptionId: UUID): Promise<void> {
+        try {
+            await controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
+        } catch (error) {
+            if (!controller.retired && controller.connection !== null) {
+                console.error('Failed to delete a stale DataSubscription:', error);
             }
+        }
+    }
+
+    private closeForTransportScopeChange(reason: string): void {
+        if (!this.started && this.snapshot.status === 'closed' && this.closeNotificationSent) {
             return;
         }
+        this.imperativelyOwned = false;
+        this.started = false;
+        this.generation++;
+        this.subscriptionId = null;
+        this.lastRevision = -1;
+        this.startPromise = null;
+        this.refreshPromise = null;
+        this.refreshRequested = false;
+        this.supportsAuthoritativeSnapshots = false;
+        this.detachControllerListeners();
+        this.snapshot = initialResourceSnapshot();
+        this.dispatch({ type: 'CLOSE' });
+        this.rejectInitialCreateOnce(new Error(`DataSubscription closed because its authentication/backend scope changed ${reason}`));
+        this.notifyClose();
+    }
 
-        const projectedChangeSet = changeSet === null ? null : this.projectFields(changeSet);
-        const projectedAppendSet = appendSet === null ? null : this.projectFields(appendSet);
-        this.records = this.normalizeRecords(this.records!.map(record => {
-            if (record.id === id) {
-                const updated = Object.assign({}, record, projectedChangeSet);
-                if (projectedAppendSet && !wasOptimisticallyUpdated) {
-                    for (const [key, value] of Object.entries(projectedAppendSet)) {
-                        (updated as Record<string, unknown>)[key] = (typeof updated[key] === 'string' ? updated[key] : '') + String(value);
-                    }
+    private hasExpectedTransportScope(): boolean {
+        return this.expectedTransportScopeKey === DataSyncController.currentTransportScopeKey();
+    }
+
+    private resolveInitialCreateOnce(records: DataRecord[]): void {
+        if (this.initialCreateSettled) {
+            return;
+        }
+        this.initialCreateSettled = true;
+        this.resolveInitialCreate(records);
+    }
+
+    private rejectInitialCreateOnce(error: Error): void {
+        if (this.initialCreateSettled) {
+            return;
+        }
+        this.initialCreateSettled = true;
+        this.rejectInitialCreate(error);
+    }
+
+    private dispatch(action: ResourceSnapshotAction<DataRecord[]>): void {
+        const nextSnapshot = reduceResourceSnapshot(this.snapshot, action);
+        if (nextSnapshot === this.snapshot) {
+            return;
+        }
+        this.snapshot = nextSnapshot;
+        switch (action.type) {
+            case 'CONNECT':
+                this.isConnected = false;
+                if (!action.reconnect) {
+                    this.isClosed = false;
                 }
-                return updated;
-            }
-
-            return record;
-        }));
-
-        this.updateSubscribers();
+                this.connectError = null;
+                break;
+            case 'SNAPSHOT':
+                this.isClosed = false;
+                this.isConnected = true;
+                this.connectError = null;
+                break;
+            case 'DISCONNECT':
+                this.isClosed = true;
+                this.isConnected = false;
+                break;
+            case 'FAIL':
+                this.isConnected = false;
+                this.connectError = action.error;
+                break;
+            case 'CLOSE':
+                this.isClosed = true;
+                this.isConnected = false;
+                this.connectError = null;
+                break;
+        }
+        this.notifySnapshotSubscribers();
+        if (action.type === 'SNAPSHOT' || action.type === 'FAIL') {
+            this.notifySubscribers();
+        }
     }
 
-    onCreate(newRecord: DataRecord, isOptimistic = false): void {
-        if (!this.supportsOptimisticUpdates()) {
-            if (!isOptimistic) {
-                this.refreshAfterComplexMutation();
-            }
+    private trackedSubscriberCount(): number {
+        return this.subscriberEntries.size + this.snapshotSubscriberEntries.size;
+    }
+
+    private retainInStore(): void {
+        // Never promote a stale render handle back into the active registry.
+        // Its commit-time snapshot check will make React resolve a resource for
+        // the current scope instead.
+        if (!this.hasExpectedTransportScope()) {
             return;
         }
-
-        const shouldAppend = this.newRecordBehaviour === APPEND_NEW_RECORD;
-        const projectedRecord = this.projectFields(newRecord) as DataRecord;
-
-        const newRecordId = newRecord.id;
-        const optimisticIndex = this.optimisticCreatedPendingRecordIds.indexOf(newRecordId);
-        const existingRecord = this.records!.find(record => record.id === newRecordId);
-        if (existingRecord) {
-            if (!isOptimistic && optimisticIndex !== -1) {
-                this.optimisticCreatedPendingRecordIds.splice(optimisticIndex, 1);
-            }
-            // The create response and DidInsert notification can both contain
-            // the same record. Reconcile by id instead of appending twice.
-            this.onUpdate(newRecordId, projectedRecord, null, isOptimistic);
-            return;
+        try {
+            this.onStoreRetain();
+        } catch (error) {
+            console.error('DataSubscription store-retain listener failed:', error);
         }
-
-        if (isOptimistic && optimisticIndex === -1) {
-            this.optimisticCreatedPendingRecordIds.push(newRecordId);
-        }
-        const records = shouldAppend ? [...this.records!, projectedRecord] : [projectedRecord, ...this.records!];
-        this.records = this.normalizeRecords(records);
-
-        this.updateSubscribers();
     }
 
-    onCreateOptimistic(newRecord: DataRecord): void {
-        if (!('id' in newRecord)) {
-            throw new Error('Requires the record to have an id');
-        }
-
-        this.onCreate(newRecord, true);
-    }
-
-    onDelete(id: UUID, isOptimistic = false): void {
-        if (!isOptimistic) {
-            const optimisticIndex = this.optimisticCreatedPendingRecordIds.indexOf(id);
-            if (optimisticIndex !== -1) {
-                this.optimisticCreatedPendingRecordIds.splice(optimisticIndex, 1);
+    private notifySnapshotSubscribers(): void {
+        for (const subscriber of Array.from(this.snapshotSubscriberEntries.values())) {
+            try {
+                subscriber();
+            } catch (error) {
+                console.error('DataSubscription snapshot subscriber failed:', error);
             }
         }
-
-        if (!this.supportsOptimisticUpdates()) {
-            if (!isOptimistic) {
-                this.refreshAfterComplexMutation();
-            }
-            return;
-        }
-
-        this.records = this.normalizeRecords(this.records!.filter(record => record.id !== id));
-        this.updateSubscribers();
-    }
-
-    subscribe(callback: (records: DataRecord[] | null) => void): () => void {
-        this.cancelScheduledCloseIfNotUsed();
-        this.subscribers.push(callback);
-
-        return () => {
-            const index = this.subscribers.indexOf(callback);
-            if (index !== -1) {
-                this.subscribers.splice(index, 1);
-            }
-
-            // We delay the close as react could be re-rendering a component
-            // we garbage collect this connecetion once it's clearly not used anymore
-            this.scheduleCloseIfNotUsed();
-        };
-    }
-
-    scheduleCloseIfNotUsed(): void {
-        this.cancelScheduledCloseIfNotUsed();
-        this.closeIfNotUsedTimeout = setTimeout(() => {
-            this.closeIfNotUsedTimeout = null;
-            this.closeIfNotUsed();
-        }, UNUSED_SUBSCRIPTION_CLOSE_DELAY);
-    }
-
-    private cancelScheduledCloseIfNotUsed(): void {
-        if (this.closeIfNotUsedTimeout !== null) {
-            clearTimeout(this.closeIfNotUsedTimeout);
-            this.closeIfNotUsedTimeout = null;
-        }
-    }
-
-    updateSubscribers(): void {
-        if (this.cache && this.records !== null) {
-            this.cache.set(JSON.stringify(this.query), this.records);
-        }
-        this.notifySubscribers();
     }
 
     private notifySubscribers(): void {
-        for (const subscriber of this.subscribers) {
-            subscriber(this.records);
+        for (const subscriber of this.subscribers.slice()) {
+            this.callSubscriber(subscriber, this.snapshot.data);
         }
     }
 
-    private normalizeRecords(records: DataRecord[]): DataRecord[] {
-        let normalized = [...records];
-        const sortableClauses = this.query.orderByClause.filter(clause => 'orderByColumn' in clause);
-
-        if (sortableClauses.length > 0) {
-            normalized.sort((left, right) => {
-                for (const clause of sortableClauses) {
-                    const comparison = compareQueryValues(left[clause.orderByColumn], right[clause.orderByColumn]);
-                    if (comparison !== 0) {
-                        return clause.orderByDirection === 'Desc' ? -comparison : comparison;
-                    }
-                }
-                return 0;
-            });
-        }
-
-        return normalized;
-    }
-
-    private projectFields<T extends Record<string, unknown>>(fields: T): T {
-        if (this.query.selectedColumns.tag === 'SelectAll') {
-            return fields;
-        }
-
-        const projected: Record<string, unknown> = {};
-        for (const column of this.query.selectedColumns.contents) {
-            if (Object.prototype.hasOwnProperty.call(fields, column)) {
-                projected[column] = fields[column];
-            }
-        }
-        return projected as T;
-    }
-
-    supportsOptimisticUpdates(): boolean {
-        const selectedColumns = this.query.selectedColumns;
-        const hasUnprojectedOrderColumn = selectedColumns.tag === 'SelectSpecific'
-            && this.query.orderByClause.some(clause => 'orderByColumn' in clause
-                && !selectedColumns.contents.includes(clause.orderByColumn));
-
-        return this.query.limit === null
-            && this.query.offset === null
-            && this.query.distinctOnColumn === null
-            && !this.query.orderByClause.some(clause => 'tag' in clause && clause.tag === 'OrderByTSRank')
-            && !hasUnprojectedOrderColumn;
-    }
-
-    private refreshAfterComplexMutation(): void {
-        if (this.supportsOptimisticUpdates() || this.isClosed) {
-            return;
-        }
-
-        this.refreshRequested = true;
-        if (this.refreshPromise !== null) {
-            return;
-        }
-
-        this.refreshPromise = this.refreshRecordsFromServer();
-    }
-
-    private async refreshRecordsFromServer(): Promise<void> {
-        this.refreshRequested = false;
+    private callSubscriber(
+        subscriber: (records: DataRecord[] | null) => void,
+        records: DataRecord[] | null,
+    ): void {
         try {
-            const response = await DataSyncController.getInstance().sendMessage({
-                tag: 'DataSyncQuery',
-                query: this.query,
-                transactionId: null
-            });
-            if (!this.isClosed) {
-                // DataSyncQuery returns the authoritative query window. Keep it
-                // verbatim so projected DISTINCT/ORDER BY columns are not read
-                // as undefined and collapsed locally.
-                this.records = response.result as DataRecord[];
-                this.updateSubscribers();
-            }
+            subscriber(records);
         } catch (error) {
-            if (!this.isClosed) {
-                console.error('Failed to refresh a complex DataSubscription:', error);
-            }
-        } finally {
-            this.refreshPromise = null;
-            if (this.refreshRequested) {
-                this.refreshAfterComplexMutation();
-            }
+            console.error('DataSubscription subscriber failed:', error);
         }
     }
 
-    getRecords(): DataRecord[] | null {
-        return this.records;
-    }
-
-    /**
-     * If there's no subscriber on this DataSubscription, we will close it.
-     */
-    closeIfNotUsed(): void {
-        const isUsed = this.subscribers.length > 0;
-        if (isUsed) {
-            return;
-        }
-
-        void this.closeWhenUnused();
-    }
-
-    private async closeWhenUnused(): Promise<void> {
-        if (!this.isClosed && !this.isConnected) {
-            try {
-                await this.createOnServerPromise;
-            } catch (_error) {
-                // close() handles failed setup and removes the local subscription.
-            }
-        }
-
-        // A React commit can subscribe while setup is still pending. Recheck
-        // after the await so that the earlier cleanup request is cancellable.
-        if (this.subscribers.length > 0) {
-            return;
-        }
-
-        try {
-            await this.close();
-        } catch (error) {
-            console.error('Failed to close an unused DataSubscription:', error);
-        }
-    }
-
-    onClose(): void {
-        // Overriden by the react 18 integration to remove the closed connection from the DataSubscriptionStore
+    /** @deprecated Server snapshots make local record placement irrelevant. */
+    detectNewRecordBehaviour(): number {
+        const firstOrderBy = this.query.orderByClause[0];
+        return firstOrderBy
+            && 'orderByColumn' in firstOrderBy
+            && firstOrderBy.orderByColumn === 'createdAt'
+            && firstOrderBy.orderByDirection === 'Desc'
+            ? PREPEND_NEW_RECORD
+            : APPEND_NEW_RECORD;
     }
 }
 
-function compareQueryValues(left: unknown, right: unknown): number {
-    if (Object.is(left, right)) {
-        return 0;
-    }
-    // PostgreSQL's default is NULLS LAST for ASC and NULLS FIRST for DESC.
-    if (left === null || left === undefined) {
-        return 1;
-    }
-    if (right === null || right === undefined) {
-        return -1;
-    }
-
-    let normalizedLeft = left instanceof Date ? left.getTime() : left;
-    let normalizedRight = right instanceof Date ? right.getTime() : right;
-    if (left instanceof Date || right instanceof Date) {
-        const leftTimestamp = toTimestamp(left);
-        const rightTimestamp = toTimestamp(right);
-        if (leftTimestamp !== null && rightTimestamp !== null) {
-            normalizedLeft = leftTimestamp;
-            normalizedRight = rightTimestamp;
-        }
-    }
-    if (Object.is(normalizedLeft, normalizedRight)) {
-        return 0;
-    }
-    if ((typeof normalizedLeft === 'number' && typeof normalizedRight === 'number')
-        || (typeof normalizedLeft === 'string' && typeof normalizedRight === 'string')
-        || (typeof normalizedLeft === 'boolean' && typeof normalizedRight === 'boolean')) {
-        return normalizedLeft < normalizedRight ? -1 : 1;
-    }
-
-    const leftText = String(normalizedLeft);
-    const rightText = String(normalizedRight);
-    return leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
+function cloneQuery(query: DynamicSQLQuery): DynamicSQLQuery {
+    return JSON.parse(JSON.stringify(query)) as DynamicSQLQuery;
 }
 
-function toTimestamp(value: unknown): number | null {
-    const timestamp = value instanceof Date
-        ? value.getTime()
-        : typeof value === 'string'
-            ? Date.parse(value)
-            : typeof value === 'number'
-                ? value
-                : NaN;
-    return Number.isFinite(timestamp) ? timestamp : null;
+function deepFreeze<T>(value: T): T {
+    if (typeof value !== 'object' || value === null || Object.isFrozen(value)) {
+        return value;
+    }
+    for (const nestedValue of Object.values(value as Record<string, unknown>)) {
+        deepFreeze(nestedValue);
+    }
+    return Object.freeze(value);
+}
+
+function trimOldestMapEntries<K, V>(map: Map<K, V>, maximumSize: number): void {
+    while (map.size > maximumSize) {
+        const oldestKey = map.keys().next().value as K | undefined;
+        if (oldestKey === undefined) {
+            return;
+        }
+        map.delete(oldestKey);
+    }
 }
 
 function initIHPBackend({ host }: { host: string }): void {
@@ -938,42 +1384,63 @@ function initIHPBackend({ host }: { host: string }): void {
     if (host.endsWith('/')) {
         throw new Error('IHP Backend host url should not have a trailing slash, please remove the last "/" from "' + host + '"');
     }
+    const previousHost = DataSyncController.ihpBackendHost;
     DataSyncController.ihpBackendHost = host;
+    // Configuration is an explicit imperative operation. Rotate an already
+    // existing controller now; a later render-only store lookup stays inert.
+    if (DataSyncController.instance !== null && previousHost !== host) {
+        DataSyncController.retireCurrentTransport();
+    }
 }
 
-export async function createRecord<T extends TableName>(table: T, record: NewRecord<T>, options: CrudOptions = {}): Promise<IHPRecord<T>> {
+export async function createRecord<T extends TableName>(
+    table: T,
+    record: NewRecord<T>,
+    options: CrudOptions = {},
+    boundController?: DataSyncController,
+): Promise<IHPRecord<T>> {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to createRecord(${JSON.stringify(table)}, ${JSON.stringify(record, null, 4)})`);
     }
     if (record !== Object(record)) {
         throw new Error(`Record needs to be an object, you passed ${JSON.stringify(record)} in a call to createRecord(${JSON.stringify(table)}, ${JSON.stringify(record, null, 4)})`);
     }
+    const dataSyncController = boundController ?? DataSyncController.getInstance();
 
     const transactionId = options.transactionId ?? null;
     const request = { tag: 'CreateRecordMessage', table, record, transactionId };
-    const shouldUpdateOptimistically = transactionId === null;
+    const coordinatesDependentWrites = transactionId === null;
+
+    if (coordinatesDependentWrites) {
+        if (record.id == null) {
+            record.id = randomUUID();
+        }
+        registerPendingCreate(dataSyncController, record.id);
+    }
 
     try {
-        if (shouldUpdateOptimistically) {
-            createOptimisticRecord(table, record);
-        }
-        await waitPendingChanges(table, record);
-
-        const response = await DataSyncController.getInstance().sendMessage(request);
-        if (shouldUpdateOptimistically) {
-            markCreateOptimisticRecordFinished(table, record, null, response.record as DataRecord);
+        await waitPendingChanges(dataSyncController, table, record);
+        const response = await dataSyncController.sendMessage(request);
+        if (coordinatesDependentWrites) {
+            finishPendingCreate(dataSyncController, record.id!, null);
         }
         return response.record as IHPRecord<T>;
     } catch (e) {
-        if (shouldUpdateOptimistically) {
-            undoCreateOptimisticRecord(table, record, e as Error);
+        if (coordinatesDependentWrites) {
+            finishPendingCreate(dataSyncController, record.id!, e as Error);
         }
 
         throw new Error(`${(e as Error).message} while calling:\n\ncreateRecord(${JSON.stringify(table)}, ${JSON.stringify(record, null, 4)})`);
     }
 }
 
-export async function updateRecord<T extends TableName>(table: T, id: UUID, patch: Partial<NewRecord<T>>, options: CrudOptions = {}): Promise<IHPRecord<T>> {
+export async function updateRecord<T extends TableName>(
+    table: T,
+    id: UUID,
+    patch: Partial<NewRecord<T>>,
+    options: CrudOptions = {},
+    boundController?: DataSyncController,
+): Promise<IHPRecord<T>> {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to updateRecord(${JSON.stringify(table)}, ${JSON.stringify(id)}, ${JSON.stringify(patch, null, 4)})`);
     }
@@ -983,27 +1450,29 @@ export async function updateRecord<T extends TableName>(table: T, id: UUID, patc
     if (patch !== Object(patch)) {
         throw new Error(`Patch needs to be an object, you passed ${JSON.stringify(patch)} in a call to updateRecord(${JSON.stringify(table)}, ${JSON.stringify(id)}, ${JSON.stringify(patch, null, 4)})`);
     }
+    const dataSyncController = boundController ?? DataSyncController.getInstance();
 
     const transactionId = options.transactionId ?? null;
     const request = { tag: 'UpdateRecordMessage', table, id, patch, transactionId };
 
-    const undoUpdateRecordOptimistic = transactionId === null
-        ? updateRecordOptimistic(table, id, patch)
-        : () => {};
-
     try {
-        await waitPendingCreation(table, id);
-        await waitPendingChanges(table, patch);
-        const response = await DataSyncController.getInstance().sendMessage(request);
+        await waitPendingCreation(dataSyncController, table, id);
+        await waitPendingChanges(dataSyncController, table, patch);
+        const response = await dataSyncController.sendMessage(request);
 
         return response.record as IHPRecord<T>;
     } catch (e) {
-        undoUpdateRecordOptimistic();
         throw new Error((e as Error).message);
     }
 }
 
-export async function updateRecords<T extends TableName>(table: T, ids: UUID[], patch: Partial<NewRecord<T>>, options: CrudOptions = {}): Promise<IHPRecord<T>[]> {
+export async function updateRecords<T extends TableName>(
+    table: T,
+    ids: UUID[],
+    patch: Partial<NewRecord<T>>,
+    options: CrudOptions = {},
+    boundController?: DataSyncController,
+): Promise<IHPRecord<T>[]> {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to updateRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)}, ${JSON.stringify(patch, null, 4)})`);
     }
@@ -1013,12 +1482,13 @@ export async function updateRecords<T extends TableName>(table: T, ids: UUID[], 
     if (patch !== Object(patch)) {
         throw new Error(`Patch needs to be an object, you passed ${JSON.stringify(patch)} in a call to updateRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)}, ${JSON.stringify(patch, null, 4)})`);
     }
+    const dataSyncController = boundController ?? DataSyncController.getInstance();
 
     const transactionId = options.transactionId ?? null;
     const request = { tag: 'UpdateRecordsMessage', table, ids, patch, transactionId };
 
     try {
-        const response = await DataSyncController.getInstance().sendMessage(request);
+        const response = await dataSyncController.sendMessage(request);
 
         return response.records as IHPRecord<T>[];
     } catch (e) {
@@ -1026,45 +1496,52 @@ export async function updateRecords<T extends TableName>(table: T, ids: UUID[], 
     }
 }
 
-export async function deleteRecord<T extends TableName>(table: T, id: UUID, options: CrudOptions = {}): Promise<void> {
+export async function deleteRecord<T extends TableName>(
+    table: T,
+    id: UUID,
+    options: CrudOptions = {},
+    boundController?: DataSyncController,
+): Promise<void> {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to deleteRecord(${JSON.stringify(table)}, ${JSON.stringify(id)})`);
     }
     if (typeof id !== "string") {
         throw new Error(`ID needs to be an UUID, you passed ${JSON.stringify(id)} in a call to deleteRecord(${JSON.stringify(table)}, ${JSON.stringify(id)})`);
     }
+    const dataSyncController = boundController ?? DataSyncController.getInstance();
 
     const transactionId = options.transactionId ?? null;
     const request = { tag: 'DeleteRecordMessage', table, id, transactionId };
 
-    let undoOptimisticDeleteRecord = () => {};
     try {
-        await waitPendingCreation(table, id);
-        if (transactionId === null) {
-            undoOptimisticDeleteRecord = deleteRecordOptimistic(table, id);
-        }
-        await DataSyncController.getInstance().sendMessage(request);
+        await waitPendingCreation(dataSyncController, table, id);
+        await dataSyncController.sendMessage(request);
 
         return;
     } catch (e) {
-        undoOptimisticDeleteRecord();
         throw new Error((e as Error).message);
     }
 }
 
-export async function deleteRecords<T extends TableName>(table: T, ids: UUID[], options: CrudOptions = {}): Promise<void> {
+export async function deleteRecords<T extends TableName>(
+    table: T,
+    ids: UUID[],
+    options: CrudOptions = {},
+    boundController?: DataSyncController,
+): Promise<void> {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to deleteRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)})`);
     }
     if (!Array.isArray(ids)) {
         throw new Error(`IDs needs to be an array, you passed ${JSON.stringify(ids)} in a call to deleteRecords(${JSON.stringify(table)}, ${JSON.stringify(ids)})`);
     }
+    const dataSyncController = boundController ?? DataSyncController.getInstance();
 
     const transactionId = options.transactionId ?? null;
     const request = { tag: 'DeleteRecordsMessage', table, ids, transactionId };
 
     try {
-        await DataSyncController.getInstance().sendMessage(request);
+        await dataSyncController.sendMessage(request);
 
         return;
     } catch (e) {
@@ -1072,19 +1549,25 @@ export async function deleteRecords<T extends TableName>(table: T, ids: UUID[], 
     }
 }
 
-export async function createRecords<T extends TableName>(table: T, records: NewRecord<T>[], options: CrudOptions = {}): Promise<IHPRecord<T>[]> {
+export async function createRecords<T extends TableName>(
+    table: T,
+    records: NewRecord<T>[],
+    options: CrudOptions = {},
+    boundController?: DataSyncController,
+): Promise<IHPRecord<T>[]> {
     if (typeof table !== "string") {
         throw new Error(`Table name needs to be a string, you passed ${JSON.stringify(table)} in a call to createRecords(${JSON.stringify(table)}, ${JSON.stringify(records, null, 4)})`);
     }
     if (!Array.isArray(records)) {
         throw new Error(`Records need to be an array, you passed ${JSON.stringify(records)} in a call to createRecords(${JSON.stringify(table)}, ${JSON.stringify(records, null, 4)})`);
     }
+    const dataSyncController = boundController ?? DataSyncController.getInstance();
 
     const transactionId = options.transactionId ?? null;
     const request = { tag: 'CreateRecordsMessage', table, records, transactionId };
 
     try {
-        const response = await DataSyncController.getInstance().sendMessage(request);
+        const response = await dataSyncController.sendMessage(request);
 
         return response.records as IHPRecord<T>[];
     } catch (e) {
@@ -1092,41 +1575,8 @@ export async function createRecords<T extends TableName>(table: T, records: NewR
     }
 }
 
-function createOptimisticRecord<T extends TableName>(table: T, record: NewRecord<T>): void {
-    const dataSyncController = DataSyncController.getInstance();
-
-    // Ensure that the record has an ID
-    if (record.id == null) {
-        record.id = randomUUID();
-    }
-    registerPendingOptimisticCreate(record.id);
-
-    // Optimistically set createdAt if the table has this field (dynamic check)
-    const rec = record as Record<string, unknown>;
-    if (dataSyncController.optimisticCreatedNeedsCreatedAtField.has(table) && rec.createdAt == null) {
-        rec.createdAt = new Date();
-    }
-
-    for (const dataSubscription of dataSyncController.dataSubscriptions) {
-        if (dataSubscription.query.table !== table) {
-            continue;
-        }
-        if (!dataSubscription.supportsOptimisticUpdates()) {
-            continue;
-        }
-        if (!recordMatchesQuery(dataSubscription.query, rec as DataRecord)) {
-            continue;
-        }
-
-        dataSubscription.onCreateOptimistic(rec as DataRecord);
-    }
-
-    dataSyncController.optimisticCreatedPendingRecordIds.push(record.id!);
-}
-
-function registerPendingOptimisticCreate(id: UUID): void {
-    const dataSyncController = DataSyncController.getInstance();
-    if (dataSyncController.pendingOptimisticCreates.has(id)) {
+function registerPendingCreate(dataSyncController: DataSyncController, id: UUID): void {
+    if (dataSyncController.pendingCreates.has(id)) {
         return;
     }
 
@@ -1136,10 +1586,10 @@ function registerPendingOptimisticCreate(id: UUID): void {
         resolve = resolvePromise;
         reject = rejectPromise;
     });
-    // A create often has no dependent operation. Mark the rejection as handled
-    // while still keeping the original promise rejectable for actual dependants.
+    // Most creates have no dependent operation. Mark rejection as observed while
+    // keeping the same promise rejectable for writes that reference this ID.
     void promise.catch(() => {});
-    dataSyncController.pendingOptimisticCreates.set(id, { promise, resolve, reject });
+    dataSyncController.pendingCreates.set(id, { promise, resolve, reject });
 }
 
 function randomUUID(): UUID {
@@ -1163,48 +1613,10 @@ function randomUUID(): UUID {
     }
 }
 
-function undoCreateOptimisticRecord<T extends TableName>(table: T, record: NewRecord<T>, reason: Error): void {
-    const dataSyncController = DataSyncController.getInstance();
-    for (const dataSubscription of dataSyncController.dataSubscriptions) {
-        if (dataSubscription.query.table !== table) {
-            continue;
-        }
-        if (!dataSubscription.optimisticCreatedPendingRecordIds.includes(record.id!)) {
-            continue;
-        }
-
-        dataSubscription.onDelete(record.id!);
-    }
-
-    markCreateOptimisticRecordFinished(table, record, reason);
-}
-
-function markCreateOptimisticRecordFinished<T extends TableName>(table: T, record: NewRecord<T>, error: Error | null = null, canonicalRecord: DataRecord | null = null): void {
-    const dataSyncController = DataSyncController.getInstance();
-
-    if (!error && canonicalRecord) {
-        for (const dataSubscription of dataSyncController.dataSubscriptions) {
-            if (dataSubscription.query.table !== table
-                || !dataSubscription.optimisticCreatedPendingRecordIds.includes(record.id!)) {
-                continue;
-            }
-
-            if (recordMatchesQuery(dataSubscription.query, canonicalRecord)) {
-                dataSubscription.onCreate(canonicalRecord);
-            } else {
-                dataSubscription.onDelete(record.id!);
-            }
-        }
-    }
-
-    const index = dataSyncController.optimisticCreatedPendingRecordIds.indexOf(record.id!);
-    if (index !== -1) {
-        dataSyncController.optimisticCreatedPendingRecordIds.splice(index, 1);
-    }
-
-    const pendingCreate = dataSyncController.pendingOptimisticCreates.get(record.id!);
+function finishPendingCreate(dataSyncController: DataSyncController, id: UUID, error: Error | null): void {
+    const pendingCreate = dataSyncController.pendingCreates.get(id);
     if (pendingCreate) {
-        dataSyncController.pendingOptimisticCreates.delete(record.id!);
+        dataSyncController.pendingCreates.delete(id);
         if (error) {
             pendingCreate.reject(error);
         } else {
@@ -1213,105 +1625,18 @@ function markCreateOptimisticRecordFinished<T extends TableName>(table: T, recor
     }
 }
 
-function updateRecordOptimistic<T extends TableName>(table: T, id: UUID, patch: Partial<NewRecord<T>>): () => void {
-    const dataSyncController = DataSyncController.getInstance();
-    const patchRecord = patch as Record<string, unknown>;
-    const rollbackOperations: (() => void)[] = [];
-    for (const dataSubscription of dataSyncController.dataSubscriptions) {
-        if (dataSubscription.query.table !== table) {
-            continue;
-        }
-        if (!dataSubscription.supportsOptimisticUpdates()) {
-            continue;
-        }
-
-        const dataSubscriptionRecords = dataSubscription.getRecords();
-        if (!dataSubscriptionRecords) {
-            continue;
-        }
-
-        for (const record of dataSubscriptionRecords) {
-            if (!record || record.id !== id) {
-                continue;
-            }
-
-            // Store values before we apply the patch to the record
-            const oldValues: Record<string, unknown> = {};
-            for (const key of Object.keys(patchRecord)) {
-                oldValues[key] = record[key];
-            }
-
-            // Apply the patch optimistically without refreshing the pre-write server state.
-            dataSubscription.optimisticUpdatedPendingRecordIds.add(id);
-            dataSubscription.onUpdate(id, patchRecord, null, true);
-
-            rollbackOperations.push(() => {
-                dataSubscription.optimisticUpdatedPendingRecordIds.delete(id);
-
-                const records = dataSubscription.getRecords();
-                if (!records) {
-                    return;
-                }
-
-                const currentRecord = records.find(record => record.id === id);
-                if (!currentRecord) {
-                    return;
-                }
-
-                const undoPatch: Record<string, unknown> = {};
-                for (const key of Object.keys(patchRecord)) {
-                    if (currentRecord[key] === patchRecord[key]) {
-                        undoPatch[key] = oldValues[key];
-                    }
-                }
-
-                dataSubscription.onUpdate(id, undoPatch, null);
-            });
-        }
-    }
-
-    return () => {
-        for (const rollbackOperation of rollbackOperations) {
-            rollbackOperation();
-        }
-    };
-}
-
-function deleteRecordOptimistic<T extends TableName>(table: T, id: UUID): () => void {
-    const dataSyncController = DataSyncController.getInstance();
-    const undoOperations: (() => void)[] = [];
-    for (const dataSubscription of dataSyncController.dataSubscriptions) {
-        if (dataSubscription.query.table !== table) {
-            continue;
-        }
-        if (!dataSubscription.supportsOptimisticUpdates()) {
-            continue;
-        }
-
-        const deletedRecord = dataSubscription.records!.find(record => record.id === id);
-        if (deletedRecord) {
-            dataSubscription.onDelete(id, true);
-            undoOperations.push(() => dataSubscription.onCreate(deletedRecord));
-        }
-    }
-
-    return () => {
-        for (const undoOperation of undoOperations) {
-            undoOperation();
-        }
-    };
-}
-
-function pendingOptimisticCreatesReferencedBy<T extends TableName>(record: NewRecord<T> | Partial<NewRecord<T>>): Promise<void>[] {
-    const dataSyncController = DataSyncController.getInstance();
+function pendingCreatesReferencedBy<T extends TableName>(
+    dataSyncController: DataSyncController,
+    record: NewRecord<T> | Partial<NewRecord<T>>,
+): Promise<void>[] {
     const rec = record as Record<string, unknown>;
     const pendingCreates = new Set<Promise<void>>();
 
     for (const attribute in rec) {
         if (attribute === 'id') {
-            continue; // The current record's id is always optimistic
+            continue; // Never treat the record's own id as a create dependency.
         }
-        const pendingCreate = dataSyncController.pendingOptimisticCreates.get(rec[attribute] as UUID);
+        const pendingCreate = dataSyncController.pendingCreates.get(rec[attribute] as UUID);
         if (pendingCreate) {
             pendingCreates.add(pendingCreate.promise);
         }
@@ -1320,12 +1645,20 @@ function pendingOptimisticCreatesReferencedBy<T extends TableName>(record: NewRe
     return Array.from(pendingCreates);
 }
 
-async function waitPendingChanges<T extends TableName>(_table: T, record: NewRecord<T> | Partial<NewRecord<T>>): Promise<void> {
-    await Promise.all(pendingOptimisticCreatesReferencedBy(record));
+async function waitPendingChanges<T extends TableName>(
+    dataSyncController: DataSyncController,
+    _table: T,
+    record: NewRecord<T> | Partial<NewRecord<T>>,
+): Promise<void> {
+    await Promise.all(pendingCreatesReferencedBy(dataSyncController, record));
 }
 
-async function waitPendingCreation<T extends TableName>(_table: T, id: UUID): Promise<void> {
-    const pendingCreate = DataSyncController.getInstance().pendingOptimisticCreates.get(id);
+async function waitPendingCreation<T extends TableName>(
+    dataSyncController: DataSyncController,
+    _table: T,
+    id: UUID,
+): Promise<void> {
+    const pendingCreate = dataSyncController.pendingCreates.get(id);
     if (pendingCreate) {
         await pendingCreate.promise;
     }

--- a/ihp-datasync/data/DataSync/src/ihp-querybuilder.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-querybuilder.ts
@@ -410,25 +410,60 @@ function query<T extends TableName>(table: T, columns?: string[]): QueryBuilder<
 }
 
 export function recordMatchesQuery(query: DynamicSQLQuery, record: DataRecord): boolean {
+    type SQLBoolean = boolean | null;
+
+    const isNull = (value: unknown): boolean => value === null || value === undefined;
+    const asSQLBoolean = (value: unknown): SQLBoolean => isNull(value) ? null : Boolean(value);
+    const sqlAnd = (left: unknown, right: unknown): SQLBoolean => {
+        const leftBoolean = asSQLBoolean(left);
+        const rightBoolean = asSQLBoolean(right);
+        if (leftBoolean === false || rightBoolean === false) {
+            return false;
+        }
+        return leftBoolean === null || rightBoolean === null ? null : true;
+    };
+    const sqlOr = (left: unknown, right: unknown): SQLBoolean => {
+        const leftBoolean = asSQLBoolean(left);
+        const rightBoolean = asSQLBoolean(right);
+        if (leftBoolean === true || rightBoolean === true) {
+            return true;
+        }
+        return leftBoolean === null || rightBoolean === null ? null : false;
+    };
+
     function evaluate(expression: ConditionExpression): unknown {
         switch (expression.tag) {
             case 'ColumnExpression': return (expression.field in record) ? record[expression.field] : null;
             case 'InfixOperatorExpression': {
+                const left = evaluate(expression.left);
+                const right = evaluate(expression.right);
                 switch (expression.op) {
-                    case 'OpEqual': return evaluate(expression.left) === evaluate(expression.right);
-                    case 'OpGreaterThan': return (evaluate(expression.left) as number) > (evaluate(expression.right) as number);
-                    case 'OpLessThan': return (evaluate(expression.left) as number) < (evaluate(expression.right) as number);
-                    case 'OpGreaterThanOrEqual': return (evaluate(expression.left) as number) >= (evaluate(expression.right) as number);
-                    case 'OpLessThanOrEqual': return (evaluate(expression.left) as number) <= (evaluate(expression.right) as number);
-                    case 'OpNotEqual': return evaluate(expression.left) !== evaluate(expression.right);
-                    case 'OpAnd': return evaluate(expression.left) && evaluate(expression.right);
-                    case 'OpOr': return evaluate(expression.left) || evaluate(expression.right);
-                    case 'OpIs': return evaluate(expression.left) == evaluate(expression.right);
-                    case 'OpIsNot': return evaluate(expression.left) != evaluate(expression.right);
+                    case 'OpEqual':
+                        if (expression.right.tag === 'LiteralExpression' && isNull(right)) {
+                            return isNull(left);
+                        }
+                        return isNull(left) || isNull(right) ? null : left === right;
+                    case 'OpGreaterThan': return isNull(left) || isNull(right) ? null : (left as number) > (right as number);
+                    case 'OpLessThan': return isNull(left) || isNull(right) ? null : (left as number) < (right as number);
+                    case 'OpGreaterThanOrEqual': return isNull(left) || isNull(right) ? null : (left as number) >= (right as number);
+                    case 'OpLessThanOrEqual': return isNull(left) || isNull(right) ? null : (left as number) <= (right as number);
+                    case 'OpNotEqual':
+                        if (expression.right.tag === 'LiteralExpression' && isNull(right)) {
+                            return !isNull(left);
+                        }
+                        return isNull(left) || isNull(right) ? null : left !== right;
+                    case 'OpAnd': return sqlAnd(left, right);
+                    case 'OpOr': return sqlOr(left, right);
+                    case 'OpIs': return isNull(left) && isNull(right) || !isNull(left) && !isNull(right) && left === right;
+                    case 'OpIsNot': return !(isNull(left) && isNull(right) || !isNull(left) && !isNull(right) && left === right);
                     case 'OpIn': {
-                        const left = evaluate(expression.left);
-                        const right = evaluate(expression.right);
-                        return Array.isArray(right) && right.includes(left);
+                        if (!Array.isArray(right)) {
+                            return false;
+                        }
+                        if (isNull(left)) {
+                            return right.some(isNull) ? true : null;
+                        }
+                        return right.filter(value => !isNull(value)).includes(left);
                     }
                     // Full-text matching depends on PostgreSQL dictionaries and stemming.
                     // If it cannot be reproduced exactly in the browser, skip the
@@ -446,7 +481,7 @@ export function recordMatchesQuery(query: DynamicSQLQuery, record: DataRecord): 
 
     return query.whereCondition === null
             ? true
-            : !!evaluate(query.whereCondition);
+            : evaluate(query.whereCondition) === true;
 }
 
 export {

--- a/ihp-datasync/data/DataSync/src/ihp-querybuilder.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-querybuilder.ts
@@ -1,4 +1,5 @@
-import { DataSyncController, DataSubscription } from './ihp-datasync.js';
+import { DataSyncController } from './ihp-datasync.js';
+import { DataSubscriptionStore } from './data-subscription-store.js';
 import type { ConditionExpression, ConditionOperator, DynamicSQLQuery, DataRecord, UUID, TableName, IHPRecord } from './types.js';
 
 function fetchAuthenticated(path: string, params: RequestInit & { headers?: Record<string, string> }): Promise<Response> {
@@ -264,8 +265,9 @@ class ConditionBuilder extends ConditionBuildable {
 class QueryBuilder<TTable extends string = string, TResult = IHPRecord<TTable>> extends ConditionBuildable<TTable> {
     override query: DynamicSQLQuery;
     transactionId: UUID | null;
+    private readonly dataSyncController: DataSyncController | null;
 
-    constructor(table: string, columns?: string[]) {
+    constructor(table: string, columns?: string[], dataSyncController: DataSyncController | null = null) {
         super(null);
         // Maps to 'DynamicSQLQuery'
         this.query = {
@@ -278,6 +280,7 @@ class QueryBuilder<TTable extends string = string, TResult = IHPRecord<TTable>> 
             offset: null
         };
         this.transactionId = null;
+        this.dataSyncController = dataSyncController;
 
         if (columns !== undefined) {
             this.select(columns);
@@ -378,17 +381,17 @@ class QueryBuilder<TTable extends string = string, TResult = IHPRecord<TTable>> 
     }
 
     async fetch(): Promise<TResult[]> {
-        const dataSyncController = DataSyncController.getInstance();
+        // Transaction queries must stay on the controller that created their
+        // transaction id. Its transport-scope guard rejects after auth/backend
+        // rotation instead of leaking the id onto a replacement connection.
+        const dataSyncController = this.dataSyncController ?? DataSyncController.getInstance();
         const response = await dataSyncController.sendMessage({
             tag: 'DataSyncQuery',
             query: this.query,
             transactionId: this.transactionId
         });
 
-        const result = response.result as TResult[];
-        dataSyncController.learnOptimisticShapeFromResult(this.query.table, result as DataRecord[]);
-
-        return result;
+        return response.result as TResult[];
     }
 
     async fetchOne(): Promise<TResult | null> {
@@ -397,10 +400,10 @@ class QueryBuilder<TTable extends string = string, TResult = IHPRecord<TTable>> 
     }
 
     subscribe(callback: (records: TResult[] | null) => void): () => void {
-        const dataSubscription = new DataSubscription(this.query);
-        void dataSubscription.createOnServer().catch(() => {
-            // The subscription exposes the error through connectError.
-        });
+        if (this.transactionId !== null || this.dataSyncController !== null) {
+            throw new Error('DataSync subscriptions are not supported inside a transaction');
+        }
+        const dataSubscription = DataSubscriptionStore.get(this.query);
         return dataSubscription.subscribe(callback as (records: DataRecord[] | null) => void);
     }
 }
@@ -465,9 +468,8 @@ export function recordMatchesQuery(query: DynamicSQLQuery, record: DataRecord): 
                         }
                         return right.filter(value => !isNull(value)).includes(left);
                     }
-                    // Full-text matching depends on PostgreSQL dictionaries and stemming.
-                    // If it cannot be reproduced exactly in the browser, skip the
-                    // optimistic insertion and wait for the server notification.
+                    // Full-text matching depends on PostgreSQL dictionaries and stemming
+                    // and cannot be reproduced exactly in this standalone helper.
                     case 'OpTSMatch': return false;
                     default: return false;
                 }

--- a/ihp-datasync/data/DataSync/src/ihp-querybuilder.ts
+++ b/ihp-datasync/data/DataSync/src/ihp-querybuilder.ts
@@ -398,7 +398,9 @@ class QueryBuilder<TTable extends string = string, TResult = IHPRecord<TTable>> 
 
     subscribe(callback: (records: TResult[] | null) => void): () => void {
         const dataSubscription = new DataSubscription(this.query);
-        dataSubscription.createOnServer();
+        void dataSubscription.createOnServer().catch(() => {
+            // The subscription exposes the error through connectError.
+        });
         return dataSubscription.subscribe(callback as (records: DataRecord[] | null) => void);
     }
 }
@@ -428,12 +430,17 @@ export function recordMatchesQuery(query: DynamicSQLQuery, record: DataRecord): 
                         const right = evaluate(expression.right);
                         return Array.isArray(right) && right.includes(left);
                     }
-                    default: throw new Error('Unsupported operator ' + (expression as { op: string }).op);
+                    // Full-text matching depends on PostgreSQL dictionaries and stemming.
+                    // If it cannot be reproduced exactly in the browser, skip the
+                    // optimistic insertion and wait for the server notification.
+                    case 'OpTSMatch': return false;
+                    default: return false;
                 }
             }
             case 'LiteralExpression': return expression.value;
             case 'ListExpression': return expression.values;
-            default: throw new Error('Unsupported expression in evaluate: ' + (expression as { tag: string }).tag);
+            case 'CallExpression': return false;
+            default: return false;
         }
     }
 

--- a/ihp-datasync/data/DataSync/src/public-api-compat.typetest.d.ts
+++ b/ihp-datasync/data/DataSync/src/public-api-compat.typetest.d.ts
@@ -14,7 +14,7 @@ import type {
     Transaction,
     UUID,
 } from './index.js';
-import type { CountSubscription } from './react.js';
+import type { CountSubscription, CountSubscriptionStore } from './react.js';
 import type { DataSubscriptionStore as ReactDataSubscriptionStore } from './react.js';
 import type { DataSubscriptionStore } from './data-subscription-store.js';
 
@@ -108,6 +108,11 @@ type StableCountSubscription = {
     subscribe(callback: () => void): () => void;
 };
 
+type StableCountSubscriptionStore = {
+    queryMap: Map<string, CountSubscription>;
+    get(query: DynamicSQLQuery): CountSubscription;
+};
+
 type StableQueryBuilderSubscription = {
     subscribe(callback: (records: DataRecord[] | null) => void): () => void;
 };
@@ -117,6 +122,7 @@ type StableReactEntrypoint = {
     AuthCompletedProvider: unknown;
     DataSubscriptionStore: typeof DataSubscriptionStore;
     CountSubscription: new(query: DynamicSQLQuery) => CountSubscription;
+    CountSubscriptionStore: typeof CountSubscriptionStore;
     useQuery(
         queryBuilder: QueryBuilder<string, DataRecord>,
         options?: DataSubscriptionOptions | null,
@@ -139,6 +145,7 @@ type _dataSubscriptionConstructorCompatibility = Assert<Implements<
 type _storeCompatibility = Assert<Implements<typeof DataSubscriptionStore, StableDataSubscriptionStore>>;
 type _reactStoreCompatibility = Assert<Implements<typeof ReactDataSubscriptionStore, StableDataSubscriptionStore>>;
 type _countCompatibility = Assert<Implements<CountSubscription, StableCountSubscription>>;
+type _countStoreCompatibility = Assert<Implements<typeof CountSubscriptionStore, StableCountSubscriptionStore>>;
 type _queryBuilderCompatibility = Assert<Implements<QueryBuilder<string, DataRecord>, StableQueryBuilderSubscription>>;
 type _reactEntrypointCompatibility = Assert<Implements<typeof import('./react.js'), StableReactEntrypoint>>;
 type _legacyReactEntrypointCompatibility = Assert<Implements<
@@ -172,3 +179,4 @@ type _writableTransactionController = Assert<IsWritable<Transaction, 'dataSyncCo
 type _writableControllerConnection = Assert<IsWritable<DataSyncController, 'connection'>>;
 type _writableControllerSubscriptions = Assert<IsWritable<DataSyncController, 'dataSubscriptions'>>;
 type _writableStoreQueryMap = Assert<IsWritable<typeof DataSubscriptionStore, 'queryMap'>>;
+type _writableCountStoreQueryMap = Assert<IsWritable<typeof CountSubscriptionStore, 'queryMap'>>;

--- a/ihp-datasync/data/DataSync/src/public-api-compat.typetest.d.ts
+++ b/ihp-datasync/data/DataSync/src/public-api-compat.typetest.d.ts
@@ -1,0 +1,174 @@
+/**
+ * Compile-only compatibility contract for the intentionally supported public
+ * DataSync surface. Keep this narrower than the emitted class declarations:
+ * optimistic-update implementation details are deliberately not API.
+ */
+import type {
+    DataSubscription,
+    DataSyncController,
+    DataRecord,
+    DataSubscriptionOptions,
+    DynamicSQLQuery,
+    QueryBuilder,
+    ServerMessage,
+    Transaction,
+    UUID,
+} from './index.js';
+import type { CountSubscription } from './react.js';
+import type { DataSubscriptionStore as ReactDataSubscriptionStore } from './react.js';
+import type { DataSubscriptionStore } from './data-subscription-store.js';
+
+type Assert<T extends true> = T;
+type Implements<Actual, Expected> = Actual extends Expected ? true : false;
+type Equal<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends
+    (<T>() => T extends Y ? 1 : 2) ? true : false;
+type IsWritable<T, K extends keyof T> = Equal<
+    Pick<T, K>,
+    { -readonly [P in K]: T[P] }
+>;
+
+type StableDataSubscription = {
+    query: DynamicSQLQuery;
+    records: DataRecord[] | null;
+    subscribers: Array<(records: DataRecord[] | null) => void>;
+    cache: Map<string, DataRecord[]> | null;
+    newRecordBehaviour: number;
+    subscriptionId: UUID | null;
+    createOnServerPromise: Promise<DataRecord[]>;
+    resolveCreateOnServer(value: DataRecord[]): void;
+    rejectCreateOnServer(reason: Error): void;
+    isClosed: boolean;
+    isConnected: boolean;
+    connectError: Error | null;
+    onClose: () => void;
+    getRecords(): DataRecord[] | null;
+    subscribe(callback: (records: DataRecord[] | null) => void): () => void;
+    createOnServer(): Promise<void>;
+    close(): Promise<void>;
+    scheduleCloseIfNotUsed(): void;
+    closeIfNotUsed(): void;
+    onMessage(message: ServerMessage): void;
+    receiveUpdate(message: ServerMessage): void;
+    onDataSyncClosed(event?: unknown): void;
+    onDataSyncReconnect(): Promise<void>;
+    detectNewRecordBehaviour(): number;
+    onCreate(record: DataRecord, isOptimistic?: boolean): void;
+    onUpdate(
+        id: UUID,
+        changeSet: Record<string, unknown> | null,
+        appendSet: Record<string, unknown> | null,
+        isOptimistic?: boolean,
+    ): void;
+    onDelete(id: UUID, isOptimistic?: boolean): void;
+    onCreateOptimistic(record: DataRecord): void;
+    supportsOptimisticUpdates(): boolean;
+    updateSubscribers(): void;
+};
+
+type StableDataSyncController = {
+    connection: WebSocket | null;
+    dataSubscriptions: DataSubscription[];
+    sendMessage(payload: Record<string, unknown>): Promise<ServerMessage>;
+    addEventListener(event: 'message', callback: (message: ServerMessage) => void): void;
+    removeEventListener(event: 'message', callback: (message: ServerMessage) => void): void;
+};
+
+type StableDataSyncControllerConstructor = {
+    new(): DataSyncController;
+    instance: DataSyncController | null;
+    ihpBackendHost: string | null;
+    getInstance(): DataSyncController;
+    getWSUrl(): string;
+    currentTransportScopeKey(): string;
+    retireCurrentTransport(): void;
+    authSessionDidChange(): void;
+};
+
+type StableDataSubscriptionConstructor = {
+    new(
+        query: DynamicSQLQuery,
+        options?: DataSubscriptionOptions | null,
+        cache?: Map<string, DataRecord[]> | null,
+    ): DataSubscription;
+};
+
+type StableDataSubscriptionStore = {
+    queryMap: Map<string, DataSubscription>;
+    cache: Map<string, DataRecord[]>;
+    get(query: DynamicSQLQuery, options?: DataSubscriptionOptions | null): DataSubscription;
+};
+
+type StableCountSubscription = {
+    query: DynamicSQLQuery;
+    count: number | null;
+    subscriptionId: UUID | null;
+    subscribers: Set<() => void>;
+    getCount(): number | null;
+    subscribe(callback: () => void): () => void;
+};
+
+type StableQueryBuilderSubscription = {
+    subscribe(callback: (records: DataRecord[] | null) => void): () => void;
+};
+
+type StableReactEntrypoint = {
+    AuthCompletedContext: unknown;
+    AuthCompletedProvider: unknown;
+    DataSubscriptionStore: typeof DataSubscriptionStore;
+    CountSubscription: new(query: DynamicSQLQuery) => CountSubscription;
+    useQuery(
+        queryBuilder: QueryBuilder<string, DataRecord>,
+        options?: DataSubscriptionOptions | null,
+    ): DataRecord[] | null;
+    useQuerySingleResult(queryBuilder: QueryBuilder<string, DataRecord>): DataRecord | null;
+    useCount(queryBuilder: QueryBuilder): number | null;
+    useIsConnected(): boolean;
+};
+
+type _dataSubscriptionCompatibility = Assert<Implements<DataSubscription, StableDataSubscription>>;
+type _controllerCompatibility = Assert<Implements<DataSyncController, StableDataSyncController>>;
+type _controllerConstructorCompatibility = Assert<Implements<
+    typeof import('./index.js').DataSyncController,
+    StableDataSyncControllerConstructor
+>>;
+type _dataSubscriptionConstructorCompatibility = Assert<Implements<
+    typeof import('./index.js').DataSubscription,
+    StableDataSubscriptionConstructor
+>>;
+type _storeCompatibility = Assert<Implements<typeof DataSubscriptionStore, StableDataSubscriptionStore>>;
+type _reactStoreCompatibility = Assert<Implements<typeof ReactDataSubscriptionStore, StableDataSubscriptionStore>>;
+type _countCompatibility = Assert<Implements<CountSubscription, StableCountSubscription>>;
+type _queryBuilderCompatibility = Assert<Implements<QueryBuilder<string, DataRecord>, StableQueryBuilderSubscription>>;
+type _reactEntrypointCompatibility = Assert<Implements<typeof import('./react.js'), StableReactEntrypoint>>;
+type _legacyReactEntrypointCompatibility = Assert<Implements<
+    typeof import('./ihp-datasync-react.js'),
+    Pick<StableReactEntrypoint, 'AuthCompletedContext' | 'AuthCompletedProvider' | 'useQuery'>
+>>;
+
+// Structural assignability does not catch an accidental `readonly` modifier,
+// so lock the historically writable class fields explicitly.
+type _writableSubscriptionQuery = Assert<IsWritable<DataSubscription, 'query'>>;
+type _writableSubscriptionRecords = Assert<IsWritable<DataSubscription, 'records'>>;
+type _writableSubscriptionSubscribers = Assert<IsWritable<DataSubscription, 'subscribers'>>;
+type _writableSubscriptionCache = Assert<IsWritable<DataSubscription, 'cache'>>;
+type _writableSubscriptionBehaviour = Assert<IsWritable<DataSubscription, 'newRecordBehaviour'>>;
+type _writableSubscriptionId = Assert<IsWritable<DataSubscription, 'subscriptionId'>>;
+type _writableCreatePromise = Assert<IsWritable<DataSubscription, 'createOnServerPromise'>>;
+type _writableClosedFlag = Assert<IsWritable<DataSubscription, 'isClosed'>>;
+type _writableConnectedFlag = Assert<IsWritable<DataSubscription, 'isConnected'>>;
+type _writableConnectError = Assert<IsWritable<DataSubscription, 'connectError'>>;
+type _writableOnClose = Assert<IsWritable<DataSubscription, 'onClose'>>;
+type _writableResolveCreate = Assert<IsWritable<DataSubscription, 'resolveCreateOnServer'>>;
+type _writableRejectCreate = Assert<IsWritable<DataSubscription, 'rejectCreateOnServer'>>;
+type _writableCountQuery = Assert<IsWritable<CountSubscription, 'query'>>;
+type _writableCount = Assert<IsWritable<CountSubscription, 'count'>>;
+type _writableCountId = Assert<IsWritable<CountSubscription, 'subscriptionId'>>;
+type _writableCountSubscribers = Assert<IsWritable<CountSubscription, 'subscribers'>>;
+type _writableBuilderQuery = Assert<IsWritable<QueryBuilder, 'query'>>;
+type _writableBuilderTransaction = Assert<IsWritable<QueryBuilder, 'transactionId'>>;
+type _writableTransactionId = Assert<IsWritable<Transaction, 'transactionId'>>;
+type _writableTransactionController = Assert<IsWritable<Transaction, 'dataSyncController'>>;
+type _writableControllerConnection = Assert<IsWritable<DataSyncController, 'connection'>>;
+type _writableControllerSubscriptions = Assert<IsWritable<DataSyncController, 'dataSubscriptions'>>;
+type _writableStoreQueryMap = Assert<IsWritable<typeof DataSubscriptionStore, 'queryMap'>>;

--- a/ihp-datasync/data/DataSync/src/react.ts
+++ b/ihp-datasync/data/DataSync/src/react.ts
@@ -1,115 +1,216 @@
-import React, { useState, useEffect, useContext, useSyncExternalStore, useMemo } from 'react';
-import { DataSubscription, DataSyncController } from './ihp-datasync.js';
+import React, { useCallback, useContext, useSyncExternalStore } from 'react';
+import { DataSyncController } from './ihp-datasync.js';
 import { QueryBuilder } from './ihp-querybuilder.js';
-import { CountSubscription } from './count-subscription.js';
-import type { DataRecord, DynamicSQLQuery, DataSubscriptionOptions, DataSyncEventMap } from './types.js';
+import { DataSubscriptionStore } from './data-subscription-store.js';
+import { CountSubscription, CountSubscriptionStore } from './count-subscription.js';
+import { initialResourceSnapshot, type ResourceSnapshot } from './subscription-reducer.js';
+import type { DataRecord, DataSubscriptionOptions, DataSyncEventMap } from './types.js';
 
-export { CountSubscription } from './count-subscription.js';
+export { CountSubscription, CountSubscriptionStore } from './count-subscription.js';
+export { DataSubscriptionStore } from './data-subscription-store.js';
 
 // Most IHP apps never use this context because they use session cookies for auth.
 // Therefore the default value is true.
 export const AuthCompletedContext = React.createContext<boolean>(true);
 
+export type AuthCompletedProviderProps = React.PropsWithChildren<{
+    value: boolean;
+}>;
+
+const disabledQuerySnapshot = initialResourceSnapshot<DataRecord[]>();
+const disabledCountSnapshot = initialResourceSnapshot<number>();
+const getDisabledQuerySnapshot = (): ResourceSnapshot<DataRecord[]> => disabledQuerySnapshot;
+const getDisabledCountSnapshot = (): ResourceSnapshot<number> => disabledCountSnapshot;
+const getDisconnectedSnapshot = (): boolean => false;
+
+const subscribeWhileAuthIncomplete = (_listener: () => void): (() => void) => {
+    // This runs in useSyncExternalStore's commit-phase subscription. Repeating
+    // the reset is intentional: no resource created for the previous opaque
+    // cookie-auth session may survive for the next authenticated user.
+    DataSyncController.authSessionDidChange();
+    return () => {};
+};
+
 /**
- * Returns the result of the current query in real-time. Returns `null` while the data is still being fetched from the server.
- * @example
- * const messages = useQuery(query('messages').orderBy('createdAt'));
+ * Provides the auth-completion state and invalidates the previous DataSync
+ * auth scope whenever auth is incomplete. Unlike using
+ * `AuthCompletedContext.Provider` directly, this reset also runs when the
+ * provider has no mounted DataSync hooks.
  */
-export function useQuery<TTable extends string, TResult>(queryBuilder: QueryBuilder<TTable, TResult>, options: DataSubscriptionOptions | null = null): TResult[] | null {
-    const dataSubscription = DataSubscriptionStore.get(queryBuilder.query, options);
-    const isAuthCompleted = useContext(AuthCompletedContext);
-    const records = useSyncExternalStore(dataSubscription.subscribe, dataSubscription.getRecords);
+export function AuthCompletedProvider({ value, children }: AuthCompletedProviderProps): React.ReactElement {
+    // Deliberately recreated on each render so a committed auth-incomplete
+    // tree reasserts the boundary even if imperative code acquired a controller
+    // between two commits.
+    const subscribeToAuthLifecycle = (_listener: () => void): (() => void) => {
+        if (!value) {
+            DataSyncController.authSessionDidChange();
+        }
+        return () => {};
+    };
+    useSyncExternalStore(
+        subscribeToAuthLifecycle,
+        getDisconnectedSnapshot,
+        getDisconnectedSnapshot,
+    );
 
-    if (dataSubscription.connectError) {
-        throw dataSubscription.connectError;
-    }
-
-    if (!isAuthCompleted) {
-        return null;
-    }
-
-    return records as TResult[] | null;
+    return React.createElement(AuthCompletedContext.Provider, { value }, children);
 }
 
 /**
- * A version of `useQuery` when you only want to fetch a single record.
- *
- * Automatically adds a `.limit(1)` to the query and returns the single result instead of a list.
- *
- * @example
- * const message = useQuerySingleresult(query('messages').filterWhere('id', '1f290b39-c6d1-4dff-8404-0581f470253c'));
+ * Returns the exact server result of the current query in real time. It returns
+ * `null` until the first server snapshot is available.
  */
-export function useQuerySingleResult<TTable extends string, TResult>(queryBuilder: QueryBuilder<TTable, TResult>): TResult | null {
+export function useQuery<TTable extends string, TResult>(
+    queryBuilder: QueryBuilder<TTable, TResult>,
+    options: DataSubscriptionOptions | null = null,
+): TResult[] | null {
+    const isAuthCompleted = useContext(AuthCompletedContext);
+    const resource = isAuthCompleted
+        ? DataSubscriptionStore.get(queryBuilder.query, options)
+        : null;
+    const snapshot = useSyncExternalStore(
+        resource !== null
+            ? resource.subscribeSnapshot
+            : listener => subscribeWhileAuthIncomplete(listener),
+        resource !== null ? resource.getSnapshot : getDisabledQuerySnapshot,
+        getDisabledQuerySnapshot,
+    );
+
+    if (snapshot.error !== null) {
+        throw snapshot.error;
+    }
+    return snapshot.data as TResult[] | null;
+}
+
+/** Adds `limit(1)` and returns the first result instead of a list. */
+export function useQuerySingleResult<TTable extends string, TResult>(
+    queryBuilder: QueryBuilder<TTable, TResult>,
+): TResult | null {
     const result = useQuery(queryBuilder.limit(1));
     return result === null ? null : result[0] ?? null;
 }
 
-export function useIsConnected(): boolean {
-    const dataSyncController = DataSyncController.getInstance();
-    const isConnectedDefault = dataSyncController.connection !== null;
+export function useCount(queryBuilder: QueryBuilder): number | null {
+    const isAuthCompleted = useContext(AuthCompletedContext);
+    const resource = isAuthCompleted
+        ? CountSubscriptionStore.get(queryBuilder.query)
+        : null;
+    const snapshot = useSyncExternalStore(
+        resource !== null
+            ? resource.subscribeSnapshot
+            : listener => subscribeWhileAuthIncomplete(listener),
+        resource !== null ? resource.getSnapshot : getDisabledCountSnapshot,
+        getDisabledCountSnapshot,
+    );
 
-    const [isConnected, setConnected] = useState(isConnectedDefault);
-
-    useEffect(() => {
-        const setConnectedTrue: DataSyncEventMap['open'] = () => setConnected(true);
-        const setConnectedFalse: DataSyncEventMap['close'] = () => setConnected(false);
-
-        dataSyncController.addEventListener('open', setConnectedTrue);
-        dataSyncController.addEventListener('close', setConnectedFalse);
-
-        return () => {
-            dataSyncController.removeEventListener('open', setConnectedTrue);
-            dataSyncController.removeEventListener('close', setConnectedFalse);
-        };
-    }, [setConnected]);
-
-    return isConnected;
+    if (snapshot.error !== null) {
+        throw snapshot.error;
+    }
+    return snapshot.data;
 }
 
-export class DataSubscriptionStore {
-    static queryMap: Map<string, DataSubscription> = new Map();
+export function useIsConnected(): boolean {
+    const isAuthCompleted = useContext(AuthCompletedContext);
+    const transportScopeKey = DataSyncController.currentTransportScopeKey();
+    const subscribeToCurrentScope = useCallback(
+        (listener: () => void) => connectionResource.subscribe(listener),
+        [transportScopeKey],
+    );
+    return useSyncExternalStore(
+        isAuthCompleted
+            ? subscribeToCurrentScope
+            : listener => subscribeWhileAuthIncomplete(listener),
+        isAuthCompleted ? connectionResource.getSnapshot : getDisconnectedSnapshot,
+        getDisconnectedSnapshot,
+    );
+}
 
-    // To avoid too many loading spinners when going backwards and forwards
-    // between pages, we cache the result of queries so we can already showing
-    // some data directly after a page transition. The data might be a bit
-    // outdated, but it will directly be overriden with the latest server state
-    // once it has arrived.
-    static cache: Map<string, DataRecord[]> = new Map();
+class ConnectionResource {
+    private readonly listeners = new Map<number, () => void>();
+    private nextListenerId = 0;
+    private controller: DataSyncController | null = null;
+    private removeInstanceListener: (() => void) | null = null;
 
-    static get(query: DynamicSQLQuery, options: DataSubscriptionOptions | null = null): DataSubscription {
-        const key = JSON.stringify(query) + JSON.stringify(options);
-        const existingSubscription = DataSubscriptionStore.queryMap.get(key);
+    constructor() {
+        this.subscribe = this.subscribe.bind(this);
+        this.getSnapshot = this.getSnapshot.bind(this);
+        this.getServerSnapshot = this.getServerSnapshot.bind(this);
+        this.onInstanceChanged = this.onInstanceChanged.bind(this);
+        this.onOpen = this.onOpen.bind(this);
+        this.onClose = this.onClose.bind(this);
+    }
 
-        if (existingSubscription) {
-            return existingSubscription;
-        } else {
+    subscribe(listener: () => void): () => void {
+        const id = this.nextListenerId++;
+        this.listeners.set(id, listener);
+        if (this.listeners.size === 1) {
+            this.removeInstanceListener = DataSyncController.addInstanceListener(this.onInstanceChanged);
+            // Subscription happens during commit, so rotating an obsolete auth
+            // scope here cannot cause a render-phase side effect.
+            this.attachController(DataSyncController.getInstance());
+        }
 
-            const subscription = new DataSubscription(query, options, DataSubscriptionStore.cache);
-            void subscription.createOnServer().catch(() => {
-                // The subscription stores the error and notifies useQuery.
-            });
-            subscription.onClose = () => {
-                if (DataSubscriptionStore.queryMap.get(key) === subscription) {
-                    DataSubscriptionStore.queryMap.delete(key);
-                }
-            };
+        let subscribed = true;
+        return () => {
+            if (!subscribed) {
+                return;
+            }
+            subscribed = false;
+            this.listeners.delete(id);
+            if (this.listeners.size === 0) {
+                this.removeInstanceListener?.();
+                this.removeInstanceListener = null;
+                this.attachController(null);
+            }
+        };
+    }
 
-            DataSubscriptionStore.queryMap.set(key, subscription);
+    getSnapshot(): boolean {
+        const controller = DataSyncController.peekInstance();
+        return controller !== null && controller.connection !== null;
+    }
 
-            // If the query changes very rapid in `useQuery` it can happen that the `dataSubscription.subscribe`
-            // is never called at all. In this case we have a unused DataSubscription laying around. We avoid
-            // to many open connections laying around by trying to close them a second after opening them.
-            // A second is enough time for react to call the subscribe function. If it's not called by then,
-            // we most likely deal with a dead subscription, so we close it.
-            subscription.scheduleCloseIfNotUsed();
+    getServerSnapshot(): boolean {
+        return false;
+    }
 
-            return subscription;
+    private onOpen(_event: Parameters<DataSyncEventMap['open']>[0]): void {
+        this.notify();
+    }
+
+    private onClose(_event: Parameters<DataSyncEventMap['close']>[0]): void {
+        this.notify();
+    }
+
+    private onInstanceChanged(controller: DataSyncController | null): void {
+        this.attachController(controller);
+        this.notify();
+    }
+
+    private attachController(controller: DataSyncController | null): void {
+        if (this.controller === controller) {
+            return;
+        }
+        if (this.controller !== null) {
+            this.controller.removeEventListener('open', this.onOpen);
+            this.controller.removeEventListener('close', this.onClose);
+        }
+        this.controller = controller;
+        if (controller !== null) {
+            controller.addEventListener('open', this.onOpen);
+            controller.addEventListener('close', this.onClose);
+        }
+    }
+
+    private notify(): void {
+        for (const listener of Array.from(this.listeners.values())) {
+            try {
+                listener();
+            } catch (error) {
+                console.error('DataSync connection subscriber failed:', error);
+            }
         }
     }
 }
 
-export function useCount(queryBuilder: QueryBuilder): number | null {
-    const queryKey = JSON.stringify(queryBuilder.query);
-    const countSubscription = useMemo(() => new CountSubscription(queryBuilder.query), [queryKey]);
-    return useSyncExternalStore(countSubscription.subscribe, countSubscription.getCount);
-}
+const connectionResource = new ConnectionResource();

--- a/ihp-datasync/data/DataSync/src/react.ts
+++ b/ihp-datasync/data/DataSync/src/react.ts
@@ -125,29 +125,64 @@ export function useIsConnected(): boolean {
     );
 }
 
-class ConnectionResource {
-    private readonly listeners = new Map<number, () => void>();
-    private nextListenerId = 0;
-    private controller: DataSyncController | null = null;
-    private removeInstanceListener: (() => void) | null = null;
+type ConnectionExternalStore = Readonly<{
+    subscribe(listener: () => void): () => void;
+    getSnapshot(): boolean;
+    getServerSnapshot(): boolean;
+}>;
 
-    constructor() {
-        this.subscribe = this.subscribe.bind(this);
-        this.getSnapshot = this.getSnapshot.bind(this);
-        this.getServerSnapshot = this.getServerSnapshot.bind(this);
-        this.onInstanceChanged = this.onInstanceChanged.bind(this);
-        this.onOpen = this.onOpen.bind(this);
-        this.onClose = this.onClose.bind(this);
-    }
+function createConnectionExternalStore(): ConnectionExternalStore {
+    const listeners = new Map<number, () => void>();
+    let nextListenerId = 0;
+    let controller: DataSyncController | null = null;
+    let removeInstanceListener: (() => void) | null = null;
 
-    subscribe(listener: () => void): () => void {
-        const id = this.nextListenerId++;
-        this.listeners.set(id, listener);
-        if (this.listeners.size === 1) {
-            this.removeInstanceListener = DataSyncController.addInstanceListener(this.onInstanceChanged);
+    const notify = (): void => {
+        for (const listener of Array.from(listeners.values())) {
+            try {
+                listener();
+            } catch (error) {
+                console.error('DataSync connection subscriber failed:', error);
+            }
+        }
+    };
+
+    const onOpen = (_event: Parameters<DataSyncEventMap['open']>[0]): void => {
+        notify();
+    };
+
+    const onClose = (_event: Parameters<DataSyncEventMap['close']>[0]): void => {
+        notify();
+    };
+
+    const attachController = (nextController: DataSyncController | null): void => {
+        if (controller === nextController) {
+            return;
+        }
+        if (controller !== null) {
+            controller.removeEventListener('open', onOpen);
+            controller.removeEventListener('close', onClose);
+        }
+        controller = nextController;
+        if (controller !== null) {
+            controller.addEventListener('open', onOpen);
+            controller.addEventListener('close', onClose);
+        }
+    };
+
+    const onInstanceChanged = (nextController: DataSyncController | null): void => {
+        attachController(nextController);
+        notify();
+    };
+
+    const subscribe = (listener: () => void): (() => void) => {
+        const id = nextListenerId++;
+        listeners.set(id, listener);
+        if (listeners.size === 1) {
+            removeInstanceListener = DataSyncController.addInstanceListener(onInstanceChanged);
             // Subscription happens during commit, so rotating an obsolete auth
             // scope here cannot cause a render-phase side effect.
-            this.attachController(DataSyncController.getInstance());
+            attachController(DataSyncController.getInstance());
         }
 
         let subscribed = true;
@@ -156,61 +191,25 @@ class ConnectionResource {
                 return;
             }
             subscribed = false;
-            this.listeners.delete(id);
-            if (this.listeners.size === 0) {
-                this.removeInstanceListener?.();
-                this.removeInstanceListener = null;
-                this.attachController(null);
+            listeners.delete(id);
+            if (listeners.size === 0) {
+                removeInstanceListener?.();
+                removeInstanceListener = null;
+                attachController(null);
             }
         };
-    }
+    };
 
-    getSnapshot(): boolean {
+    const getSnapshot = (): boolean => {
         const controller = DataSyncController.peekInstance();
         return controller !== null && controller.connection !== null;
-    }
+    };
 
-    getServerSnapshot(): boolean {
+    const getServerSnapshot = (): boolean => {
         return false;
-    }
+    };
 
-    private onOpen(_event: Parameters<DataSyncEventMap['open']>[0]): void {
-        this.notify();
-    }
-
-    private onClose(_event: Parameters<DataSyncEventMap['close']>[0]): void {
-        this.notify();
-    }
-
-    private onInstanceChanged(controller: DataSyncController | null): void {
-        this.attachController(controller);
-        this.notify();
-    }
-
-    private attachController(controller: DataSyncController | null): void {
-        if (this.controller === controller) {
-            return;
-        }
-        if (this.controller !== null) {
-            this.controller.removeEventListener('open', this.onOpen);
-            this.controller.removeEventListener('close', this.onClose);
-        }
-        this.controller = controller;
-        if (controller !== null) {
-            controller.addEventListener('open', this.onOpen);
-            controller.addEventListener('close', this.onClose);
-        }
-    }
-
-    private notify(): void {
-        for (const listener of Array.from(this.listeners.values())) {
-            try {
-                listener();
-            } catch (error) {
-                console.error('DataSync connection subscriber failed:', error);
-            }
-        }
-    }
+    return Object.freeze({ subscribe, getSnapshot, getServerSnapshot });
 }
 
-const connectionResource = new ConnectionResource();
+const connectionResource = createConnectionExternalStore();

--- a/ihp-datasync/data/DataSync/src/react.ts
+++ b/ihp-datasync/data/DataSync/src/react.ts
@@ -1,7 +1,10 @@
-import React, { useState, useEffect, useContext, useSyncExternalStore, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useContext, useSyncExternalStore, useMemo } from 'react';
 import { DataSubscription, DataSyncController } from './ihp-datasync.js';
 import { QueryBuilder } from './ihp-querybuilder.js';
-import type { DataRecord, DynamicSQLQuery, DataSubscriptionOptions, DataSyncEventMap, ServerMessage, TableName } from './types.js';
+import { CountSubscription } from './count-subscription.js';
+import type { DataRecord, DynamicSQLQuery, DataSubscriptionOptions, DataSyncEventMap } from './types.js';
+
+export { CountSubscription } from './count-subscription.js';
 
 // Most IHP apps never use this context because they use session cookies for auth.
 // Therefore the default value is true.
@@ -38,7 +41,7 @@ export function useQuery<TTable extends string, TResult>(queryBuilder: QueryBuil
  */
 export function useQuerySingleResult<TTable extends string, TResult>(queryBuilder: QueryBuilder<TTable, TResult>): TResult | null {
     const result = useQuery(queryBuilder.limit(1));
-    return result === null ? null : result[0];
+    return result === null ? null : result[0] ?? null;
 }
 
 export function useIsConnected(): boolean {
@@ -82,7 +85,9 @@ export class DataSubscriptionStore {
         } else {
 
             const subscription = new DataSubscription(query, options, DataSubscriptionStore.cache);
-            subscription.createOnServer();
+            void subscription.createOnServer().catch(() => {
+                // The subscription stores the error and notifies useQuery.
+            });
             subscription.onClose = () => {
                 if (DataSubscriptionStore.queryMap.get(key) === subscription) {
                     DataSubscriptionStore.queryMap.delete(key);
@@ -104,43 +109,7 @@ export class DataSubscriptionStore {
 }
 
 export function useCount(queryBuilder: QueryBuilder): number | null {
-    const count = useRef<number | null>(null);
-    const getSnapshot = useMemo(() => () => count.current, []);
-    const subscribe = useMemo(() => (onStoreChange: () => void) => {
-        const controller = DataSyncController.getInstance();
-        let isActive = true;
-        let subscriptionId: string | null = null;
-        const onMessage: DataSyncEventMap['message'] = (message) => {
-            if (message.tag === 'DidChangeCount' && message.subscriptionId === subscriptionId) {
-                count.current = message.count as number;
-                onStoreChange();
-            }
-        };
-        controller.sendMessage({ tag: 'CreateCountSubscription', query: queryBuilder.query })
-            .then((response) => {
-                if (isActive) {
-                    subscriptionId = response.subscriptionId as string;
-                    count.current = response.count as number;
-                    onStoreChange();
-
-                    controller.addEventListener('message', onMessage);
-                } else {
-                    controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId: response.subscriptionId });
-                }
-            })
-            .catch((error: unknown) => {
-                console.error('useCount: Failed to create count subscription', error);
-            });
-
-        return () => {
-            isActive = false;
-
-            if (subscriptionId) {
-                controller.sendMessage({ tag: 'DeleteDataSubscription', subscriptionId });
-            }
-            controller.removeEventListener('message', onMessage);
-        };
-    }, [JSON.stringify(queryBuilder.query)]);
-
-    return useSyncExternalStore(subscribe, getSnapshot);
+    const queryKey = JSON.stringify(queryBuilder.query);
+    const countSubscription = useMemo(() => new CountSubscription(queryBuilder.query), [queryKey]);
+    return useSyncExternalStore(countSubscription.subscribe, countSubscription.getCount);
 }

--- a/ihp-datasync/data/DataSync/src/resource-key.ts
+++ b/ihp-datasync/data/DataSync/src/resource-key.ts
@@ -1,0 +1,18 @@
+import type { DataSubscriptionOptions, DynamicSQLQuery } from './types.js';
+
+/** Pure, transport-scoped key shared by row and count resource registries. */
+export function dataResourceKeyForScope(
+    scope: string,
+    query: DynamicSQLQuery,
+    options: DataSubscriptionOptions | null = null,
+): string {
+    return JSON.stringify([scope, query, options]);
+}
+
+/** Counts intentionally share the query key format with a distinct namespace. */
+export function countResourceKeyForScope(
+    scope: string,
+    query: DynamicSQLQuery,
+): string {
+    return `count:${dataResourceKeyForScope(scope, query)}`;
+}

--- a/ihp-datasync/data/DataSync/src/resource-registry.ts
+++ b/ihp-datasync/data/DataSync/src/resource-registry.ts
@@ -1,0 +1,115 @@
+import { WeakValueMap } from './weak-value-map.js';
+
+/**
+ * Lifecycle callbacks attached by a resource factory to the resource it
+ * creates. Passing the resource explicitly keeps identity checks reliable and
+ * avoids a partially initialized closure while the factory is running.
+ */
+export type ResourceRegistryLifecycle<Key, Value extends object> = Readonly<{
+    key: Key;
+    retain(value: Value): void;
+    close(value: Value): void;
+}>;
+
+export type ResourceRegistryOptions<Input, Key, Value extends object> = Readonly<{
+    key(input: Input): Key;
+    create(
+        input: Input,
+        lifecycle: ResourceRegistryLifecycle<Key, Value>,
+    ): Value;
+}>;
+
+export type ResourceRegistry<Input, Key, Value extends object> = Readonly<{
+    /** Strong references to resources with at least one committed owner. */
+    readonly active: Map<Key, Value>;
+    /**
+     * Returns the canonical active or render-pending resource for the input.
+     * The lookup itself never promotes the resource into the active map.
+     */
+    getOrCreate(input: Input): Value;
+    /** Replaces the public compatibility Map and forgets render-only values. */
+    replaceActive(next: Map<Key, Value>): void;
+    /** Clears both active and render-pending resources. */
+    clear(): void;
+}>;
+
+/**
+ * Creates a React- and transport-independent canonical resource registry.
+ *
+ * Render-only lookups are held weakly. A resource factory can attach the
+ * provided lifecycle callbacks and promote the value only when a consumer is
+ * committed. Closing is identity-checked so a stale resource cannot evict a
+ * newer value for the same key.
+ */
+export function createResourceRegistry<Input, Key, Value extends object>(
+    options: ResourceRegistryOptions<Input, Key, Value>,
+): ResourceRegistry<Input, Key, Value> {
+    const pending = new WeakValueMap<Key, Value>();
+    const instrumentedMaps = new WeakSet<Map<Key, Value>>();
+    const resetPending = (): void => pending.clear();
+    const instrumentClear = (map: Map<Key, Value>): Map<Key, Value> => {
+        if (instrumentedMaps.has(map)) {
+            return map;
+        }
+        const clearMap = map.clear.bind(map);
+        try {
+            map.clear = (): void => {
+                clearMap();
+                resetPending();
+            };
+            instrumentedMaps.add(map);
+        } catch (_error) {
+            // A frozen compatibility Map is still a valid Map (and its native
+            // mutators still work), but its methods cannot be instrumented.
+            // Replacing it already reset pending entries; keep accepting the
+            // historical writable static-field assignment.
+        }
+        return map;
+    };
+    let active = instrumentClear(new Map<Key, Value>());
+
+    const getOrCreate = (input: Input): Value => {
+        const key = options.key(input);
+        const activeValue = active.get(key);
+        if (activeValue !== undefined) {
+            return activeValue;
+        }
+
+        const pendingValue = pending.get(key);
+        if (pendingValue !== undefined) {
+            return pendingValue;
+        }
+
+        const lifecycle: ResourceRegistryLifecycle<Key, Value> = Object.freeze({
+            key,
+            retain(value: Value): void {
+                active.set(key, value);
+            },
+            close(value: Value): void {
+                if (active.get(key) === value) {
+                    active.delete(key);
+                }
+                pending.delete(key, value);
+            },
+        });
+        const value = options.create(input, lifecycle);
+        pending.set(key, value);
+        return value;
+    };
+
+    const registry: ResourceRegistry<Input, Key, Value> = {
+        get active(): Map<Key, Value> {
+            return active;
+        },
+        getOrCreate,
+        replaceActive(next: Map<Key, Value>): void {
+            active = instrumentClear(next);
+            pending.clear();
+        },
+        clear(): void {
+            active.clear();
+            pending.clear();
+        },
+    };
+    return Object.freeze(registry);
+}

--- a/ihp-datasync/data/DataSync/src/subscription-machine.ts
+++ b/ihp-datasync/data/DataSync/src/subscription-machine.ts
@@ -1,0 +1,826 @@
+import {
+    initialResourceSnapshot,
+    reduceResourceSnapshot,
+    type ResourceSnapshot,
+} from './subscription-reducer.js';
+import type { UUID } from './types.js';
+
+/** The server protocol used by a live subscription generation. */
+export type SubscriptionMode = 'legacy' | 'snapshot';
+
+/**
+ * Immutable lifecycle state for a server-backed value.
+ *
+ * Effectful values such as controllers, promises, timers, caches and listener
+ * functions deliberately do not belong here. A runtime closure interprets the
+ * returned commands and feeds their results back as events.
+ */
+export type SubscriptionState<T> = Readonly<{
+    scope: 'current' | 'stale';
+    demand: Readonly<{
+        subscribers: number;
+        imperative: boolean;
+    }>;
+    generation: number;
+    phase: SubscriptionPhase;
+    snapshot: ResourceSnapshot<T>;
+    refresh: 'clean' | 'running' | 'dirty';
+    disposalToken: number;
+    initialResult: 'pending' | 'settled';
+}>;
+
+export type SubscriptionPhase =
+    | Readonly<{ tag: 'idle' }>
+    | Readonly<{ tag: 'creating'; reconnect: boolean }>
+    | Readonly<{
+        tag: 'live';
+        subscriptionId: UUID;
+        mode: SubscriptionMode;
+        revision: number;
+    }>
+    | Readonly<{ tag: 'offline' }>
+    | Readonly<{ tag: 'failed' }>
+    | Readonly<{ tag: 'closed' }>;
+
+/** Resource-specific differences which should be explicit, not duplicated. */
+export type SubscriptionPolicy = Readonly<{
+    clearDataOnDisconnect: boolean;
+    refreshLegacyInvalidations: boolean;
+    cacheSnapshots: boolean;
+    publishLegacyOnDisconnect: boolean;
+    publishLegacyOnFailure: boolean;
+    initialCloseMessage: string;
+    initialUnusedMessage: string;
+    scopeRetiredMessage: string;
+}>;
+
+/** Row subscriptions retain their last confirmed value while reconnecting. */
+export const rowSubscriptionPolicy: SubscriptionPolicy = Object.freeze({
+    clearDataOnDisconnect: false,
+    refreshLegacyInvalidations: true,
+    cacheSnapshots: true,
+    publishLegacyOnDisconnect: false,
+    publishLegacyOnFailure: true,
+    initialCloseMessage: 'DataSubscription closed before its initial server snapshot arrived',
+    initialUnusedMessage: 'DataSubscription became unused before its initial server snapshot arrived',
+    scopeRetiredMessage: 'DataSubscription closed because its authentication/backend scope changed',
+});
+
+/** Count subscriptions historically clear and publish on disconnect. */
+export const countSubscriptionPolicy: SubscriptionPolicy = Object.freeze({
+    clearDataOnDisconnect: true,
+    refreshLegacyInvalidations: false,
+    cacheSnapshots: false,
+    publishLegacyOnDisconnect: true,
+    publishLegacyOnFailure: false,
+    initialCloseMessage: 'CountSubscription closed before its initial server value arrived',
+    initialUnusedMessage: 'CountSubscription became unused before its initial server value arrived',
+    scopeRetiredMessage: 'CountSubscription closed because its authentication/backend scope changed',
+});
+
+export type CreatedSubscription<T> = Readonly<{
+    subscriptionId: UUID;
+    value: T;
+    mode: SubscriptionMode;
+    revision: number;
+}>;
+
+export type SubscriptionEvent<T> =
+    | Readonly<{
+        type: 'DEMAND_CHANGED';
+        subscribers: number;
+        imperative: boolean;
+    }>
+    | Readonly<{ type: 'SCHEDULE_IDLE_CHECK' }>
+    | Readonly<{ type: 'IDLE_CHECK'; token: number }>
+    | Readonly<{
+        type: 'CREATE_SUCCEEDED';
+        generation: number;
+        created: CreatedSubscription<T>;
+    }>
+    | Readonly<{
+        type: 'CREATE_FAILED';
+        generation: number;
+        error: Error;
+    }>
+    | Readonly<{
+        type: 'SERVER_SNAPSHOT';
+        generation: number;
+        subscriptionId: UUID;
+        value: T;
+        revision: number;
+    }>
+    | Readonly<{
+        /** Ordered, unrevisioned server value, primarily used by counts. */
+        type: 'SERVER_VALUE';
+        generation: number;
+        subscriptionId: UUID;
+        value: T;
+    }>
+    | Readonly<{
+        type: 'LEGACY_INVALIDATED';
+        generation: number;
+        subscriptionId: UUID;
+    }>
+    | Readonly<{
+        type: 'REFRESH_SUCCEEDED';
+        generation: number;
+        value: T;
+    }>
+    | Readonly<{
+        type: 'REFRESH_FAILED';
+        generation: number;
+        error: Error;
+    }>
+    | Readonly<{ type: 'TRANSPORT_CLOSED' }>
+    | Readonly<{ type: 'TRANSPORT_RECONNECTED' }>
+    | Readonly<{ type: 'SCOPE_RETIRED' }>
+    | Readonly<{ type: 'CLOSE_REQUESTED' }>
+    | Readonly<{ type: 'COMPAT_VALUE_SET'; value: T | null }>;
+
+export type SubscriptionCommand<T> =
+    | Readonly<{
+        type: 'CREATE_REMOTE';
+        generation: number;
+        reconnect: boolean;
+    }>
+    | Readonly<{
+        type: 'DELETE_REMOTE';
+        generation: number;
+        subscriptionId: UUID;
+    }>
+    | Readonly<{ type: 'REFRESH_REMOTE'; generation: number }>
+    | Readonly<{ type: 'QUEUE_IDLE_CHECK'; token: number }>
+    | Readonly<{ type: 'CACHE_WRITE'; value: T }>
+    | Readonly<{
+        type: 'SETTLE_INITIAL';
+        result:
+            | Readonly<{ ok: true; value: T }>
+            | Readonly<{ ok: false; error: Error }>;
+    }>
+    | Readonly<{ type: 'REPORT_REFRESH_FAILURE'; error: Error }>
+    | Readonly<{ type: 'EVICT_FROM_REGISTRY' }>;
+
+/** Which observer groups the imperative shell should notify. */
+export type SubscriptionPublication = 'none' | 'snapshot' | 'legacy' | 'both';
+
+export type SubscriptionTransition<T> = Readonly<{
+    state: SubscriptionState<T>;
+    commands: readonly SubscriptionCommand<T>[];
+    publication: SubscriptionPublication;
+}>;
+
+const noCommands = Object.freeze([]) as readonly SubscriptionCommand<never>[];
+
+/** Creates the frozen starting state, optionally seeded by a scoped cache. */
+export function initialSubscriptionState<T>(
+    initialData?: T | null,
+): SubscriptionState<T> {
+    return freezeState({
+        scope: 'current',
+        demand: { subscribers: 0, imperative: false },
+        generation: 0,
+        phase: { tag: 'idle' },
+        snapshot: initialResourceSnapshot(initialData),
+        refresh: 'clean',
+        disposalToken: 0,
+        initialResult: 'pending',
+    });
+}
+
+/**
+ * Pure transition function for row and count subscriptions.
+ *
+ * The runtime must install `transition.state` before interpreting commands.
+ * Async command completions must be represented by another event carrying the
+ * command's generation. Publications happen after synchronous commands such as
+ * cache writes and initial-promise settlement have been interpreted.
+ */
+export function transitionSubscription<T>(
+    state: SubscriptionState<T>,
+    event: SubscriptionEvent<T>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    switch (event.type) {
+        case 'DEMAND_CHANGED':
+            return demandChanged(state, event, policy);
+        case 'SCHEDULE_IDLE_CHECK':
+            return scheduleIdleCheck(state);
+        case 'IDLE_CHECK':
+            return idleCheck(state, event.token, policy);
+        case 'CREATE_SUCCEEDED':
+            return createSucceeded(state, event, policy);
+        case 'CREATE_FAILED':
+            return createFailed(state, event, policy);
+        case 'SERVER_SNAPSHOT':
+            return serverSnapshot(state, event, policy);
+        case 'SERVER_VALUE':
+            return serverValue(state, event, policy);
+        case 'LEGACY_INVALIDATED':
+            return legacyInvalidated(state, event, policy);
+        case 'REFRESH_SUCCEEDED':
+            return refreshSucceeded(state, event, policy);
+        case 'REFRESH_FAILED':
+            return refreshFailed(state, event);
+        case 'TRANSPORT_CLOSED':
+            return transportClosed(state, policy);
+        case 'TRANSPORT_RECONNECTED':
+            return transportReconnected(state);
+        case 'SCOPE_RETIRED':
+            return scopeRetired(state, policy);
+        case 'CLOSE_REQUESTED':
+            return closeRequested(state, policy);
+        case 'COMPAT_VALUE_SET':
+            return compatValueSet(state, event.value, policy);
+    }
+}
+
+function scheduleIdleCheck<T>(
+    state: SubscriptionState<T>,
+): SubscriptionTransition<T> {
+    const disposalToken = state.disposalToken + 1;
+    return changed(
+        updateState(state, { disposalToken }),
+        [{ type: 'QUEUE_IDLE_CHECK', token: disposalToken }],
+    );
+}
+
+function compatValueSet<T>(
+    state: SubscriptionState<T>,
+    value: T | null,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    const snapshot = value === null
+        ? initialResourceSnapshot<T>()
+        : reduceResourceSnapshot(state.snapshot, { type: 'SNAPSHOT', data: value });
+    const phase = value !== null && state.phase.tag === 'live'
+        ? { ...state.phase, revision: state.phase.revision + 1 }
+        : state.phase;
+    const commands: SubscriptionCommand<T>[] = value !== null && policy.cacheSnapshots
+        ? [{ type: 'CACHE_WRITE', value }]
+        : [];
+    return changed(
+        updateState(state, { phase, snapshot }),
+        commands,
+        value === null || snapshot !== state.snapshot ? 'both' : 'none',
+    );
+}
+
+function demandChanged<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'DEMAND_CHANGED' }>,
+    _policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (!Number.isSafeInteger(event.subscribers) || event.subscribers < 0) {
+        throw new RangeError('Subscription demand must be a non-negative safe integer');
+    }
+
+    if (
+        state.demand.subscribers === event.subscribers
+        && state.demand.imperative === event.imperative
+    ) {
+        return unchanged(state);
+    }
+
+    const wasDemanded = hasDemand(state.demand);
+    const demand = { subscribers: event.subscribers, imperative: event.imperative };
+    const isDemanded = hasDemand(demand);
+    const demandBoundaryChanged = wasDemanded !== isDemanded;
+    const updated = updateState(state, {
+        demand,
+        disposalToken: demandBoundaryChanged
+            ? state.disposalToken + 1
+            : state.disposalToken,
+    });
+
+    if (!wasDemanded && isDemanded) {
+        if (updated.scope === 'stale') {
+            return changed(updated);
+        }
+        switch (updated.phase.tag) {
+            case 'idle':
+            case 'closed':
+            case 'failed':
+                return beginCreate(updated, false);
+            case 'offline':
+                return beginCreate(updated, true);
+            case 'creating':
+            case 'live':
+                return changed(updated);
+        }
+    }
+
+    if (wasDemanded && !isDemanded) {
+        return changed(updated, [{
+            type: 'QUEUE_IDLE_CHECK',
+            token: updated.disposalToken,
+        }]);
+    }
+
+    return changed(updated);
+}
+
+function idleCheck<T>(
+    state: SubscriptionState<T>,
+    token: number,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (
+        token !== state.disposalToken
+        || hasDemand(state.demand)
+        || state.phase.tag === 'closed'
+    ) {
+        return unchanged(state);
+    }
+    return closeCurrent(state, false, policy);
+}
+
+function createSucceeded<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'CREATE_SUCCEEDED' }>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    const { created } = event;
+    const isCurrentCreate = state.scope === 'current'
+        && state.phase.tag === 'creating'
+        && event.generation === state.generation;
+
+    if (!isCurrentCreate) {
+        if (
+            state.phase.tag === 'live'
+            && event.generation === state.generation
+            && state.phase.subscriptionId === created.subscriptionId
+        ) {
+            return unchanged(state);
+        }
+        return changed(state, [{
+            type: 'DELETE_REMOTE',
+            generation: event.generation,
+            subscriptionId: created.subscriptionId,
+        }]);
+    }
+
+    const revision = created.mode === 'snapshot' ? created.revision : 0;
+    const snapshot = reduceResourceSnapshot(state.snapshot, {
+        type: 'SNAPSHOT',
+        data: created.value,
+    });
+    const shouldSettleInitial = state.initialResult === 'pending';
+    const nextState = updateState(state, {
+        phase: {
+            tag: 'live',
+            subscriptionId: created.subscriptionId,
+            mode: created.mode,
+            revision,
+        },
+        snapshot,
+        refresh: 'clean',
+        initialResult: shouldSettleInitial ? 'settled' : state.initialResult,
+    });
+    const commands: SubscriptionCommand<T>[] = [];
+    if (policy.cacheSnapshots) {
+        commands.push({ type: 'CACHE_WRITE', value: created.value });
+    }
+    if (shouldSettleInitial) {
+        commands.push({
+            type: 'SETTLE_INITIAL',
+            result: { ok: true, value: created.value },
+        });
+    }
+    return changed(
+        nextState,
+        commands,
+        snapshot === state.snapshot ? 'none' : 'both',
+    );
+}
+
+function createFailed<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'CREATE_FAILED' }>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (
+        state.scope !== 'current'
+        || state.phase.tag !== 'creating'
+        || event.generation !== state.generation
+    ) {
+        return unchanged(state);
+    }
+
+    const snapshot = reduceResourceSnapshot(state.snapshot, {
+        type: 'FAIL',
+        error: event.error,
+    });
+    const shouldSettleInitial = state.initialResult === 'pending';
+    const nextState = updateState(state, {
+        phase: { tag: 'failed' },
+        snapshot,
+        refresh: 'clean',
+        initialResult: shouldSettleInitial ? 'settled' : state.initialResult,
+    });
+    const commands: SubscriptionCommand<T>[] = shouldSettleInitial
+        ? [{
+            type: 'SETTLE_INITIAL',
+            result: { ok: false, error: event.error },
+        }]
+        : [];
+    return changed(
+        nextState,
+        commands,
+        snapshot === state.snapshot
+            ? 'none'
+            : policy.publishLegacyOnFailure ? 'both' : 'snapshot',
+    );
+}
+
+function serverSnapshot<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'SERVER_SNAPSHOT' }>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (!isCurrentLiveEvent(state, event.generation, event.subscriptionId)) {
+        return unchanged(state);
+    }
+    const live = state.phase;
+    if (live.tag !== 'live') {
+        return unchanged(state);
+    }
+    if (live.mode === 'snapshot' && event.revision <= live.revision) {
+        return unchanged(state);
+    }
+
+    return acceptServerValue(
+        state,
+        event.value,
+        {
+            tag: 'live',
+            subscriptionId: live.subscriptionId,
+            mode: 'snapshot',
+            revision: event.revision,
+        },
+        'clean',
+        policy,
+    );
+}
+
+function serverValue<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'SERVER_VALUE' }>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (!isCurrentLiveEvent(state, event.generation, event.subscriptionId)) {
+        return unchanged(state);
+    }
+    const live = state.phase;
+    if (live.tag !== 'live' || live.mode !== 'legacy') {
+        return unchanged(state);
+    }
+    return acceptServerValue(
+        state,
+        event.value,
+        { ...live, revision: live.revision + 1 },
+        state.refresh,
+        policy,
+    );
+}
+
+function legacyInvalidated<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'LEGACY_INVALIDATED' }>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (
+        !policy.refreshLegacyInvalidations
+        || !isCurrentLiveEvent(state, event.generation, event.subscriptionId)
+        || state.phase.tag !== 'live'
+        || state.phase.mode !== 'legacy'
+    ) {
+        return unchanged(state);
+    }
+    switch (state.refresh) {
+        case 'clean':
+            return changed(
+                updateState(state, { refresh: 'running' }),
+                [{ type: 'REFRESH_REMOTE', generation: state.generation }],
+            );
+        case 'running':
+            return changed(updateState(state, { refresh: 'dirty' }));
+        case 'dirty':
+            return unchanged(state);
+    }
+}
+
+function refreshSucceeded<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'REFRESH_SUCCEEDED' }>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (
+        state.scope !== 'current'
+        || event.generation !== state.generation
+        || state.phase.tag !== 'live'
+        || state.phase.mode !== 'legacy'
+        || state.refresh === 'clean'
+    ) {
+        return unchanged(state);
+    }
+
+    const wasDirty = state.refresh === 'dirty';
+    const commands: SubscriptionCommand<T>[] = [];
+    if (policy.cacheSnapshots) {
+        commands.push({ type: 'CACHE_WRITE', value: event.value });
+    }
+    if (wasDirty) {
+        commands.push({ type: 'REFRESH_REMOTE', generation: state.generation });
+    }
+    const snapshot = reduceResourceSnapshot(state.snapshot, {
+        type: 'SNAPSHOT',
+        data: event.value,
+    });
+    const nextState = updateState(state, {
+        phase: { ...state.phase, revision: state.phase.revision + 1 },
+        snapshot,
+        refresh: wasDirty ? 'running' : 'clean',
+    });
+    return changed(
+        nextState,
+        commands,
+        snapshot === state.snapshot ? 'none' : 'both',
+    );
+}
+
+function refreshFailed<T>(
+    state: SubscriptionState<T>,
+    event: Extract<SubscriptionEvent<T>, { type: 'REFRESH_FAILED' }>,
+): SubscriptionTransition<T> {
+    if (
+        state.scope !== 'current'
+        || event.generation !== state.generation
+        || state.phase.tag !== 'live'
+        || state.phase.mode !== 'legacy'
+        || state.refresh === 'clean'
+    ) {
+        return unchanged(state);
+    }
+    const wasDirty = state.refresh === 'dirty';
+    const commands: SubscriptionCommand<T>[] = [{
+        type: 'REPORT_REFRESH_FAILURE',
+        error: event.error,
+    }];
+    if (wasDirty) {
+        commands.push({ type: 'REFRESH_REMOTE', generation: state.generation });
+    }
+    return changed(
+        updateState(state, { refresh: wasDirty ? 'running' : 'clean' }),
+        commands,
+    );
+}
+
+function transportClosed<T>(
+    state: SubscriptionState<T>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (
+        state.scope === 'stale'
+        || state.phase.tag === 'idle'
+        || state.phase.tag === 'closed'
+        || state.phase.tag === 'offline'
+    ) {
+        return unchanged(state);
+    }
+    const snapshot = reduceResourceSnapshot(state.snapshot, {
+        type: 'DISCONNECT',
+        clearData: policy.clearDataOnDisconnect,
+    });
+    const nextState = updateState(state, {
+        generation: state.generation + 1,
+        phase: { tag: 'offline' },
+        snapshot,
+        refresh: 'clean',
+    });
+    return changed(
+        nextState,
+        [],
+        snapshot === state.snapshot
+            ? 'none'
+            : policy.publishLegacyOnDisconnect ? 'both' : 'snapshot',
+    );
+}
+
+function transportReconnected<T>(
+    state: SubscriptionState<T>,
+): SubscriptionTransition<T> {
+    if (
+        state.scope !== 'current'
+        || !hasDemand(state.demand)
+        || (state.phase.tag !== 'offline' && state.phase.tag !== 'failed')
+    ) {
+        return unchanged(state);
+    }
+    return beginCreate(state, true);
+}
+
+function scopeRetired<T>(
+    state: SubscriptionState<T>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    if (state.scope === 'stale') {
+        return unchanged(state);
+    }
+    const clearedSnapshot = reduceResourceSnapshot(
+        initialResourceSnapshot<T>(),
+        { type: 'CLOSE' },
+    );
+    const shouldSettleInitial = state.initialResult === 'pending';
+    const error = new Error(policy.scopeRetiredMessage);
+    const nextState = updateState(state, {
+        scope: 'stale',
+        generation: state.generation + 1,
+        phase: { tag: 'closed' },
+        snapshot: clearedSnapshot,
+        refresh: 'clean',
+        disposalToken: state.disposalToken + 1,
+        initialResult: shouldSettleInitial ? 'settled' : state.initialResult,
+    });
+    const commands: SubscriptionCommand<T>[] = [];
+    if (shouldSettleInitial) {
+        commands.push({
+            type: 'SETTLE_INITIAL',
+            result: { ok: false, error },
+        });
+    }
+    commands.push({ type: 'EVICT_FROM_REGISTRY' });
+    return changed(
+        nextState,
+        commands,
+        clearedSnapshot === state.snapshot ? 'none' : 'snapshot',
+    );
+}
+
+function closeRequested<T>(
+    state: SubscriptionState<T>,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    const demandWasEmpty = !hasDemand(state.demand);
+    const demand = { subscribers: 0, imperative: false };
+    if (
+        state.scope === 'stale'
+        || (state.phase.tag === 'closed' && demandWasEmpty)
+    ) {
+        if (demandWasEmpty) {
+            return unchanged(state);
+        }
+        return changed(updateState(state, { demand }));
+    }
+    const withoutDemand = updateState(state, {
+        demand,
+        disposalToken: state.disposalToken + 1,
+    });
+    return closeCurrent(withoutDemand, true, policy);
+}
+
+function beginCreate<T>(
+    state: SubscriptionState<T>,
+    reconnect: boolean,
+): SubscriptionTransition<T> {
+    const generation = state.generation + 1;
+    const snapshot = reduceResourceSnapshot(state.snapshot, {
+        type: 'CONNECT',
+        reconnect,
+    });
+    const nextState = updateState(state, {
+        generation,
+        phase: { tag: 'creating', reconnect },
+        snapshot,
+        refresh: 'clean',
+    });
+    return changed(
+        nextState,
+        [{ type: 'CREATE_REMOTE', generation, reconnect }],
+        snapshot === state.snapshot ? 'none' : 'snapshot',
+    );
+}
+
+function closeCurrent<T>(
+    state: SubscriptionState<T>,
+    explicit: boolean,
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    const commands: SubscriptionCommand<T>[] = [];
+    if (state.phase.tag === 'live') {
+        commands.push({
+            type: 'DELETE_REMOTE',
+            generation: state.generation,
+            subscriptionId: state.phase.subscriptionId,
+        });
+    }
+
+    const shouldSettleInitial = state.initialResult === 'pending';
+    if (shouldSettleInitial) {
+        commands.push({
+            type: 'SETTLE_INITIAL',
+            result: {
+                ok: false,
+                error: new Error(explicit
+                    ? policy.initialCloseMessage
+                    : policy.initialUnusedMessage),
+            },
+        });
+    }
+    commands.push({ type: 'EVICT_FROM_REGISTRY' });
+
+    const snapshot = reduceResourceSnapshot(state.snapshot, { type: 'CLOSE' });
+    const nextState = updateState(state, {
+        generation: state.generation + 1,
+        phase: { tag: 'closed' },
+        snapshot,
+        refresh: 'clean',
+        initialResult: shouldSettleInitial ? 'settled' : state.initialResult,
+    });
+    return changed(
+        nextState,
+        commands,
+        snapshot === state.snapshot ? 'none' : 'snapshot',
+    );
+}
+
+function acceptServerValue<T>(
+    state: SubscriptionState<T>,
+    value: T,
+    phase: Extract<SubscriptionPhase, { tag: 'live' }>,
+    refresh: SubscriptionState<T>['refresh'],
+    policy: SubscriptionPolicy,
+): SubscriptionTransition<T> {
+    const snapshot = reduceResourceSnapshot(state.snapshot, {
+        type: 'SNAPSHOT',
+        data: value,
+    });
+    const commands: SubscriptionCommand<T>[] = policy.cacheSnapshots
+        ? [{ type: 'CACHE_WRITE', value }]
+        : [];
+    const nextState = updateState(state, { phase, snapshot, refresh });
+    return changed(
+        nextState,
+        commands,
+        snapshot === state.snapshot ? 'none' : 'both',
+    );
+}
+
+function isCurrentLiveEvent<T>(
+    state: SubscriptionState<T>,
+    generation: number,
+    subscriptionId: UUID,
+): boolean {
+    return state.scope === 'current'
+        && state.generation === generation
+        && state.phase.tag === 'live'
+        && state.phase.subscriptionId === subscriptionId;
+}
+
+function hasDemand(demand: SubscriptionState<unknown>['demand']): boolean {
+    return demand.subscribers > 0 || demand.imperative;
+}
+
+function updateState<T>(
+    state: SubscriptionState<T>,
+    patch: Partial<SubscriptionState<T>>,
+): SubscriptionState<T> {
+    return freezeState({ ...state, ...patch });
+}
+
+function freezeState<T>(state: SubscriptionState<T>): SubscriptionState<T> {
+    return Object.freeze({
+        ...state,
+        demand: Object.freeze({ ...state.demand }),
+        phase: Object.freeze({ ...state.phase }),
+    });
+}
+
+function unchanged<T>(state: SubscriptionState<T>): SubscriptionTransition<T> {
+    return Object.freeze({
+        state,
+        commands: noCommands as readonly SubscriptionCommand<T>[],
+        publication: 'none' as const,
+    });
+}
+
+function changed<T>(
+    state: SubscriptionState<T>,
+    commands: SubscriptionCommand<T>[] = [],
+    publication: SubscriptionPublication = 'none',
+): SubscriptionTransition<T> {
+    const frozenCommands = commands.length === 0
+        ? noCommands as readonly SubscriptionCommand<T>[]
+        : Object.freeze(commands.map(freezeCommand));
+    return Object.freeze({ state, commands: frozenCommands, publication });
+}
+
+function freezeCommand<T>(command: SubscriptionCommand<T>): SubscriptionCommand<T> {
+    if (command.type === 'SETTLE_INITIAL') {
+        return Object.freeze({
+            ...command,
+            result: Object.freeze({ ...command.result }),
+        });
+    }
+    return Object.freeze({ ...command });
+}

--- a/ihp-datasync/data/DataSync/src/subscription-reducer.ts
+++ b/ihp-datasync/data/DataSync/src/subscription-reducer.ts
@@ -1,0 +1,113 @@
+/** The observable lifecycle of a server-backed resource. */
+export type ResourceStatus =
+    | 'idle'
+    | 'connecting'
+    | 'live'
+    | 'reconnecting'
+    | 'error'
+    | 'closed';
+
+/**
+ * An immutable value exposed by a server-backed external store.
+ *
+ * `data` is normally retained while reconnecting or after an error so a
+ * consumer can continue to render the last confirmed server snapshot. A
+ * resource whose legacy contract cleared on disconnect can request that
+ * resource-specific transition explicitly.
+ */
+export type ResourceSnapshot<T> = Readonly<{
+    data: T | null;
+    status: ResourceStatus;
+    error: Error | null;
+}>;
+
+export type ResourceSnapshotAction<T> =
+    | Readonly<{ type: 'CONNECT'; reconnect: boolean }>
+    | Readonly<{ type: 'SNAPSHOT'; data: T }>
+    | Readonly<{ type: 'DISCONNECT'; clearData?: boolean }>
+    | Readonly<{ type: 'FAIL'; error: Error }>
+    | Readonly<{ type: 'CLOSE' }>;
+
+/** Shared initial snapshot. It is safe to reuse because snapshots are immutable. */
+export const idleResourceSnapshot: ResourceSnapshot<never> = Object.freeze({
+    data: null,
+    status: 'idle',
+    error: null,
+});
+
+/**
+ * Creates an idle snapshot, optionally seeded with a cached server value.
+ * Empty snapshots share one object; seeded snapshots are frozen individually.
+ */
+export function initialResourceSnapshot<T>(data?: T | null): ResourceSnapshot<T> {
+    if (data === null || data === undefined) {
+        return idleResourceSnapshot;
+    }
+
+    return Object.freeze({
+        data,
+        status: 'idle',
+        error: null,
+    });
+}
+
+/** @deprecated Prefer the lifecycle-oriented `initialResourceSnapshot` name. */
+export const createIdleResourceSnapshot = initialResourceSnapshot;
+
+/**
+ * Applies a resource lifecycle event without mutating the previous snapshot.
+ * Semantic no-ops return the previous object so `useSyncExternalStore` readers
+ * can rely on referential stability.
+ */
+export function reduceResourceSnapshot<T>(
+    snapshot: ResourceSnapshot<T>,
+    action: ResourceSnapshotAction<T>
+): ResourceSnapshot<T> {
+    switch (action.type) {
+        case 'CONNECT':
+            return transition(snapshot, {
+                data: snapshot.data,
+                status: action.reconnect ? 'reconnecting' : 'connecting',
+                error: null,
+            });
+        case 'SNAPSHOT':
+            return transition(snapshot, {
+                data: action.data,
+                status: 'live',
+                error: null,
+            });
+        case 'DISCONNECT':
+            return transition(snapshot, {
+                data: action.clearData ? null : snapshot.data,
+                status: 'reconnecting',
+                error: null,
+            });
+        case 'FAIL':
+            return transition(snapshot, {
+                data: snapshot.data,
+                status: 'error',
+                error: action.error,
+            });
+        case 'CLOSE':
+            return transition(snapshot, {
+                data: snapshot.data,
+                status: 'closed',
+                error: null,
+            });
+    }
+}
+
+function transition<T>(
+    previous: ResourceSnapshot<T>,
+    next: ResourceSnapshot<T>
+): ResourceSnapshot<T> {
+    if (
+        Object.is(previous.data, next.data)
+        && previous.status === next.status
+        && Object.is(previous.error, next.error)
+    ) {
+        return previous;
+    }
+
+    return Object.freeze(next);
+}

--- a/ihp-datasync/data/DataSync/src/subscription-resource.ts
+++ b/ihp-datasync/data/DataSync/src/subscription-resource.ts
@@ -1,0 +1,559 @@
+import {
+    initialSubscriptionState,
+    transitionSubscription,
+    type CreatedSubscription,
+    type SubscriptionEvent,
+    type SubscriptionPolicy,
+    type SubscriptionPublication,
+    type SubscriptionState,
+} from './subscription-machine.js';
+import type { ResourceSnapshot } from './subscription-reducer.js';
+import type { ServerMessage } from './types.js';
+
+export type SubscriptionTransportEvent =
+    | Readonly<{ type: 'message'; message: ServerMessage }>
+    | Readonly<{ type: 'closed'; scopeChanged: boolean }>
+    | Readonly<{ type: 'reconnected' }>;
+
+/** Minimal effect port between a subscription resource and the socket client. */
+export type SubscriptionTransport = Readonly<{
+    scopeKey: string;
+    request(message: Record<string, unknown>): Promise<ServerMessage>;
+    subscribe(listener: (event: SubscriptionTransportEvent) => void): () => void;
+    isCurrent(): boolean;
+}>;
+
+export type SubscriptionProtocol<T> = Readonly<{
+    create(transport: SubscriptionTransport): Promise<CreatedSubscription<T>>;
+    delete(transport: SubscriptionTransport, subscriptionId: string): Promise<void>;
+    refresh?(transport: SubscriptionTransport): Promise<T>;
+    decodeMessage(
+        message: ServerMessage,
+        state: SubscriptionState<T>,
+    ): SubscriptionEvent<T> | null;
+    isRelevantMessage?(
+        message: ServerMessage,
+        state: SubscriptionState<T>,
+    ): boolean;
+    createError?(error: unknown): Error;
+}>;
+
+export type SubscriptionResourceEnvironment<T> = Readonly<{
+    expectedScopeKey: string;
+    currentScopeKey(): string;
+    acquireTransport(): SubscriptionTransport;
+    policy: SubscriptionPolicy;
+    initialData?: T | null;
+    cloneInitialResult?(value: T): T;
+    writeCache?(value: T): void;
+    evict?(): void;
+    publish?(
+        publication: SubscriptionPublication,
+        state: SubscriptionState<T>,
+        previousState: SubscriptionState<T>,
+    ): void;
+    onState?(state: SubscriptionState<T>, event: SubscriptionEvent<T>): void;
+    reportError?(message: string, error: unknown): void;
+    queueMicrotask?(callback: () => void): void;
+}>;
+
+export type SubscriptionResource<T> = Readonly<{
+    getState(): SubscriptionState<T>;
+    getSnapshot(): ResourceSnapshot<T>;
+    updateDemand(subscribers: number, imperative: boolean): void;
+    scheduleCloseIfUnused(): void;
+    ensureCreated(): Promise<void>;
+    close(): Promise<void>;
+    receiveMessage(message: ServerMessage): void;
+    transportClosed(scopeChanged?: boolean): void;
+    transportReconnected(): Promise<void>;
+    invalidateLegacy(): void;
+    dispatchCompatibilityValue(value: T | null): void;
+    dispatchCompatibilitySnapshot(value: T, revision?: number): void;
+    initialResult: Promise<T>;
+    resolveInitial(value: T): void;
+    rejectInitial(error: Error): void;
+}>;
+
+type Deferred<T> = Readonly<{
+    promise: Promise<T>;
+    resolve(value: T): void;
+    reject(error: Error): void;
+}>;
+
+/**
+ * Builds the imperative shell around the pure subscription state machine.
+ *
+ * The closure owns effect handles, but every domain-state change is fed back
+ * through `transitionSubscription`. Promise completions never mutate state.
+ */
+export function createSubscriptionResource<T>(
+    protocol: SubscriptionProtocol<T>,
+    environment: SubscriptionResourceEnvironment<T>,
+): SubscriptionResource<T> {
+    let state = initialSubscriptionState(environment.initialData);
+    let transport: SubscriptionTransport | null = null;
+    let unsubscribeTransport: (() => void) | null = null;
+    const generationTransports = new Map<number, SubscriptionTransport>();
+    const createTasks = new Map<number, Promise<void>>();
+    const deleteTasks = new Set<Promise<void>>();
+    const deleteTasksByKey = new Map<string, Promise<void>>();
+    const eventQueue: SubscriptionEvent<T>[] = [];
+    let processingEvents = false;
+    const deferred = createDeferred<T>();
+    void deferred.promise.catch(() => {});
+
+    const report = (message: string, error: unknown): void => {
+        try {
+            environment.reportError?.(message, error);
+        } catch (reportError) {
+            console.error(message, error, reportError);
+        }
+    };
+
+    const isScopeCurrent = (): boolean =>
+        environment.currentScopeKey() === environment.expectedScopeKey;
+
+    const detachTransport = (): void => {
+        const unsubscribe = unsubscribeTransport;
+        unsubscribeTransport = null;
+        transport = null;
+        if (unsubscribe !== null) {
+            try {
+                unsubscribe();
+            } catch (error) {
+                report('Failed to detach a subscription transport listener:', error);
+            }
+        }
+    };
+
+    const onTransportEvent = (event: SubscriptionTransportEvent): void => {
+        switch (event.type) {
+            case 'message':
+                receiveMessage(event.message);
+                return;
+            case 'closed':
+                if (state.phase.tag === 'live') {
+                    generationTransports.delete(state.generation);
+                }
+                dispatch({
+                    type: event.scopeChanged ? 'SCOPE_RETIRED' : 'TRANSPORT_CLOSED',
+                });
+                return;
+            case 'reconnected':
+                dispatch({ type: 'TRANSPORT_RECONNECTED' });
+                return;
+        }
+    };
+
+    const ensureTransport = (): SubscriptionTransport | null => {
+        if (!isScopeCurrent()) {
+            dispatch({ type: 'SCOPE_RETIRED' });
+            return null;
+        }
+        if (transport !== null) {
+            if (transport.scopeKey === environment.expectedScopeKey && transport.isCurrent()) {
+                return transport;
+            }
+            dispatch({ type: 'SCOPE_RETIRED' });
+            return null;
+        }
+
+        let acquired: SubscriptionTransport;
+        try {
+            acquired = environment.acquireTransport();
+        } catch (error) {
+            dispatch({
+                type: 'CREATE_FAILED',
+                generation: state.generation,
+                error: toError(error),
+            });
+            return null;
+        }
+        if (
+            acquired.scopeKey !== environment.expectedScopeKey
+            || !isScopeCurrent()
+            || !acquired.isCurrent()
+        ) {
+            dispatch({ type: 'SCOPE_RETIRED' });
+            return null;
+        }
+
+        transport = acquired;
+        try {
+            unsubscribeTransport = acquired.subscribe(onTransportEvent);
+        } catch (error) {
+            transport = null;
+            dispatch({
+                type: 'CREATE_FAILED',
+                generation: state.generation,
+                error: toError(error),
+            });
+            return null;
+        }
+        return acquired;
+    };
+
+    const startCreate = (generation: number): void => {
+        const createTransport = ensureTransport();
+        if (createTransport === null) {
+            return;
+        }
+        if (state.phase.tag !== 'creating' || state.generation !== generation) {
+            return;
+        }
+        generationTransports.set(generation, createTransport);
+        let task: Promise<void>;
+        task = invokeEffect(() => protocol.create(createTransport)).then(created => {
+            if (!isScopeCurrent() || !createTransport.isCurrent()) {
+                dispatch({ type: 'SCOPE_RETIRED' });
+            }
+            dispatch({ type: 'CREATE_SUCCEEDED', generation, created });
+            const isLiveCreate = state.scope === 'current'
+                && state.generation === generation
+                && state.phase.tag === 'live'
+                && state.phase.subscriptionId === created.subscriptionId;
+            if (!isLiveCreate) {
+                return deleteTasksByKey.get(deleteTaskKey(generation, created.subscriptionId));
+            }
+        }).catch(error => {
+            if (generationTransports.get(generation) === createTransport) {
+                generationTransports.delete(generation);
+            }
+            if (
+                state.scope !== 'current'
+                || state.phase.tag !== 'creating'
+                || state.generation !== generation
+            ) {
+                return;
+            }
+            let createError: Error;
+            try {
+                createError = protocol.createError?.(error) ?? toError(error);
+            } catch (formatError) {
+                createError = toError(formatError);
+            }
+            dispatch({ type: 'CREATE_FAILED', generation, error: createError });
+            throw createError;
+        }).finally(() => {
+            if (createTasks.get(generation) === task) {
+                createTasks.delete(generation);
+            }
+        });
+        createTasks.set(generation, task);
+        void task.catch(() => {});
+    };
+
+    const startDelete = (generation: number, subscriptionId: string): void => {
+        const deleteTransport = generationTransports.get(generation) ?? transport;
+        if (deleteTransport === null) {
+            return;
+        }
+        const key = deleteTaskKey(generation, subscriptionId);
+        let task: Promise<void>;
+        task = invokeEffect(() => protocol.delete(deleteTransport, subscriptionId))
+            .catch(error => {
+                if (deleteTransport.isCurrent()) {
+                    report('Failed to delete a stale subscription:', error);
+                }
+            })
+            .finally(() => {
+                deleteTasks.delete(task);
+                if (deleteTasksByKey.get(key) === task) {
+                    deleteTasksByKey.delete(key);
+                }
+                if (generationTransports.get(generation) === deleteTransport) {
+                    generationTransports.delete(generation);
+                }
+            });
+        deleteTasks.add(task);
+        deleteTasksByKey.set(key, task);
+    };
+
+    const startRefresh = (generation: number): void => {
+        const refresh = protocol.refresh;
+        const refreshTransport = generationTransports.get(generation) ?? transport;
+        if (refresh === undefined || refreshTransport === null) {
+            dispatch({
+                type: 'REFRESH_FAILED',
+                generation,
+                error: new Error('Subscription protocol does not support refresh'),
+            });
+            return;
+        }
+        if (!isScopeCurrent() || !refreshTransport.isCurrent()) {
+            dispatch({ type: 'SCOPE_RETIRED' });
+            return;
+        }
+        void invokeEffect(() => refresh(refreshTransport)).then(value => {
+            if (!isScopeCurrent() || !refreshTransport.isCurrent()) {
+                dispatch({ type: 'SCOPE_RETIRED' });
+                return;
+            }
+            dispatch({ type: 'REFRESH_SUCCEEDED', generation, value });
+        }).catch(error => {
+            dispatch({ type: 'REFRESH_FAILED', generation, error: toError(error) });
+        });
+    };
+
+    const interpretCommands = (
+        commands: ReturnType<typeof transitionSubscription<T>>['commands'],
+    ): void => {
+        for (const command of commands) {
+            switch (command.type) {
+                case 'CREATE_REMOTE':
+                    startCreate(command.generation);
+                    break;
+                case 'DELETE_REMOTE':
+                    startDelete(command.generation, command.subscriptionId);
+                    break;
+                case 'REFRESH_REMOTE':
+                    startRefresh(command.generation);
+                    break;
+                case 'QUEUE_IDLE_CHECK':
+                    (environment.queueMicrotask ?? queueMicrotask)(() => {
+                        dispatch({ type: 'IDLE_CHECK', token: command.token });
+                    });
+                    break;
+                case 'CACHE_WRITE':
+                    if (
+                        isScopeCurrent()
+                        && transport?.scopeKey === environment.expectedScopeKey
+                        && transport.isCurrent()
+                    ) {
+                        try {
+                            environment.writeCache?.(command.value);
+                        } catch (error) {
+                            report('Failed to cache a subscription snapshot:', error);
+                        }
+                    }
+                    break;
+                case 'SETTLE_INITIAL':
+                    if (command.result.ok) {
+                        deferred.resolve(
+                            environment.cloneInitialResult?.(command.result.value)
+                                ?? command.result.value,
+                        );
+                    } else {
+                        deferred.reject(command.result.error);
+                    }
+                    break;
+                case 'REPORT_REFRESH_FAILURE':
+                    report('Failed to refresh a legacy subscription:', command.error);
+                    break;
+                case 'EVICT_FROM_REGISTRY':
+                    try {
+                        environment.evict?.();
+                    } catch (error) {
+                        report('Failed to evict a subscription resource:', error);
+                    }
+                    detachTransport();
+                    break;
+            }
+        }
+    };
+
+    function dispatch(event: SubscriptionEvent<T>): void {
+        eventQueue.push(event);
+        if (processingEvents) {
+            return;
+        }
+        processingEvents = true;
+        try {
+            while (eventQueue.length > 0) {
+                const nextEvent = eventQueue.shift();
+                if (nextEvent === undefined) {
+                    continue;
+                }
+                const previousState = state;
+                const transition = transitionSubscription(
+                    previousState,
+                    nextEvent,
+                    environment.policy,
+                );
+                state = transition.state;
+                if (state !== previousState) {
+                    try {
+                        environment.onState?.(state, nextEvent);
+                    } catch (error) {
+                        report('Subscription state observer failed:', error);
+                    }
+                }
+                interpretCommands(transition.commands);
+                const scopeRetirementQueued = eventQueue.some(
+                    queuedEvent => queuedEvent.type === 'SCOPE_RETIRED',
+                );
+                if (transition.publication !== 'none' && !scopeRetirementQueued) {
+                    try {
+                        environment.publish?.(
+                            transition.publication,
+                            state,
+                            previousState,
+                        );
+                    } catch (error) {
+                        report('Subscription publication failed:', error);
+                    }
+                }
+            }
+        } finally {
+            processingEvents = false;
+        }
+    }
+
+    function receiveMessage(message: ServerMessage): void {
+        try {
+            if (protocol.isRelevantMessage?.(message, state) === false) {
+                return;
+            }
+        } catch (error) {
+            report('Failed to prefilter a subscription message:', error);
+            return;
+        }
+        if (!isScopeCurrent() || transport?.isCurrent() === false) {
+            dispatch({ type: 'SCOPE_RETIRED' });
+            return;
+        }
+        let event: SubscriptionEvent<T> | null;
+        try {
+            event = protocol.decodeMessage(message, state);
+        } catch (error) {
+            report('Failed to decode a subscription message:', error);
+            return;
+        }
+        if (event !== null) {
+            dispatch(event);
+        }
+    }
+
+    const updateDemand = (subscribers: number, imperative: boolean): void => {
+        if ((subscribers > 0 || imperative) && !isScopeCurrent()) {
+            dispatch({ type: 'SCOPE_RETIRED' });
+            return;
+        }
+        dispatch({ type: 'DEMAND_CHANGED', subscribers, imperative });
+    };
+
+    const close = async (): Promise<void> => {
+        dispatch({ type: 'CLOSE_REQUESTED' });
+        // A consumer may call close() reentrantly from a publication callback.
+        // In that case CLOSE_REQUESTED is queued until the current transition
+        // finishes, so yield once before snapshotting the Delete tasks it
+        // created. Normal non-reentrant closes have already dispatched here.
+        await Promise.resolve();
+        const tasks = Array.from(deleteTasks);
+        if (tasks.length > 0) {
+            await Promise.all(tasks);
+        }
+    };
+
+    const ensureCreated = (): Promise<void> => {
+        if (state.scope === 'stale') {
+            return Promise.reject(new Error(environment.policy.scopeRetiredMessage));
+        }
+        if (state.phase.tag === 'live') {
+            return Promise.resolve();
+        }
+        if (state.phase.tag === 'offline' || state.phase.tag === 'failed') {
+            if (state.demand.subscribers > 0 || state.demand.imperative) {
+                dispatch({ type: 'TRANSPORT_RECONNECTED' });
+            }
+        }
+        if (state.phase.tag === 'creating') {
+            return createTasks.get(state.generation) ?? Promise.resolve();
+        }
+        return Promise.resolve();
+    };
+
+    return Object.freeze({
+        getState: () => state,
+        getSnapshot: () => state.snapshot,
+        updateDemand,
+        scheduleCloseIfUnused: () => dispatch({ type: 'SCHEDULE_IDLE_CHECK' }),
+        ensureCreated,
+        close,
+        receiveMessage,
+        transportClosed: (scopeChanged = false) => dispatch({
+            type: scopeChanged ? 'SCOPE_RETIRED' : 'TRANSPORT_CLOSED',
+        }),
+        transportReconnected: () => {
+            dispatch({ type: 'TRANSPORT_RECONNECTED' });
+            return createTasks.get(state.generation) ?? Promise.resolve();
+        },
+        invalidateLegacy: () => {
+            if (!isScopeCurrent()) {
+                dispatch({ type: 'SCOPE_RETIRED' });
+                return;
+            }
+            if (state.phase.tag !== 'live') {
+                return;
+            }
+            dispatch({
+                type: 'LEGACY_INVALIDATED',
+                generation: state.generation,
+                subscriptionId: state.phase.subscriptionId,
+            });
+        },
+        dispatchCompatibilityValue: value => dispatch({ type: 'COMPAT_VALUE_SET', value }),
+        dispatchCompatibilitySnapshot: (value, revision) => {
+            if (!isScopeCurrent()) {
+                dispatch({ type: 'SCOPE_RETIRED' });
+                return;
+            }
+            if (state.phase.tag === 'live') {
+                dispatch({
+                    type: 'SERVER_SNAPSHOT',
+                    generation: state.generation,
+                    subscriptionId: state.phase.subscriptionId,
+                    value,
+                    revision: revision ?? state.phase.revision + 1,
+                });
+                return;
+            }
+            dispatch({ type: 'COMPAT_VALUE_SET', value });
+        },
+        initialResult: deferred.promise,
+        resolveInitial: deferred.resolve,
+        rejectInitial: deferred.reject,
+    });
+}
+
+function createDeferred<T>(): Deferred<T> {
+    let settled = false;
+    let resolvePromise!: (value: T) => void;
+    let rejectPromise!: (error: Error) => void;
+    const promise = new Promise<T>((resolve, reject) => {
+        resolvePromise = resolve;
+        rejectPromise = reject;
+    });
+    return Object.freeze({
+        promise,
+        resolve(value: T): void {
+            if (!settled) {
+                settled = true;
+                resolvePromise(value);
+            }
+        },
+        reject(error: Error): void {
+            if (!settled) {
+                settled = true;
+                rejectPromise(error);
+            }
+        },
+    });
+}
+
+function toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+}
+
+function invokeEffect<T>(effect: () => Promise<T>): Promise<T> {
+    try {
+        return effect();
+    } catch (error) {
+        return Promise.reject(error);
+    }
+}
+
+function deleteTaskKey(generation: number, subscriptionId: string): string {
+    return `${generation}:${subscriptionId}`;
+}

--- a/ihp-datasync/data/DataSync/src/transaction.ts
+++ b/ihp-datasync/data/DataSync/src/transaction.ts
@@ -5,18 +5,23 @@ import type { UUID, CrudOptions, DataSyncEventMap, TableName, IHPRecord, NewReco
 export class Transaction {
     transactionId: UUID | null;
     dataSyncController: DataSyncController;
+    private readonly transactionController: DataSyncController;
 
     constructor() {
         this.transactionId = null;
         this.onClose = this.onClose.bind(this);
-        this.dataSyncController = DataSyncController.getInstance();
+        this.transactionController = DataSyncController.getInstance();
+        // Keep the historically writable public field as a compatibility
+        // facade. Internal operations remain pinned to the captured controller
+        // even if application code reassigns this property.
+        this.dataSyncController = this.transactionController;
     }
 
     async start(): Promise<void> {
-        const response = await this.dataSyncController.sendMessage({ tag: 'StartTransaction' });
+        const response = await this.transactionController.sendMessage({ tag: 'StartTransaction' });
         this.transactionId = response.transactionId as UUID;
 
-        this.dataSyncController.addEventListener('close', this.onClose);
+        this.transactionController.addEventListener('close', this.onClose);
     }
 
     async commit(): Promise<void> {
@@ -24,7 +29,7 @@ export class Transaction {
             throw new Error('You need to call `.start()` before you can commit the transaction');
         }
 
-        await this.dataSyncController.sendMessage({ tag: 'CommitTransaction', id: this.transactionId });
+        await this.transactionController.sendMessage({ tag: 'CommitTransaction', id: this.transactionId });
         this.onClose();
     }
 
@@ -33,13 +38,13 @@ export class Transaction {
             throw new Error('You need to call `.start()` before you can rollback the transaction');
         }
 
-        await this.dataSyncController.sendMessage({ tag: 'RollbackTransaction', id: this.transactionId });
+        await this.transactionController.sendMessage({ tag: 'RollbackTransaction', id: this.transactionId });
         this.onClose();
     }
 
     onClose(): void {
         this.transactionId = null;
-        this.dataSyncController.removeEventListener('close', this.onClose);
+        this.transactionController.removeEventListener('close', this.onClose);
     }
 
     getIdOrFail(): UUID {
@@ -55,33 +60,33 @@ export class Transaction {
     }
 
     query<T extends TableName>(table: T): QueryBuilder<T, IHPRecord<T>> {
-        const tableQuery = new QueryBuilder<T, IHPRecord<T>>(table);
+        const tableQuery = new QueryBuilder<T, IHPRecord<T>>(table, undefined, this.transactionController);
         tableQuery.transactionId = this.getIdOrFail();
         return tableQuery;
     }
 
     createRecord<T extends TableName>(table: T, record: NewRecord<T>): Promise<IHPRecord<T>> {
-        return createRecord(table, record, this.buildOptions());
+        return createRecord(table, record, this.buildOptions(), this.transactionController);
     }
 
     createRecords<T extends TableName>(table: T, records: NewRecord<T>[]): Promise<IHPRecord<T>[]> {
-        return createRecords(table, records, this.buildOptions());
+        return createRecords(table, records, this.buildOptions(), this.transactionController);
     }
 
     updateRecord<T extends TableName>(table: T, id: UUID, patch: Partial<NewRecord<T>>): Promise<IHPRecord<T>> {
-        return updateRecord(table, id, patch, this.buildOptions());
+        return updateRecord(table, id, patch, this.buildOptions(), this.transactionController);
     }
 
     updateRecords<T extends TableName>(table: T, ids: UUID[], patch: Partial<NewRecord<T>>): Promise<IHPRecord<T>[]> {
-        return updateRecords(table, ids, patch, this.buildOptions());
+        return updateRecords(table, ids, patch, this.buildOptions(), this.transactionController);
     }
 
     deleteRecord<T extends TableName>(table: T, id: UUID): Promise<void> {
-        return deleteRecord(table, id, this.buildOptions());
+        return deleteRecord(table, id, this.buildOptions(), this.transactionController);
     }
 
     deleteRecords<T extends TableName>(table: T, ids: UUID[]): Promise<void> {
-        return deleteRecords(table, ids, this.buildOptions());
+        return deleteRecords(table, ids, this.buildOptions(), this.transactionController);
     }
 }
 
@@ -93,7 +98,16 @@ export async function withTransaction<T>(callback: (transaction: Transaction) =>
         await transaction.commit();
         return result;
     } catch (exception) {
-        await transaction.rollback();
+        if (transaction.transactionId !== null) {
+            try {
+                await transaction.rollback();
+            } catch (rollbackError) {
+                // The callback/commit failure is the primary error. In
+                // particular, auth-scope retirement clears or invalidates the
+                // transaction and a second rollback failure must not mask it.
+                console.error('Failed to roll back a DataSync transaction:', rollbackError);
+            }
+        }
         throw exception;
     }
 }

--- a/ihp-datasync/data/DataSync/src/types.ts
+++ b/ihp-datasync/data/DataSync/src/types.ts
@@ -90,6 +90,7 @@ export const NewRecordBehaviour = {
 } as const;
 
 export interface DataSubscriptionOptions {
+    /** @deprecated Exact server snapshots determine membership and ordering. */
     newRecordBehaviour?: typeof APPEND_NEW_RECORD | typeof PREPEND_NEW_RECORD;
 }
 
@@ -122,7 +123,8 @@ export interface PendingRequest {
 // Server response tags (matches Haskell DataSyncResponse)
 export type ServerMessageTag =
     | 'DataSyncResult' | 'DataSyncError' | 'FailedToDecodeMessageError'
-    | 'DidCreateDataSubscription' | 'DidCreateCountSubscription' | 'DidDeleteDataSubscription'
+    | 'DidCreateDataSubscription' | 'DidCreateDataSubscriptionV2' | 'DidReplaceDataSubscription'
+    | 'DidCreateCountSubscription' | 'DidDeleteDataSubscription'
     | 'DidInsert' | 'DidUpdate' | 'DidDelete' | 'DidChangeCount'
     | 'DidCreateRecord' | 'DidCreateRecords' | 'DidUpdateRecord' | 'DidUpdateRecords'
     | 'DidDeleteRecord' | 'DidDeleteRecords'

--- a/ihp-datasync/data/DataSync/src/types.ts
+++ b/ihp-datasync/data/DataSync/src/types.ts
@@ -23,7 +23,8 @@ export type TableName = [_TableName] extends [never] ? string : _TableName;
 export type IHPRecord<T extends string> = T extends keyof TableRegistry ? TableRegistry[T] : DataRecord;
 // Intersect with { id?: UUID } so TypeScript can prove id access in generic contexts.
 // Every IHP record has an id primary key with a default, so this is always true.
-export type NewRecord<T extends string> = (T extends keyof NewRecordRegistry ? NewRecordRegistry[T] : DataRecord) & { id?: UUID };
+type UnregisteredNewRecord = { id?: UUID; [key: string]: unknown };
+export type NewRecord<T extends string> = (T extends keyof NewRecordRegistry ? NewRecordRegistry[T] : UnregisteredNewRecord) & { id?: UUID };
 
 // Condition operators (matches Haskell ConditionOperator)
 export type ConditionOperator =
@@ -112,8 +113,10 @@ export type DataSyncEventCallback = (payload: never) => void;
 // Pending request tracking
 export interface PendingRequest {
     requestId: number;
-    resolve: (value: unknown) => void;
+    resolve: (value: ServerMessage) => void;
     reject: (reason: unknown) => void;
+    timeout: ReturnType<typeof setTimeout> | null;
+    sent: boolean;
 }
 
 // Server response tags (matches Haskell DataSyncResponse)

--- a/ihp-datasync/data/DataSync/src/typetest.ts
+++ b/ihp-datasync/data/DataSync/src/typetest.ts
@@ -2,7 +2,7 @@
 // This file is compiled as part of tsc --noEmit but produces no runtime output.
 // All @ts-expect-error directives must suppress real errors or tsc will fail.
 import { query, createRecord, updateRecord, deleteRecord } from './index.js';
-import type { UUID } from './types.js';
+import type { UUID, NewRecord } from './types.js';
 
 declare module './types.js' {
     interface TableRegistry {
@@ -19,6 +19,7 @@ declare module './types.js' {
 const q1 = query('tasks');
 const q2 = query('tasks').where('title', 'hello');
 const q3 = query('tasks').orderBy('title');
+const unregisteredRecordWithoutId: NewRecord<'unregistered_table'> = { title: 'works without generated types' };
 async function goodCrud() {
     await createRecord('tasks', { title: 'hello' });
     await createRecord('tasks', { title: 'hello', done: true });

--- a/ihp-datasync/data/DataSync/src/weak-value-map.ts
+++ b/ihp-datasync/data/DataSync/src/weak-value-map.ts
@@ -1,0 +1,126 @@
+type WeakReference<T extends object> = {
+    deref(): T | undefined;
+};
+
+type WeakReferenceConstructor = {
+    new<T extends object>(target: T): WeakReference<T>;
+};
+
+type Finalizer<T> = {
+    register(target: object, heldValue: T, unregisterToken?: object): void;
+    unregister(unregisterToken: object): boolean;
+};
+
+type FinalizerConstructor = {
+    new<T>(cleanup: (heldValue: T) => void): Finalizer<T>;
+};
+
+type FinalizerEntry<K, V extends object> = {
+    key: K;
+    reference: WeakReference<V>;
+};
+
+const weakReferenceConstructor = (
+    globalThis as unknown as { WeakRef?: WeakReferenceConstructor }
+).WeakRef;
+
+const finalizerConstructor = (
+    globalThis as unknown as { FinalizationRegistry?: FinalizerConstructor }
+).FinalizationRegistry;
+
+const maximumStrongFallbackEntries = 1000;
+
+/**
+ * A canonical-key registry that does not keep render-only resources alive.
+ *
+ * Old JavaScript runtimes without WeakRef use a bounded strong-reference
+ * fallback. This keeps normal render/commit sharing while preventing abandoned
+ * concurrent renders from growing memory without limit. Exceeding the generous
+ * bound can only create a duplicate inert resource; it cannot mix snapshots or
+ * authentication scopes.
+ */
+export class WeakValueMap<K, V extends object> {
+    private readonly entries = new Map<K, WeakReference<V>>();
+    private readonly finalizer: Finalizer<FinalizerEntry<K, V>> | null;
+
+    constructor() {
+        this.finalizer = weakReferenceConstructor !== undefined && finalizerConstructor !== undefined
+            ? new finalizerConstructor<FinalizerEntry<K, V>>(({ key, reference }) => {
+                if (this.entries.get(key) === reference) {
+                    this.entries.delete(key);
+                }
+            })
+            : null;
+    }
+
+    get(key: K): V | undefined {
+        const reference = this.entries.get(key);
+        if (reference === undefined) {
+            return undefined;
+        }
+        const value = reference.deref();
+        if (value === undefined) {
+            this.entries.delete(key);
+        }
+        return value;
+    }
+
+    set(key: K, value: V): void {
+        this.delete(key);
+        const reference = weakReferenceConstructor !== undefined
+            ? new weakReferenceConstructor(value)
+            : { deref: () => value };
+        this.entries.set(key, reference);
+        this.finalizer?.register(value, { key, reference }, value);
+        this.pruneCollectedEntries();
+        if (weakReferenceConstructor === undefined) {
+            this.trimStrongFallback();
+        }
+    }
+
+    delete(key: K, expectedValue?: V): boolean {
+        const reference = this.entries.get(key);
+        if (reference === undefined) {
+            return false;
+        }
+        const value = reference.deref();
+        if (expectedValue !== undefined && value !== expectedValue) {
+            return false;
+        }
+        this.entries.delete(key);
+        if (value !== undefined) {
+            this.finalizer?.unregister(value);
+        }
+        return true;
+    }
+
+    clear(): void {
+        if (this.finalizer !== null) {
+            for (const reference of this.entries.values()) {
+                const value = reference.deref();
+                if (value !== undefined) {
+                    this.finalizer.unregister(value);
+                }
+            }
+        }
+        this.entries.clear();
+    }
+
+    private pruneCollectedEntries(): void {
+        for (const [key, reference] of this.entries) {
+            if (reference.deref() === undefined) {
+                this.entries.delete(key);
+            }
+        }
+    }
+
+    private trimStrongFallback(): void {
+        while (this.entries.size > maximumStrongFallbackEntries) {
+            const oldestKey = this.entries.keys().next().value as K | undefined;
+            if (oldestKey === undefined) {
+                return;
+            }
+            this.entries.delete(oldestKey);
+        }
+    }
+}

--- a/ihp-datasync/data/DataSync/subscription-machine.test.js
+++ b/ihp-datasync/data/DataSync/subscription-machine.test.js
@@ -1,0 +1,429 @@
+import {
+    countSubscriptionPolicy,
+    initialSubscriptionState,
+    rowSubscriptionPolicy,
+    transitionSubscription,
+} from './subscription-machine.js';
+
+const demand = (state, subscribers, imperative = false, policy = rowSubscriptionPolicy) =>
+    transitionSubscription(state, {
+        type: 'DEMAND_CHANGED',
+        subscribers,
+        imperative,
+    }, policy);
+
+const create = (state, {
+    id = 'subscription-1',
+    value = [{ id: 'row-1' }],
+    mode = 'snapshot',
+    revision = 0,
+} = {}, policy = rowSubscriptionPolicy) => transitionSubscription(state, {
+    type: 'CREATE_SUCCEEDED',
+    generation: state.generation,
+    created: { subscriptionId: id, value, mode, revision },
+}, policy);
+
+describe('pure subscription machine', () => {
+    test('an explicit idle check closes an unused idle resource and rejects its initial result', () => {
+        const idle = initialSubscriptionState();
+        const scheduled = transitionSubscription(idle, {
+            type: 'SCHEDULE_IDLE_CHECK',
+        }, rowSubscriptionPolicy);
+
+        expect(scheduled.state.phase).toEqual({ tag: 'idle' });
+        expect(scheduled.state.disposalToken).toBe(idle.disposalToken + 1);
+        expect(scheduled.commands).toEqual([{
+            type: 'QUEUE_IDLE_CHECK',
+            token: scheduled.state.disposalToken,
+        }]);
+
+        const closed = transitionSubscription(scheduled.state, {
+            type: 'IDLE_CHECK',
+            token: scheduled.state.disposalToken,
+        }, rowSubscriptionPolicy);
+
+        expect(closed.state.phase).toEqual({ tag: 'closed' });
+        expect(closed.state.initialResult).toBe('settled');
+        expect(closed.state.snapshot.status).toBe('closed');
+        expect(closed.commands).toHaveLength(2);
+        expect(closed.commands[0]).toMatchObject({
+            type: 'SETTLE_INITIAL',
+            result: { ok: false },
+        });
+        expect(closed.commands[0].result.error.message)
+            .toBe(rowSubscriptionPolicy.initialUnusedMessage);
+        expect(closed.commands[1]).toEqual({ type: 'EVICT_FROM_REGISTRY' });
+    });
+
+    test('demand arriving before an explicit idle callback cancels its token', () => {
+        const scheduled = transitionSubscription(initialSubscriptionState(), {
+            type: 'SCHEDULE_IDLE_CHECK',
+        }, rowSubscriptionPolicy);
+        const scheduledToken = scheduled.state.disposalToken;
+        const demanded = demand(scheduled.state, 1);
+
+        expect(demanded.state.disposalToken).toBeGreaterThan(scheduledToken);
+        expect(demanded.commands).toEqual([{
+            type: 'CREATE_REMOTE',
+            generation: 1,
+            reconnect: false,
+        }]);
+
+        const staleCallback = transitionSubscription(demanded.state, {
+            type: 'IDLE_CHECK',
+            token: scheduledToken,
+        }, rowSubscriptionPolicy);
+
+        expect(staleCallback.state).toBe(demanded.state);
+        expect(staleCallback.commands).toEqual([]);
+        expect(staleCallback.state.phase).toEqual({ tag: 'creating', reconnect: false });
+    });
+
+    test('starts only on first demand and schedules disposal only after last demand', () => {
+        const idle = initialSubscriptionState();
+        const first = demand(idle, 1);
+
+        expect(first.state.phase).toEqual({ tag: 'creating', reconnect: false });
+        expect(first.state.snapshot.status).toBe('connecting');
+        expect(first.commands).toEqual([{
+            type: 'CREATE_REMOTE',
+            generation: 1,
+            reconnect: false,
+        }]);
+
+        const second = demand(first.state, 2);
+        expect(second.commands).toEqual([]);
+        expect(second.state.generation).toBe(1);
+
+        const oneRemaining = demand(second.state, 1);
+        expect(oneRemaining.commands).toEqual([]);
+
+        const released = demand(oneRemaining.state, 0);
+        expect(released.commands).toEqual([{
+            type: 'QUEUE_IDLE_CHECK',
+            token: released.state.disposalToken,
+        }]);
+        expect(released.state.phase.tag).toBe('creating');
+    });
+
+    test('a new demand cancels an already queued idle check by token identity', () => {
+        const started = demand(initialSubscriptionState(), 1).state;
+        const released = demand(started, 0).state;
+        const oldToken = released.disposalToken;
+        const retainedAgain = demand(released, 1).state;
+
+        expect(retainedAgain.disposalToken).toBeGreaterThan(oldToken);
+        const staleCheck = transitionSubscription(retainedAgain, {
+            type: 'IDLE_CHECK',
+            token: oldToken,
+        }, rowSubscriptionPolicy);
+
+        expect(staleCheck.state).toBe(retainedAgain);
+        expect(staleCheck.commands).toEqual([]);
+    });
+
+    test('the matching idle check closes and a late create is deleted without publication', () => {
+        const creating = demand(initialSubscriptionState(), 1).state;
+        const generation = creating.generation;
+        const released = demand(creating, 0).state;
+        const closed = transitionSubscription(released, {
+            type: 'IDLE_CHECK',
+            token: released.disposalToken,
+        }, rowSubscriptionPolicy);
+
+        expect(closed.state.phase.tag).toBe('closed');
+        expect(closed.commands.map(command => command.type)).toEqual([
+            'SETTLE_INITIAL',
+            'EVICT_FROM_REGISTRY',
+        ]);
+
+        const late = transitionSubscription(closed.state, {
+            type: 'CREATE_SUCCEEDED',
+            generation,
+            created: {
+                subscriptionId: 'late-subscription',
+                value: [{ id: 'secret' }],
+                mode: 'snapshot',
+                revision: 0,
+            },
+        }, rowSubscriptionPolicy);
+
+        expect(late.state).toBe(closed.state);
+        expect(late.publication).toBe('none');
+        expect(late.commands).toEqual([{
+            type: 'DELETE_REMOTE',
+            generation,
+            subscriptionId: 'late-subscription',
+        }]);
+        expect(late.state.snapshot.data).toBeNull();
+    });
+
+    test('accepts only increasing snapshot revisions and preserves no-op identity', () => {
+        const live = create(demand(initialSubscriptionState(), 1).state, {
+            revision: 4,
+        }).state;
+        const previousSnapshot = live.snapshot;
+
+        const duplicate = transitionSubscription(live, {
+            type: 'SERVER_SNAPSHOT',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+            value: [{ id: 'duplicate' }],
+            revision: 4,
+        }, rowSubscriptionPolicy);
+        const older = transitionSubscription(live, {
+            type: 'SERVER_SNAPSHOT',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+            value: [{ id: 'older' }],
+            revision: 3,
+        }, rowSubscriptionPolicy);
+
+        expect(duplicate.state).toBe(live);
+        expect(older.state).toBe(live);
+        expect(duplicate.state.snapshot).toBe(previousSnapshot);
+
+        const replacement = [{ id: 'newer' }];
+        const newer = transitionSubscription(live, {
+            type: 'SERVER_SNAPSHOT',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+            value: replacement,
+            revision: 5,
+        }, rowSubscriptionPolicy);
+
+        expect(newer.state).not.toBe(live);
+        expect(newer.state.snapshot.data).toBe(replacement);
+        expect(newer.state.phase).toEqual({
+            tag: 'live',
+            subscriptionId: 'subscription-1',
+            mode: 'snapshot',
+            revision: 5,
+        });
+    });
+
+    test('coalesces legacy invalidations into at most one follow-up refresh', () => {
+        const live = create(demand(initialSubscriptionState(), 1).state, {
+            mode: 'legacy',
+        }).state;
+        const first = transitionSubscription(live, {
+            type: 'LEGACY_INVALIDATED',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+        }, rowSubscriptionPolicy);
+        const second = transitionSubscription(first.state, {
+            type: 'LEGACY_INVALIDATED',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+        }, rowSubscriptionPolicy);
+        const third = transitionSubscription(second.state, {
+            type: 'LEGACY_INVALIDATED',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+        }, rowSubscriptionPolicy);
+
+        expect(first.state.refresh).toBe('running');
+        expect(first.commands).toEqual([{
+            type: 'REFRESH_REMOTE',
+            generation: live.generation,
+        }]);
+        expect(second.state.refresh).toBe('dirty');
+        expect(second.commands).toEqual([]);
+        expect(third.state).toBe(second.state);
+
+        const refreshed = transitionSubscription(second.state, {
+            type: 'REFRESH_SUCCEEDED',
+            generation: live.generation,
+            value: [{ id: 'refreshed' }],
+        }, rowSubscriptionPolicy);
+        expect(refreshed.state.refresh).toBe('running');
+        expect(refreshed.commands.map(command => command.type)).toEqual([
+            'CACHE_WRITE',
+            'REFRESH_REMOTE',
+        ]);
+    });
+
+    test('a revisioned snapshot upgrade makes an in-flight legacy refresh stale', () => {
+        const live = create(demand(initialSubscriptionState(), 1).state, {
+            mode: 'legacy',
+        }).state;
+        const refreshing = transitionSubscription(live, {
+            type: 'LEGACY_INVALIDATED',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+        }, rowSubscriptionPolicy).state;
+        const upgraded = transitionSubscription(refreshing, {
+            type: 'SERVER_SNAPSHOT',
+            generation: live.generation,
+            subscriptionId: 'subscription-1',
+            value: [{ id: 'v2' }],
+            revision: 0,
+        }, rowSubscriptionPolicy);
+
+        expect(upgraded.state.refresh).toBe('clean');
+        expect(upgraded.state.phase).toMatchObject({ mode: 'snapshot', revision: 0 });
+
+        const staleRefresh = transitionSubscription(upgraded.state, {
+            type: 'REFRESH_SUCCEEDED',
+            generation: live.generation,
+            value: [{ id: 'stale-legacy' }],
+        }, rowSubscriptionPolicy);
+        expect(staleRefresh.state).toBe(upgraded.state);
+        expect(staleRefresh.state.snapshot.data).toEqual([{ id: 'v2' }]);
+    });
+
+    test('network disconnect retains rows, clears counts, and reconnects demanded resources', () => {
+        const rows = [{ id: 'row-1' }];
+        const rowLive = create(demand(initialSubscriptionState(), 1).state, {
+            value: rows,
+        }).state;
+        const rowOffline = transitionSubscription(rowLive, {
+            type: 'TRANSPORT_CLOSED',
+        }, rowSubscriptionPolicy);
+
+        expect(rowOffline.state.snapshot).toEqual({
+            data: rows,
+            status: 'reconnecting',
+            error: null,
+        });
+        expect(rowOffline.publication).toBe('snapshot');
+
+        const countLive = create(
+            demand(initialSubscriptionState(), 1, false, countSubscriptionPolicy).state,
+            { value: 3, mode: 'legacy' },
+            countSubscriptionPolicy,
+        ).state;
+        const countOffline = transitionSubscription(countLive, {
+            type: 'TRANSPORT_CLOSED',
+        }, countSubscriptionPolicy);
+
+        expect(countOffline.state.snapshot.data).toBeNull();
+        expect(countOffline.publication).toBe('both');
+
+        const reconnecting = transitionSubscription(rowOffline.state, {
+            type: 'TRANSPORT_RECONNECTED',
+        }, rowSubscriptionPolicy);
+        expect(reconnecting.state.phase).toEqual({ tag: 'creating', reconnect: true });
+        expect(reconnecting.commands).toEqual([{
+            type: 'CREATE_REMOTE',
+            generation: reconnecting.state.generation,
+            reconnect: true,
+        }]);
+    });
+
+    test('scope retirement clears security-sensitive data and rejects an unsettled initial result', () => {
+        const cached = [{ id: 'old-user-secret' }];
+        const creating = demand(initialSubscriptionState(cached), 1).state;
+        const retired = transitionSubscription(creating, {
+            type: 'SCOPE_RETIRED',
+        }, rowSubscriptionPolicy);
+
+        expect(retired.state.scope).toBe('stale');
+        expect(retired.state.phase.tag).toBe('closed');
+        expect(retired.state.snapshot).toEqual({
+            data: null,
+            status: 'closed',
+            error: null,
+        });
+        expect(retired.commands.map(command => command.type)).toEqual([
+            'SETTLE_INITIAL',
+            'EVICT_FROM_REGISTRY',
+        ]);
+        expect(retired.commands[0].result.ok).toBe(false);
+    });
+
+    test('successful and failed creates settle the initial result exactly once', () => {
+        const creating = demand(initialSubscriptionState(), 1).state;
+        const value = [{ id: 'row-1' }];
+        const succeeded = create(creating, { value });
+
+        expect(succeeded.state.initialResult).toBe('settled');
+        expect(succeeded.commands).toEqual([
+            { type: 'CACHE_WRITE', value },
+            { type: 'SETTLE_INITIAL', result: { ok: true, value } },
+        ]);
+
+        const replacement = transitionSubscription(succeeded.state, {
+            type: 'SERVER_SNAPSHOT',
+            generation: succeeded.state.generation,
+            subscriptionId: 'subscription-1',
+            value: [{ id: 'row-2' }],
+            revision: 1,
+        }, rowSubscriptionPolicy);
+        expect(replacement.commands.some(command => command.type === 'SETTLE_INITIAL')).toBe(false);
+
+        const otherCreating = demand(initialSubscriptionState(), 1).state;
+        const error = new Error('create failed');
+        const failed = transitionSubscription(otherCreating, {
+            type: 'CREATE_FAILED',
+            generation: otherCreating.generation,
+            error,
+        }, rowSubscriptionPolicy);
+        expect(failed.state.initialResult).toBe('settled');
+        expect(failed.commands).toEqual([{
+            type: 'SETTLE_INITIAL',
+            result: { ok: false, error },
+        }]);
+    });
+
+    test('never mutates prior state or snapshot wrappers', () => {
+        const idle = initialSubscriptionState([{ id: 'cached' }]);
+        const original = {
+            generation: idle.generation,
+            phase: idle.phase,
+            snapshot: idle.snapshot,
+            demand: idle.demand,
+        };
+        const started = demand(idle, 1);
+
+        expect(idle.generation).toBe(original.generation);
+        expect(idle.phase).toBe(original.phase);
+        expect(idle.snapshot).toBe(original.snapshot);
+        expect(idle.demand).toBe(original.demand);
+        expect(Object.isFrozen(idle)).toBe(true);
+        expect(Object.isFrozen(idle.phase)).toBe(true);
+        expect(Object.isFrozen(idle.demand)).toBe(true);
+        expect(Object.isFrozen(idle.snapshot)).toBe(true);
+        expect(Object.isFrozen(started.state)).toBe(true);
+        expect(Object.isFrozen(started.commands)).toBe(true);
+        expect(Object.isFrozen(started.commands[0])).toBe(true);
+    });
+
+    test('models legacy writable value facades without changing transport ownership', () => {
+        const idle = initialSubscriptionState();
+        const redundantClear = transitionSubscription(idle, {
+            type: 'COMPAT_VALUE_SET',
+            value: null,
+        }, rowSubscriptionPolicy);
+        expect(redundantClear.state.snapshot).toBe(idle.snapshot);
+        expect(redundantClear.publication).toBe('both');
+
+        const assigned = transitionSubscription(idle, {
+            type: 'COMPAT_VALUE_SET',
+            value: [{ id: 'manual' }],
+        }, rowSubscriptionPolicy);
+
+        expect(assigned.state.phase).toEqual(idle.phase);
+        expect(assigned.state.snapshot).toEqual({
+            data: [{ id: 'manual' }],
+            status: 'live',
+            error: null,
+        });
+        expect(assigned.commands).toEqual([{
+            type: 'CACHE_WRITE',
+            value: [{ id: 'manual' }],
+        }]);
+        expect(assigned.publication).toBe('both');
+
+        const cleared = transitionSubscription(assigned.state, {
+            type: 'COMPAT_VALUE_SET',
+            value: null,
+        }, rowSubscriptionPolicy);
+        expect(cleared.state.phase).toEqual(idle.phase);
+        expect(cleared.state.snapshot).toEqual({
+            data: null,
+            status: 'idle',
+            error: null,
+        });
+    });
+});

--- a/ihp-datasync/data/DataSync/subscription-reducer.test.js
+++ b/ihp-datasync/data/DataSync/subscription-reducer.test.js
@@ -1,0 +1,106 @@
+import {
+    createIdleResourceSnapshot,
+    idleResourceSnapshot,
+    initialResourceSnapshot,
+    reduceResourceSnapshot,
+} from './subscription-reducer.js';
+
+describe('reduceResourceSnapshot', () => {
+    test('uses one immutable idle snapshot for every resource type', () => {
+        const first = createIdleResourceSnapshot();
+        const second = createIdleResourceSnapshot();
+
+        expect(first).toBe(idleResourceSnapshot);
+        expect(second).toBe(first);
+        expect(initialResourceSnapshot()).toBe(first);
+        expect(first).toEqual({ data: null, status: 'idle', error: null });
+        expect(Object.isFrozen(first)).toBe(true);
+    });
+
+    test('can seed an idle snapshot from a server cache without marking it live', () => {
+        const records = [{ id: 'cached-task' }];
+        const snapshot = initialResourceSnapshot(records);
+
+        expect(snapshot).toEqual({ data: records, status: 'idle', error: null });
+        expect(snapshot.data).toBe(records);
+        expect(snapshot).not.toBe(idleResourceSnapshot);
+        expect(Object.isFrozen(snapshot)).toBe(true);
+        expect(initialResourceSnapshot(null)).toBe(idleResourceSnapshot);
+    });
+
+    test('moves through the initial connection and live snapshot states', () => {
+        const idle = createIdleResourceSnapshot();
+        const connecting = reduceResourceSnapshot(idle, { type: 'CONNECT', reconnect: false });
+        const records = [{ id: 'task-1' }];
+        const live = reduceResourceSnapshot(connecting, { type: 'SNAPSHOT', data: records });
+
+        expect(connecting).toEqual({ data: null, status: 'connecting', error: null });
+        expect(live).toEqual({ data: records, status: 'live', error: null });
+        expect(connecting).not.toBe(idle);
+        expect(live).not.toBe(connecting);
+        expect(Object.isFrozen(live)).toBe(true);
+    });
+
+    test('retains the last server snapshot while disconnected and reconnecting', () => {
+        const records = [{ id: 'task-1' }];
+        const live = reduceResourceSnapshot(createIdleResourceSnapshot(), { type: 'SNAPSHOT', data: records });
+        const disconnected = reduceResourceSnapshot(live, { type: 'DISCONNECT' });
+        const reconnecting = reduceResourceSnapshot(disconnected, { type: 'CONNECT', reconnect: true });
+
+        expect(disconnected).toEqual({ data: records, status: 'reconnecting', error: null });
+        expect(reconnecting.data).toBe(records);
+        expect(reconnecting).toBe(disconnected);
+    });
+
+    test('retains data on failure and replaces the observable error', () => {
+        const records = [{ id: 'task-1' }];
+        const live = reduceResourceSnapshot(createIdleResourceSnapshot(), { type: 'SNAPSHOT', data: records });
+        const firstError = new Error('first failure');
+        const failed = reduceResourceSnapshot(live, { type: 'FAIL', error: firstError });
+        const secondError = new Error('second failure');
+        const failedAgain = reduceResourceSnapshot(failed, { type: 'FAIL', error: secondError });
+
+        expect(failed).toEqual({ data: records, status: 'error', error: firstError });
+        expect(failedAgain.data).toBe(records);
+        expect(failedAgain.error).toBe(secondError);
+        expect(failedAgain).not.toBe(failed);
+    });
+
+    test('keeps the previous identity for semantic no-ops', () => {
+        const records = [{ id: 'task-1' }];
+        const live = reduceResourceSnapshot(createIdleResourceSnapshot(), { type: 'SNAPSHOT', data: records });
+        const error = new Error('failure');
+        const failed = reduceResourceSnapshot(live, { type: 'FAIL', error });
+        const reconnecting = reduceResourceSnapshot(live, { type: 'DISCONNECT' });
+        const closed = reduceResourceSnapshot(live, { type: 'CLOSE' });
+
+        expect(reduceResourceSnapshot(live, { type: 'SNAPSHOT', data: records })).toBe(live);
+        expect(reduceResourceSnapshot(failed, { type: 'FAIL', error })).toBe(failed);
+        expect(reduceResourceSnapshot(reconnecting, { type: 'DISCONNECT' })).toBe(reconnecting);
+        expect(reduceResourceSnapshot(closed, { type: 'CLOSE' })).toBe(closed);
+    });
+
+    test('treats a new data reference as a new observable snapshot', () => {
+        const records = [{ id: 'task-1' }];
+        const live = reduceResourceSnapshot(createIdleResourceSnapshot(), { type: 'SNAPSHOT', data: records });
+        const replacement = [{ id: 'task-1' }];
+        const updated = reduceResourceSnapshot(live, { type: 'SNAPSHOT', data: replacement });
+
+        expect(updated).not.toBe(live);
+        expect(updated.data).toBe(replacement);
+    });
+
+    test('clears an error when connecting, receiving data, or closing', () => {
+        const error = new Error('failure');
+        const failed = reduceResourceSnapshot(createIdleResourceSnapshot(), { type: 'FAIL', error });
+        const connecting = reduceResourceSnapshot(failed, { type: 'CONNECT', reconnect: false });
+        const failedAgain = reduceResourceSnapshot(connecting, { type: 'FAIL', error });
+        const live = reduceResourceSnapshot(failedAgain, { type: 'SNAPSHOT', data: 1 });
+        const failedOnceMore = reduceResourceSnapshot(live, { type: 'FAIL', error });
+        const closed = reduceResourceSnapshot(failedOnceMore, { type: 'CLOSE' });
+
+        expect(connecting.error).toBeNull();
+        expect(live.error).toBeNull();
+        expect(closed).toEqual({ data: 1, status: 'closed', error: null });
+    });
+});

--- a/ihp-datasync/data/DataSync/subscription-resource.test.js
+++ b/ihp-datasync/data/DataSync/subscription-resource.test.js
@@ -1,0 +1,530 @@
+import { jest } from '@jest/globals';
+
+import { rowSubscriptionPolicy } from './subscription-machine.js';
+import { createSubscriptionResource } from './subscription-resource.js';
+
+const flushPromises = async () => {
+    for (let index = 0; index < 6; index += 1) {
+        await Promise.resolve();
+    }
+};
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+function fakeTransport(scopeKey = 'scope-a') {
+    let current = true;
+    const listeners = new Set();
+    const unsubscribes = [];
+    const transport = {
+        scopeKey,
+        request: jest.fn(),
+        subscribe: jest.fn(listener => {
+            listeners.add(listener);
+            const unsubscribe = jest.fn(() => listeners.delete(listener));
+            unsubscribes.push(unsubscribe);
+            return unsubscribe;
+        }),
+        isCurrent: jest.fn(() => current),
+    };
+
+    return {
+        transport,
+        listeners,
+        unsubscribes,
+        emit(event) {
+            for (const listener of [...listeners]) {
+                listener(event);
+            }
+        },
+        setCurrent(value) {
+            current = value;
+        },
+    };
+}
+
+function created(subscriptionId, value, revision = 0, mode = 'snapshot') {
+    return { subscriptionId, value, revision, mode };
+}
+
+function makeHarness({
+    scopeKey = 'scope-a',
+    transports = [fakeTransport(scopeKey)],
+    create = async () => created('subscription-1', [{ id: 'initial' }]),
+    deleteSubscription = async () => {},
+    refresh,
+    decodeMessage = () => null,
+    isRelevantMessage,
+    publish,
+    onState,
+    initialData,
+} = {}) {
+    let currentScopeKeyValue = scopeKey;
+    let nextTransport = 0;
+    const idleChecks = [];
+    const cacheWrites = [];
+    const publications = [];
+    const states = [];
+    const errors = [];
+    const evictions = [];
+    const acquireTransport = jest.fn(() => {
+        const fixture = transports[nextTransport];
+        nextTransport += 1;
+        if (fixture === undefined) {
+            throw new Error('No fake transport available');
+        }
+        return fixture.transport;
+    });
+    const currentScopeKey = jest.fn(() => currentScopeKeyValue);
+    const protocol = {
+        create: jest.fn(create),
+        delete: jest.fn(deleteSubscription),
+        refresh: refresh === undefined ? undefined : jest.fn(refresh),
+        decodeMessage: jest.fn(decodeMessage),
+        isRelevantMessage: isRelevantMessage === undefined
+            ? undefined
+            : jest.fn(isRelevantMessage),
+    };
+    let resource;
+    resource = createSubscriptionResource(protocol, {
+        expectedScopeKey: scopeKey,
+        currentScopeKey,
+        acquireTransport,
+        policy: rowSubscriptionPolicy,
+        initialData,
+        writeCache: value => cacheWrites.push(value),
+        evict: () => evictions.push(resource),
+        publish: (publication, state, previousState) => {
+            publications.push({ publication, state, previousState });
+            publish?.(publication, state, previousState, resource);
+        },
+        onState: state => {
+            states.push(state);
+            onState?.(state, resource);
+        },
+        reportError: (message, error) => errors.push({ message, error }),
+        queueMicrotask: callback => idleChecks.push(callback),
+    });
+
+    return {
+        resource,
+        protocol,
+        acquireTransport,
+        currentScopeKey,
+        idleChecks,
+        cacheWrites,
+        publications,
+        states,
+        errors,
+        evictions,
+        setCurrentScopeKey(value) {
+            currentScopeKeyValue = value;
+        },
+    };
+}
+
+describe('subscription resource runtime', () => {
+    test('scheduleCloseIfUnused defers closing a never-demanded resource', async () => {
+        const harness = makeHarness();
+        const initialFailure = harness.resource.initialResult.catch(error => error);
+
+        harness.resource.scheduleCloseIfUnused();
+
+        expect(harness.resource.getState().phase).toEqual({ tag: 'idle' });
+        expect(harness.idleChecks).toHaveLength(1);
+        expect(harness.acquireTransport).not.toHaveBeenCalled();
+        expect(harness.evictions).toHaveLength(0);
+
+        harness.idleChecks.shift()();
+
+        expect(harness.resource.getState().phase).toEqual({ tag: 'closed' });
+        expect(harness.acquireTransport).not.toHaveBeenCalled();
+        expect(harness.evictions).toHaveLength(1);
+        await expect(initialFailure).resolves.toMatchObject({
+            message: rowSubscriptionPolicy.initialUnusedMessage,
+        });
+    });
+
+    test('an irrelevant message skips scope validation and decoding', () => {
+        const harness = makeHarness({
+            isRelevantMessage: () => false,
+            decodeMessage: () => {
+                throw new Error('irrelevant message must not be decoded');
+            },
+        });
+        harness.setCurrentScopeKey('scope-b');
+        const message = { tag: 'DidChangeCount', subscriptionId: 'another-resource' };
+
+        harness.resource.receiveMessage(message);
+
+        expect(harness.protocol.isRelevantMessage).toHaveBeenCalledWith(
+            message,
+            harness.resource.getState(),
+        );
+        expect(harness.currentScopeKey).not.toHaveBeenCalled();
+        expect(harness.protocol.decodeMessage).not.toHaveBeenCalled();
+        expect(harness.resource.getState()).toMatchObject({
+            scope: 'current',
+            phase: { tag: 'idle' },
+        });
+    });
+
+    test('an abandoned resource with no demand never acquires a transport', async () => {
+        const harness = makeHarness();
+
+        await flushPromises();
+        expect(harness.acquireTransport).not.toHaveBeenCalled();
+        expect(harness.protocol.create).not.toHaveBeenCalled();
+
+        await harness.resource.close();
+        await flushPromises();
+
+        expect(harness.acquireTransport).not.toHaveBeenCalled();
+        expect(harness.protocol.create).not.toHaveBeenCalled();
+        expect(harness.resource.getState().phase).toEqual({ tag: 'closed' });
+    });
+
+    test('multiple consumers share one transport, listener, and create request', async () => {
+        const fixture = fakeTransport();
+        const createResult = deferred();
+        const harness = makeHarness({
+            transports: [fixture],
+            create: () => createResult.promise,
+        });
+
+        harness.resource.updateDemand(1, false);
+        harness.resource.updateDemand(2, false);
+        harness.resource.updateDemand(2, true);
+        await flushPromises();
+
+        expect(harness.acquireTransport).toHaveBeenCalledTimes(1);
+        expect(fixture.transport.subscribe).toHaveBeenCalledTimes(1);
+        expect(harness.protocol.create).toHaveBeenCalledTimes(1);
+
+        const value = [{ id: 'shared' }];
+        createResult.resolve(created('shared-subscription', value, 4));
+        await expect(harness.resource.initialResult).resolves.toBe(value);
+        expect(harness.resource.getState().phase).toEqual({
+            tag: 'live',
+            subscriptionId: 'shared-subscription',
+            mode: 'snapshot',
+            revision: 4,
+        });
+
+        await harness.resource.close();
+    });
+
+    test('new demand strictly cancels the queued last-demand idle check', async () => {
+        const createResult = deferred();
+        const harness = makeHarness({ create: () => createResult.promise });
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+        harness.resource.updateDemand(0, false);
+        expect(harness.idleChecks).toHaveLength(1);
+
+        harness.resource.updateDemand(1, false);
+        harness.idleChecks.shift()();
+
+        expect(harness.resource.getState().phase.tag).toBe('creating');
+        expect(harness.evictions).toHaveLength(0);
+        expect(harness.protocol.delete).not.toHaveBeenCalled();
+        expect(harness.protocol.create).toHaveBeenCalledTimes(1);
+
+        createResult.resolve(created('kept-alive', [{ id: 'kept' }]));
+        await flushPromises();
+        await harness.resource.close();
+    });
+
+    test('a late create is deleted on its original transport', async () => {
+        const transportA = fakeTransport();
+        const transportB = fakeTransport();
+        const createA = deferred();
+        const createB = deferred();
+        const harness = makeHarness({
+            transports: [transportA, transportB],
+            create: transport => transport === transportA.transport
+                ? createA.promise
+                : createB.promise,
+        });
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+        harness.resource.updateDemand(0, false);
+        harness.idleChecks.shift()();
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+
+        expect(harness.acquireTransport).toHaveBeenCalledTimes(2);
+        createA.resolve(created('late-a', [{ id: 'stale' }]));
+        await flushPromises();
+
+        expect(harness.protocol.delete)
+            .toHaveBeenCalledWith(transportA.transport, 'late-a');
+        expect(harness.protocol.delete)
+            .not.toHaveBeenCalledWith(transportB.transport, 'late-a');
+        expect(harness.resource.getSnapshot().data).toBeNull();
+
+        createB.resolve(created('live-b', [{ id: 'current' }]));
+        await flushPromises();
+        await harness.resource.close();
+    });
+
+    test('an obsolete create task settles only after its stale remote id is deleted', async () => {
+        const createResult = deferred();
+        const deleteResult = deferred();
+        const harness = makeHarness({
+            create: () => createResult.promise,
+            deleteSubscription: () => deleteResult.promise,
+        });
+        const initialFailure = harness.resource.initialResult.catch(error => error);
+
+        harness.resource.updateDemand(1, false);
+        const creating = harness.resource.ensureCreated();
+        let createSettled = false;
+        void creating.then(() => {
+            createSettled = true;
+        });
+        harness.resource.updateDemand(0, false);
+        harness.idleChecks.shift()();
+
+        createResult.resolve(created('late-delete-barrier', [{ id: 'stale' }]));
+        await flushPromises();
+        expect(harness.protocol.delete).toHaveBeenCalledWith(
+            expect.any(Object),
+            'late-delete-barrier',
+        );
+        expect(createSettled).toBe(false);
+
+        deleteResult.resolve();
+        await creating;
+        expect(createSettled).toBe(true);
+        await expect(initialFailure).resolves.toEqual(expect.objectContaining({
+            message: rowSubscriptionPolicy.initialUnusedMessage,
+        }));
+    });
+
+    test('an obsolete create failure preserves the earlier close result', async () => {
+        const createResult = deferred();
+        const harness = makeHarness({ create: () => createResult.promise });
+        const initialFailure = harness.resource.initialResult.catch(error => error);
+
+        harness.resource.updateDemand(1, false);
+        const creating = harness.resource.ensureCreated();
+        harness.resource.updateDemand(0, false);
+        harness.idleChecks.shift()();
+        createResult.reject(new Error('late wire failure'));
+
+        await expect(creating).resolves.toBeUndefined();
+        await expect(initialFailure).resolves.toEqual(expect.objectContaining({
+            message: rowSubscriptionPolicy.initialUnusedMessage,
+        }));
+        expect(harness.resource.getSnapshot().status).toBe('closed');
+        expect(harness.protocol.delete).not.toHaveBeenCalled();
+    });
+
+    test('a scope race cannot publish or cache the late create value', async () => {
+        const fixture = fakeTransport();
+        const createResult = deferred();
+        const harness = makeHarness({
+            transports: [fixture],
+            create: () => createResult.promise,
+        });
+        const initialFailure = harness.resource.initialResult.catch(error => error);
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+        harness.setCurrentScopeKey('scope-b');
+        const secret = [{ id: 'must-not-escape' }];
+        createResult.resolve(created('stale-scope', secret, 1));
+        await flushPromises();
+
+        expect(harness.resource.getState().scope).toBe('stale');
+        expect(harness.resource.getSnapshot()).toMatchObject({
+            data: null,
+            status: 'closed',
+        });
+        expect(harness.cacheWrites).not.toContain(secret);
+        expect(harness.publications.some(({ state }) => state.snapshot.data === secret))
+            .toBe(false);
+        expect(harness.protocol.delete)
+            .toHaveBeenCalledWith(fixture.transport, 'stale-scope');
+        await expect(initialFailure).resolves.toBeInstanceOf(Error);
+    });
+
+    test('reconnect starts exactly one replacement create through the one listener', async () => {
+        const fixture = fakeTransport();
+        const firstCreate = deferred();
+        const secondCreate = deferred();
+        const creates = [firstCreate, secondCreate];
+        const harness = makeHarness({
+            transports: [fixture],
+            create: () => creates.shift().promise,
+        });
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+        firstCreate.resolve(created('before-disconnect', [{ id: 'first' }]));
+        await flushPromises();
+
+        fixture.emit({ type: 'closed', scopeChanged: false });
+        expect(harness.resource.getState().phase).toEqual({ tag: 'offline' });
+        fixture.emit({ type: 'reconnected' });
+        fixture.emit({ type: 'reconnected' });
+        await flushPromises();
+
+        expect(harness.acquireTransport).toHaveBeenCalledTimes(1);
+        expect(fixture.transport.subscribe).toHaveBeenCalledTimes(1);
+        expect(harness.protocol.create).toHaveBeenCalledTimes(2);
+
+        secondCreate.resolve(created('after-reconnect', [{ id: 'second' }], 2));
+        await flushPromises();
+        expect(harness.resource.getState().phase).toMatchObject({
+            tag: 'live',
+            subscriptionId: 'after-reconnect',
+        });
+
+        await harness.resource.close();
+    });
+
+    test('the attached listener decodes server messages into machine events', async () => {
+        const fixture = fakeTransport();
+        const replacement = [{ id: 'replacement' }];
+        const decodeMessage = (message, state) => {
+            if (message.tag !== 'DidReplaceDataSubscription' || state.phase.tag !== 'live') {
+                return null;
+            }
+            return {
+                type: 'SERVER_SNAPSHOT',
+                generation: state.generation,
+                subscriptionId: state.phase.subscriptionId,
+                value: message.value,
+                revision: message.revision,
+            };
+        };
+        const harness = makeHarness({
+            transports: [fixture],
+            create: async () => created('decoded-subscription', [{ id: 'initial' }], 1),
+            decodeMessage,
+        });
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+        const message = {
+            tag: 'DidReplaceDataSubscription',
+            value: replacement,
+            revision: 2,
+        };
+        fixture.emit({ type: 'message', message });
+
+        expect(harness.protocol.decodeMessage).toHaveBeenCalledTimes(1);
+        expect(harness.protocol.decodeMessage.mock.calls[0][0]).toBe(message);
+        expect(harness.resource.getSnapshot().data).toBe(replacement);
+        expect(harness.cacheWrites.at(-1)).toBe(replacement);
+        expect(harness.resource.getState().phase).toMatchObject({ revision: 2 });
+
+        await harness.resource.close();
+    });
+
+    test('reentrant publication dispatch is processed in FIFO order', async () => {
+        const order = [];
+        const reentrant = [{ id: 'reentrant' }];
+        let dispatched = false;
+        const harness = makeHarness({
+            create: async () => created('reentrant-subscription', [{ id: 'initial' }], 1),
+            publish: (_publication, state, _previousState, resource) => {
+                if (state.phase.tag !== 'live') {
+                    return;
+                }
+                order.push(`publish:${state.snapshot.data[0].id}`);
+                if (!dispatched) {
+                    dispatched = true;
+                    resource.dispatchCompatibilityValue(reentrant);
+                }
+            },
+        });
+        const originalWriteCache = harness.cacheWrites.push.bind(harness.cacheWrites);
+        harness.cacheWrites.push = value => {
+            order.push(`cache:${value[0].id}`);
+            return originalWriteCache(value);
+        };
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+
+        expect(order).toEqual([
+            'cache:initial',
+            'publish:initial',
+            'cache:reentrant',
+            'publish:reentrant',
+        ]);
+        expect(harness.resource.getSnapshot().data).toBe(reentrant);
+
+        await harness.resource.close();
+    });
+
+    test('close awaits deletion of a live remote subscription', async () => {
+        const deleteResult = deferred();
+        const harness = makeHarness({
+            create: async () => created('live-to-delete', [{ id: 'live' }]),
+            deleteSubscription: () => deleteResult.promise,
+        });
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+        expect(harness.resource.getState().phase.tag).toBe('live');
+
+        let closed = false;
+        const closing = harness.resource.close().then(() => {
+            closed = true;
+        });
+        await flushPromises();
+
+        expect(harness.protocol.delete).toHaveBeenCalledWith(
+            expect.any(Object),
+            'live-to-delete',
+        );
+        expect(closed).toBe(false);
+
+        deleteResult.resolve();
+        await closing;
+        expect(closed).toBe(true);
+    });
+
+    test('a reentrant close during publication still awaits its remote delete', async () => {
+        const deleteResult = deferred();
+        let closing;
+        let closed = false;
+        const harness = makeHarness({
+            create: async () => created('reentrant-delete', [{ id: 'live' }]),
+            deleteSubscription: () => deleteResult.promise,
+            publish: (_publication, state, _previousState, resource) => {
+                if (state.phase.tag === 'live' && closing === undefined) {
+                    closing = resource.close().then(() => {
+                        closed = true;
+                    });
+                }
+            },
+        });
+
+        harness.resource.updateDemand(1, false);
+        await flushPromises();
+
+        expect(harness.protocol.delete).toHaveBeenCalledWith(
+            expect.any(Object),
+            'reentrant-delete',
+        );
+        expect(closed).toBe(false);
+
+        deleteResult.resolve();
+        await closing;
+        expect(closed).toBe(true);
+    });
+});

--- a/ihp-datasync/data/DataSync/yarn.lock
+++ b/ihp-datasync/data/DataSync/yarn.lock
@@ -1784,7 +1784,7 @@ jest@^30.2.0:
     import-local "^3.2.0"
     jest-cli "30.2.0"
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -1828,6 +1828,13 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+loose-envify@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^10.2.0:
   version "10.4.3"
@@ -1928,6 +1935,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 once@^1.3.0:
   version "1.4.0"
@@ -2048,10 +2060,42 @@ pure-rand@^7.0.0:
   resolved "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz"
   integrity sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==
 
-react-is@^18.3.1:
+react-dom@18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.2"
+
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.3.1.tgz#e693608a1f96283400d4a3afead6893f958b80b4"
+  integrity sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==
+  dependencies:
+    react-is "^18.3.1"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.2"
+
+react@18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -2069,6 +2113,13 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 semver@^6.3.1:
   version "6.3.1"

--- a/ihp-pglistener/IHP/PGListener.hs
+++ b/ihp-pglistener/IHP/PGListener.hs
@@ -17,24 +17,29 @@ module IHP.PGListener
 , stop
 , withPGListener
 , subscribe
+, subscribeWithReconnect
 , subscribeJSON
+, subscribeJSONWithReconnect
 , unsubscribe
 , onReconnect
+, waitUntilListening
+, waitUntilListeningTo
 ) where
 
 import Prelude hiding (init, show, error)
 import qualified Prelude
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.IORef
 import Data.String.Conversions (cs)
 import Data.UUID (UUID)
 import qualified Data.UUID.V4 as UUID
-import Control.Monad (forever, unless, forM_)
+import Control.Monad (forever, unless, when, forM_, void)
 import Data.Maybe (fromMaybe)
 import Control.Exception (SomeException, displayException, uninterruptibleMask_)
-import Control.Concurrent.Async (Async, async, cancel, uninterruptibleCancel)
+import Control.Concurrent.Async (Async, async, cancel, uninterruptibleCancel, waitCatch)
 import Data.Function ((&))
 
 import System.Log.FastLogger (FastLogger, toLogStr)
@@ -123,8 +128,23 @@ init databaseUrl logger = do
 -- > PGListener.stop pgListener
 --
 stop :: PGListener -> IO ()
-stop PGListener { notifyLoopAsync } = do
+stop PGListener { notifyLoopAsync, subscriptions, listeningTo, listenTo, reconnectCallbacks } = Exception.mask_ do
     cancel notifyLoopAsync
+    void (waitCatch notifyLoopAsync)
+
+    -- 'listeningTo' is also the lifecycle lock. Once the impossible PostgreSQL
+    -- channel sentinel is installed in 'listenTo', later subscribe/onReconnect
+    -- calls cannot repopulate state after this drain. Keeping the tombstone out
+    -- of the public 'listeningTo' set preserves its live-channel semantics and
+    -- the historical PGListener record construction shape.
+    readers <- MVar.modifyMVar listeningTo \_activeChannels -> do
+        void (MVar.tryTakeMVar listenTo)
+        MVar.putMVar listenTo stoppedListenerChannel
+        currentReaders <- atomicModifyIORef' subscriptions \currentSubscriptions ->
+            (HashMap.empty, Prelude.map (.reader) (concat (HashMap.elems currentSubscriptions)))
+        atomicModifyIORef_ reconnectCallbacks (const [])
+        pure (Set.empty, currentReaders)
+    mapM_ uninterruptibleCancel readers
 
 withPGListener :: ByteString -> Logger -> (PGListener -> IO a) -> IO a
 withPGListener databaseUrl logger =
@@ -146,9 +166,29 @@ withPGListener databaseUrl logger =
 -- When the subscription is not used anymore, call 'unsubscribe' to stop the callback from being called anymore.
 --
 subscribe :: Channel -> Callback -> PGListener -> IO Subscription
-subscribe channel callback pgListener = do
+subscribe channel callback pgListener =
+    subscribeInternal channel ignoreReconnectNotification pgListener
+    where
+        ignoreReconnectNotification notification =
+            unless (notification.notificationChannel == reconnectNotificationChannel) (callback notification)
+
+-- | Subscription primitive with a lightweight callback that is run
+-- after all desired LISTEN statements have been restored on a new connection.
+-- The callback should only signal work; expensive work would delay notification
+-- delivery for every channel.
+subscribeWithReconnect :: Channel -> Callback -> IO () -> PGListener -> IO Subscription
+subscribeWithReconnect channel callback reconnectCallback pgListener =
+    subscribeInternal channel dispatch pgListener
+    where
+        dispatch notification
+            | notification.notificationChannel == reconnectNotificationChannel = reconnectCallback
+            | otherwise = callback notification
+
+subscribeInternal :: Channel -> Callback -> PGListener -> IO Subscription
+subscribeInternal channel callback pgListener = Exception.mask \restore -> do
+    when (ByteString.elem 0 channel) do
+        Exception.throwIO (userError "PGListener channels cannot contain NUL")
     id <- UUID.nextRandom
-    listenToChannelIfNeeded channel pgListener
 
     -- We use a queue here to guarantee that the messages are processed in the right order
     -- while keeping high performance.
@@ -162,14 +202,37 @@ subscribe channel callback pgListener = do
         logException :: SomeException -> IO ()
         logException exception = logError pgListener ("Error in pg_notify handler: " <> cs (displayException exception))
 
-    reader <- async $ forever do
-            message <- Queue.readChan outChan
-            callback message `Exception.catch` logException
+    reader <- Async.asyncWithUnmask \unmask -> unmask $ forever do
+        message <- Queue.readChan outChan
+        callback message `Exception.catch` logException
     let subscription = Subscription { .. }
 
-    modifyIORef' (pgListener.subscriptions) (HashMap.insertWith mappend channel [subscription] )
+    let removeSubscription = atomicModifyIORef_ (pgListener.subscriptions) (deleteSubscription subscription)
+    let cleanupRegistration = removeSubscription >> uninterruptibleCancel reader
 
-    pure subscription
+    let addSubscription = atomicModifyIORef' (pgListener.subscriptions) $ \subscriptions ->
+            (HashMap.insertWith mappend channel [subscription] subscriptions, ())
+
+    -- Install the local subscriber before requesting LISTEN. Registration and
+    -- the stop tombstone check share the live-set MVar, making stop linearizable
+    -- without adding a field to the public PGListener constructor.
+    let register = MVar.modifyMVar_ pgListener.listeningTo \activeChannels -> do
+            stopped <- listenerIsStopped pgListener
+            when stopped do
+                Exception.throwIO (userError "PGListener has already been stopped")
+            addSubscription
+            unless (channel `Set.member` activeChannels) do
+                -- The MVar is only a wakeup. The listener reconciles every
+                -- channel in the subscriptions map, so collapsed wakeups are safe.
+                void (MVar.tryPutMVar pgListener.listenTo channel)
+            pure activeChannels
+
+    register `Exception.onException` cleanupRegistration
+
+    -- Restore async exceptions before ownership of the reader is transferred to
+    -- the caller. A cancellation in this final hand-off runs cleanup instead of
+    -- leaking a registered reader whose Subscription was never returned.
+    restore (pure subscription) `Exception.onException` cleanupRegistration
 
 -- | Like 'subscribe' but decodes the notification payload from JSON and passes the decoded data structure to the callback
 --
@@ -192,6 +255,20 @@ subscribeJSON channel callback pgListener = subscribe channel callback' pgListen
                 Just payload -> callback payload
                 Nothing -> logError pgListener ("PGListener.subscribeJSON: Failed to parse " <> tshow payload)
 
+-- | Like 'subscribeJSON', but also schedules a callback whenever PostgreSQL
+-- LISTEN state has been restored after a connection loss. This allows consumers
+-- to authoritatively revalidate state for notifications that may have committed
+-- while the listener was disconnected.
+subscribeJSONWithReconnect :: Aeson.FromJSON jsonValue => Channel -> (jsonValue -> IO ()) -> IO () -> PGListener -> IO Subscription
+subscribeJSONWithReconnect channel callback reconnectCallback pgListener =
+    subscribeWithReconnect channel callback' reconnectCallback pgListener
+    where
+        callback' notification = do
+            let payload = notification.notificationData
+            case Aeson.decodeStrict' payload of
+                Just payload -> callback payload
+                Nothing -> logError pgListener ("PGListener.subscribeJSONWithReconnect: Failed to parse " <> tshow payload)
+
 -- | Stops the callback of a subscription from receiving further notifications
 --
 -- > pgListener <- PGListener.init
@@ -202,10 +279,7 @@ subscribeJSON channel callback pgListener = subscribe channel callback' pgListen
 --
 unsubscribe :: Subscription -> PGListener -> IO ()
 unsubscribe subscription@(Subscription { .. }) pgListener = do
-    let
-        deleteById :: [Subscription] -> [Subscription]
-        deleteById = List.deleteBy (\a b -> a.id == b.id) subscription
-    modifyIORef' (pgListener.subscriptions) (HashMap.adjust deleteById channel)
+    atomicModifyIORef_ (pgListener.subscriptions) (deleteSubscription subscription)
     uninterruptibleCancel reader
     pure ()
 
@@ -221,18 +295,33 @@ unsubscribe subscription@(Subscription { .. }) pgListener = do
 --
 onReconnect :: (Hasql.Connection -> IO ()) -> PGListener -> IO ()
 onReconnect callback pgListener =
-    modifyIORef' (pgListener.reconnectCallbacks) (callback :)
+    MVar.withMVar pgListener.listeningTo \_ -> do
+        stopped <- listenerIsStopped pgListener
+        unless stopped do
+            atomicModifyIORef_ (pgListener.reconnectCallbacks) (callback :)
 
--- | Runs a @LISTEN ..;@ statements on the postgres connection, if not already listening on that channel
-listenToChannelIfNeeded :: Channel -> PGListener -> IO ()
-listenToChannelIfNeeded channel pgListener = do
-    listeningTo <- MVar.readMVar (pgListener.listeningTo)
-    let alreadyListening = channel `Set.member` listeningTo
+-- | Wait until a channel is known to be LISTENing on the current live
+-- PostgreSQL connection. The live set is cleared before each reconnect, so a
+-- successful result always belongs to the current connection generation.
+waitUntilListening :: Int -> Channel -> PGListener -> IO Bool
+waitUntilListening timeoutMicroseconds channel =
+    waitUntilListeningTo timeoutMicroseconds (Set.singleton channel)
 
-    unless alreadyListening do
-        MVar.putMVar (pgListener.listenTo) channel
-
-
+-- | Like 'waitUntilListening', for a set of channels that must all be live on
+-- the same current connection generation.
+waitUntilListeningTo :: Int -> Set Channel -> PGListener -> IO Bool
+waitUntilListeningTo timeoutMicroseconds channels pgListener = go (max 0 timeoutMicroseconds)
+    where
+        go remaining = do
+            activeChannels <- MVar.readMVar pgListener.listeningTo
+            if channels `Set.isSubsetOf` activeChannels
+                then pure True
+                else if remaining <= 0
+                    then pure False
+                    else do
+                        let delay = min 1_000 remaining
+                        Control.Concurrent.threadDelay delay
+                        go (remaining - delay)
 
 -- | Acquires a dedicated hasql connection from the given database URL.
 acquireConnection :: ByteString -> IO Hasql.Connection
@@ -249,24 +338,40 @@ notifyLoop :: Logger -> ByteString -> MVar (Set Channel) -> MVar Channel -> IORe
 notifyLoop logger databaseUrl listeningToVar listenToVar subscriptions reconnectCallbacksRef = do
     -- Wait until the first LISTEN is requested before opening a database connection
     MVar.readMVar listenToVar
+    connectionGenerationRef <- newIORef (0 :: Int)
 
     let innerLoop = do
             connection <- acquireConnection databaseUrl
-            let cleanup = Hasql.release connection
+            let cleanup = do
+                    MVar.modifyMVar_ listeningToVar (const (pure Set.empty))
+                    Hasql.release connection
 
             flip Exception.finally cleanup do
-                -- If listeningTo already contains channels, this means that previously the database connection
-                -- died, so we're restarting here. Therefore we need to replay all LISTEN calls to restore the previous state
-                listeningTo <- MVar.readMVar listeningToVar
-                forM_ listeningTo (listenToChannel connection)
+                -- Subscription keys are the durable desired set. The public
+                -- listeningTo MVar contains only channels live on this connection.
+                desiredChannels <- desiredSubscriptionChannels subscriptions
+                forM_ desiredChannels (listenToChannel connection)
+                MVar.modifyMVar_ listeningToVar (const (pure desiredChannels))
 
-                -- Fire reconnection callbacks (non-empty listeningTo = reconnection, not initial connect)
-                unless (Set.null listeningTo) do
+                previousGeneration <- atomicModifyIORef' connectionGenerationRef \generation ->
+                    (generation + 1, generation)
+
+                -- Fire reconnection callbacks only after every desired LISTEN has
+                -- been restored and the new generation is visible to waiters.
+                when (previousGeneration > 0) do
                     callbacks <- readIORef reconnectCallbacksRef
                     forM_ callbacks \callback ->
                         Exception.tryAny (callback connection) >>= \case
                             Left e -> logger (toLogStr ("PGListener reconnect callback failed: " <> displayException e))
                             Right _ -> pure ()
+
+                    currentSubscriptions <- readIORef subscriptions
+                    let reconnectNotification = Notification
+                            { notificationChannel = reconnectNotificationChannel
+                            , notificationData = ""
+                            }
+                    forM_ (concat (HashMap.elems currentSubscriptions)) \subscription ->
+                        Queue.writeChan subscription.inChan reconnectNotification
 
                 -- We use 'race' to alternate between waiting for notifications and
                 -- processing new LISTEN requests. This avoids a deadlock: both
@@ -306,13 +411,17 @@ notifyLoop logger databaseUrl listeningToVar listenToVar subscriptions reconnect
                             Left () ->
                                 -- waitForNotifications returned (connection lost) - exit to trigger retry
                                 pure ()
-                            Right newChannel -> do
-                                MVar.modifyMVar_ listeningToVar \currentListeningTo ->
-                                    if newChannel `Set.member` currentListeningTo
-                                        then pure currentListeningTo
-                                        else do
-                                            listenToChannel connection newChannel
-                                            pure (Set.insert newChannel currentListeningTo)
+                            Right _wakeupChannel -> do
+                                -- The MVar is a wakeup, not a complete work queue. Multiple
+                                -- concurrent subscribe calls may collapse into one slot, so
+                                -- always reconcile the full desired set with this generation.
+                                desiredChannels <- desiredSubscriptionChannels subscriptions
+                                activeChannels <- MVar.readMVar listeningToVar
+                                let missingChannels = desiredChannels `Set.difference` activeChannels
+                                forM_ missingChannels \missingChannel -> do
+                                    listenToChannel connection missingChannel
+                                    MVar.modifyMVar_ listeningToVar \channels ->
+                                        pure (Set.insert missingChannel channels)
                                 notifyAndListenLoop
 
                 notifyAndListenLoop
@@ -352,3 +461,35 @@ listenToChannel connection channel = do
 
 logError :: PGListener -> Text -> IO ()
 logError pgListener message = pgListener.logger (toLogStr message)
+
+-- PostgreSQL identifiers cannot contain NUL, so this can never collide with a
+-- real notification channel.
+reconnectNotificationChannel :: Channel
+reconnectNotificationChannel = "\0ihp_pglistener_reconnect"
+
+-- Stored only in the private wakeup slot after 'stop'. PostgreSQL identifiers
+-- cannot contain NUL, and 'subscribeInternal' rejects such channels.
+stoppedListenerChannel :: Channel
+stoppedListenerChannel = "\0ihp_pglistener_stopped"
+
+listenerIsStopped :: PGListener -> IO Bool
+listenerIsStopped pgListener =
+    (== Just stoppedListenerChannel) <$> MVar.tryReadMVar pgListener.listenTo
+
+desiredSubscriptionChannels :: IORef (HashMap Channel [Subscription]) -> IO (Set Channel)
+desiredSubscriptionChannels subscriptionsRef = do
+    subscriptions <- readIORef subscriptionsRef
+    pure (Set.fromList (HashMap.keys subscriptions))
+
+deleteSubscription :: Subscription -> HashMap Channel [Subscription] -> HashMap Channel [Subscription]
+deleteSubscription subscription =
+    HashMap.update removeById subscription.channel
+    where
+        removeById subscriptions =
+            case List.deleteBy (\a b -> a.id == b.id) subscription subscriptions of
+                [] -> Nothing
+                remaining -> Just remaining
+
+atomicModifyIORef_ :: IORef value -> (value -> value) -> IO ()
+atomicModifyIORef_ ref update =
+    atomicModifyIORef' ref (\value -> (update value, ()))

--- a/ihp-pglistener/Test/PGListenerSpec.hs
+++ b/ihp-pglistener/Test/PGListenerSpec.hs
@@ -12,8 +12,10 @@ import Data.IORef
 import Data.String.Conversions (cs)
 import Data.Function ((&))
 import Data.HashMap.Strict as HashMap
+import qualified Data.Set as Set
 import Control.Concurrent (threadDelay)
-import Control.Monad (forM_)
+import qualified Control.Concurrent.MVar as MVar
+import Control.Monad (forM_, void)
 import qualified Control.Concurrent.Async as Async
 import qualified Control.Exception.Safe as Exception
 import System.Environment (lookupEnv)
@@ -64,6 +66,14 @@ execSQL connStr sql = Exception.bracket (acquireConnection connStr) Hasql.releas
         Right () -> pure ()
         Left err -> error ("SQL exec failed: " <> show err)
 
+withApplicationName :: ByteString -> ByteString -> ByteString
+withApplicationName connStr applicationName
+    | "postgresql://" `BS8.isPrefixOf` connStr || "postgres://" `BS8.isPrefixOf` connStr =
+        connStr <> separator <> "application_name=" <> applicationName
+    | otherwise = connStr <> " application_name=" <> applicationName
+    where
+        separator = if BS8.elem '?' connStr then "&" else "?"
+
 tests :: Spec
 tests = do
     describe "IHP.PGListener" do
@@ -80,6 +90,52 @@ tests = do
                     subscriptionsCount <- length . concat . HashMap.elems <$> readIORef pgListener.subscriptions
                     subscriptionsCount `shouldBe` 1
 
+            it "keeps desired subscriptions separate from live readiness" do
+                PGListener.withPGListener "" logger \pgListener -> do
+                    _ <- pgListener & PGListener.subscribe "desired_but_not_live" (const (pure ()))
+
+                    subscriptions <- readIORef pgListener.subscriptions
+                    HashMap.member "desired_but_not_live" subscriptions `shouldBe` True
+                    liveChannels <- MVar.readMVar pgListener.listeningTo
+                    Set.member "desired_but_not_live" liveChannels `shouldBe` False
+
+                    -- The invalid connection string cannot establish LISTEN. Readiness
+                    -- must not be inferred from the subscription set, and waiting
+                    -- must remain bounded.
+                    ready <- PGListener.waitUntilListening 10_000 "desired_but_not_live" pgListener
+                    ready `shouldBe` False
+
+            it "times out while no LISTEN connection has been requested" do
+                PGListener.withPGListener "" logger \pgListener -> do
+                    ready <- PGListener.waitUntilListening 5_000 "never_requested" pgListener
+                    ready `shouldBe` False
+
+            it "preserves the public PGListener record construction shape" do
+                listeningTo <- MVar.newMVar Set.empty
+                listenTo <- MVar.newEmptyMVar
+                subscriptions <- newIORef HashMap.empty
+                notifyLoopAsync <- Async.async (pure ())
+                reconnectCallbacks <- newIORef []
+                let pgListener = PGListener.PGListener
+                        { logger
+                        , databaseUrl = ""
+                        , listeningTo
+                        , listenTo
+                        , subscriptions
+                        , notifyLoopAsync
+                        , reconnectCallbacks
+                        }
+                pgListener.databaseUrl `shouldBe` ""
+                Async.cancel notifyLoopAsync
+
+            it "adds an application name to URI and keyword connection strings" do
+                withApplicationName "postgresql:///postgres" "listener"
+                    `shouldBe` "postgresql:///postgres?application_name=listener"
+                withApplicationName "postgresql:///postgres?host=/tmp" "listener"
+                    `shouldBe` "postgresql:///postgres?host=/tmp&application_name=listener"
+                withApplicationName "host=/tmp dbname=postgres" "listener"
+                    `shouldBe` "host=/tmp dbname=postgres application_name=listener"
+
         describe "unsubscribe" do
             it "remove the subscription" do
                 PGListener.withPGListener "" logger \pgListener -> do
@@ -90,7 +146,51 @@ tests = do
 
                     subscriptionsCount `shouldBe` 0
 
+        describe "stop" do
+            it "cancels and drains subscription readers and registrations" do
+                Exception.bracket (PGListener.init "" logger) PGListener.stop \pgListener -> do
+                    subscription <- pgListener & PGListener.subscribeWithReconnect
+                        "stop_test"
+                        (const (pure ()))
+                        (pure ())
+                    PGListener.onReconnect (const (pure ())) pgListener
+
+                    PGListener.stop pgListener
+
+                    readerResult <- Async.poll subscription.reader
+                    readerResult `shouldSatisfy` \case
+                        Just _ -> True
+                        Nothing -> False
+                    (HashMap.null <$> readIORef pgListener.subscriptions) `shouldReturn` True
+                    MVar.readMVar pgListener.listeningTo `shouldReturn` Set.empty
+                    (Prelude.null <$> readIORef pgListener.reconnectCallbacks) `shouldReturn` True
+
+                    -- stop is a lifecycle barrier: registrations racing after
+                    -- the drain must not create readers or reconnect callbacks.
+                    lateSubscription <- Exception.tryAny
+                        (pgListener & PGListener.subscribe "after_stop" (const (pure ())))
+                    case lateSubscription of
+                        Left _ -> pure ()
+                        Right _ -> expectationFailure "subscribe succeeded after PGListener.stop"
+                    PGListener.onReconnect (const (pure ())) pgListener
+                    (HashMap.null <$> readIORef pgListener.subscriptions) `shouldReturn` True
+                    (Prelude.null <$> readIORef pgListener.reconnectCallbacks) `shouldReturn` True
+
         describe "multi-channel notifications" do
+            it "restores every desired LISTEN when concurrent wakeups collapse" do
+                withDB \connStr -> do
+                    PGListener.withPGListener connStr logger \pgListener -> do
+                        let channels = Set.fromList
+                                [ BS8.pack ("collapsed_wakeup_" <> show index)
+                                | index <- [(1 :: Int)..50]
+                                ]
+                        _subscriptions <- Async.mapConcurrently
+                            (\channel -> pgListener & PGListener.subscribe channel (const (pure ())))
+                            (Set.toList channels)
+
+                        PGListener.waitUntilListeningTo 2_000_000 channels pgListener
+                            `shouldReturn` True
+
             it "should receive notifications on multiple channels" do
                 withDB \connStr -> do
                     PGListener.withPGListener connStr logger \pgListener -> do
@@ -102,8 +202,10 @@ tests = do
                         _sub2 <- pgListener & PGListener.subscribe "test_channel_2" \n ->
                             modifyIORef' received2 (n.notificationData :)
 
-                        -- Allow time for LISTEN commands to be processed
-                        threadDelay 200_000
+                        ready <- PGListener.waitUntilListeningTo 2_000_000
+                            (Set.fromList ["test_channel_1", "test_channel_2"])
+                            pgListener
+                        ready `shouldBe` True
 
                         -- Send notifications via a separate hasql connection
                         execSQL connStr "NOTIFY test_channel_1, 'hello1'"
@@ -122,10 +224,12 @@ tests = do
                     PGListener.withPGListener connStr logger \pgListener -> do
                         received <- newIORef ([] :: [ByteString])
 
-                        -- Subscribe to channel_1 and wait for the LISTEN to be processed
+                        -- Subscribe to channel_1 and wait for the current LISTEN
+                        -- generation rather than sleeping on stale desired state.
                         _sub1 <- pgListener & PGListener.subscribe "nodrop_1" \n ->
                             modifyIORef' received (n.notificationData :)
-                        threadDelay 200_000
+                        ready <- PGListener.waitUntilListening 2_000_000 "nodrop_1" pgListener
+                        ready `shouldBe` True
 
                         -- One thread continuously sends notifications on channel_1.
                         -- Concurrently, the main thread subscribes to new channels,
@@ -161,3 +265,38 @@ tests = do
 
                         r <- readIORef received
                         length r `shouldBe` totalNotifications
+
+            it "restores LISTEN state and signals reconnect subscribers" do
+                withDB \connStr -> do
+                    -- Give the dedicated LISTEN connection a stable identifier.
+                    -- pg_stat_activity.query is not reliable here because libpq's
+                    -- notification API does not leave the LISTEN text there while
+                    -- the backend is idle.
+                    let listenerApplicationName = "ihp_pglistener_reconnect_test"
+                    let listenerConnStr = withApplicationName connStr listenerApplicationName
+                    PGListener.withPGListener listenerConnStr logger \pgListener -> do
+                        let channel = "reconnect_restore_test"
+                        reconnected <- MVar.newEmptyMVar
+                        received <- MVar.newEmptyMVar
+                        _subscription <- pgListener & PGListener.subscribeWithReconnect channel
+                            (\notification -> void (MVar.tryPutMVar received notification.notificationData))
+                            (void (MVar.tryPutMVar reconnected ()))
+
+                        PGListener.waitUntilListening 2_000_000 channel pgListener `shouldReturn` True
+
+                        execSQL connStr (BS8.pack (
+                            "DO $$ DECLARE listener_pid integer; BEGIN " <>
+                            "SELECT pid INTO listener_pid FROM pg_stat_activity " <>
+                            "WHERE datname = current_database() AND pid <> pg_backend_pid() " <>
+                            "AND application_name = '" <> BS8.unpack listenerApplicationName <> "' LIMIT 1; " <>
+                            "IF listener_pid IS NULL THEN RAISE EXCEPTION 'listener backend not found'; END IF; " <>
+                            "PERFORM pg_terminate_backend(listener_pid); END $$;"
+                            ))
+
+                        reconnectResult <- Async.race (threadDelay 10_000_000) (MVar.takeMVar reconnected)
+                        reconnectResult `shouldBe` Right ()
+                        PGListener.waitUntilListening 2_000_000 channel pgListener `shouldReturn` True
+
+                        execSQL connStr "NOTIFY reconnect_restore_test, 'restored'"
+                        notificationResult <- Async.race (threadDelay 2_000_000) (MVar.takeMVar received)
+                        notificationResult `shouldBe` Right "restored"


### PR DESCRIPTION
## Summary
- make WebSocket request timeouts and reconnect lifecycle request-safe
- coordinate optimistic creates and avoid optimistic state inside transactions
- preserve subscription query semantics and recreate count subscriptions after reconnect
- fix subscription error propagation and TypeScript fallback/null behavior
- preserve the complete limited result window during optimistic writes
- bound stalled WebSocket connection attempts and retain the stale-reconnect guard from `master`

## Root cause
The frontend used one global timeout for concurrent requests, tied optimistic dependencies to incoming events instead of the actual create operation, and treated transaction-local writes as committed UI state. Live query and count subscriptions also did not fully rebuild or normalize their state after mutations and reconnects.

A follow-up review found that complex-query refreshes could run before optimistic writes reached the server, limited result normalization could discard records needed for rollback, and WebSocket handshakes had no timeout.

## User impact
Requests no longer hang after unrelated WebSocket traffic, disconnects, or stalled connection attempts. Transaction rollbacks do not leave ghost records, related creates no longer deadlock, and live/count queries remain consistent across updates and reconnects. Failed optimistic writes restore the complete prior query window.

## Validation
- `yarn typecheck`
- `yarn build`
- `yarn test --runInBand` (156 tests)
- `nix build path:.#datasync-js --no-link`