### PR TITLE
ci: run integration-test on GHC 9.14

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -197,6 +197,93 @@ that is defined in flake-module.nix
                     p.hoogle
                     p.haskell-language-server
                 ]);
+
+                # Same allocation check as ihp-hsx-bench, on the 9.14 package set.
+                ghc914-ihp-hsx-bench = (pkgs.haskell.lib.doBenchmark pkgs.ghc914.ihp-hsx).overrideAttrs (old: {
+                    postCheck = (old.postCheck or "") + ''
+                        # The shared ARM runner concurrently builds the multi-GHC
+                        # checks. Keep tasty-bench's per-case timeout above its
+                        # 100s default so transient runner load does not turn an
+                        # allocation-regression check into a timing failure.
+                        ./Setup bench --benchmark-options='+RTS -T -RTS --timeout 300s --csv bench-results.csv'
+
+                        # Compare allocations (column 4) against baseline.
+                        # Allocations are deterministic — same code = same count — so
+                        # any increase signals a real regression, not noise.
+                        ${pkgs.gawk}/bin/awk -F, '
+                          NR==FNR && FNR>1 { baseline[$1]=$4; next }
+                          FNR>1 {
+                            name=$1; alloc=$4; base=baseline[name]
+                            if (base > 0 && alloc > base * 1.1) {
+                              printf "REGRESSION: %s allocates %d bytes (baseline %d, +%.0f%%)\n", name, alloc, base, (alloc-base)/base*100
+                              fail=1
+                            }
+                          }
+                          END { if (fail) exit 1 }
+                        ' bench-baseline.csv bench-results.csv
+                    '';
+                });
+
+                # Same app compile as integration-test, but with GHC 9.14.
+                ghc914-integration-test = pkgs.stdenv.mkDerivation {
+                    name = "ihp-ghc914-integration-test";
+                    src = self;
+                    sourceRoot = "source/integration-test";
+                    nativeBuildInputs = [
+                        (pkgs.ghc914.ghc.withPackages (p: with p; [
+                            ihp ihp-hsx ihp-hspec ihp-ide ihp-schema-compiler
+                            ihp-typed-sql
+                            hspec
+                        ]))
+                        pkgs.gnumake
+                        pkgs.postgresql
+                    ];
+                    buildPhase = ''
+                        export IHP_LIB=${ihpLib}
+
+                        # Start temporary PostgreSQL
+                        export PGDATA="$TMPDIR/pgdata"
+                        export PGHOST="$TMPDIR/pghost"
+                        mkdir -p "$PGHOST"
+                        initdb -D "$PGDATA" --no-locale --encoding=UTF8
+                        echo "unix_socket_directories = '$PGHOST'" >> "$PGDATA/postgresql.conf"
+                        echo "listen_addresses = '''" >> "$PGDATA/postgresql.conf"
+                        pg_ctl -D "$PGDATA" -l "$TMPDIR/pg.log" start
+
+                        # Create the test database (withIHPApp replaces '/app' in the URL)
+                        createdb -h "$PGHOST" app
+                        export DATABASE_URL="postgresql:///app?host=$PGHOST"
+
+                        # Test/TypedSqlSpec.hs uses [typedSql| … |], which describes each
+                        # query against DATABASE_URL at COMPILE time, so the schema must
+                        # exist before we compile. (withIHPApp creates its own per-test
+                        # databases at runtime; this load only serves the compile-time
+                        # describe.) Load IHP's schema first, then the app's.
+                        psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f ${self}/ihp-schema-compiler/data/IHPSchema.sql
+                        psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f Application/Schema.sql
+
+                        # Generate types from Schema.sql
+                        make -f $IHP_LIB/lib/IHP/Makefile.dist build/Generated/Types.hs
+
+                        # Compile and run integration tests
+                        GHC_EXTS=$(make -f $IHP_LIB/lib/IHP/Makefile.dist print-ghc-extensions | sed 's/-fbyte-code//g')
+                        ghc --make \
+                            $GHC_EXTS \
+                            -threaded \
+                            -i. -ibuild -iConfig \
+                            -package-env - \
+                            -package ihp -package ihp-hspec -package ihp-typed-sql -package hspec \
+                            -main-is Test.Main \
+                            Test/Main.hs -o test-runner
+                        ./test-runner
+
+                        # Cleanup
+                        pg_ctl -D "$PGDATA" stop || true
+                    '';
+                    installPhase = ''
+                        touch $out
+                    '';
+                };
             }))
         ;
 


### PR DESCRIPTION
## Summary
Add `ghc914-integration-test` (copy of `integration-test` on `pkgs.ghc914`) and `ghc914-ihp-hsx-bench`.

`TypeAbstractions` was **not** added: no pattern type applications in IHP / integration-test. Bench baseline CSV was not rebased (9.14 bench not run locally).

No default-compiler change. This is a flip gate.

Depends on the HLS / cache-warm PR (stacked for devenv-module.nix).