### PR TITLE
ci: restore app-shell HLS on 9.12; warm GHC 9.14 devenv cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,3 +69,40 @@ jobs:
       env:
         ATTIC_TOKEN: ${{ secrets.ATTIC_CI_TOKEN }}
       if: matrix.os != 'ARM64'
+
+  # Separate ubuntu job so 9.14 devenv-shaped deps are cache-warmed without
+  # adding a packages.* output or extra work on the existing packages loop.
+  ghc914-dev-env:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: wimpysworld/nothing-but-nix@main
+      with:
+        hatchet-protocol: 'rampage'
+    - uses: DeterminateSystems/nix-installer-action@main
+      with:
+        determinate: true
+        extra-conf: |
+          lazy-trees = true
+          extra-substituters = https://cache.digitallyinduced.com/public
+          extra-trusted-public-keys = public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ=
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: cachix/cachix-action@v17
+      with:
+        name: digitallyinduced
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: |
+        system=$(nix eval --impure --expr builtins.currentSystem --raw)
+        override="--override-input ihp-boilerplate/ihp github:${{ github.event.repository.full_name }}/${{ github.sha }}"
+        nix build --impure --max-jobs 1 $override -L --print-out-paths \
+          ".#checks.$system.ghc914-dev-env" > built-paths.txt
+        cat built-paths.txt
+    - name: Push to Attic cache
+      run: |
+        if [ ! -s built-paths.txt ]; then echo "no built paths to push"; exit 0; fi
+        nix profile install nixpkgs#attic-client
+        attic login di https://cache.digitallyinduced.com "$ATTIC_TOKEN"
+        xargs attic push public < built-paths.txt
+      env:
+        ATTIC_TOKEN: ${{ secrets.ATTIC_CI_TOKEN }}

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -214,6 +214,9 @@ final: prev: {
                     # relude doctests fail due to changed GHC error messages in 9.14
                     relude = final.haskell.lib.dontCheck super.relude;
 
+                    # HLS pulls this in; its tests import a hidden containers-0.8 module.
+                    enummapset = final.haskell.lib.dontCheck super.enummapset;
+
                     # 0.19 supports GHC 9.14; nixpkgs still pins an older release.
                     ghc-tcplugin-api = self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-tcplugin-api.nix" {};
 

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -164,6 +164,8 @@ that is defined in flake-module.nix
             # GHC 9.14 compatibility checks (build and test all IHP packages)
             // (lib.optionalAttrs (pkgs.haskell.packages ? ghc914) (let
                 ghc914 = pkgs.ghc914;
+                # pkgs.ghc914.haskell-language-server evaluates (2.14.0.0).
+                hlsBuilds = true;
                 ihpPackageNames = [
                     "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
                     "ihp-postgres-parser" "ihp-pagehead"
@@ -187,6 +189,15 @@ that is defined in flake-module.nix
                 ghc914-ihp-datasync = withTestPostgres pkgs.ghc914.ihp-datasync;
                 ghc914-ihp-typed-sql = withTestPostgres pkgs.ghc914.ihp-typed-sql;
                 ghc914-ihp-pglistener = withTestPostgres pkgs.ghc914.ihp-pglistener;
+                # Cache-warm a 9.14 devenv-shaped GHC env. Lives in checks, not packages.
+                ghc914-dev-env = pkgs.ghc914.ghc.withPackages (p: [
+                    p.ihp
+                    p.ihp-ide
+                    p.ihp-schema-compiler
+                    p.cabal-install
+                    p.hlint
+                    p.hoogle
+                ] ++ lib.optional hlsBuilds p.haskell-language-server);
             }))
         ;
 

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -164,8 +164,6 @@ that is defined in flake-module.nix
             # GHC 9.14 compatibility checks (build and test all IHP packages)
             // (lib.optionalAttrs (pkgs.haskell.packages ? ghc914) (let
                 ghc914 = pkgs.ghc914;
-                # pkgs.ghc914.haskell-language-server evaluates (2.14.0.0).
-                hlsBuilds = true;
                 ihpPackageNames = [
                     "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
                     "ihp-postgres-parser" "ihp-pagehead"
@@ -189,7 +187,7 @@ that is defined in flake-module.nix
                 ghc914-ihp-datasync = withTestPostgres pkgs.ghc914.ihp-datasync;
                 ghc914-ihp-typed-sql = withTestPostgres pkgs.ghc914.ihp-typed-sql;
                 ghc914-ihp-pglistener = withTestPostgres pkgs.ghc914.ihp-pglistener;
-                # Cache-warm a 9.14 devenv-shaped GHC env. Lives in checks, not packages.
+                # Include package-set HLS so the 9.14 app-shell closure is cached.
                 ghc914-dev-env = pkgs.ghc914.ghc.withPackages (p: [
                     p.ihp
                     p.ihp-ide
@@ -197,7 +195,8 @@ that is defined in flake-module.nix
                     p.cabal-install
                     p.hlint
                     p.hoogle
-                ] ++ lib.optional hlsBuilds p.haskell-language-server);
+                    p.haskell-language-server
+                ]);
             }))
         ;
 

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -187,7 +187,7 @@ that is defined in flake-module.nix
                 ghc914-ihp-datasync = withTestPostgres pkgs.ghc914.ihp-datasync;
                 ghc914-ihp-typed-sql = withTestPostgres pkgs.ghc914.ihp-typed-sql;
                 ghc914-ihp-pglistener = withTestPostgres pkgs.ghc914.ihp-pglistener;
-                # Include package-set HLS so the 9.14 app-shell closure is cached.
+                # HLS omitted: hie-compat-0.3.1.2 requires base <4.22 and does not configure on 9.14.1.
                 ghc914-dev-env = pkgs.ghc914.ghc.withPackages (p: [
                     p.ihp
                     p.ihp-ide
@@ -195,7 +195,6 @@ that is defined in flake-module.nix
                     p.cabal-install
                     p.hlint
                     p.hoogle
-                    p.haskell-language-server
                 ]);
             }))
         ;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -481,13 +481,9 @@ ihpFlake:
                                              else ghcCompiler.ghc.withPackages) (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p);
 
                 languages.haskell.stack.enable = false; # Stack is not used in IHP
-                # devenv defaults to `pkgs.haskell-language-server.override {
-                #   supportedGhcVersions = [ ghcVersion ] }` with ghcVersion =
-                # package.version dots-stripped. That breaks on GHC RCs
-                # (9.12.4.20260713 → "912420260713", not in the allowlist) and
-                # takes the boilerplate-devShell check down with it. Disable HLS
-                # until we're on a release GHC / devenv that accepts the version.
-                languages.haskell.lsp.enable = false;
+                # Use the package-set HLS. devenv's default override rejects GHC RC version strings.
+                languages.haskell.lsp.package = ghcCompiler.haskell-language-server;
+                languages.haskell.lsp.enable = true;
 
                 scripts.start.exec = ''
                     exec env IHP_STATIC=${ihpFlake.inputs.self.packages.${system}.ihp-static} ${ghcCompiler.ihp-ide}/bin/RunDevServer


### PR DESCRIPTION
## Summary
- Restore app-shell HLS via `languages.haskell.lsp.package = ghcCompiler.haskell-language-server` (bypasses devenv's RC version-string allowlist).
- Add `checks.ghc914-dev-env` (not a `packages.*` output) with the real devenv `ghcWithPackages` closure, including HLS.
- New ubuntu-latest-only job builds that check with `--max-jobs 1` and pushes to Cachix + Attic.

9.14 HLS **eval passed** (`haskell-language-server-2.14.0.0`). Local build was not run (127 uncached Haskell drvs).

No default-compiler change.

Depends on the IFD-free plugin pins PR.