### PR TITLE
Decode complete table selections as model tuples

### DIFF
--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -143,6 +143,23 @@ items <- sqlQueryTyped [typedSqlStar|
 |]
 ```
 
+When the select list consists entirely of qualified table stars, each star is
+decoded into that table's generated record type. Tables on the nullable side
+of an outer join are wrapped in `Maybe`:
+
+```haskell
+rows <- sqlQueryTyped [typedSqlStar|
+    SELECT i.*, a.*
+    FROM items i
+    LEFT JOIN authors a ON a.id = i.author_id
+|]
+
+-- rows :: [(Item, Maybe Author)]
+```
+
+This grouping applies only to complete qualified stars such as `i.*`. Mixed
+select lists such as `i.*, a.name` continue to produce a labeled `SqlRow`.
+
 ## Inserting Rows
 
 ### Why `INSERT … VALUES` without a column list is disallowed by default

--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -160,22 +160,6 @@ items <- sqlQueryTyped [typedSqlStar|
 |]
 ```
 
-The same model grouping also applies when the select list consists entirely of
-qualified table stars:
-
-```haskell
-rows <- sqlQueryTyped [typedSqlStar|
-    SELECT i.*, a.*
-    FROM items i
-    LEFT JOIN authors a ON a.id = i.author_id
-|]
-
--- rows :: [(Item, Maybe Author)]
-```
-
-Mixed select lists such as `i.*, a.name` continue to produce a labeled
-`SqlRow`.
-
 ## Inserting Rows
 
 ### Why `INSERT … VALUES` without a column list is disallowed by default

--- a/Guide/typed-sql.markdown
+++ b/Guide/typed-sql.markdown
@@ -119,6 +119,23 @@ items <- sqlQueryTyped [typedSql|
 
 The compile error message will suggest the exact column names to use.
 
+When qualified named columns form complete table records in schema order, each
+record is decoded into its generated model type. A table on the nullable side
+of an outer join is wrapped in `Maybe`:
+
+```haskell
+rows <- sqlQueryTyped [typedSql|
+    SELECT i.id, i.name, i.views, a.id, a.name
+    FROM items i
+    LEFT JOIN authors a ON a.id = i.author_id
+|]
+
+-- rows :: [(Item, Maybe Author)]
+```
+
+Partial, reordered, unqualified, or expression-mixed selections continue to
+produce a labeled `SqlRow`.
+
 ### Opting in with `typedSqlStar`
 
 If you understand the risk and want to use `table.*` anyway (e.g., during rapid prototyping), use the `typedSqlStar` quasiquoter:
@@ -143,9 +160,8 @@ items <- sqlQueryTyped [typedSqlStar|
 |]
 ```
 
-When the select list consists entirely of qualified table stars, each star is
-decoded into that table's generated record type. Tables on the nullable side
-of an outer join are wrapped in `Maybe`:
+The same model grouping also applies when the select list consists entirely of
+qualified table stars:
 
 ```haskell
 rows <- sqlQueryTyped [typedSqlStar|
@@ -157,8 +173,8 @@ rows <- sqlQueryTyped [typedSqlStar|
 -- rows :: [(Item, Maybe Author)]
 ```
 
-This grouping applies only to complete qualified stars such as `i.*`. Mixed
-select lists such as `i.*, a.name` continue to produce a labeled `SqlRow`.
+Mixed select lists such as `i.*, a.name` continue to produce a labeled
+`SqlRow`.
 
 ## Inserting Rows
 

--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -240,6 +240,9 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = Generated.Statements.RowDecoderUser.rowDecoder
 
+                    instance FromRowHasqlNullable Generated.ActualTypes.User where
+                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
+
                     type instance GetModelName (User') = "User"
 
                     instance CanCreate Generated.ActualTypes.User where
@@ -342,6 +345,9 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = Generated.Statements.RowDecoderUser.rowDecoder
 
+                    instance FromRowHasqlNullable Generated.ActualTypes.User where
+                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
+
                     type instance GetModelName (User') = "User"
 
                     instance CanCreate Generated.ActualTypes.User where
@@ -441,6 +447,9 @@ tests = do
 
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = Generated.Statements.RowDecoderUser.rowDecoder
+
+                    instance FromRowHasqlNullable Generated.ActualTypes.User where
+                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
 
                     type instance GetModelName (User') = "User"
 
@@ -575,6 +584,9 @@ tests = do
 
                     instance FromRowHasql Generated.ActualTypes.LandingPage where
                         hasqlRowDecoder = Generated.Statements.RowDecoderLandingPage.rowDecoder
+
+                    instance FromRowHasqlNullable Generated.ActualTypes.LandingPage where
+                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderLandingPage.nullableRowDecoder
 
                     type instance GetModelName (LandingPage' _ _) = "LandingPage"
 
@@ -946,6 +958,9 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.Post where
                         hasqlRowDecoder = Generated.Statements.RowDecoderPost.rowDecoder
 
+                    instance FromRowHasqlNullable Generated.ActualTypes.Post where
+                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderPost.nullableRowDecoder
+
                     type instance GetModelName (Post') = "Post"
 
                     instance CanCreate Generated.ActualTypes.Post where
@@ -1079,6 +1094,15 @@ tests = do
                         title <- Decoders.column (Decoders.nonNullable Decoders.text)
                         body <- Decoders.column (Decoders.nonNullable Decoders.text)
                         pure (let theRecord = Generated.ActualTypes.Post id title body def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+
+                    nullableRowDecoder :: Decoders.Row (Maybe Generated.ActualTypes.Post)
+                    nullableRowDecoder = do
+                        id <- Decoders.column (Decoders.nullable Mapping.decoder)
+                        title <- Decoders.column (Decoders.nullable Decoders.text)
+                        body <- Decoders.column (Decoders.nullable Decoders.text)
+                        pure (case (id, title, body) of
+                            (Just idValue, Just titleValue, Just bodyValue) -> Just (let theRecord = Generated.ActualTypes.Post idValue titleValue bodyValue def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            _ -> Nothing)
                     |]
 
             it "should generate nonNullable decoder for PRIMARY KEY column even without explicit NOT NULL (#2531)" do
@@ -1106,6 +1130,15 @@ tests = do
                         ticker <- Decoders.column (Decoders.nonNullable Decoders.text)
                         date <- Decoders.column (Decoders.nonNullable Decoders.date)
                         pure (let theRecord = Generated.ActualTypes.Bar id ticker date def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+
+                    nullableRowDecoder :: Decoders.Row (Maybe Generated.ActualTypes.Bar)
+                    nullableRowDecoder = do
+                        id <- Decoders.column (Decoders.nullable Mapping.decoder)
+                        ticker <- Decoders.column (Decoders.nullable Decoders.text)
+                        date <- Decoders.column (Decoders.nullable Decoders.date)
+                        pure (case (id, ticker, date) of
+                            (Just idValue, Just tickerValue, Just dateValue) -> Just (let theRecord = Generated.ActualTypes.Bar idValue tickerValue dateValue def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            _ -> Nothing)
                     |]
 
             it "should generate a BIGSERIAL PRIMARY KEY row decoder (#2648)" do
@@ -1135,6 +1168,14 @@ tests = do
                         id <- Decoders.column (Decoders.nonNullable Mapping.decoder)
                         validity <- Decoders.column (Decoders.nonNullable Mapping.decoder)
                         pure (let theRecord = Generated.ActualTypes.Validity id validity def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+
+                    nullableRowDecoder :: Decoders.Row (Maybe Generated.ActualTypes.Validity)
+                    nullableRowDecoder = do
+                        id <- Decoders.column (Decoders.nullable Mapping.decoder)
+                        validity <- Decoders.column (Decoders.nullable Mapping.decoder)
+                        pure (case (id, validity) of
+                            (Just idValue, Just validityValue) -> Just (let theRecord = Generated.ActualTypes.Validity idValue validityValue def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) } in theRecord)
+                            _ -> Nothing)
                     |]
 
             it "should generate correct Create statement module" do

--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -240,8 +240,8 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = Generated.Statements.RowDecoderUser.rowDecoder
 
-                    instance FromRowHasqlNullable Generated.ActualTypes.User where
-                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
+                    instance FromRowHasql (Maybe Generated.ActualTypes.User) where
+                        hasqlRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
 
                     type instance GetModelName (User') = "User"
 
@@ -345,8 +345,8 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = Generated.Statements.RowDecoderUser.rowDecoder
 
-                    instance FromRowHasqlNullable Generated.ActualTypes.User where
-                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
+                    instance FromRowHasql (Maybe Generated.ActualTypes.User) where
+                        hasqlRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
 
                     type instance GetModelName (User') = "User"
 
@@ -448,8 +448,8 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.User where
                         hasqlRowDecoder = Generated.Statements.RowDecoderUser.rowDecoder
 
-                    instance FromRowHasqlNullable Generated.ActualTypes.User where
-                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
+                    instance FromRowHasql (Maybe Generated.ActualTypes.User) where
+                        hasqlRowDecoder = Generated.Statements.RowDecoderUser.nullableRowDecoder
 
                     type instance GetModelName (User') = "User"
 
@@ -585,8 +585,8 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.LandingPage where
                         hasqlRowDecoder = Generated.Statements.RowDecoderLandingPage.rowDecoder
 
-                    instance FromRowHasqlNullable Generated.ActualTypes.LandingPage where
-                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderLandingPage.nullableRowDecoder
+                    instance FromRowHasql (Maybe Generated.ActualTypes.LandingPage) where
+                        hasqlRowDecoder = Generated.Statements.RowDecoderLandingPage.nullableRowDecoder
 
                     type instance GetModelName (LandingPage' _ _) = "LandingPage"
 
@@ -958,8 +958,8 @@ tests = do
                     instance FromRowHasql Generated.ActualTypes.Post where
                         hasqlRowDecoder = Generated.Statements.RowDecoderPost.rowDecoder
 
-                    instance FromRowHasqlNullable Generated.ActualTypes.Post where
-                        hasqlNullableRowDecoder = Generated.Statements.RowDecoderPost.nullableRowDecoder
+                    instance FromRowHasql (Maybe Generated.ActualTypes.Post) where
+                        hasqlRowDecoder = Generated.Statements.RowDecoderPost.nullableRowDecoder
 
                     type instance GetModelName (Post') = "Post"
 

--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -1105,6 +1105,26 @@ tests = do
                             _ -> Nothing)
                     |]
 
+            it "should use unwrapped keys for relations in nullable row decoders" do
+                let relationStatements = parseSqlStatements [trimming|
+                    CREATE TABLE users (
+                        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL
+                    );
+                    CREATE TABLE badges (
+                        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
+                        user_id UUID NOT NULL
+                    );
+                    ALTER TABLE badges ADD CONSTRAINT badges_ref_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE NO ACTION;
+                |]
+                let isUsersTable = \case
+                        StatementCreateTable CreateTable { name = "users" } -> True
+                        _ -> False
+                let Just (StatementCreateTable usersTable) = find isUsersTable relationStatements
+                let ?schema = Schema relationStatements
+                let output = compileRowDecoderModule usersTable
+
+                output `shouldSatisfy` ("QueryBuilder.filterWhere (#userId, idValue)" `Text.isInfixOf`)
+
             it "should generate nonNullable decoder for PRIMARY KEY column even without explicit NOT NULL (#2531)" do
                 let bugStatements =
                         [ StatementCreateTable CreateTable

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -918,12 +918,15 @@ instance FromRowHasql (Maybe #{modelName}) where
 |]
 
 compileFromRowQueryBuilder :: (?schema :: Schema) => CreateTable -> (Text, Text, Maybe Text) -> Text
-compileFromRowQueryBuilder table (refTableName, refFieldName, maybeRefColumn) = "(QueryBuilder.filterWhere (#" <> columnNameToFieldName refFieldName <> ", " <> primaryKeyField <> ") (QueryBuilder.query @" <> tableNameToModelName refTableName <> "))"
+compileFromRowQueryBuilder table ref = compileFromRowQueryBuilderWith table ref (\fieldName -> fieldName)
+
+compileFromRowQueryBuilderWith :: (?schema :: Schema) => CreateTable -> (Text, Text, Maybe Text) -> (Text -> Text) -> Text
+compileFromRowQueryBuilderWith table (refTableName, refFieldName, maybeRefColumn) transformPrimaryKeyField = "(QueryBuilder.filterWhere (#" <> columnNameToFieldName refFieldName <> ", " <> primaryKeyField <> ") (QueryBuilder.query @" <> tableNameToModelName refTableName <> "))"
     where
         primaryKeyField :: Text
         primaryKeyField = if refColumn.notNull then actualPrimaryKeyField else "Just " <> actualPrimaryKeyField
         actualPrimaryKeyField :: Text
-        actualPrimaryKeyField = case maybeRefColumn of
+        actualPrimaryKeyField = transformPrimaryKeyField $ case maybeRefColumn of
                 -- When the FK constraint specifies the referenced column, use it directly.
                 -- This handles composite PK tables where a FK references a specific column
                 -- (which must have a standalone UNIQUE constraint).
@@ -1457,9 +1460,13 @@ compileRowDecoderModule table@(CreateTable { name }) =
         nullableCompileField (fieldName, _)
             | Just column <- find (\column -> columnNameToFieldName column.name == fieldName) columns =
                 if hasqlColumnIsNullable table column then fieldName else fieldName <> "Value"
-            | isOneToManyField fieldName = let (Just (_, ref)) = find (\(n, _) -> n == fieldName) referencingWithFieldNames in compileFromRowQueryBuilder table ref
+            | isOneToManyField fieldName = let (Just (_, ref)) = find (\(n, _) -> n == fieldName) referencingWithFieldNames in compileFromRowQueryBuilderWith table ref nullableFieldName
             | fieldName == "meta" = "def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }"
             | otherwise = "def"
+        nullableFieldName fieldName =
+            case find (\column -> columnNameToFieldName column.name == fieldName) columns of
+                Just column | not (hasqlColumnIsNullable table column) -> fieldName <> "Value"
+                _ -> fieldName
         nullableConstructorArgs = intercalate " " (map nullableCompileField (dataFields table))
         requiredFieldNames = columns
             |> filter (not . hasqlColumnIsNullable table)

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -363,7 +363,7 @@ defaultImports = [trimming|
     import qualified Control.DeepSeq as DeepSeq
     import qualified Data.Dynamic
     import Data.Scientific
-    import IHP.Hasql.FromRow (FromRowHasql(..), FromRowHasqlNullable(..))
+    import IHP.Hasql.FromRow (FromRowHasql(..))
     import qualified Hasql.Decoders as Decoders
     import qualified Hasql.Encoders
     import qualified Hasql.Implicits.Encoders
@@ -913,8 +913,8 @@ compileFromRowHasqlInstance table@(CreateTable { name, columns }) =
     in cs [i|instance FromRowHasql #{modelName} where
     hasqlRowDecoder = #{rowDecoderModule}.rowDecoder
 
-instance FromRowHasqlNullable #{modelName} where
-    hasqlNullableRowDecoder = #{rowDecoderModule}.nullableRowDecoder
+instance FromRowHasql (Maybe #{modelName}) where
+    hasqlRowDecoder = #{rowDecoderModule}.nullableRowDecoder
 |]
 
 compileFromRowQueryBuilder :: (?schema :: Schema) => CreateTable -> (Text, Text, Maybe Text) -> Text

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -363,7 +363,7 @@ defaultImports = [trimming|
     import qualified Control.DeepSeq as DeepSeq
     import qualified Data.Dynamic
     import Data.Scientific
-    import IHP.Hasql.FromRow (FromRowHasql(..))
+    import IHP.Hasql.FromRow (FromRowHasql(..), FromRowHasqlNullable(..))
     import qualified Hasql.Decoders as Decoders
     import qualified Hasql.Encoders
     import qualified Hasql.Implicits.Encoders
@@ -912,6 +912,9 @@ compileFromRowHasqlInstance table@(CreateTable { name, columns }) =
         rowDecoderModule = "Generated.Statements.RowDecoder" <> tableNameToModelName name
     in cs [i|instance FromRowHasql #{modelName} where
     hasqlRowDecoder = #{rowDecoderModule}.rowDecoder
+
+instance FromRowHasqlNullable #{modelName} where
+    hasqlNullableRowDecoder = #{rowDecoderModule}.nullableRowDecoder
 |]
 
 compileFromRowQueryBuilder :: (?schema :: Schema) => CreateTable -> (Text, Text, Maybe Text) -> Text
@@ -966,6 +969,24 @@ hasqlColumnDecoder table column@Column { name, columnType, notNull, generator } 
 
         baseDecoder = hasqlValueDecoder columnType
         decoder = if needsIdWrapper then "Mapping.decoder" else baseDecoder
+
+-- | Decode a model column on the nullable side of an outer join. PostgreSQL
+-- returns NULL for every column when the joined row is absent, including
+-- columns which are NOT NULL in the underlying table.
+hasqlNullableColumnDecoder :: (?schema :: Schema) => CreateTable -> Column -> Text
+hasqlNullableColumnDecoder table column@Column { name, columnType } =
+    "Decoders.column (Decoders.nullable " <> decoder <> ")"
+    where
+        -- A single-column primary key is represented as Id' table. Composite
+        -- key components keep their scalar types, matching hasqlColumnDecoder.
+        isPrimaryKey = [name] == primaryKeyColumnNames table.primaryKeyConstraint
+        isForeignKey = isJust (findForeignKeyConstraint table column)
+        decoder = if isPrimaryKey || isForeignKey then "Mapping.decoder" else hasqlValueDecoder columnType
+
+hasqlColumnIsNullable :: CreateTable -> Column -> Bool
+hasqlColumnIsNullable table Column { name, notNull, generator } =
+    let isPrimaryKey = name `elem` primaryKeyColumnNames table.primaryKeyConstraint
+    in not isPrimaryKey && (not notNull || isJust generator)
 
 hasqlValueDecoder :: PostgresType -> Text
 hasqlValueDecoder = \case
@@ -1431,20 +1452,45 @@ compileRowDecoderModule table@(CreateTable { name }) =
         isOneToManyField fieldName = fieldName `elem` (map fst referencingWithFieldNames)
 
         columnBindings = map (\col -> "    " <> columnNameToFieldName col.name <> " <- " <> hasqlColumnDecoder table col) columns
+        nullableColumnBindings = map (\col -> "    " <> columnNameToFieldName col.name <> " <- " <> hasqlNullableColumnDecoder table col) columns
         constructorArgs = intercalate " " (map compileField (dataFields table))
+        nullableCompileField (fieldName, _)
+            | Just column <- find (\column -> columnNameToFieldName column.name == fieldName) columns =
+                if hasqlColumnIsNullable table column then fieldName else fieldName <> "Value"
+            | isOneToManyField fieldName = let (Just (_, ref)) = find (\(n, _) -> n == fieldName) referencingWithFieldNames in compileFromRowQueryBuilder table ref
+            | fieldName == "meta" = "def { originalDatabaseRecord = Just (Data.Dynamic.toDyn theRecord) }"
+            | otherwise = "def"
+        nullableConstructorArgs = intercalate " " (map nullableCompileField (dataFields table))
+        requiredFieldNames = columns
+            |> filter (not . hasqlColumnIsNullable table)
+            |> map (columnNameToFieldName . (.name))
+        presentPattern = case requiredFieldNames of
+            [fieldName] -> "Just " <> fieldName <> "Value"
+            fieldNames -> "(" <> intercalate ", " (map (\fieldName -> "Just " <> fieldName <> "Value") fieldNames) <> ")"
+        presentExpression = case requiredFieldNames of
+            [fieldName] -> fieldName
+            fieldNames -> "(" <> intercalate ", " fieldNames <> ")"
         -- The recursive let (theRecord references itself via toDyn) must be inside
         -- the pure expression, not as a do-block let statement, because GHC's
         -- ApplicativeDo cannot desugar recursive do-block lets and Decoders.Row
         -- has no Monad instance. A let-in inside pure(...) is just a pure Haskell
         -- expression that ApplicativeDo doesn't need to analyze.
         pureExpr = "    pure (let theRecord = " <> qualifiedConstructorNameFromTableName name <> " " <> constructorArgs <> " in theRecord)"
+        nullablePureExpr = "    pure (case " <> presentExpression <> " of\n"
+            <> "        " <> presentPattern <> " -> Just (let theRecord = " <> qualifiedConstructorNameFromTableName name <> " " <> nullableConstructorArgs <> " in theRecord)\n"
+            <> "        _ -> Nothing)"
     in "{-# LANGUAGE ApplicativeDo, OverloadedLabels, TypeApplications, ScopedTypeVariables #-}\n"
-        <> statementModuleHeader table moduleName ["rowDecoder"] extraImports
+        <> statementModuleHeader table moduleName ["rowDecoder", "nullableRowDecoder"] extraImports
         <> Text.unlines
         ([ "rowDecoder :: Decoders.Row " <> qualifiedModelName
          , "rowDecoder = do"
          ] <> columnBindings <>
          [ pureExpr
+         , ""
+         , "nullableRowDecoder :: Decoders.Row (Maybe " <> qualifiedModelName <> ")"
+         , "nullableRowDecoder = do"
+         ] <> nullableColumnBindings <>
+         [ nullablePureExpr
          ])
 
 compileCreateStatement :: (?schema :: Schema, ?compilerOptions :: CompilerOptions) => CreateTable -> Text
@@ -1733,4 +1779,3 @@ compileDynamicCreateManyStatement moduleName qualifiedModelName tableName writab
         , "decoder :: Decoders.Result [" <> qualifiedModelName <> "]"
         , "decoder = Decoders.rowList RowDecoder.rowDecoder"
         ]
-

--- a/ihp-typed-sql/IHP/TypedSql/Decoders.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Decoders.hs
@@ -3,6 +3,7 @@
 
 module IHP.TypedSql.Decoders
     ( resultDecoderForColumns
+    , resultDecoderForFullTableSelections
     ) where
 
 import           Control.Monad                     (zipWithM)
@@ -18,7 +19,7 @@ import           IHP.ModelSupport.Types           (Id' (..))
 import           IHP.Prelude
 
 import           IHP.TypedSql.Metadata            (ColumnMeta (..), DescribeColumn (..), PgTypeInfo (..), TableMeta (..))
-import           IHP.TypedSql.TypeMapping        (detectFullTable)
+import           IHP.TypedSql.TypeMapping        (FullTableSelection (..), detectFullTable)
 
 -- | Build a hasql result decoder for the described SQL columns.
 -- For full-table selections we reuse FromRowHasql; otherwise we decode a scalar/tuple.
@@ -33,6 +34,21 @@ resultDecoderForColumns typeInfo tables joinNullableOids nonNullableColumns colu
                 [column] -> rowDecoderForColumn typeInfo tables joinNullableOids (0 `Set.member` nonNullableColumns) column
                 _ -> tupleRowDecoderForColumns typeInfo tables joinNullableOids nonNullableColumns columns
             pure rowDecoder
+
+-- | Decode one or more qualified full-table stars into generated models.
+resultDecoderForFullTableSelections :: [FullTableSelection] -> TH.ExpQ
+resultDecoderForFullTableSelections selections =
+    case map decoder selections of
+        [] -> pure (TH.AppE (TH.VarE 'pure) (TH.ConE '()))
+        [single] -> pure single
+        firstDecoder:restDecoders -> do
+            let tupleConstructor = TH.ConE (TH.tupleDataName (length selections))
+                withFirst = TH.AppE (TH.AppE (TH.VarE '(<$>)) tupleConstructor) firstDecoder
+            pure (foldl (\acc nextDecoder -> TH.AppE (TH.AppE (TH.VarE '(<*>)) acc) nextDecoder) withFirst restDecoders)
+  where
+    decoder FullTableSelection { ftsNullable }
+        | ftsNullable = TH.VarE 'HasqlFromRow.hasqlNullableRowDecoder
+        | otherwise = TH.VarE 'HasqlFromRow.hasqlRowDecoder
 
 tupleRowDecoderForColumns :: Map.Map PQ.Oid PgTypeInfo -> Map.Map PQ.Oid TableMeta -> Set.Set PQ.Oid -> Set.Set Int -> [DescribeColumn] -> TH.ExpQ
 tupleRowDecoderForColumns typeInfo tables joinNullableOids nonNullableColumns columns = do

--- a/ihp-typed-sql/IHP/TypedSql/Decoders.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Decoders.hs
@@ -46,9 +46,7 @@ resultDecoderForFullTableSelections selections =
                 withFirst = TH.AppE (TH.AppE (TH.VarE '(<$>)) tupleConstructor) firstDecoder
             pure (foldl (\acc nextDecoder -> TH.AppE (TH.AppE (TH.VarE '(<*>)) acc) nextDecoder) withFirst restDecoders)
   where
-    decoder FullTableSelection { ftsNullable }
-        | ftsNullable = TH.VarE 'HasqlFromRow.hasqlNullableRowDecoder
-        | otherwise = TH.VarE 'HasqlFromRow.hasqlRowDecoder
+    decoder _ = TH.VarE 'HasqlFromRow.hasqlRowDecoder
 
 tupleRowDecoderForColumns :: Map.Map PQ.Oid PgTypeInfo -> Map.Map PQ.Oid TableMeta -> Set.Set PQ.Oid -> Set.Set Int -> [DescribeColumn] -> TH.ExpQ
 tupleRowDecoderForColumns typeInfo tables joinNullableOids nonNullableColumns columns = do

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -8,6 +8,7 @@ module IHP.TypedSql.ParamHints
     , extractNonNullableComputedColumnsFromAst
     , resolveParamHintTypes
     , detectStarSelects
+    , extractQualifiedStarTablesFromAst
     , detectInsertWithoutColumns
     ) where
 
@@ -690,6 +691,94 @@ detectStarSelects :: Ast.PreparableStmt -> [String]
 detectStarSelects = \case
     Ast.SelectPreparableStmt selectStmt -> starFromSelectStmt selectStmt
     _ -> []
+
+-- | Resolve a select list made entirely from qualified table stars.
+--
+-- Each result contains the underlying table name and whether that particular
+-- table reference is on the nullable side of an outer join. Keeping the
+-- qualifier until after join analysis is important for self joins, where two
+-- aliases share the same PostgreSQL table OID.
+extractQualifiedStarTablesFromAst :: Ast.PreparableStmt -> Maybe [(Text, Bool)]
+extractQualifiedStarTablesFromAst stmt = do
+    aliases <- qualifiedStarAliasesFromStmt stmt
+    let aliasMap = buildAliasMapFromStmt stmt
+        nullableAliases = nullableQualifiersFromStmt stmt
+    mapM
+        (\alias -> (\tableName -> (tableName, alias `Set.member` nullableAliases)) <$> Map.lookup alias aliasMap)
+        aliases
+
+qualifiedStarAliasesFromStmt :: Ast.PreparableStmt -> Maybe [Text]
+qualifiedStarAliasesFromStmt = \case
+    Ast.SelectPreparableStmt selectStmt -> qualifiedStarAliasesFromSelectStmt selectStmt
+    _ -> Nothing
+
+qualifiedStarAliasesFromSelectStmt :: Ast.SelectStmt -> Maybe [Text]
+qualifiedStarAliasesFromSelectStmt = \case
+    Left (Ast.SelectNoParens _with selectClause _sort _limit _lock) ->
+        qualifiedStarAliasesFromSelectClause selectClause
+    Right selectWithParens -> qualifiedStarAliasesFromSelectWithParens selectWithParens
+
+qualifiedStarAliasesFromSelectWithParens :: Ast.SelectWithParens -> Maybe [Text]
+qualifiedStarAliasesFromSelectWithParens = \case
+    Ast.NoParensSelectWithParens (Ast.SelectNoParens _with selectClause _sort _limit _lock) ->
+        qualifiedStarAliasesFromSelectClause selectClause
+    Ast.WithParensSelectWithParens inner -> qualifiedStarAliasesFromSelectWithParens inner
+
+qualifiedStarAliasesFromSelectClause :: Ast.SelectClause -> Maybe [Text]
+qualifiedStarAliasesFromSelectClause = \case
+    Left (Ast.NormalSimpleSelect (Just targeting) _into _from _where _group _having _window) ->
+        case targeting of
+            Ast.NormalTargeting targets -> mapM qualifiedStarAliasFromTargetEl (toList targets)
+            Ast.DistinctTargeting _ targets -> mapM qualifiedStarAliasFromTargetEl (toList targets)
+            _ -> Nothing
+    Right selectWithParens -> qualifiedStarAliasesFromSelectWithParens selectWithParens
+    _ -> Nothing
+
+qualifiedStarAliasFromTargetEl :: Ast.TargetEl -> Maybe Text
+qualifiedStarAliasFromTargetEl = \case
+    Ast.ExprTargetEl (Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref ident (Just indirection)))) ->
+        case toList indirection of
+            [Ast.AllIndirectionEl] -> Just (identToText ident)
+            _ -> Nothing
+    _ -> Nothing
+
+nullableQualifiersFromStmt :: Ast.PreparableStmt -> Set.Set Text
+nullableQualifiersFromStmt = \case
+    Ast.SelectPreparableStmt (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) ->
+        nullableQualifiersFromSelectClause selectClause
+    _ -> Set.empty
+
+nullableQualifiersFromSelectClause :: Ast.SelectClause -> Set.Set Text
+nullableQualifiersFromSelectClause = \case
+    Left (Ast.NormalSimpleSelect _targeting _into maybeFrom _where _group _having _window) ->
+        maybe Set.empty (foldMap nullableQualifiersFromTableRef . toList) maybeFrom
+    Right (Ast.NoParensSelectWithParens (Ast.SelectNoParens _with selectClause _sort _limit _lock)) ->
+        nullableQualifiersFromSelectClause selectClause
+    Right (Ast.WithParensSelectWithParens inner) -> nullableQualifiersFromSelectWithParens inner
+    _ -> Set.empty
+
+nullableQualifiersFromSelectWithParens :: Ast.SelectWithParens -> Set.Set Text
+nullableQualifiersFromSelectWithParens = \case
+    Ast.NoParensSelectWithParens (Ast.SelectNoParens _with selectClause _sort _limit _lock) ->
+        nullableQualifiersFromSelectClause selectClause
+    Ast.WithParensSelectWithParens inner -> nullableQualifiersFromSelectWithParens inner
+
+nullableQualifiersFromTableRef :: Ast.TableRef -> Set.Set Text
+nullableQualifiersFromTableRef = \case
+    Ast.JoinTableRef joinedTable _alias -> nullableQualifiersFromJoinedTable joinedTable
+    _ -> Set.empty
+
+nullableQualifiersFromJoinedTable :: Ast.JoinedTable -> Set.Set Text
+nullableQualifiersFromJoinedTable = \case
+    Ast.InParensJoinedTable inner -> nullableQualifiersFromJoinedTable inner
+    Ast.MethJoinedTable meth left right ->
+        let nested = Set.union (nullableQualifiersFromTableRef left) (nullableQualifiersFromTableRef right)
+            qualifiers = Map.keysSet . buildAliasMapFromTableRef
+        in case joinTypeFromMeth meth of
+            Just (Ast.LeftJoinType _)  -> Set.union nested (qualifiers right)
+            Just (Ast.RightJoinType _) -> Set.union nested (qualifiers left)
+            Just (Ast.FullJoinType _)  -> Set.union nested (Set.union (qualifiers left) (qualifiers right))
+            _ -> nested
 
 starFromSelectStmt :: Ast.SelectStmt -> [String]
 starFromSelectStmt (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -9,6 +9,7 @@ module IHP.TypedSql.ParamHints
     , resolveParamHintTypes
     , detectStarSelects
     , extractQualifiedStarTablesFromAst
+    , extractQualifiedColumnTablesFromAst
     , detectInsertWithoutColumns
     ) where
 
@@ -707,6 +708,21 @@ extractQualifiedStarTablesFromAst stmt = do
         (\alias -> (\tableName -> (tableName, alias `Set.member` nullableAliases)) <$> Map.lookup alias aliasMap)
         aliases
 
+-- | Resolve a select list made entirely from qualified, named table columns.
+-- One entry is returned per selected column. The qualifier is retained so
+-- adjacent full-table groups remain distinguishable in self joins.
+extractQualifiedColumnTablesFromAst :: Ast.PreparableStmt -> Maybe [(Text, Text, Bool)]
+extractQualifiedColumnTablesFromAst stmt = do
+    qualifiers <- qualifiedColumnQualifiersFromStmt stmt
+    let aliasMap = buildAliasMapFromStmt stmt
+        nullableAliases = nullableQualifiersFromStmt stmt
+    mapM
+        (\qualifier ->
+            (\tableName -> (qualifier, tableName, qualifier `Set.member` nullableAliases))
+                <$> Map.lookup qualifier aliasMap
+        )
+        qualifiers
+
 qualifiedStarAliasesFromStmt :: Ast.PreparableStmt -> Maybe [Text]
 qualifiedStarAliasesFromStmt = \case
     Ast.SelectPreparableStmt selectStmt -> qualifiedStarAliasesFromSelectStmt selectStmt
@@ -739,6 +755,48 @@ qualifiedStarAliasFromTargetEl = \case
     Ast.ExprTargetEl (Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref ident (Just indirection)))) ->
         case toList indirection of
             [Ast.AllIndirectionEl] -> Just (identToText ident)
+            _ -> Nothing
+    _ -> Nothing
+
+qualifiedColumnQualifiersFromStmt :: Ast.PreparableStmt -> Maybe [Text]
+qualifiedColumnQualifiersFromStmt = \case
+    Ast.SelectPreparableStmt selectStmt -> qualifiedColumnQualifiersFromSelectStmt selectStmt
+    _ -> Nothing
+
+qualifiedColumnQualifiersFromSelectStmt :: Ast.SelectStmt -> Maybe [Text]
+qualifiedColumnQualifiersFromSelectStmt = \case
+    Left (Ast.SelectNoParens _with selectClause _sort _limit _lock) ->
+        qualifiedColumnQualifiersFromSelectClause selectClause
+    Right selectWithParens -> qualifiedColumnQualifiersFromSelectWithParens selectWithParens
+
+qualifiedColumnQualifiersFromSelectWithParens :: Ast.SelectWithParens -> Maybe [Text]
+qualifiedColumnQualifiersFromSelectWithParens = \case
+    Ast.NoParensSelectWithParens (Ast.SelectNoParens _with selectClause _sort _limit _lock) ->
+        qualifiedColumnQualifiersFromSelectClause selectClause
+    Ast.WithParensSelectWithParens inner -> qualifiedColumnQualifiersFromSelectWithParens inner
+
+qualifiedColumnQualifiersFromSelectClause :: Ast.SelectClause -> Maybe [Text]
+qualifiedColumnQualifiersFromSelectClause = \case
+    Left (Ast.NormalSimpleSelect (Just targeting) _into _from _where _group _having _window) ->
+        case targeting of
+            Ast.NormalTargeting targets -> mapM qualifiedColumnQualifierFromTargetEl (toList targets)
+            Ast.DistinctTargeting _ targets -> mapM qualifiedColumnQualifierFromTargetEl (toList targets)
+            _ -> Nothing
+    Right selectWithParens -> qualifiedColumnQualifiersFromSelectWithParens selectWithParens
+    _ -> Nothing
+
+qualifiedColumnQualifierFromTargetEl :: Ast.TargetEl -> Maybe Text
+qualifiedColumnQualifierFromTargetEl = \case
+    Ast.ExprTargetEl expr -> qualifiedColumnQualifierFromExpr expr
+    Ast.ImplicitlyAliasedExprTargetEl expr _alias -> qualifiedColumnQualifierFromExpr expr
+    Ast.AliasedExprTargetEl expr _alias -> qualifiedColumnQualifierFromExpr expr
+    _ -> Nothing
+
+qualifiedColumnQualifierFromExpr :: Ast.AExpr -> Maybe Text
+qualifiedColumnQualifierFromExpr = \case
+    Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref ident (Just indirection))) ->
+        case toList indirection of
+            [Ast.AttrNameIndirectionEl _column] -> Just (identToText ident)
             _ -> Nothing
     _ -> Nothing
 

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -35,13 +35,15 @@ import           IHP.TypedSql.ParamHints        (extractParamHintsFromAst, extra
                                                  extractNonNullableComputedColumnsFromAst,
                                                  parseSql, resolveParamHintTypes, detectStarSelects,
                                                  extractQualifiedStarTablesFromAst,
+                                                 extractQualifiedColumnTablesFromAst,
                                                  detectInsertWithoutColumns)
 import           IHP.TypedSql.ParamEncoder      (typedSqlParam)
 import           IHP.TypedSql.Placeholders      (PlaceholderPlan (..), parseExpr,
                                                  planPlaceholders)
 import           IHP.TypedSql.RowType           (SqlRow (..), sanitizeColumnName, deduplicateNames, sqlRowType)
 import           IHP.TypedSql.TypeMapping       (hsTypeForColumns, hsTypesForColumns, hsTypeForParam, detectFullTable,
-                                                 detectFullTableSelections, hsTypeForFullTableSelections)
+                                                 detectFullTableSelections, detectNamedFullTableSelections,
+                                                 hsTypeForFullTableSelections)
 import           IHP.TypedSql.Types             (QueryCardinality (..), QueryExecResult (..), TypedQuery (..))
 
 -- | QuasiQuoter entry point for typed SQL.
@@ -166,8 +168,11 @@ typedSqlExp allowStar rawSql = do
     let isMultiColumnAdhoc = not isFullTable && length drColumns > 1
     let fullTableSelections = do
             ast <- parsedAst
-            requestedTables <- extractQualifiedStarTablesFromAst ast
-            detectFullTableSelections drTables requestedTables drColumns
+            case extractQualifiedStarTablesFromAst ast of
+                Just requestedTables -> detectFullTableSelections drTables requestedTables drColumns
+                Nothing -> do
+                    requestedColumns <- extractQualifiedColumnTablesFromAst ast
+                    detectNamedFullTableSelections drTables requestedColumns drColumns
 
     (resultType, resultDecoder) <-
         case fullTableSelections of

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -28,18 +28,20 @@ import           IHP.Hasql.Encoders              ()
 
 import           IHP.TypedSql.Cardinality      (inferCardinality)
 import           IHP.TypedSql.CompileTimeDatabase (dependentSchemaFiles)
-import           IHP.TypedSql.Decoders          (resultDecoderForColumns)
+import           IHP.TypedSql.Decoders          (resultDecoderForColumns, resultDecoderForFullTableSelections)
 import           IHP.TypedSql.Metadata          (DescribeColumn (..), DescribeResult (..), PgTypeInfo (..), TableMeta (..),
                                                  describeStatement)
 import           IHP.TypedSql.ParamHints        (extractParamHintsFromAst, extractJoinNullableTablesFromAst,
                                                  extractNonNullableComputedColumnsFromAst,
                                                  parseSql, resolveParamHintTypes, detectStarSelects,
+                                                 extractQualifiedStarTablesFromAst,
                                                  detectInsertWithoutColumns)
 import           IHP.TypedSql.ParamEncoder      (typedSqlParam)
 import           IHP.TypedSql.Placeholders      (PlaceholderPlan (..), parseExpr,
                                                  planPlaceholders)
 import           IHP.TypedSql.RowType           (SqlRow (..), sanitizeColumnName, deduplicateNames, sqlRowType)
-import           IHP.TypedSql.TypeMapping       (hsTypeForColumns, hsTypesForColumns, hsTypeForParam, detectFullTable)
+import           IHP.TypedSql.TypeMapping       (hsTypeForColumns, hsTypesForColumns, hsTypeForParam, detectFullTable,
+                                                 detectFullTableSelections, hsTypeForFullTableSelections)
 import           IHP.TypedSql.Types             (QueryCardinality (..), QueryExecResult (..), TypedQuery (..))
 
 -- | QuasiQuoter entry point for typed SQL.
@@ -162,10 +164,17 @@ typedSqlExp allowStar rawSql = do
 
     let isFullTable = isJust (detectFullTable drTables drColumns)
     let isMultiColumnAdhoc = not isFullTable && length drColumns > 1
+    let fullTableSelections = do
+            ast <- parsedAst
+            requestedTables <- extractQualifiedStarTablesFromAst ast
+            detectFullTableSelections drTables requestedTables drColumns
 
     (resultType, resultDecoder) <-
-        if isMultiColumnAdhoc
-            then do
+        case fullTableSelections of
+            Just selections -> do
+                decoder <- resultDecoderForFullTableSelections selections
+                pure (hsTypeForFullTableSelections selections, decoder)
+            Nothing | isMultiColumnAdhoc -> do
                 -- Wrap the tuple in SqlRow for labeled field access
                 columnTypes <- hsTypesForColumns drTypes drTables joinNullableOids nonNullableColumns drColumns
                 let colNames = deduplicateNames (map (sanitizeColumnName . dcName) drColumns)
@@ -175,7 +184,7 @@ typedSqlExp allowStar rawSql = do
                 -- fmap SqlRow tupleDecoder
                 let wrappedDecoder = TH.AppE (TH.AppE (TH.VarE 'fmap) (TH.ConE 'SqlRow)) tupleDecoder
                 pure (rowType, wrappedDecoder)
-            else do
+            Nothing -> do
                 rt <- hsTypeForColumns drTypes drTables joinNullableOids nonNullableColumns drColumns
                 decoder <- resultDecoderForColumns drTypes drTables joinNullableOids nonNullableColumns drColumns
                 pure (rt, decoder)

--- a/ihp-typed-sql/IHP/TypedSql/TypeMapping.hs
+++ b/ihp-typed-sql/IHP/TypedSql/TypeMapping.hs
@@ -6,6 +6,9 @@ module IHP.TypedSql.TypeMapping
     , hsTypeForColumn
     , hsTypesForColumns
     , detectFullTable
+    , FullTableSelection (..)
+    , detectFullTableSelections
+    , hsTypeForFullTableSelections
     ) where
 
 import           Control.Monad            (guard, zipWithM)
@@ -27,6 +30,13 @@ import           PostgresqlTypes.Tsvector (Tsvector)
 import           PostgresqlTypes.Interval (Interval)
 
 import           IHP.TypedSql.Metadata    (ColumnMeta (..), DescribeColumn (..), PgTypeInfo (..), TableMeta (..))
+
+-- | One qualified @table.*@ result group.
+data FullTableSelection = FullTableSelection
+    { ftsTableName :: !Text
+    , ftsNullable  :: !Bool
+    , ftsColumns   :: ![DescribeColumn]
+    }
 
 -- | Build the Haskell type for a parameter, based on its OID.
 -- High-level: map a PG type OID into a TH Type.
@@ -74,6 +84,35 @@ detectFullTable tables cols = do
             TableMeta { tmName } <- Map.lookup tableOid tables
             pure tmName
         _ -> Nothing
+
+-- | Match qualified stars against the described PostgreSQL columns. The
+-- expected width of every table lets this distinguish aliases in a self join,
+-- even though libpq reports the same table OID for both result groups.
+detectFullTableSelections :: Map.Map PQ.Oid TableMeta -> [(Text, Bool)] -> [DescribeColumn] -> Maybe [FullTableSelection]
+detectFullTableSelections tables requested columns = go requested columns
+  where
+    go [] [] = Just []
+    go [] _ = Nothing
+    go ((tableName, nullable):rest) remaining = do
+        (tableOid, TableMeta { tmColumnOrder }) <-
+            find (\(_, TableMeta { tmName }) -> tmName == tableName) (Map.toList tables)
+        let (tableColumns, remainingColumns) = List.splitAt (length tmColumnOrder) remaining
+        guard (length tableColumns == length tmColumnOrder)
+        guard (all ((== tableOid) . dcTable) tableColumns)
+        guard (mapMaybe dcAttnum tableColumns == tmColumnOrder)
+        following <- go rest remainingColumns
+        pure (FullTableSelection tableName nullable tableColumns : following)
+
+-- | Build the model or model-tuple type represented by qualified stars.
+hsTypeForFullTableSelections :: [FullTableSelection] -> TH.Type
+hsTypeForFullTableSelections selections =
+    case map selectionType selections of
+        [single] -> single
+        types -> foldl TH.AppT (TH.TupleT (length types)) types
+  where
+    selectionType FullTableSelection { ftsTableName, ftsNullable } =
+        let modelType = TH.ConT (TH.mkName (CS.cs (tableNameToModelName ftsTableName)))
+        in if ftsNullable then TH.AppT (TH.ConT ''Maybe) modelType else modelType
 
 -- | Map a single column into a Haskell type, with key-aware rules.
 -- The @forceNonNull@ flag overrides the nullable fallback for computed columns

--- a/ihp-typed-sql/IHP/TypedSql/TypeMapping.hs
+++ b/ihp-typed-sql/IHP/TypedSql/TypeMapping.hs
@@ -8,6 +8,7 @@ module IHP.TypedSql.TypeMapping
     , detectFullTable
     , FullTableSelection (..)
     , detectFullTableSelections
+    , detectNamedFullTableSelections
     , hsTypeForFullTableSelections
     ) where
 
@@ -98,6 +99,30 @@ detectFullTableSelections tables requested columns = go requested columns
             find (\(_, TableMeta { tmName }) -> tmName == tableName) (Map.toList tables)
         let (tableColumns, remainingColumns) = List.splitAt (length tmColumnOrder) remaining
         guard (length tableColumns == length tmColumnOrder)
+        guard (all ((== tableOid) . dcTable) tableColumns)
+        guard (mapMaybe dcAttnum tableColumns == tmColumnOrder)
+        following <- go rest remainingColumns
+        pure (FullTableSelection tableName nullable tableColumns : following)
+
+-- | Match explicit qualified column lists against complete table records.
+-- Columns must be contiguous and in schema order. Partial, reordered, or mixed
+-- groups deliberately fall back to SqlRow.
+detectNamedFullTableSelections :: Map.Map PQ.Oid TableMeta -> [(Text, Text, Bool)] -> [DescribeColumn] -> Maybe [FullTableSelection]
+detectNamedFullTableSelections tables requested columns =
+    go (List.groupBy sameQualifier requested) columns
+  where
+    sameQualifier (leftQualifier, _, _) (rightQualifier, _, _) = leftQualifier == rightQualifier
+
+    go [] [] = Just []
+    go [] _ = Nothing
+    go (requestGroup:rest) remaining = do
+        (_, tableName, nullable) <- listToMaybe requestGroup
+        guard (all (\(_, requestedTable, requestedNullable) -> requestedTable == tableName && requestedNullable == nullable) requestGroup)
+        (tableOid, TableMeta { tmColumnOrder }) <-
+            find (\(_, TableMeta { tmName }) -> tmName == tableName) (Map.toList tables)
+        guard (length requestGroup == length tmColumnOrder)
+        let (tableColumns, remainingColumns) = List.splitAt (length requestGroup) remaining
+        guard (length tableColumns == length requestGroup)
         guard (all ((== tableOid) . dcTable) tableColumns)
         guard (mapMaybe dcAttnum tableColumns == tmColumnOrder)
         following <- go rest remainingColumns

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -3,6 +3,7 @@ module Test.TypedSqlSpec where
 import           Control.Concurrent                 (threadDelay)
 import qualified Control.Exception                 as Exception
 import qualified Data.List                         as List
+import qualified Data.Map.Strict                   as Map
 import qualified Data.Set                          as Set
 import qualified Data.Text                         as Text
 import qualified Data.Text.IO                      as Text
@@ -14,7 +15,11 @@ import           IHP.Prelude
 import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullableTables,
                                                     extractNonNullableComputedColumnsFromAst,
                                                     detectStarSelects,
+                                                    extractQualifiedStarTablesFromAst,
                                                     detectInsertWithoutColumns)
+import           IHP.TypedSql.Metadata             (DescribeColumn (..), TableMeta (..))
+import           IHP.TypedSql.TypeMapping          (FullTableSelection (..), detectFullTableSelections)
+import qualified Database.PostgreSQL.LibPQ         as PQ
 import           System.Directory                  (createDirectoryIfMissing,
                                                     doesDirectoryExist,
                                                     doesFileExist,
@@ -934,6 +939,43 @@ tests = do
             let Just ast = parseSql "(SELECT * FROM items)"
             detectStarSelects ast `shouldBe` ["*"]
 
+        it "resolves qualified stars and outer-join nullability" do
+            let Just ast = parseSql "SELECT i.*, a.* FROM items i LEFT JOIN authors a ON a.id = i.author_id"
+            extractQualifiedStarTablesFromAst ast
+                `shouldBe` Just [("items", False), ("authors", True)]
+
+        it "keeps self-join alias nullability separate" do
+            let Just ast = parseSql "SELECT parent.*, child.* FROM authors parent LEFT JOIN authors child ON child.id = parent.parent_id"
+            extractQualifiedStarTablesFromAst ast
+                `shouldBe` Just [("authors", False), ("authors", True)]
+
+        it "does not group mixed stars and expressions" do
+            let Just ast = parseSql "SELECT i.*, a.name FROM items i JOIN authors a ON a.id = i.author_id"
+            extractQualifiedStarTablesFromAst ast `shouldBe` Nothing
+
+        it "partitions repeated table metadata for self-join stars" do
+            let tableOid = PQ.Oid 42
+                tableMeta = TableMeta
+                    { tmOid = tableOid
+                    , tmName = "authors"
+                    , tmColumns = Map.empty
+                    , tmColumnOrder = [1, 2]
+                    , tmPrimaryKeys = Set.singleton 1
+                    , tmForeignKeys = Map.empty
+                    }
+                column attnum = DescribeColumn
+                    { dcName = "column"
+                    , dcType = tableOid
+                    , dcTable = tableOid
+                    , dcAttnum = Just attnum
+                    }
+                result = detectFullTableSelections
+                    (Map.singleton tableOid tableMeta)
+                    [("authors", False), ("authors", True)]
+                    [column 1, column 2, column 1, column 2]
+            fmap (map (\selection -> (selection.ftsTableName, selection.ftsNullable, length selection.ftsColumns))) result
+                `shouldBe` Just [("authors", False, 2), ("authors", True, 2)]
+
         it "detectInsertWithoutColumns detects INSERT VALUES without column list" do
             let Just ast = parseSql "INSERT INTO items VALUES (1, 'name')"
             detectInsertWithoutColumns ast `shouldBe` ["INSERT INTO items"]
@@ -1481,7 +1523,7 @@ compilePassModule = Text.unlines
     , "import IHP.Prelude"
     , "import GHC.Records (HasField)"
     , "import IHP.ModelSupport (Id'(..), PrimaryKey)"
-    , "import IHP.Hasql.FromRow (FromRowHasql (..))"
+    , "import IHP.Hasql.FromRow (FromRowHasql (..), FromRowHasqlNullable (..))"
     , "import IHP.TypedSql (QueryCardinality (..), QueryExecResult (..), TypedQuery, typedSql, typedSqlStar)"
     , "import IHP.TypedSql.RowType (SqlRow)"
     , "import qualified Data.Aeson as Aeson"
@@ -1509,6 +1551,37 @@ compilePassModule = Text.unlines
     , "            <*> HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.float8)"
     , "            <*> HasqlDecoders.column (HasqlDecoders.nonNullable (HasqlDecoders.listArray (HasqlDecoders.nonNullable HasqlDecoders.text)))"
     , ""
+    , "instance FromRowHasqlNullable TypedSqlTestItem where"
+    , "    hasqlNullableRowDecoder ="
+    , "        buildItem"
+    , "            <$> (fmap (fmap Id) (HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.uuid)))"
+    , "            <*> (fmap (fmap Id) (HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.uuid)))"
+    , "            <*> HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.text)"
+    , "            <*> (fmap (fmap fromIntegral) (HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.int4)))"
+    , "            <*> HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.float8)"
+    , "            <*> HasqlDecoders.column (HasqlDecoders.nullable (HasqlDecoders.listArray (HasqlDecoders.nonNullable HasqlDecoders.text)))"
+    , "      where"
+    , "        buildItem (Just itemId) authorId (Just name) (Just views) score (Just tags) = Just (TypedSqlTestItem itemId authorId name views score tags)"
+    , "        buildItem _ _ _ _ _ _ = Nothing"
+    , ""
+    , "data TypedSqlTestAuthor = TypedSqlTestAuthor"
+    , "    { typedSqlTestAuthorId :: Id' \"typed_sql_test_authors\""
+    , "    , typedSqlTestAuthorName :: Text"
+    , "    } deriving (Eq, Show)"
+    , ""
+    , "instance FromRowHasql TypedSqlTestAuthor where"
+    , "    hasqlRowDecoder = TypedSqlTestAuthor"
+    , "        <$> (fmap Id (HasqlDecoders.column (HasqlDecoders.nonNullable HasqlDecoders.uuid)))"
+    , "        <*> HasqlDecoders.column (HasqlDecoders.nonNullable HasqlDecoders.text)"
+    , ""
+    , "instance FromRowHasqlNullable TypedSqlTestAuthor where"
+    , "    hasqlNullableRowDecoder = buildAuthor"
+    , "        <$> (fmap (fmap Id) (HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.uuid)))"
+    , "        <*> HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.text)"
+    , "      where"
+    , "        buildAuthor (Just authorId) (Just name) = Just (TypedSqlTestAuthor authorId name)"
+    , "        buildAuthor _ _ = Nothing"
+    , ""
     , "qName :: TypedQuery 'AtMostOneRow 'ReturnsRows Text"
     , "qName = [typedSql| SELECT name FROM typed_sql_test_items LIMIT 1 |]"
     , ""
@@ -1517,6 +1590,21 @@ compilePassModule = Text.unlines
     , ""
     , "qAllFieldsAlias :: TypedQuery 'AtMostOneRow 'ReturnsRows TypedSqlTestItem"
     , "qAllFieldsAlias = [typedSqlStar| SELECT i.* FROM typed_sql_test_items i JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , ""
+    , "qInnerJoinStars :: TypedQuery 'AtMostOneRow 'ReturnsRows (TypedSqlTestItem, TypedSqlTestAuthor)"
+    , "qInnerJoinStars = [typedSqlStar| SELECT i.*, a.* FROM typed_sql_test_items i INNER JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , ""
+    , "qLeftJoinStars :: TypedQuery 'AtMostOneRow 'ReturnsRows (TypedSqlTestItem, Maybe TypedSqlTestAuthor)"
+    , "qLeftJoinStars = [typedSqlStar| SELECT i.*, a.* FROM typed_sql_test_items i LEFT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , ""
+    , "qRightJoinStars :: TypedQuery 'AtMostOneRow 'ReturnsRows (Maybe TypedSqlTestItem, TypedSqlTestAuthor)"
+    , "qRightJoinStars = [typedSqlStar| SELECT i.*, a.* FROM typed_sql_test_items i RIGHT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , ""
+    , "qFullJoinStars :: TypedQuery 'AtMostOneRow 'ReturnsRows (Maybe TypedSqlTestItem, Maybe TypedSqlTestAuthor)"
+    , "qFullJoinStars = [typedSqlStar| SELECT i.*, a.* FROM typed_sql_test_items i FULL JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , ""
+    , "qNullableSingleStar :: TypedQuery 'AtMostOneRow 'ReturnsRows (Maybe TypedSqlTestAuthor)"
+    , "qNullableSingleStar = [typedSqlStar| SELECT a.* FROM typed_sql_test_items i LEFT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     , ""
     , "qPrimaryKey :: TypedQuery 'AtMostOneRow 'ReturnsRows (Id' \"typed_sql_test_items\")"
     , "qPrimaryKey = [typedSql| SELECT id FROM typed_sql_test_items LIMIT 1 |]"

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -16,9 +16,11 @@ import           IHP.TypedSql.ParamHints           (parseSql, extractJoinNullabl
                                                     extractNonNullableComputedColumnsFromAst,
                                                     detectStarSelects,
                                                     extractQualifiedStarTablesFromAst,
+                                                    extractQualifiedColumnTablesFromAst,
                                                     detectInsertWithoutColumns)
 import           IHP.TypedSql.Metadata             (DescribeColumn (..), TableMeta (..))
-import           IHP.TypedSql.TypeMapping          (FullTableSelection (..), detectFullTableSelections)
+import           IHP.TypedSql.TypeMapping          (FullTableSelection (..), detectFullTableSelections,
+                                                    detectNamedFullTableSelections)
 import qualified Database.PostgreSQL.LibPQ         as PQ
 import           System.Directory                  (createDirectoryIfMissing,
                                                     doesDirectoryExist,
@@ -953,6 +955,20 @@ tests = do
             let Just ast = parseSql "SELECT i.*, a.name FROM items i JOIN authors a ON a.id = i.author_id"
             extractQualifiedStarTablesFromAst ast `shouldBe` Nothing
 
+        it "resolves qualified named columns and outer-join nullability" do
+            let Just ast = parseSql "SELECT i.id, i.name, a.id, a.name FROM items i LEFT JOIN authors a ON a.id = i.author_id"
+            extractQualifiedColumnTablesFromAst ast
+                `shouldBe` Just
+                    [ ("i", "items", False)
+                    , ("i", "items", False)
+                    , ("a", "authors", True)
+                    , ("a", "authors", True)
+                    ]
+
+        it "does not group named columns mixed with expressions" do
+            let Just ast = parseSql "SELECT i.id, UPPER(i.name) FROM items i"
+            extractQualifiedColumnTablesFromAst ast `shouldBe` Nothing
+
         it "partitions repeated table metadata for self-join stars" do
             let tableOid = PQ.Oid 42
                 tableMeta = TableMeta
@@ -975,6 +991,30 @@ tests = do
                     [column 1, column 2, column 1, column 2]
             fmap (map (\selection -> (selection.ftsTableName, selection.ftsNullable, length selection.ftsColumns))) result
                 `shouldBe` Just [("authors", False, 2), ("authors", True, 2)]
+
+        it "groups complete named-column table records" do
+            let itemsOid = PQ.Oid 42
+                authorsOid = PQ.Oid 43
+                tableMeta tableOid tableName = TableMeta
+                    { tmOid = tableOid
+                    , tmName = tableName
+                    , tmColumns = Map.empty
+                    , tmColumnOrder = [1, 2]
+                    , tmPrimaryKeys = Set.singleton 1
+                    , tmForeignKeys = Map.empty
+                    }
+                column tableOid attnum = DescribeColumn
+                    { dcName = "column"
+                    , dcType = tableOid
+                    , dcTable = tableOid
+                    , dcAttnum = Just attnum
+                    }
+                result = detectNamedFullTableSelections
+                    (Map.fromList [(itemsOid, tableMeta itemsOid "items"), (authorsOid, tableMeta authorsOid "authors")])
+                    [("i", "items", False), ("i", "items", False), ("a", "authors", True), ("a", "authors", True)]
+                    [column itemsOid 1, column itemsOid 2, column authorsOid 1, column authorsOid 2]
+            fmap (map (\selection -> (selection.ftsTableName, selection.ftsNullable))) result
+                `shouldBe` Just [("items", False), ("authors", True)]
 
         it "detectInsertWithoutColumns detects INSERT VALUES without column list" do
             let Just ast = parseSql "INSERT INTO items VALUES (1, 'name')"
@@ -1523,7 +1563,7 @@ compilePassModule = Text.unlines
     , "import IHP.Prelude"
     , "import GHC.Records (HasField)"
     , "import IHP.ModelSupport (Id'(..), PrimaryKey)"
-    , "import IHP.Hasql.FromRow (FromRowHasql (..), FromRowHasqlNullable (..))"
+    , "import IHP.Hasql.FromRow (FromRowHasql (..))"
     , "import IHP.TypedSql (QueryCardinality (..), QueryExecResult (..), TypedQuery, typedSql, typedSqlStar)"
     , "import IHP.TypedSql.RowType (SqlRow)"
     , "import qualified Data.Aeson as Aeson"
@@ -1551,8 +1591,8 @@ compilePassModule = Text.unlines
     , "            <*> HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.float8)"
     , "            <*> HasqlDecoders.column (HasqlDecoders.nonNullable (HasqlDecoders.listArray (HasqlDecoders.nonNullable HasqlDecoders.text)))"
     , ""
-    , "instance FromRowHasqlNullable TypedSqlTestItem where"
-    , "    hasqlNullableRowDecoder ="
+    , "instance FromRowHasql (Maybe TypedSqlTestItem) where"
+    , "    hasqlRowDecoder ="
     , "        buildItem"
     , "            <$> (fmap (fmap Id) (HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.uuid)))"
     , "            <*> (fmap (fmap Id) (HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.uuid)))"
@@ -1574,8 +1614,8 @@ compilePassModule = Text.unlines
     , "        <$> (fmap Id (HasqlDecoders.column (HasqlDecoders.nonNullable HasqlDecoders.uuid)))"
     , "        <*> HasqlDecoders.column (HasqlDecoders.nonNullable HasqlDecoders.text)"
     , ""
-    , "instance FromRowHasqlNullable TypedSqlTestAuthor where"
-    , "    hasqlNullableRowDecoder = buildAuthor"
+    , "instance FromRowHasql (Maybe TypedSqlTestAuthor) where"
+    , "    hasqlRowDecoder = buildAuthor"
     , "        <$> (fmap (fmap Id) (HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.uuid)))"
     , "        <*> HasqlDecoders.column (HasqlDecoders.nullable HasqlDecoders.text)"
     , "      where"
@@ -1605,6 +1645,9 @@ compilePassModule = Text.unlines
     , ""
     , "qNullableSingleStar :: TypedQuery 'AtMostOneRow 'ReturnsRows (Maybe TypedSqlTestAuthor)"
     , "qNullableSingleStar = [typedSqlStar| SELECT a.* FROM typed_sql_test_items i LEFT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
+    , ""
+    , "qLeftJoinNamedColumns :: TypedQuery 'AtMostOneRow 'ReturnsRows (TypedSqlTestItem, Maybe TypedSqlTestAuthor)"
+    , "qLeftJoinNamedColumns = [typedSql| SELECT i.id, i.author_id, i.name, i.views, i.score, i.tags, a.id, a.name FROM typed_sql_test_items i LEFT JOIN typed_sql_test_authors a ON a.id = i.author_id LIMIT 1 |]"
     , ""
     , "qPrimaryKey :: TypedQuery 'AtMostOneRow 'ReturnsRows (Id' \"typed_sql_test_items\")"
     , "qPrimaryKey = [typedSql| SELECT id FROM typed_sql_test_items LIMIT 1 |]"

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -2,11 +2,10 @@
 
 ## Unreleased
 
-- Complete qualified table records are now grouped into generated model types,
-  whether written as explicit named columns or as `table.*` with
-  `typedSqlStar`. Tables on the nullable side of an outer join are wrapped in
-  `Maybe`, so a complete `Item` and `Author` selection across a `LEFT JOIN`
-  produces `(Item, Maybe Author)` instead of one flat `SqlRow`
+- Complete qualified named-column table records are now grouped into generated
+  model types. Tables on the nullable side of an outer join are wrapped in
+  `Maybe`, so complete `Item` and `Author` column groups across a `LEFT JOIN`
+  produce `(Item, Maybe Author)` instead of one flat `SqlRow`
   ([#2781](https://github.com/digitallyinduced/ihp/issues/2781)).
 
 - Each compiler process now uses a compact private compile-time PostgreSQL

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
-- Qualified full-table stars are now grouped into generated model records.
-  For example, `SELECT i.*, a.*` across a `LEFT JOIN` produces
-  `(Item, Maybe Author)` instead of one flat `SqlRow` ([#2781](https://github.com/digitallyinduced/ihp/issues/2781)).
+- Complete qualified table records are now grouped into generated model types,
+  whether written as explicit named columns or as `table.*` with
+  `typedSqlStar`. Tables on the nullable side of an outer join are wrapped in
+  `Maybe`, so a complete `Item` and `Author` selection across a `LEFT JOIN`
+  produces `(Item, Maybe Author)` instead of one flat `SqlRow`
+  ([#2781](https://github.com/digitallyinduced/ihp/issues/2781)).
 
 - Each compiler process now uses a compact private compile-time PostgreSQL
   cluster under the worktree's `.devenv/state` directory. PostgreSQL stops after

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Qualified full-table stars are now grouped into generated model records.
+  For example, `SELECT i.*, a.*` across a `LEFT JOIN` produces
+  `(Item, Maybe Author)` instead of one flat `SqlRow` ([#2781](https://github.com/digitallyinduced/ihp/issues/2781)).
+
 - Each compiler process now uses a compact private compile-time PostgreSQL
   cluster under the worktree's `.devenv/state` directory. PostgreSQL stops after
   metadata operations become idle, the disposable cluster is rebuilt on schema

--- a/ihp-typed-sql/ihp-typed-sql.cabal
+++ b/ihp-typed-sql/ihp-typed-sql.cabal
@@ -103,6 +103,7 @@ test-suite tests
             , filepath
             , hspec
             , process
+            , postgresql-libpq
             , string-conversions
             , temporary-ospath
             , text

--- a/ihp/IHP/Hasql/FromRow.hs
+++ b/ihp/IHP/Hasql/FromRow.hs
@@ -15,6 +15,7 @@ Also provides parser functions used by the generated decoders for custom Postgre
 -}
 module IHP.Hasql.FromRow
 ( FromRowHasql (..)
+, FromRowHasqlNullable (..)
 , HasqlDecodeColumn (..)
 ) where
 
@@ -34,6 +35,14 @@ import IHP.ModelSupport.Types (Id'(..), PrimaryKey)
 class FromRowHasql a where
     -- | Decoder for a single row
     hasqlRowDecoder :: Decoders.Row a
+
+-- | Decode a model selected from the nullable side of an outer join.
+--
+-- Generated model types provide this instance. Unlike 'FromRowHasql', every
+-- database column is accepted as nullable and an absent joined row becomes
+-- 'Nothing'.
+class FromRowHasqlNullable a where
+    hasqlNullableRowDecoder :: Decoders.Row (Maybe a)
 
 -- | Typeclass for building column-level row decoders, handling nullable/non-nullable.
 -- Uses 'Mapping.IsScalar' from hasql-mapping for value-level decoding.
@@ -94,5 +103,4 @@ instance (HasqlDecodeColumn a, HasqlDecodeColumn b, HasqlDecodeColumn c, HasqlDe
 
 instance (HasqlDecodeColumn a, HasqlDecodeColumn b, HasqlDecodeColumn c, HasqlDecodeColumn d, HasqlDecodeColumn e) => FromRowHasql (a, b, c, d, e) where
     hasqlRowDecoder = (,,,,) <$> hasqlColumnDecoder <*> hasqlColumnDecoder <*> hasqlColumnDecoder <*> hasqlColumnDecoder <*> hasqlColumnDecoder
-
 

--- a/ihp/IHP/Hasql/FromRow.hs
+++ b/ihp/IHP/Hasql/FromRow.hs
@@ -15,7 +15,6 @@ Also provides parser functions used by the generated decoders for custom Postgre
 -}
 module IHP.Hasql.FromRow
 ( FromRowHasql (..)
-, FromRowHasqlNullable (..)
 , HasqlDecodeColumn (..)
 ) where
 
@@ -35,14 +34,6 @@ import IHP.ModelSupport.Types (Id'(..), PrimaryKey)
 class FromRowHasql a where
     -- | Decoder for a single row
     hasqlRowDecoder :: Decoders.Row a
-
--- | Decode a model selected from the nullable side of an outer join.
---
--- Generated model types provide this instance. Unlike 'FromRowHasql', every
--- database column is accepted as nullable and an absent joined row becomes
--- 'Nothing'.
-class FromRowHasqlNullable a where
-    hasqlNullableRowDecoder :: Decoders.Row (Maybe a)
 
 -- | Typeclass for building column-level row decoders, handling nullable/non-nullable.
 -- Uses 'Mapping.IsScalar' from hasql-mapping for value-level decoding.
@@ -103,4 +94,3 @@ instance (HasqlDecodeColumn a, HasqlDecodeColumn b, HasqlDecodeColumn c, HasqlDe
 
 instance (HasqlDecodeColumn a, HasqlDecodeColumn b, HasqlDecodeColumn c, HasqlDecodeColumn d, HasqlDecodeColumn e) => FromRowHasql (a, b, c, d, e) where
     hasqlRowDecoder = (,,,,) <$> hasqlColumnDecoder <*> hasqlColumnDecoder <*> hasqlColumnDecoder <*> hasqlColumnDecoder <*> hasqlColumnDecoder
-


### PR DESCRIPTION
Closes #2781.

## What changed

- Decode contiguous, complete, schema-ordered qualified named-column groups into generated model records.
- Represent tables on nullable outer-join sides through the existing `FromRowHasql (Maybe Model)` interface.
- Support INNER, LEFT, RIGHT, FULL, and self-join groupings.
- Keep partial, reordered, unqualified, and expression-mixed selections on the existing `SqlRow` path.
- Preserve the existing `typedSqlStar` escape hatch without recommending stars for model-tuple queries.
- Document explicit named columns as the recommended form and add an unreleased changelog entry.

## Why

PostgreSQL metadata already preserved correct per-column nullability, but typed SQL flattened complete multi-table selections into one anonymous `SqlRow`. This made joined queries incompatible with the generated model types used by the rest of an IHP application.

Explicit named columns are supported so callers do not need to opt into schema-drift-prone star selections. Normal `typedSql` continues to reject `*`.

## Validation

- Schema compiler tests: 47 examples, 0 failures.
- New explicit-column, outer-join, mixed-selection, and self-join grouping tests pass.
- Modified typed-SQL and schema-compiler modules load successfully in GHCi.
- `git diff --check` passes.

The complete PostgreSQL-backed typed-SQL suite could not run locally because the machine had exhausted its System V shared-memory segment limit; unrelated automatic database tests failed during `initdb`.