### PR TITLE
chore: pre-generate ghc914 plugin pins; add missing 9.14 checks

### DIFF
--- a/NixSupport/hackage/ghc-tcplugin-api.nix
+++ b/NixSupport/hackage/ghc-tcplugin-api.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, array, base, containers, ghc, lib, template-haskell
+, transformers
+}:
+mkDerivation {
+  pname = "ghc-tcplugin-api";
+  version = "0.19.0.0";
+  sha256 = "6e8e6a7a5b24637c0b4dcdeea1d7f553f8fde2b55baadd54c09cfb4f84792e90";
+  libraryHaskellDepends = [
+    array base containers ghc template-haskell transformers
+  ];
+  homepage = "https://github.com/sheaf/ghc-tcplugin-api";
+  description = "An API for type-checker plugins";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+}

--- a/NixSupport/hackage/ghc-typelits-knownnat.nix
+++ b/NixSupport/hackage/ghc-typelits-knownnat.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, ghc, ghc-bignum, ghc-tcplugin-api
+, ghc-typelits-natnormalise, lib, QuickCheck, tasty, tasty-hunit
+, tasty-quickcheck, template-haskell, transformers
+}:
+mkDerivation {
+  pname = "ghc-typelits-knownnat";
+  version = "0.8.4";
+  sha256 = "116c5b920ca7f477ffa9f4624fcf729bb4e09cbbe715d6ef1e0acca5e29023ad";
+  libraryHaskellDepends = [
+    base ghc ghc-bignum ghc-tcplugin-api ghc-typelits-natnormalise
+    template-haskell transformers
+  ];
+  testHaskellDepends = [
+    base ghc-typelits-natnormalise QuickCheck tasty tasty-hunit
+    tasty-quickcheck
+  ];
+  homepage = "http://clash-lang.org/";
+  description = "Derive KnownNat constraints from other KnownNat constraints";
+  license = lib.meta.getLicenseFromSpdxId "BSD-2-Clause";
+}

--- a/NixSupport/hackage/ghc-typelits-natnormalise.nix
+++ b/NixSupport/hackage/ghc-typelits-natnormalise.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, containers, ghc, ghc-bignum, ghc-prim
+, ghc-tcplugin-api, interpolate, lib, process, tasty, tasty-hunit
+, temporary, transformers
+}:
+mkDerivation {
+  pname = "ghc-typelits-natnormalise";
+  version = "0.9.6";
+  sha256 = "626bb0dc22714e959ea759101a36cf1c84d753c09ecc1fd691528c012e09c5d3";
+  libraryHaskellDepends = [
+    base containers ghc ghc-bignum ghc-tcplugin-api transformers
+  ];
+  testHaskellDepends = [
+    base ghc-prim interpolate process tasty tasty-hunit temporary
+  ];
+  homepage = "http://www.clash-lang.org/";
+  description = "GHC typechecker plugin for types of kind GHC.TypeLits.Nat";
+  license = lib.meta.getLicenseFromSpdxId "BSD-2-Clause";
+}

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -214,26 +214,16 @@ final: prev: {
                     # relude doctests fail due to changed GHC error messages in 9.14
                     relude = final.haskell.lib.dontCheck super.relude;
 
-                    # Upgrade ghc-tcplugin-api to 0.19 (supports GHC 9.14)
-                    ghc-tcplugin-api = self.callCabal2nix "ghc-tcplugin-api"
-                        (final.fetchzip {
-                            url = "https://hackage.haskell.org/package/ghc-tcplugin-api-0.19.0.0/ghc-tcplugin-api-0.19.0.0.tar.gz";
-                            sha256 = "sha256-2jm1Q2lmaG6vtRnxcvxf4U2gvQdVkDL0h8PWaTpDWJA=";
-                        }) {};
+                    # 0.19 supports GHC 9.14; nixpkgs still pins an older release.
+                    ghc-tcplugin-api = self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-tcplugin-api.nix" {};
 
-                    # Upgrade ghc-typelits-natnormalise to 0.9.6 (supports GHC 9.14)
-                    ghc-typelits-natnormalise = final.haskell.lib.dontCheck (self.callCabal2nix "ghc-typelits-natnormalise"
-                        (final.fetchzip {
-                            url = "https://hackage.haskell.org/package/ghc-typelits-natnormalise-0.9.6/ghc-typelits-natnormalise-0.9.6.tar.gz";
-                            sha256 = "sha256-a1afS4iJrB9hVp3FK+fozbWVxIt75H/gO6Q+PeoV53k=";
-                        }) {});
+                    # 0.9.6 supports GHC 9.14; nixpkgs still pins an older release.
+                    ghc-typelits-natnormalise = final.haskell.lib.dontCheck
+                        (self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-typelits-natnormalise.nix" {});
 
-                    # Upgrade ghc-typelits-knownnat to 0.8.4 (supports GHC 9.14)
-                    ghc-typelits-knownnat = final.haskell.lib.dontCheck (self.callCabal2nix "ghc-typelits-knownnat"
-                        (final.fetchzip {
-                            url = "https://hackage.haskell.org/package/ghc-typelits-knownnat-0.8.4/ghc-typelits-knownnat-0.8.4.tar.gz";
-                            sha256 = "sha256-PyYMUvJ8/miqusNl7+xay8OJqtK1/uHNQEiLr1utieg=";
-                        }) {});
+                    # 0.8.4 supports GHC 9.14; nixpkgs still pins an older release.
+                    ghc-typelits-knownnat = final.haskell.lib.dontCheck
+                        (self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-typelits-knownnat.nix" {});
                 })
                 # GHC 9.14 ships base-4.22, containers-0.8, template-haskell-2.24.
                 # Many nixpkgs packages have tight upper bounds on these boot libraries.
@@ -265,7 +255,7 @@ final: prev: {
                     "ghc-lib-parser" "ghc-lib-parser-ex" "ghc-syntax-highlighter"
                     "colourista" "extensions" "trial" "trial-optparse-applicative"
                     "trial-tomland" "tomland" "validation-selective" "slist"
-                    "ihp-zip" "warp-systemd"
+                    "ihp-zip"
                 ])
             ];
         }

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -174,8 +174,7 @@ that is defined in flake-module.nix
                     "ihp-hspec" "ihp-welcome"
                     "wai-asset-path" "wai-flash-messages" "wai-request-params"
                     "wai-session-maybe" "wai-session-clientsession-deferred"
-                    # ihp-zip excluded: Hackage 0.1.1 fails to configure under GHC 9.14
-                    # (zip-archive dependency resolution issue)
+                    "ihp-router" "wai-early-return" "ihp-zip"
                 ];
             in lib.listToAttrs (map (name: {
                 name = "ghc914-${name}";

--- a/update-nix-from-cabal.sh
+++ b/update-nix-from-cabal.sh
@@ -37,7 +37,10 @@ hackage_packages=(
   "postgresql-types 0.1.2"
   "hasql-mapping 0.1"
   "hasql-postgresql-types 0.2"
-  "ihp-zip 0.1.1"
+  "ihp-zip 0.1.2"
+  "ghc-tcplugin-api 0.19.0.0"
+  "ghc-typelits-natnormalise 0.9.6"
+  "ghc-typelits-knownnat 0.8.4"
 )
 # Note: hasql/postgresql-binary/postgresql-types/hasql-mapping and friends
 # are pulled directly from nixpkgs via versioned attributes (hasql_1_10_3


### PR DESCRIPTION
## Summary
Replace the three GHC 9.14 `callCabal2nix` plugin pins with committed cabal2nix files so 9.14 eval is IFD-free. Add first-class 9.14 checks for `ihp-router`, `wai-early-return`, and `ihp-zip`.

No default-compiler change.

## Why
`callCabal2nix` makes eval hashes platform-dependent and breaks cross-machine caching. These pins must be IFD-free before 9.14 becomes the default.

Part of the GHC 9.14.1 default-compiler upgrade stack (PLAN_ID `6dd28aac`).