### PR TITLE
Add an opt-in host-local GHC build cache

### DIFF
--- a/Guide/deployment.markdown
+++ b/Guide/deployment.markdown
@@ -1467,9 +1467,12 @@ reproducible, but it also means that GHC cannot see the `.hi` and `.o` files
 from the previous production build. Large applications may therefore spend
 most of a deployment recompiling modules that have not changed.
 
-IHP can retain these files in a persistent Nix profile and pass them to the
-next optimized build. Enable the incremental production build runner in your
-project's `flake.nix`:
+IHP can use a mutable directory on the build host as an intentionally impure
+compiler cache. The directory is not a derivation input: source and declared
+dependencies still determine the normal Nix output path, while GHC can reuse
+validated files left by an earlier build.
+
+Enable the cached production package in your project's `flake.nix`:
 
 ```nix
 perSystem = { pkgs, ... }: {
@@ -1481,24 +1484,46 @@ perSystem = { pkgs, ... }: {
             # Recommended when multiple projects share the same build user.
             # Defaults to ihp.appName.
             cacheNamespace = "my-company/my-app";
+
+            # This is the default and normally does not need to be set.
+            cacheDirectory = "/var/cache/ihp-ghc";
         };
     };
 };
 ```
 
-Build the application with:
+On a NixOS build host that imports `ihp.nixosModules.app` or
+`ihp.nixosModules.appWithPostgres`, enable the matching host configuration:
+
+```nix
+services.ihp.ghcBuildCache.enable = true;
+```
+
+For a standalone build host, import `ihp.nixosModules.ghcBuildCache` and enable
+the same option. Its `cacheDirectory` must match the flake setting. The module
+creates the group-writable directory, sets Nix sandboxing to `relaxed`, and
+advertises the `ihp-ghc-cache` system feature so cached builds are only sent to
+configured builders. The cached app-library derivation carries `__noChroot`;
+ordinary derivations remain sandboxed.
+
+Build the application with either:
 
 ```bash
 nix run .#production-build-cached
+# or
+nix build .#optimized-prod-server-cached
 ```
 
-The first run is a normal cold build. After a successful compilation the
-runner atomically advances a Nix profile under
-`$XDG_STATE_HOME/ihp` (or `$HOME/.local/state/ihp`). Later runs select that
-immutable store path during an impure inner evaluation. GHC validates the
-cached files and recompiles only affected modules. A failed compilation leaves
-the previous cache untouched, and concurrent runs sharing a namespace are
-serialized.
+The first run is a normal cold build. Later application-library builds copy the
+host cache into their fresh build directory, and GHC validates the `.hi` and
+`.o` files before reusing them. After compilation, IHP synchronizes the updated
+files back to the host cache. Builds sharing the same cache are serialized.
+
+Because the cache is invisible to Nix, rebuilding unchanged source remains a
+normal Nix cache hit and does not execute the compiler at all. For any given
+source and build configuration, the cached package has a stable derivation path
+that is independent of the mutable cache contents. Application modules are
+compiled once and used directly by the production executables.
 
 The cache identity includes IHP, GHC, the Haskell package environment, target
 platform, optimization level, static-library setting, and relation-support
@@ -1506,22 +1531,23 @@ setting. Changes to any of these start with a fresh cache automatically. Use a
 stable, project-specific `cacheNamespace` if multiple applications build as
 the same user; otherwise its default value, `ihp.appName`, is sufficient.
 
-Only selection of the previous store path is impure. Once selected, it is a
-declared derivation input and compilation still runs in the Nix sandbox. The
-profile is merely an optimization: deleting it makes the next build cold and
-does not affect deployed releases or binary-cache entries.
+This deliberately weakens Nix's hermeticity. The cached app-library derivation
+runs outside the filesystem sandbox and can access the build host, so enable it
+only for trusted application source on a dedicated builder. Treat the cache as
+disposable: deleting it makes the next build cold and does not affect deployed
+releases or binary-cache entries. Keep pure CI builds as a correctness check.
 
-For CI or production, keep the profile on the machine that performs the GHC
-build. This avoids transferring the comparatively large intermediates output
-between a remote builder and the deployment server. Regular `nix build`
-options can be passed after `--`, for example:
+The cache always lives on the machine that performs the GHC build. This avoids
+transferring the comparatively large intermediates tree between a remote
+builder and the deployment server. Regular `nix build` options can be passed
+after `--`, for example:
 
 ```bash
 nix run .#production-build-cached -- --builders '' --cores 8
 ```
 
-Advanced deployment systems can manage the profile themselves via the
-low-level `ihp.previousAppLibIntermediates` option and the
+Advanced deployment systems that prefer immutable store paths can still use
+the low-level `ihp.previousAppLibIntermediates` option together with the
 `optimized-app-lib-intermediates` package output. Do not combine that option
 with `incrementalProductionBuild.enable`.
 

--- a/Guide/deployment.markdown
+++ b/Guide/deployment.markdown
@@ -1467,143 +1467,63 @@ reproducible, but it also means that GHC cannot see the `.hi` and `.o` files
 from the previous production build. Large applications may therefore spend
 most of a deployment recompiling modules that have not changed.
 
-Optimized IHP application packages have a separate `intermediates` output for
-these files. Set `ihp.previousAppLibIntermediates` to the `intermediates`
-output of a successful earlier build and GHC will validate the files itself,
-reuse the compatible ones, and rebuild the affected modules.
-
-The previous output cannot be discovered during a pure Nix evaluation: it is
-state that changes after every successful deployment. The following example
-uses a Nix profile as an atomic pointer to the latest successful output and
-selects that pointer with `builtins.getEnv` during an impure evaluation.
-
-Add the `let` bindings, the `previousAppLibIntermediates` option, and the
-supporting flake outputs below to your existing `perSystem` block:
+IHP can retain these files in a persistent Nix profile and pass them to the
+next optimized build. Enable the incremental production build runner in your
+project's `flake.nix`:
 
 ```nix
-perSystem = { config, self', pkgs, system, ... }:
-    let
-        # The key changes when the compiler, Haskell package set, platform, or
-        # production build flags change. Incompatible caches therefore start
-        # with a new profile instead of being passed to GHC.
-        appHaskellEnvironment =
-            config.ihp.ghcCompiler.ghcWithPackages
-                config.ihp.haskellPackages;
-        intermediatesCacheKey = builtins.substring 0 24 (
-            builtins.hashString "sha256" (
-                "${system}:${appHaskellEnvironment}:"
-                + "optimized:${config.ihp.optimizationLevel}:"
-                + "static=${if config.ihp.buildStaticLibraries then "1" else "0"}"
-            )
-        );
-    in
-    {
-        ihp = {
-            # Keep the rest of your existing IHP configuration here.
+perSystem = { pkgs, ... }: {
+    ihp = {
+        # Keep the rest of your existing IHP configuration here.
+        incrementalProductionBuild = {
             enable = true;
-            appName = "app";
-            projectPath = ./.;
 
-            previousAppLibIntermediates =
-                let
-                    cachePath = builtins.getEnv
-                        "IHP_PREVIOUS_APP_LIB_INTERMEDIATES";
-                in
-                    if cachePath == "" then
-                        null
-                    else if builtins.pathExists cachePath then
-                        builtins.storePath cachePath
-                    else
-                        throw "IHP_PREVIOUS_APP_LIB_INTERMEDIATES does not exist: ${cachePath}";
-        };
-
-        packages.optimized-app-lib-intermediates =
-            self'.packages.optimized-prod-server.passthru.appLibPackage.intermediates;
-
-        packages.production-build-cached = pkgs.writeShellApplication {
-            name = "ihp-production-build-cached";
-            runtimeInputs = [ pkgs.coreutils pkgs.flock pkgs.nix ];
-            text = ''
-                set -euo pipefail
-
-                state_root="''${XDG_STATE_HOME:-$HOME/.local/state}/ihp"
-                cache_profile="''${IHP_GHC_CACHE_PROFILE:-$state_root/ghc-intermediates-${intermediatesCacheKey}}"
-                mkdir -p "$(dirname "$cache_profile")"
-
-                # A profile is one shared cache head. Serializing the whole
-                # read/build/update sequence prevents concurrent deployments
-                # from replacing a newer cache with an older one.
-                exec 9>"$cache_profile.lock"
-                flock 9
-
-                if [[ -e "$cache_profile" ]]; then
-                    previous_intermediates="$(realpath "$cache_profile")"
-                    if nix store path-info "$previous_intermediates" >/dev/null 2>&1; then
-                        export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$previous_intermediates"
-                        echo "GHC intermediates cache: $previous_intermediates"
-                    else
-                        echo "GHC intermediates cache is stale; starting cold" >&2
-                        unset IHP_PREVIOUS_APP_LIB_INTERMEDIATES
-                    fi
-                else
-                    echo "GHC intermediates cache: cold (${intermediatesCacheKey})"
-                fi
-
-                # Build before moving the profile. A compiler error leaves the
-                # last successful cache untouched.
-                nix build --impure --no-write-lock-file "$@" \
-                    .#optimized-app-lib-intermediates
-                nix build --impure --no-write-lock-file \
-                    --profile "$cache_profile" \
-                    .#optimized-app-lib-intermediates
-                nix-env --profile "$cache_profile" --delete-generations old
-
-                # Re-evaluate with the cache for the current source revision,
-                # then build the complete production package from it.
-                export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$(realpath "$cache_profile")"
-                nix build --impure --no-write-lock-file "$@" \
-                    .#optimized-prod-server
-            '';
-        };
-
-        apps.production-build-cached = {
-            type = "app";
-            program = "${self'.packages.production-build-cached}/bin/ihp-production-build-cached";
+            # Recommended when multiple projects share the same build user.
+            # Defaults to ihp.appName.
+            cacheNamespace = "my-company/my-app";
         };
     };
+};
 ```
 
-Build the application through the wrapper instead of calling the production
-package directly:
+Build the application with:
 
 ```bash
-nix run --impure .#production-build-cached
+nix run .#production-build-cached
 ```
 
-The first run is a normal cold build. Later runs use the profile selected for
-the current compiler and build configuration. Source changes do not change the
-profile namespace; GHC decides which individual modules remain valid. A GHC,
-dependency, platform, optimization, or static-library change selects a new
-namespace and intentionally starts cold.
+The first run is a normal cold build. After a successful compilation the
+runner atomically advances a Nix profile under
+`$XDG_STATE_HOME/ihp` (or `$HOME/.local/state/ihp`). Later runs select that
+immutable store path during an impure inner evaluation. GHC validates the
+cached files and recompiles only affected modules. A failed compilation leaves
+the previous cache untouched, and concurrent runs sharing a namespace are
+serialized.
 
-Only the selection of the previous store path is impure. After evaluation that
-path is an ordinary declared derivation input, and the actual compilation still
-runs in the Nix sandbox. Do not point
-`IHP_PREVIOUS_APP_LIB_INTERMEDIATES` at a writable directory or at output from
-an untrusted build host.
+The cache identity includes IHP, GHC, the Haskell package environment, target
+platform, optimization level, static-library setting, and relation-support
+setting. Changes to any of these start with a fresh cache automatically. Use a
+stable, project-specific `cacheNamespace` if multiple applications build as
+the same user; otherwise its default value, `ihp.appName`, is sufficient.
+
+Only selection of the previous store path is impure. Once selected, it is a
+declared derivation input and compilation still runs in the Nix sandbox. The
+profile is merely an optimization: deleting it makes the next build cold and
+does not affect deployed releases or binary-cache entries.
 
 For CI or production, keep the profile on the machine that performs the GHC
 build. This avoids transferring the comparatively large intermediates output
-between a remote builder and the deployment server. Pass regular `nix build`
-options after the app name, for example:
+between a remote builder and the deployment server. Regular `nix build`
+options can be passed after `--`, for example:
 
 ```bash
-nix run --impure .#production-build-cached -- --builders '' --cores 8
+nix run .#production-build-cached -- --builders '' --cores 8
 ```
 
-The cache is an optimization, not a release artifact. Keep your normal binary
-cache and deployment rollback mechanism; deleting the profile merely makes the
-next build cold.
+Advanced deployment systems can manage the profile themselves via the
+low-level `ihp.previousAppLibIntermediates` option and the
+`optimized-app-lib-intermediates` package output. Do not combine that option
+with `incrementalProductionBuild.enable`.
 
 ### Starting the app
 

--- a/Guide/deployment.markdown
+++ b/Guide/deployment.markdown
@@ -1460,6 +1460,151 @@ nix build .#script-Welcome
 nix run .#script-Welcome
 ```
 
+### Reusing GHC intermediates between production builds
+
+Nix normally gives every source revision a fresh build directory. This is
+reproducible, but it also means that GHC cannot see the `.hi` and `.o` files
+from the previous production build. Large applications may therefore spend
+most of a deployment recompiling modules that have not changed.
+
+Optimized IHP application packages have a separate `intermediates` output for
+these files. Set `ihp.previousAppLibIntermediates` to the `intermediates`
+output of a successful earlier build and GHC will validate the files itself,
+reuse the compatible ones, and rebuild the affected modules.
+
+The previous output cannot be discovered during a pure Nix evaluation: it is
+state that changes after every successful deployment. The following example
+uses a Nix profile as an atomic pointer to the latest successful output and
+selects that pointer with `builtins.getEnv` during an impure evaluation.
+
+Add the `let` bindings, the `previousAppLibIntermediates` option, and the
+supporting flake outputs below to your existing `perSystem` block:
+
+```nix
+perSystem = { config, self', pkgs, system, ... }:
+    let
+        # The key changes when the compiler, Haskell package set, platform, or
+        # production build flags change. Incompatible caches therefore start
+        # with a new profile instead of being passed to GHC.
+        appHaskellEnvironment =
+            config.ihp.ghcCompiler.ghcWithPackages
+                config.ihp.haskellPackages;
+        intermediatesCacheKey = builtins.substring 0 24 (
+            builtins.hashString "sha256" (
+                "${system}:${appHaskellEnvironment}:"
+                + "optimized:${config.ihp.optimizationLevel}:"
+                + "static=${if config.ihp.buildStaticLibraries then "1" else "0"}"
+            )
+        );
+    in
+    {
+        ihp = {
+            # Keep the rest of your existing IHP configuration here.
+            enable = true;
+            appName = "app";
+            projectPath = ./.;
+
+            previousAppLibIntermediates =
+                let
+                    cachePath = builtins.getEnv
+                        "IHP_PREVIOUS_APP_LIB_INTERMEDIATES";
+                in
+                    if cachePath == "" then
+                        null
+                    else if builtins.pathExists cachePath then
+                        builtins.storePath cachePath
+                    else
+                        throw "IHP_PREVIOUS_APP_LIB_INTERMEDIATES does not exist: ${cachePath}";
+        };
+
+        packages.optimized-app-lib-intermediates =
+            self'.packages.optimized-prod-server.passthru.appLibPackage.intermediates;
+
+        packages.production-build-cached = pkgs.writeShellApplication {
+            name = "ihp-production-build-cached";
+            runtimeInputs = [ pkgs.coreutils pkgs.flock pkgs.nix ];
+            text = ''
+                set -euo pipefail
+
+                state_root="''${XDG_STATE_HOME:-$HOME/.local/state}/ihp"
+                cache_profile="''${IHP_GHC_CACHE_PROFILE:-$state_root/ghc-intermediates-${intermediatesCacheKey}}"
+                mkdir -p "$(dirname "$cache_profile")"
+
+                # A profile is one shared cache head. Serializing the whole
+                # read/build/update sequence prevents concurrent deployments
+                # from replacing a newer cache with an older one.
+                exec 9>"$cache_profile.lock"
+                flock 9
+
+                if [[ -e "$cache_profile" ]]; then
+                    previous_intermediates="$(realpath "$cache_profile")"
+                    if nix store path-info "$previous_intermediates" >/dev/null 2>&1; then
+                        export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$previous_intermediates"
+                        echo "GHC intermediates cache: $previous_intermediates"
+                    else
+                        echo "GHC intermediates cache is stale; starting cold" >&2
+                        unset IHP_PREVIOUS_APP_LIB_INTERMEDIATES
+                    fi
+                else
+                    echo "GHC intermediates cache: cold (${intermediatesCacheKey})"
+                fi
+
+                # Build before moving the profile. A compiler error leaves the
+                # last successful cache untouched.
+                nix build --impure --no-write-lock-file "$@" \
+                    .#optimized-app-lib-intermediates
+                nix build --impure --no-write-lock-file \
+                    --profile "$cache_profile" \
+                    .#optimized-app-lib-intermediates
+                nix-env --profile "$cache_profile" --delete-generations old
+
+                # Re-evaluate with the cache for the current source revision,
+                # then build the complete production package from it.
+                export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$(realpath "$cache_profile")"
+                nix build --impure --no-write-lock-file "$@" \
+                    .#optimized-prod-server
+            '';
+        };
+
+        apps.production-build-cached = {
+            type = "app";
+            program = "${self'.packages.production-build-cached}/bin/ihp-production-build-cached";
+        };
+    };
+```
+
+Build the application through the wrapper instead of calling the production
+package directly:
+
+```bash
+nix run --impure .#production-build-cached
+```
+
+The first run is a normal cold build. Later runs use the profile selected for
+the current compiler and build configuration. Source changes do not change the
+profile namespace; GHC decides which individual modules remain valid. A GHC,
+dependency, platform, optimization, or static-library change selects a new
+namespace and intentionally starts cold.
+
+Only the selection of the previous store path is impure. After evaluation that
+path is an ordinary declared derivation input, and the actual compilation still
+runs in the Nix sandbox. Do not point
+`IHP_PREVIOUS_APP_LIB_INTERMEDIATES` at a writable directory or at output from
+an untrusted build host.
+
+For CI or production, keep the profile on the machine that performs the GHC
+build. This avoids transferring the comparatively large intermediates output
+between a remote builder and the deployment server. Pass regular `nix build`
+options after the app name, for example:
+
+```bash
+nix run --impure .#production-build-cached -- --builders '' --cores 8
+```
+
+The cache is an optimization, not a release artifact. Keep your normal binary
+cache and deployment rollback mechanism; deleting the profile merely makes the
+next build cold.
+
 ### Starting the app
 
 After building, you can start your app by running:

--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -21,9 +21,12 @@
 , ihpSchemaSql ? null       # Path to IHPSchema.sql (required when buildWithPostgres = true)
 , migrationCheck ? null     # Optional derivation that validates Application/Migration before building the app
 , previousIntermediates ? null # Optional intermediate output from a previous optimized app library build
+, impureIntermediatesCache ? null # Optional mutable host cache, intentionally invisible to the Nix dependency graph
 , buildStaticLibraries ? true # Build static Haskell libraries in addition to shared libraries
 , ghcAllocationArea ? null # Optional GHC compile-time RTS allocation area, e.g. "128M"
 }:
+
+assert impureIntermediatesCache == null || previousIntermediates == null;
 
 let
     splitSections = if !pkgs.stdenv.hostPlatform.isDarwin then "-split-sections" else "";
@@ -437,18 +440,69 @@ CABAL_EOF
                     ];
             });
 
-    mkAppLibPackage = withIntermediates: configureHaskellBuild (pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
-        ghc.callPackage ({ mkDerivation, base }: mkDerivation {
-            pname = "${appName}-lib";
-            version = "0.1.0";
-            src = appLibSrc;
-            libraryHaskellDepends = [ base modelsPackage ] ++ builtins.filter (p: p != null) (haskellDeps ghc);
-            doInstallIntermediates = withIntermediates;
-            enableSeparateIntermediatesOutput = withIntermediates;
-            inherit previousIntermediates;
-            license = pkgs.lib.licenses.free;
-        }) {}
-    )));
+    appLibIntermediatesDir = "share/haskell/${ghc.ghc.version}/${appName}-lib-0.1.0/dist";
+
+    withImpureIntermediatesCache = pkg:
+        if impureIntermediatesCache == null
+        then pkg
+        else
+            let
+                cachedPackage = pkgs.haskell.lib.overrideCabal pkg (old: {
+                    # This path is deliberately a plain string without Nix store
+                    # context. The cached derivation runs without a chroot, so its
+                    # contents can speed up GHC without changing the derivation.
+                    previousIntermediates = "${impureIntermediatesCache}/current";
+                    libraryToolDepends = (old.libraryToolDepends or []) ++ [ pkgs.flock pkgs.rsync ];
+                    preBuild = (old.preBuild or "") + ''
+                        impure_cache_root=${pkgs.lib.escapeShellArg impureIntermediatesCache}
+                        impure_cache_parent="$(dirname "$impure_cache_root")"
+                        impure_cache_intermediates="$impure_cache_root/current/${appLibIntermediatesDir}"
+
+                        if [[ ! -d "$impure_cache_parent" || ! -w "$impure_cache_parent" ]]; then
+                            echo "IHP GHC cache is not writable: $impure_cache_parent" >&2
+                            echo "Configure the builder host's ihp.nixosModules.ghcBuildCache module." >&2
+                            exit 1
+                        fi
+
+                        umask 0002
+                        mkdir -p "$impure_cache_root"
+                        exec 9>"$impure_cache_root/cache.lock"
+                        flock 9
+                        mkdir -p "$impure_cache_intermediates/build"
+                    '';
+                    postBuild = (old.postBuild or "") + ''
+                        # GHC has successfully validated and updated dist/build. Keep
+                        # it as a mutable compiler cache; it is not a build output and
+                        # must never become a Nix dependency.
+                        rsync -a --delete --chmod=Dg+rws,Fg+rw \
+                            dist/build/ "$impure_cache_intermediates/build/"
+                        flock -u 9
+                    '';
+                });
+            in cachedPackage.overrideAttrs (old: {
+                # With sandbox=relaxed, only derivations carrying this flag run
+                # outside the sandbox. This is required for a writable cache;
+                # sandbox-paths are intentionally mounted read-only.
+                __noChroot = true;
+                requiredSystemFeatures = (old.requiredSystemFeatures or []) ++ [ "ihp-ghc-cache" ];
+            });
+
+    mkAppLibPackage = { withIntermediates, useImpureCache ? false }:
+        let
+            package = configureHaskellBuild (pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
+                ghc.callPackage ({ mkDerivation, base }: mkDerivation {
+                    pname = "${appName}-lib";
+                    version = "0.1.0";
+                    src = appLibSrc;
+                    libraryHaskellDepends = [ base modelsPackage ] ++ builtins.filter (p: p != null) (haskellDeps ghc);
+                    doInstallIntermediates = withIntermediates;
+                    enableSeparateIntermediatesOutput = withIntermediates;
+                    inherit previousIntermediates;
+                    license = pkgs.lib.licenses.free;
+                }) {}
+            )));
+        in
+            if useImpureCache then withImpureIntermediatesCache package else package;
 
     withAppLibPostgres = pkg:
         if buildWithPostgres
@@ -464,8 +518,13 @@ CABAL_EOF
     # .intermediates (the optimized-app-lib-intermediates output consumed via
     # the prevBuild input, including older revisions of consuming repos) keep
     # evaluating unchanged.
-    appLibPackage = withAppLibPostgres (mkAppLibPackage false);
-    appLibPackageWithIntermediates = withAppLibPostgres (mkAppLibPackage optimized);
+    appLibPackage = withAppLibPostgres (mkAppLibPackage {
+        withIntermediates = false;
+        useImpureCache = impureIntermediatesCache != null;
+    });
+    appLibPackageWithIntermediates = withAppLibPostgres (mkAppLibPackage {
+        withIntermediates = optimized;
+    });
 
     allHaskellPackagesWithAppLib = ghc.ghcWithPackages (p: [ appLibPackage ]);
 

--- a/NixSupport/nixosModules/app.nix
+++ b/NixSupport/nixosModules/app.nix
@@ -6,6 +6,7 @@ in
     imports = [
         ihp.nixosModules.options
         ihp.nixosModules.binaryCache
+        ihp.nixosModules.ghcBuildCache
         ihp.nixosModules.services_app
         ihp.nixosModules.services_worker
         ihp.nixosModules.services_migrate
@@ -15,4 +16,3 @@ in
     # Pin the nixpkgs to the IHP nixpkgs
     nix.registry.nixpkgs.flake = nixpkgs;
 }
-

--- a/NixSupport/nixosModules/appWithPostgres.nix
+++ b/NixSupport/nixosModules/appWithPostgres.nix
@@ -11,6 +11,7 @@ in
     imports = [
         ihp.nixosModules.options
         ihp.nixosModules.binaryCache
+        ihp.nixosModules.ghcBuildCache
         ihp.nixosModules.services_app
         ihp.nixosModules.services_appKeygen
         ihp.nixosModules.services_worker

--- a/NixSupport/nixosModules/ghcBuildCache.nix
+++ b/NixSupport/nixosModules/ghcBuildCache.nix
@@ -1,0 +1,44 @@
+{ config, lib, ... }:
+let
+    cfg = config.services.ihp.ghcBuildCache;
+in
+{
+    options.services.ihp.ghcBuildCache = {
+        enable = lib.mkEnableOption ''
+            the unsafe host-local GHC intermediates cache for IHP production builds
+        '';
+
+        cacheDirectory = lib.mkOption {
+            type = lib.types.addCheck lib.types.str (path: lib.hasPrefix "/" path);
+            default = "/var/cache/ihp-ghc";
+            description = ''
+                Absolute path to the mutable cache directory on the build host.
+                This must match ihp.incrementalProductionBuild.cacheDirectory.
+            '';
+        };
+
+        owner = lib.mkOption {
+            type = lib.types.str;
+            default = "root";
+            description = "Owner of the GHC intermediates cache directory.";
+        };
+
+        group = lib.mkOption {
+            type = lib.types.str;
+            default = "nixbld";
+            description = "Group allowed to read and write the GHC intermediates cache.";
+        };
+    };
+
+    config = lib.mkIf cfg.enable {
+        systemd.tmpfiles.rules = [
+            "d ${cfg.cacheDirectory} 2770 ${cfg.owner} ${cfg.group} -"
+        ];
+
+        # sandbox-paths are read-only, so the cached app-library derivation
+        # carries __noChroot. In relaxed mode all other ordinary derivations
+        # remain sandboxed.
+        nix.settings.sandbox = "relaxed";
+        nix.settings.system-features = lib.mkAfter [ "ihp-ghc-cache" ];
+    };
+}

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -157,7 +157,7 @@ ihpFlake:
                         recompiles only modules affected by source changes.
 
                         This is the low-level interface for custom build orchestration.
-                        For the profile-backed IHP runner, use
+                        For the host-local mutable IHP cache, use
                         `incrementalProductionBuild.enable` instead.
                     '';
                     type = lib.types.nullOr lib.types.package;
@@ -166,8 +166,8 @@ ihpFlake:
 
                 incrementalProductionBuild = {
                     enable = lib.mkEnableOption ''
-                        a profile-backed production build command that reuses GHC
-                        object and interface files from the last successful build
+                        an unsafe host-local compiler cache that reuses GHC object
+                        and interface files without adding them to the Nix dependency graph
                     '';
 
                     cacheNamespace = lib.mkOption {
@@ -177,6 +177,16 @@ ihpFlake:
                         '';
                         type = lib.types.nullOr lib.types.str;
                         default = null;
+                    };
+
+                    cacheDirectory = lib.mkOption {
+                        description = ''
+                            Absolute host directory used by the deliberately
+                            unsandboxed cached app-library derivation. Its contents
+                            are intentionally not Nix inputs.
+                        '';
+                        type = lib.types.addCheck lib.types.str (path: lib.hasPrefix "/" path);
+                        default = "/var/cache/ihp-ghc";
                     };
                 };
 
@@ -244,22 +254,13 @@ ihpFlake:
                 + "static=${if cfg.buildStaticLibraries then "1" else "0"}:"
                 + "relations=${if cfg.relationSupport then "1" else "0"}"
             ));
-            incrementalPreviousIntermediates =
-                let cachePath = builtins.getEnv "IHP_PREVIOUS_APP_LIB_INTERMEDIATES";
-                in if cachePath == ""
-                    then null
-                    else if builtins.pathExists cachePath
-                        then builtins.storePath cachePath
-                        else throw "IHP_PREVIOUS_APP_LIB_INTERMEDIATES does not exist: ${cachePath}";
-            effectivePreviousIntermediates =
-                if incrementalBuild.enable
-                then if cfg.previousAppLibIntermediates == null
-                    then incrementalPreviousIntermediates
-                    else throw "ihp.previousAppLibIntermediates and ihp.incrementalProductionBuild.enable cannot be used together"
-                else cfg.previousAppLibIntermediates;
+            incrementalIntermediatesCache =
+                if cfg.previousAppLibIntermediates != null
+                then throw "ihp.previousAppLibIntermediates and ihp.incrementalProductionBuild.enable cannot be used together"
+                else "${incrementalBuild.cacheDirectory}/${incrementalCacheNamespaceKey}-${incrementalIntermediatesCacheKey}";
             # Auto-detect whether a build-time PostgreSQL is needed (e.g. ihp-typed-sql)
             buildWithPostgres = builtins.any (p: (p.pname or "") == "ihp-typed-sql") (cfg.haskellPackages ghcCompiler);
-            mkProdServer = { optimized, optimizationLevel }: import "${ihp}/NixSupport/default.nix" {
+            mkProdServer = { optimized, optimizationLevel, impureIntermediatesCache ? null }: import "${ihp}/NixSupport/default.nix" {
                 ihp = ihp;
                 haskellDeps = cfg.haskellPackages;
                 otherDeps = p: cfg.packages;
@@ -276,7 +277,8 @@ ihpFlake:
                 ihp-static = ihpFlake.inputs.self.packages.${system}.ihp-static;
                 static = self'.packages.static;
                 inherit buildWithPostgres;
-                previousIntermediates = if optimized then effectivePreviousIntermediates else null;
+                previousIntermediates = if optimized then cfg.previousAppLibIntermediates else null;
+                inherit impureIntermediatesCache;
                 inherit (cfg) buildStaticLibraries ghcAllocationArea;
                 appSchemaSql = "${self'.packages.schema}/Schema.sql";
                 ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";
@@ -284,6 +286,11 @@ ihpFlake:
             optimizedProdServer = mkProdServer {
                 optimized = true;
                 optimizationLevel = cfg.optimizationLevel;
+            };
+            cachedOptimizedProdServer = mkProdServer {
+                optimized = true;
+                optimizationLevel = cfg.optimizationLevel;
+                impureIntermediatesCache = incrementalIntermediatesCache;
             };
             unoptimizedProdServer = mkProdServer {
                 optimized = false;
@@ -387,57 +394,14 @@ ihpFlake:
                 };
             } // scriptPackages
             // lib.optionalAttrs incrementalBuild.enable {
+                optimized-prod-server-cached = cachedOptimizedProdServer;
+
                 production-build-cached = pkgs.writeShellApplication {
                     name = "ihp-production-build-cached";
-                    runtimeInputs = [ pkgs.coreutils pkgs.flock pkgs.nix ];
+                    runtimeInputs = [ pkgs.nix ];
                     text = ''
-                        set -euo pipefail
-
-                        state_root="''${XDG_STATE_HOME:-$HOME/.local/state}/ihp"
-                        cache_profile="''${IHP_GHC_CACHE_PROFILE:-$state_root/ghc-intermediates-${incrementalCacheNamespaceKey}-${incrementalIntermediatesCacheKey}}"
-                        mkdir -p "$(dirname "$cache_profile")"
-
-                        # A profile is one shared cache head. Serialize the
-                        # read/build/update sequence so concurrent builds cannot
-                        # replace a newer cache with an older one.
-                        exec 9>"$cache_profile.lock"
-                        flock 9
-
-                        if [[ -e "$cache_profile" ]]; then
-                            previous_intermediates="$(realpath "$cache_profile")"
-                            if nix store path-info "$previous_intermediates" >/dev/null 2>&1; then
-                                export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$previous_intermediates"
-                                echo "GHC intermediates cache: $previous_intermediates"
-                            else
-                                echo "GHC intermediates cache is stale; starting cold" >&2
-                                unset IHP_PREVIOUS_APP_LIB_INTERMEDIATES
-                            fi
-                        else
-                            echo "GHC intermediates cache: cold (${incrementalIntermediatesCacheKey})"
-                        fi
-
-                        # Do not advance the profile until compilation succeeds.
-                        mapfile -t current_outputs < <(
-                            nix build --impure --no-write-lock-file \
-                                --no-link --print-out-paths "$@" \
-                                .#optimized-app-lib-intermediates
-                        )
-                        [[ ''${#current_outputs[@]} -eq 1 ]] || {
-                            echo "expected one intermediates output, got ''${#current_outputs[@]}" >&2
-                            exit 1
-                        }
-                        current_intermediates="''${current_outputs[0]}"
-                        [[ $current_intermediates == /nix/store/*-intermediates ]] || {
-                            echo "unexpected intermediates output: $current_intermediates" >&2
-                            exit 1
-                        }
-
-                        nix-env --profile "$cache_profile" --set "$current_intermediates"
-                        nix-env --profile "$cache_profile" --delete-generations old
-
-                        export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$current_intermediates"
-                        nix build --impure --no-write-lock-file "$@" \
-                            .#optimized-prod-server
+                        exec nix build --no-write-lock-file "$@" \
+                            .#optimized-prod-server-cached
                     '';
                 };
             }

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -155,9 +155,29 @@ ihpFlake:
                         Intermediate output from a previous optimized application build.
                         When set, GHC reuses still-valid object and interface files and
                         recompiles only modules affected by source changes.
+
+                        This is the low-level interface for custom build orchestration.
+                        For the profile-backed IHP runner, use
+                        `incrementalProductionBuild.enable` instead.
                     '';
                     type = lib.types.nullOr lib.types.package;
                     default = null;
+                };
+
+                incrementalProductionBuild = {
+                    enable = lib.mkEnableOption ''
+                        a profile-backed production build command that reuses GHC
+                        object and interface files from the last successful build
+                    '';
+
+                    cacheNamespace = lib.mkOption {
+                        description = ''
+                            Stable project identifier used to separate persistent GHC
+                            caches on a shared builder. Defaults to `ihp.appName`.
+                        '';
+                        type = lib.types.nullOr lib.types.str;
+                        default = null;
+                    };
                 };
 
                 scripts.optimized = lib.mkOption {
@@ -210,6 +230,33 @@ ihpFlake:
             ihp = ihpFlake.inputs.self;
             ghcCompiler = cfg.ghcCompiler;
             ihpLib = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
+            incrementalBuild = cfg.incrementalProductionBuild;
+            incrementalCacheNamespace =
+                if incrementalBuild.cacheNamespace == null
+                then cfg.appName
+                else incrementalBuild.cacheNamespace;
+            incrementalCacheNamespaceKey = builtins.substring 0 24
+                (builtins.hashString "sha256" incrementalCacheNamespace);
+            appHaskellEnvironment = ghcCompiler.ghcWithPackages cfg.haskellPackages;
+            incrementalIntermediatesCacheKey = builtins.substring 0 24 (builtins.hashString "sha256" (
+                "${system}:${ihp}:${appHaskellEnvironment}:"
+                + "optimized:${cfg.optimizationLevel}:"
+                + "static=${if cfg.buildStaticLibraries then "1" else "0"}:"
+                + "relations=${if cfg.relationSupport then "1" else "0"}"
+            ));
+            incrementalPreviousIntermediates =
+                let cachePath = builtins.getEnv "IHP_PREVIOUS_APP_LIB_INTERMEDIATES";
+                in if cachePath == ""
+                    then null
+                    else if builtins.pathExists cachePath
+                        then builtins.storePath cachePath
+                        else throw "IHP_PREVIOUS_APP_LIB_INTERMEDIATES does not exist: ${cachePath}";
+            effectivePreviousIntermediates =
+                if incrementalBuild.enable
+                then if cfg.previousAppLibIntermediates == null
+                    then incrementalPreviousIntermediates
+                    else throw "ihp.previousAppLibIntermediates and ihp.incrementalProductionBuild.enable cannot be used together"
+                else cfg.previousAppLibIntermediates;
             # Auto-detect whether a build-time PostgreSQL is needed (e.g. ihp-typed-sql)
             buildWithPostgres = builtins.any (p: (p.pname or "") == "ihp-typed-sql") (cfg.haskellPackages ghcCompiler);
             mkProdServer = { optimized, optimizationLevel }: import "${ihp}/NixSupport/default.nix" {
@@ -229,7 +276,7 @@ ihpFlake:
                 ihp-static = ihpFlake.inputs.self.packages.${system}.ihp-static;
                 static = self'.packages.static;
                 inherit buildWithPostgres;
-                previousIntermediates = if optimized then cfg.previousAppLibIntermediates else null;
+                previousIntermediates = if optimized then effectivePreviousIntermediates else null;
                 inherit (cfg) buildStaticLibraries ghcAllocationArea;
                 appSchemaSql = "${self'.packages.schema}/Schema.sql";
                 ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";
@@ -260,13 +307,20 @@ ihpFlake:
         in lib.mkIf cfg.enable {
             _module.args.pkgs = lib.mkDefault (import inputs.nixpkgs { inherit system; overlays = config.devenv.shells.default.overlays; config = { }; });
 
-            apps = scriptApps;
+            apps = scriptApps // lib.optionalAttrs incrementalBuild.enable {
+                production-build-cached = {
+                    type = "app";
+                    program = "${self'.packages.production-build-cached}/bin/ihp-production-build-cached";
+                };
+            };
 
             # release build package
             packages = {
                 default = unoptimizedProdServer;
 
                 optimized-prod-server = optimizedProdServer;
+
+                optimized-app-lib-intermediates = optimizedProdServer.passthru.appLibPackage.intermediates;
 
                 unoptimized-prod-server = unoptimizedProdServer;
 
@@ -332,6 +386,61 @@ ihpFlake:
                     '';
                 };
             } // scriptPackages
+            // lib.optionalAttrs incrementalBuild.enable {
+                production-build-cached = pkgs.writeShellApplication {
+                    name = "ihp-production-build-cached";
+                    runtimeInputs = [ pkgs.coreutils pkgs.flock pkgs.nix ];
+                    text = ''
+                        set -euo pipefail
+
+                        state_root="''${XDG_STATE_HOME:-$HOME/.local/state}/ihp"
+                        cache_profile="''${IHP_GHC_CACHE_PROFILE:-$state_root/ghc-intermediates-${incrementalCacheNamespaceKey}-${incrementalIntermediatesCacheKey}}"
+                        mkdir -p "$(dirname "$cache_profile")"
+
+                        # A profile is one shared cache head. Serialize the
+                        # read/build/update sequence so concurrent builds cannot
+                        # replace a newer cache with an older one.
+                        exec 9>"$cache_profile.lock"
+                        flock 9
+
+                        if [[ -e "$cache_profile" ]]; then
+                            previous_intermediates="$(realpath "$cache_profile")"
+                            if nix store path-info "$previous_intermediates" >/dev/null 2>&1; then
+                                export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$previous_intermediates"
+                                echo "GHC intermediates cache: $previous_intermediates"
+                            else
+                                echo "GHC intermediates cache is stale; starting cold" >&2
+                                unset IHP_PREVIOUS_APP_LIB_INTERMEDIATES
+                            fi
+                        else
+                            echo "GHC intermediates cache: cold (${incrementalIntermediatesCacheKey})"
+                        fi
+
+                        # Do not advance the profile until compilation succeeds.
+                        mapfile -t current_outputs < <(
+                            nix build --impure --no-write-lock-file \
+                                --no-link --print-out-paths "$@" \
+                                .#optimized-app-lib-intermediates
+                        )
+                        [[ ''${#current_outputs[@]} -eq 1 ]] || {
+                            echo "expected one intermediates output, got ''${#current_outputs[@]}" >&2
+                            exit 1
+                        }
+                        current_intermediates="''${current_outputs[0]}"
+                        [[ $current_intermediates == /nix/store/*-intermediates ]] || {
+                            echo "unexpected intermediates output: $current_intermediates" >&2
+                            exit 1
+                        }
+
+                        nix-env --profile "$cache_profile" --set "$current_intermediates"
+                        nix-env --profile "$cache_profile" --delete-generations old
+
+                        export IHP_PREVIOUS_APP_LIB_INTERMEDIATES="$current_intermediates"
+                        nix build --impure --no-write-lock-file "$@" \
+                            .#optimized-prod-server
+                    '';
+                };
+            }
             // (if cfg.static.makeBundling then {
                 staticFilesCompiledByMake = pkgs.stdenv.mkDerivation {
                     name = "${config.ihp.appName}-staticFilesCompiledByMake";

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
                     services_appKeygen = ./NixSupport/nixosModules/services/app-keygen.nix;
                     options = ./NixSupport/nixosModules/options.nix;
                     binaryCache = ./NixSupport/nixosModules/binaryCache.nix;
+                    ghcBuildCache = ./NixSupport/nixosModules/ghcBuildCache.nix;
                 };
             };
         }


### PR DESCRIPTION
## Summary

- add an opt-in `ihp.incrementalProductionBuild` API backed by a mutable host-local GHC intermediates cache
- keep the cache invisible to the Nix dependency graph, so changing cache contents does not create a new derivation or an endless chain of store-path dependencies
- expose a separate `optimized-prod-server-cached` package and `nix run .#production-build-cached`, while leaving the normal production package pure
- compile application modules once and reuse that library directly in the production executables
- add `ihp.nixosModules.ghcBuildCache`, which provisions the cache, enables relaxed sandbox mode, and advertises a required builder feature
- retain `ihp.previousAppLibIntermediates` and `optimized-app-lib-intermediates` as the pure low-level interface for custom orchestration

## Usage

Application flake:

```nix
ihp.incrementalProductionBuild = {
    enable = true;
    cacheNamespace = "my-company/my-app";
};
```

NixOS build host:

```nix
services.ihp.ghcBuildCache.enable = true;
```

Build with:

```bash
nix run .#production-build-cached
# or
nix build .#optimized-prod-server-cached
```

## Purity and safety boundary

The cached app-library derivation deliberately carries `__noChroot = true` and requires the `ihp-ghc-cache` system feature. With the host set to `sandbox = "relaxed"`, only that marked derivation runs outside the filesystem sandbox; ordinary derivations remain sandboxed.

This is intentionally unsafe and should only be enabled for trusted application source on a dedicated builder. The normal `optimized-prod-server` remains the pure correctness path.

## Validation

- parsed all changed Nix expressions with `nix-instantiate --parse`
- evaluated the new package and runner outputs in a minimal external IHP fixture
- inspected the app-library derivation: one output, `__noChroot = 1`, required `ihp-ghc-cache` feature, and `flock`/`rsync` build tools
- mutated the host cache and verified that the app-library `drvPath` remained identical
- changed application source and verified that the app-library `drvPath` changed
- inspected the production derivation graph and verified that it contains exactly one application-library derivation
- evaluated the NixOS module and verified `sandbox = "relaxed"`, the builder feature, and the `2770 root:nixbld` tmpfiles rule

An end-to-end warm build was not run on the development Mac because its Nix daemon is not configured for relaxed sandboxing. The target fails early there instead of silently building with an inaccessible cache; the host configuration is part of this PR.
