### PR TITLE
Secure the local ToolServer boundary

### DIFF
--- a/ihp-ide/IHP/IDE/Data/View/EditRow.hs
+++ b/ihp-ide/IHP/IDE/Data/View/EditRow.hs
@@ -71,7 +71,7 @@ instance View EditRowView where
                         </div>
                     </div>|]
 
-            onClick tableName fieldName id = "window.location.assign(" <> tshow (pathTo (ToggleBooleanFieldAction tableName (cs fieldName) id)) <> ")"
+            onClick tableName fieldName id = "fetch(" <> tshow (pathTo (ToggleBooleanFieldAction tableName (cs fieldName) id)) <> ", { method: 'POST' }).then(() => window.location.reload())"
             renderInputMethod :: (ColumnDefinition, DynamicField) -> Html
             renderInputMethod (def, val) | (def.columnType) == "boolean" && isNothing (val.fieldValue) = [hsx|
                             {isBooleanParam True def}

--- a/ihp-ide/IHP/IDE/Data/View/NewRow.hs
+++ b/ihp-ide/IHP/IDE/Data/View/NewRow.hs
@@ -63,7 +63,7 @@ instance View NewRowView where
                         </div>
                     </div>|]
 
-            onClick tableName fieldName id = "window.location.assign(" <> tshow (pathTo (ToggleBooleanFieldAction tableName (cs fieldName) id)) <> ")"
+            onClick tableName fieldName id = "fetch(" <> tshow (pathTo (ToggleBooleanFieldAction tableName (cs fieldName) id)) <> ", { method: 'POST' }).then(() => window.location.reload())"
             renderInputMethod :: ColumnDefinition -> Html 
             renderInputMethod col | (col.columnType) == "boolean" = [hsx|
                             {isBooleanParam True col}

--- a/ihp-ide/IHP/IDE/Data/View/ShowTableRows.hs
+++ b/ihp-ide/IHP/IDE/Data/View/ShowTableRows.hs
@@ -73,7 +73,7 @@ instance View ShowTableRowsView where
 
             columnNames = map (.fieldName) (fromMaybe [] (head rows))
 
-            onClick tableName fieldName primaryKey = "window.location.assign(" <> tshow (pathTo (ToggleBooleanFieldAction tableName (cs fieldName) primaryKey)) <> ")"
+            onClick tableName fieldName primaryKey = "fetch(" <> tshow (pathTo (ToggleBooleanFieldAction tableName (cs fieldName) primaryKey)) <> ", { method: 'POST' }).then(() => window.location.reload())"
 
             totalPages = [1..ceiling (fromIntegral(totalRows) / fromIntegral(pageSize))]
 

--- a/ihp-ide/IHP/IDE/SchemaDesigner/View/Layout.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/View/Layout.hs
@@ -385,7 +385,7 @@ renderColumn Column { name, columnType, defaultValue, notNull, isUnique } id tab
     <a href={EditColumnAction tableName id}>Edit Column</a>
     <a href={DeleteColumnAction tableName id name} class="js-delete">Delete Column</a>
     <div></div>
-    <form action={ToggleColumnUniqueAction tableName id}>
+    <form method="POST" action={ToggleColumnUniqueAction tableName id}>
         <button type="submit" class="link-button">
             {toggleButtonText}
         </button>

--- a/ihp-ide/IHP/IDE/ToolServer.hs
+++ b/ihp-ide/IHP/IDE/ToolServer.hs
@@ -1,4 +1,4 @@
-module IHP.IDE.ToolServer (runToolServer, withToolServerApplication, ToolServerApplicationWithConfig(..)) where
+module IHP.IDE.ToolServer (runToolServer, withToolServerApplication, ToolServerApplicationWithConfig(..), toolServerSecurityMiddleware) where
 
 import IHP.Prelude
 import System.Log.FastLogger (LogType'(..), withFastLogger, defaultBufSize, toLogStr)
@@ -39,6 +39,7 @@ import IHP.Controller.Layout
 import qualified IHP.IDE.LiveReloadNotificationServer as LiveReloadNotificationServer
 import qualified IHP.Version as Version
 import qualified Control.Exception.Safe as Exception
+import qualified Network.HTTP.Types as HTTP
 
 import qualified Network.Wai.Application.Static as Static
 import qualified Network.Wai.Middleware.Approot as Approot
@@ -66,6 +67,7 @@ startToolServer' toolServerApplication port isDebugMode liveReloadClients = do
         let openAppUrl = openUrl ("http://localhost:" <> tshow port <> "/")
         let warpSettings = Warp.defaultSettings
                 |> Warp.setPort port
+                |> Warp.setHost "127.0.0.1"
                 |> Warp.setBeforeMainLoop openAppUrl
 
         let logMiddleware = if isDebugMode then weightedApp.frameworkConfig.requestLoggerMiddleware else IHP.Prelude.id
@@ -152,7 +154,31 @@ withToolServerApplication toolServerApplication port liveReloadClients action = 
                             (LiveReloadNotificationServer.app liveReloadClients)
                             innerApplication
 
-            action ToolServerApplicationWithConfig { application, frameworkConfig }
+            let securedApplication = toolServerSecurityMiddleware port application
+            action ToolServerApplicationWithConfig { application = securedApplication, frameworkConfig }
+
+-- | Protects the complete ToolServer application before any route or static
+-- asset is dispatched. Only local Host values are accepted, and browser
+-- mutations must come from the ToolServer's own origin.
+toolServerSecurityMiddleware :: Int -> Wai.Middleware
+toolServerSecurityMiddleware port app request respond
+    | not (trustedHost request) = reject HTTP.status403 "Untrusted Host"
+    | isMutation request && not (trustedOrigin request) = reject HTTP.status403 "Untrusted request origin"
+    | otherwise = app request respond
+    where
+        reject status message = respond (Wai.responseLBS status [(HTTP.hContentType, "text/plain; charset=utf-8")] message)
+
+        trustedHost req = maybe False (`elem` allowedHosts) (lookup HTTP.hHost req.requestHeaders)
+        allowedHosts =
+            [ "localhost:" <> cs (show port)
+            , "127.0.0.1:" <> cs (show port)
+            , "[::1]:" <> cs (show port)
+            ]
+
+        isMutation req = req.requestMethod `elem` [HTTP.methodPost, HTTP.methodPut, HTTP.methodPatch, HTTP.methodDelete]
+        trustedOrigin req = case lookup "Origin" req.requestHeaders of
+            Nothing -> True
+            Just origin -> origin == "http://" <> fromMaybe "" (lookup HTTP.hHost req.requestHeaders)
 
 initStaticApp :: IO Wai.Application
 initStaticApp = do

--- a/ihp-ide/IHP/IDE/ToolServer/Routes.hs
+++ b/ihp-ide/IHP/IDE/ToolServer/Routes.hs
@@ -30,7 +30,7 @@ POST       /CreateColumn                                                        
 GET        /EditColumn?tableName&columnId                                            EditColumnAction
 POST|PATCH /UpdateColumn                                                             UpdateColumnAction
 DELETE     /DeleteColumn?tableName&columnId&columnName                               DeleteColumnAction
-GET        /ToggleColumnUnique?tableName&columnId                                    ToggleColumnUniqueAction
+POST       /ToggleColumnUnique?tableName&columnId                                    ToggleColumnUniqueAction
 GET        /NewForeignKey?tableName&columnName                                       NewForeignKeyAction
 POST       /CreateForeignKey                                                         CreateForeignKeyAction
 GET        /EditForeignKey?tableName&columnName&constraintName&referenceTable        EditForeignKeyAction
@@ -75,7 +75,7 @@ GET        /NewRow?tableName                                                    
 GET        /EditRow?tableName&targetPrimaryKey                                       EditRowAction
 POST|PATCH /UpdateRow                                                                UpdateRowAction
 GET        /EditRowValue?tableName&targetName&id                                     EditRowValueAction
-GET        /ToggleBooleanField?tableName&targetName&targetPrimaryKey                 ToggleBooleanFieldAction
+POST       /ToggleBooleanField?tableName&targetName&targetPrimaryKey                 ToggleBooleanFieldAction
 POST|PATCH /UpdateValue                                                              UpdateValueAction
 GET        /ShowForeignKeyHoverCard?tableName&id&columnName                          ShowForeignKeyHoverCardAction
 GET        /AutocompleteForeignKeyColumn?tableName&columnName&term                   AutocompleteForeignKeyColumnAction

--- a/ihp-ide/Test/IDE/ToolServer/MiddlewareSpec.hs
+++ b/ihp-ide/Test/IDE/ToolServer/MiddlewareSpec.hs
@@ -17,7 +17,7 @@ import Network.Wai.Test
 import Network.HTTP.Types
 import qualified Data.ByteString.Lazy as LBS
 
-import IHP.IDE.ToolServer (withToolServerApplication, ToolServerApplicationWithConfig(..))
+import IHP.IDE.ToolServer (withToolServerApplication, ToolServerApplicationWithConfig(..), toolServerSecurityMiddleware)
 import IHP.IDE.ToolServer.Types
 import qualified System.Environment as Env
 import Network.Socket (PortNumber)
@@ -44,12 +44,54 @@ buildTestApp = do
 
 tests :: Spec
 tests = beforeAll buildTestApp $ do
+    describe "ToolServer security boundary" $ do
+        it "rejects an unexpected Host before dispatch" $ \_ -> do
+            dispatchCount <- newIORef (0 :: Int)
+            let protectedApp = toolServerSecurityMiddleware 8000 (countingApp dispatchCount)
+            response <- runSession (srequest (requestWith methodGet [(hHost, "attacker.example:8000")])) protectedApp
+            simpleStatus response `shouldBe` status403
+            readIORef dispatchCount `shouldReturn` 0
+
+        it "rejects a cross-origin mutation before dispatch" $ \_ -> do
+            dispatchCount <- newIORef (0 :: Int)
+            let protectedApp = toolServerSecurityMiddleware 8000 (countingApp dispatchCount)
+            response <- runSession (srequest (requestWith methodPost [("Origin", "http://attacker.example")])) protectedApp
+            simpleStatus response `shouldBe` status403
+            readIORef dispatchCount `shouldReturn` 0
+
+        it "allows a legitimate local navigation" $ \_ -> do
+            dispatchCount <- newIORef (0 :: Int)
+            let protectedApp = toolServerSecurityMiddleware 8000 (countingApp dispatchCount)
+            response <- runSession (srequest (requestWith methodGet [])) protectedApp
+            simpleStatus response `shouldBe` status204
+            readIORef dispatchCount `shouldReturn` 1
+
+        it "allows a legitimate same-origin mutation" $ \_ -> do
+            dispatchCount <- newIORef (0 :: Int)
+            let protectedApp = toolServerSecurityMiddleware 8000 (countingApp dispatchCount)
+            response <- runSession (srequest (requestWith methodPost [("Origin", "http://localhost:8000")])) protectedApp
+            simpleStatus response `shouldBe` status204
+            readIORef dispatchCount `shouldReturn` 1
+
     describe "ToolServer Middleware Stack" $ do
         it "includes requestBodyMiddleware so controllers can parse form params" $ \app -> do
             response <- runSession (postWithParams "/Migrations/CreateMigration" [("description", "test"), ("createOnly", "true")]) app
             let body = cs (simpleBody response) :: Text
             body `shouldNotSatisfy` ("lookupRequestVault" `isInfixOf`)
             body `shouldNotSatisfy` ("Could not find RequestBody" `isInfixOf`)
+
+countingApp :: IORef Int -> Application
+countingApp dispatchCount _ respond = do
+    modifyIORef' dispatchCount (+ 1)
+    respond (responseLBS status204 [] "")
+
+requestWith :: Method -> RequestHeaders -> SRequest
+requestWith method headers = SRequest (defaultRequest
+    { requestHeaders = if any ((== hHost) . fst) headers then headers else (hHost, "localhost:8000") : headers
+    , requestMethod = method
+    , rawPathInfo = "/Generators"
+    , pathInfo = ["Generators"]
+    }) ""
 
 postWithParams :: ByteString -> [(ByteString, ByteString)] -> Session SResponse
 postWithParams path params = srequest $ SRequest req (LBS.fromStrict $ renderSimpleQuery False params)
@@ -58,5 +100,9 @@ postWithParams path params = srequest $ SRequest req (LBS.fromStrict $ renderSim
         { requestMethod = methodPost
         , pathInfo = filter (/= "") $ decodePathSegments path
         , rawPathInfo = path
-        , requestHeaders = [(hContentType, "application/x-www-form-urlencoded")]
+        , requestHeaders =
+            [ (hHost, "localhost:8000")
+            , ("Origin", "http://localhost:8000")
+            , (hContentType, "application/x-www-form-urlencoded")
+            ]
         }


### PR DESCRIPTION
## What changed

- bind the IHP ToolServer to IPv4 loopback instead of Warp's wildcard listener
- reject unexpected `Host` values before route dispatch
- reject cross-origin `POST`, `PUT`, `PATCH`, and `DELETE` requests
- convert the two state-changing toggle routes from GET to POST and update their callers
- add focused middleware regression coverage for denied and legitimate requests

## Why

The development ToolServer exposes schema, migration, code-generation, database, log, and process authority. Warp's default wildcard listener made those routes reachable from the network, while the request stack did not enforce a local Host or same-origin mutation boundary.

The ToolServer is local development tooling, so this change follows the conventional development-server model: loopback-only by default, with browser mutations restricted to the ToolServer's own origin.

## Impact

Normal local browser navigation and forms continue to work. Implicit remote ToolServer access is no longer supported. The boolean and uniqueness toggle actions now use POST instead of GET.

## Validation

- focused ToolServer suite: 5 examples, 0 failures
- complete IHP IDE suite: 446 examples, 0 failures
- `git diff --check`
