### PR TITLE
feat: default IHP to GHC 9.14.1; keep 9.12 via pkgs.ghc912

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Breaking Changes
 
+- Default GHC is now 9.14.1. Stay on 9.12 with `ihp.ghcCompiler = pkgs.ghc912`. Delete any old `ghc = prev.ghc912` overlay.
 - `DefaultScope` has been removed. `query @Model` now always starts without
   implicit filters; define and use explicit query functions for reusable scopes.
 - `typedSql` now tracks conservative query cardinality and statement result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Breaking Changes
 
-- Default GHC is now 9.14.1. Stay on 9.12 with `ihp.ghcCompiler = pkgs.ghc912`. Delete any old `ghc = prev.ghc912` overlay. App HLS is off: package-set HLS does not configure on 9.14.1 (`hie-compat` requires `base < 4.22`).
+- Default GHC is now 9.14.1. Stay on 9.12 with `ihp.ghcCompiler = pkgs.ghc912`. Delete any old `ghc = prev.ghc912` overlay. App HLS and `hlint` are off on 9.14: `hie-compat` requires `base < 4.22`, and `apply-refact` 0.15 does not compile.
 - `DefaultScope` has been removed. `query @Model` now always starts without
   implicit filters; define and use explicit query functions for reusable scopes.
 - `typedSql` now tracks conservative query cardinality and statement result

--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -680,7 +680,13 @@ We highly recommend only using nixpkgs versions which are provided by IHP becaus
 
 IHP's default compiler is GHC 9.14.1 (`pkgs.ghc`). To stay on GHC 9.12:
 
-    ihp.ghcCompiler = pkgs.ghc912;
+```nix
+perSystem = { pkgs, ... }: {
+    ihp = {
+        ghcCompiler = pkgs.ghc912;
+    };
+};
+```
 
 Then `direnv reload`. Do not remap `pkgs.ghc` with a `final: prev: { ghc = prev.ghc912; }`
 overlay — older Guide revisions suggested that, and it now silently overrides the default.

--- a/Guide/package-management.markdown
+++ b/Guide/package-management.markdown
@@ -678,23 +678,12 @@ We highly recommend only using nixpkgs versions which are provided by IHP becaus
 
 ### Switching GHC Versions
 
-IHP ships with GHC 9.10 by default. This is the recommended version and all IHP packages are binary-cached for it.
+IHP's default compiler is GHC 9.14.1 (`pkgs.ghc`). To stay on GHC 9.12:
 
-GHC 9.12 is available as an experimental opt-in. To switch, add an overlay in your project's `flake.nix` that remaps `ghc` to `ghc912`:
+    ihp.ghcCompiler = pkgs.ghc912;
 
-```nix
-devenv.shells.default = {
-    overlays = lib.mkAfter [
-        (final: prev: { ghc = prev.ghc912; })
-    ];
-};
-```
-
-This works because IHP's overlay provides both `pkgs.ghc` (GHC 9.10) and `pkgs.ghc912` (GHC 9.12) with all IHP packages. The extra overlay swaps the default. After adding the overlay, run `direnv reload` to rebuild the development environment.
-
-**Note:** GHC 9.12 is not yet binary-cached. Everything will build from source, which takes significantly longer on the first build. We recommend setting up your own [cachix binary cache](https://cachix.org/) if you use GHC 9.12 regularly.
-
-To switch back to GHC 9.10, remove the overlay and run `direnv reload`.
+Then `direnv reload`. Do not remap `pkgs.ghc` with a `final: prev: { ghc = prev.ghc912; }`
+overlay — older Guide revisions suggested that, and it now silently overrides the default.
 
 ### Binary Cache
 

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -248,7 +248,7 @@ let
 in {
     # nix-prefetch-darcs consumes the top-level darcs attribute directly. Keep it
     # on the same bounds-relaxed build as the default GHC package set.
-    darcs = final.ghc.darcs;
+    darcs = final.ghc912.darcs;
 
     # Default: GHC 9.14.1. The default path requires haskell.packages.ghc914.
     ghc =

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -201,8 +201,6 @@ let
             # time <1.15 and fails on GHC 9.14's containers-0.8 / time-1.15.
             # Jailbreaking lets that pinned version build on the new boot libs.
             "Cabal-syntax_3_14_2_0"
-            # hlint -> apply-refact 0.15 caps containers <0.8 and ghc-exactprint <1.13.
-            "apply-refact"
             # darcs 2.18.5 caps http-client-tls <0.4 and tls <2.2, while
             # the RC3 package set provides newer compatible releases.
             "darcs"

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -143,121 +143,133 @@ let
                 });
         };
 in
-final: prev: {
+final: prev:
+let
+    # The RC3 nixpkgs snapshot updated ghc-exactprint to 1.14.1.0,
+    # while its GHC 9.14 configuration still references the removed
+    # 1.14.0.0 attribute. Keep the old name as a compatibility alias
+    # until nixpkgs updates configuration-ghc-9.14.x.nix.
+    exactprintAlias = self: super: {
+        ghc-exactprint_1_14_0_0 = final.haskell.lib.dontCheck super.ghc-exactprint_1_14_1_0;
+    };
+
+    ghc914Extras = self: super: {
+        # say tests fail due to CRLF newline handling changes
+        say = final.haskell.lib.dontCheck super.say;
+
+        # text-icu tests fail due to newer ICU BlockCode enum range
+        text-icu = final.haskell.lib.dontCheck super.text-icu;
+
+        # cryptonite tests have a flaky failure (1 of 1548)
+        cryptonite = final.haskell.lib.dontCheck super.cryptonite;
+
+        # relude doctests fail due to changed GHC error messages in 9.14
+        relude = final.haskell.lib.dontCheck super.relude;
+
+        # 0.19 supports GHC 9.14; nixpkgs still pins an older release.
+        ghc-tcplugin-api = self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-tcplugin-api.nix" {};
+
+        # 0.9.6 supports GHC 9.14; nixpkgs still pins an older release.
+        ghc-typelits-natnormalise = final.haskell.lib.dontCheck
+            (self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-typelits-natnormalise.nix" {});
+
+        # 0.8.4 supports GHC 9.14; nixpkgs still pins an older release.
+        ghc-typelits-knownnat = final.haskell.lib.dontCheck
+            (self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-typelits-knownnat.nix" {});
+    };
+
+    # GHC 9.14 ships base-4.22, containers-0.8, template-haskell-2.24.
+    # Many nixpkgs packages have tight upper bounds on these boot libraries.
+    ghc914Jailbreaks =
+        let
+            jailbreak = names: self: super:
+                builtins.listToAttrs (map (name: {
+                    inherit name;
+                    value = final.haskell.lib.doJailbreak super.${name};
+                }) (builtins.filter (name: super ? ${name}) names));
+        in jailbreak [
+            # cabal-install 3.16.1.0 / cabal-install-solver want Cabal &
+            # Cabal-syntax >=3.16.1.0, but GHC 9.14 ships the 3.16.0.0 boot
+            # libs (a patch-release skew) — drop the bound.
+            "cabal-install" "cabal-install-solver" "cabal-install-parsers"
+            "cabal-add"
+            # hlint -> extensions pins Cabal-syntax <3.15, so nixpkgs builds
+            # the Cabal-syntax_3_14_2_0 attr — which caps containers <0.8 /
+            # time <1.15 and fails on GHC 9.14's containers-0.8 / time-1.15.
+            # Jailbreaking lets that pinned version build on the new boot libs.
+            "Cabal-syntax_3_14_2_0"
+            # darcs 2.18.5 caps http-client-tls <0.4 and tls <2.2, while
+            # the RC3 package set provides newer compatible releases.
+            "darcs"
+            "lucid" "lucid2" "clay" "tasty-hspec" "config-ini" "fsnotify"
+            "string-interpolate" "rebase" "rerebase" "with-utf8" "minio-hs"
+            "sandwich" "brick" "postgresql-simple" "hasql-dynamic-statements"
+            "hasql-implicits" "warp-systemd" "ghc-trace-events"
+            "algebraic-graphs" "hie-bios" "stan" "modern-uri"
+            "ghc-lib-parser" "ghc-lib-parser-ex" "ghc-syntax-highlighter"
+            "colourista" "extensions" "trial" "trial-optparse-applicative"
+            "trial-tomland" "tomland" "validation-selective" "slist"
+            "ihp-zip"
+        ];
+
+    ghc912Extras = self: super: {
+        # say tests fail due to CRLF newline handling changes
+        say = final.haskell.lib.dontCheck super.say;
+
+        # text-icu tests fail due to newer ICU BlockCode enum range
+        text-icu = final.haskell.lib.dontCheck super.text-icu;
+
+        # cryptonite tests have a flaky failure (1 of 1548)
+        cryptonite = final.haskell.lib.dontCheck super.cryptonite;
+
+        # The GHC 9.12 package set builds HLS 2.14 against Cabal 3.16,
+        # while its ormolu/fourmolu/stylish-haskell plugins still use
+        # Cabal 3.14. These are isolated plugin dependencies, but Cabal's
+        # multiple-version warning is fatal in the nixpkgs Haskell
+        # builder unless explicitly allowed.
+        haskell-language-server = final.haskell.lib.allowInconsistentDependencies
+            super.haskell-language-server;
+
+        # darcs 2.18.5 caps http-client-tls <0.4 and tls <2.2, while
+        # the 9.12 package set provides newer compatible releases. A full
+        # doJailbreak conflicts with nixpkgs' patched darcs.cabal, so only
+        # relax these two bounds after the nixpkgs patches are applied.
+        darcs = super.darcs.overrideAttrs (old: {
+            postPatch = (old.postPatch or "") + ''
+                substituteInPlace darcs.cabal \
+                    --replace-fail "http-client-tls   >= 0.3.5 && < 0.4" "http-client-tls   >= 0.3.5" \
+                    --replace-fail "tls               >= 2.0.6 && < 2.2" "tls               >= 2.0.6"
+            '';
+        });
+    };
+in {
     # nix-prefetch-darcs consumes the top-level darcs attribute directly. Keep it
     # on the same bounds-relaxed build as the default GHC package set.
     darcs = final.ghc.darcs;
 
-    # Default: GHC 9.12 — the pinned nixpkgs `haskellPackages` compiler.
-    # The dontCheck overrides below apply to that default build.
-    ghc = final.haskellPackages.override {
-        overrides = final.lib.composeManyExtensions [
-            (ihpOverrides final)
-            (self: super: {
-                # say tests fail due to CRLF newline handling changes
-                say = final.haskell.lib.dontCheck super.say;
-
-                # text-icu tests fail due to newer ICU BlockCode enum range
-                text-icu = final.haskell.lib.dontCheck super.text-icu;
-
-                # cryptonite tests have a flaky failure (1 of 1548)
-                cryptonite = final.haskell.lib.dontCheck super.cryptonite;
-
-                # The GHC 9.12 RC package set builds HLS 2.14 against Cabal 3.16,
-                # while its ormolu/fourmolu/stylish-haskell plugins still use
-                # Cabal 3.14. These are isolated plugin dependencies, but Cabal's
-                # multiple-version warning is fatal in the nixpkgs Haskell
-                # builder unless explicitly allowed.
-                haskell-language-server = final.haskell.lib.allowInconsistentDependencies
-                    super.haskell-language-server;
-
-                # darcs 2.18.5 caps http-client-tls <0.4 and tls <2.2, while
-                # the RC3 package set provides newer compatible releases. A full
-                # doJailbreak conflicts with nixpkgs' patched darcs.cabal, so only
-                # relax these two bounds after the nixpkgs patches are applied.
-                darcs = super.darcs.overrideAttrs (old: {
-                    postPatch = (old.postPatch or "") + ''
-                        substituteInPlace darcs.cabal \
-                            --replace-fail "http-client-tls   >= 0.3.5 && < 0.4" "http-client-tls   >= 0.3.5" \
-                            --replace-fail "tls               >= 2.0.6 && < 2.2" "tls               >= 2.0.6"
-                    '';
-                });
-            })
-        ];
-    };
-
-    # `ghc912` is an alias of the default `ghc` set: the pinned nixpkgs default
-    # compiler is already GHC 9.12, so a separate set would be an exact duplicate.
-    # The alias keeps `pkgs.ghc912.*` references working; drop it once they migrate
-    # to `pkgs.ghc`.
-    ghc912 = final.ghc;
-
-    # GHC 9.14 — opt-in for apps using the digitallyinduced binary cache.
-    # To use: set `ihp.ghcCompiler = pkgs.ghc914;` in your flake-module config.
-    ghc914 =
+    # Default: GHC 9.14.1. The default path requires haskell.packages.ghc914.
+    ghc =
         if prev.haskell.packages ? ghc914
         then final.haskell.packages.ghc914.override {
             overrides = final.lib.composeManyExtensions [
-                # The RC3 nixpkgs snapshot updated ghc-exactprint to 1.14.1.0,
-                # while its GHC 9.14 configuration still references the removed
-                # 1.14.0.0 attribute. Keep the old name as a compatibility alias
-                # until nixpkgs updates configuration-ghc-9.14.x.nix.
-                (self: super: {
-                    ghc-exactprint_1_14_0_0 = final.haskell.lib.dontCheck super.ghc-exactprint_1_14_1_0;
-                })
+                exactprintAlias
                 (ihpOverrides final)
-                (self: super: {
-                    say = final.haskell.lib.dontCheck super.say;
-                    text-icu = final.haskell.lib.dontCheck super.text-icu;
-                    cryptonite = final.haskell.lib.dontCheck super.cryptonite;
-
-                    # relude doctests fail due to changed GHC error messages in 9.14
-                    relude = final.haskell.lib.dontCheck super.relude;
-
-                    # 0.19 supports GHC 9.14; nixpkgs still pins an older release.
-                    ghc-tcplugin-api = self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-tcplugin-api.nix" {};
-
-                    # 0.9.6 supports GHC 9.14; nixpkgs still pins an older release.
-                    ghc-typelits-natnormalise = final.haskell.lib.dontCheck
-                        (self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-typelits-natnormalise.nix" {});
-
-                    # 0.8.4 supports GHC 9.14; nixpkgs still pins an older release.
-                    ghc-typelits-knownnat = final.haskell.lib.dontCheck
-                        (self.callPackage "${flakeRoot}/NixSupport/hackage/ghc-typelits-knownnat.nix" {});
-                })
-                # GHC 9.14 ships base-4.22, containers-0.8, template-haskell-2.24.
-                # Many nixpkgs packages have tight upper bounds on these boot libraries.
-                (let
-                    jailbreak = names: self: super:
-                        builtins.listToAttrs (map (name: {
-                            inherit name;
-                            value = final.haskell.lib.doJailbreak super.${name};
-                        }) (builtins.filter (name: super ? ${name}) names));
-                in jailbreak [
-                    # cabal-install 3.16.1.0 / cabal-install-solver want Cabal &
-                    # Cabal-syntax >=3.16.1.0, but GHC 9.14 ships the 3.16.0.0 boot
-                    # libs (a patch-release skew) — drop the bound.
-                    "cabal-install" "cabal-install-solver" "cabal-install-parsers"
-                    "cabal-add"
-                    # hlint -> extensions pins Cabal-syntax <3.15, so nixpkgs builds
-                    # the Cabal-syntax_3_14_2_0 attr — which caps containers <0.8 /
-                    # time <1.15 and fails on GHC 9.14's containers-0.8 / time-1.15.
-                    # Jailbreaking lets that pinned version build on the new boot libs.
-                    "Cabal-syntax_3_14_2_0"
-                    # darcs 2.18.5 caps http-client-tls <0.4 and tls <2.2, while
-                    # the RC3 package set provides newer compatible releases.
-                    "darcs"
-                    "lucid" "lucid2" "clay" "tasty-hspec" "config-ini" "fsnotify"
-                    "string-interpolate" "rebase" "rerebase" "with-utf8" "minio-hs"
-                    "sandwich" "brick" "postgresql-simple" "hasql-dynamic-statements"
-                    "hasql-implicits" "warp-systemd" "ghc-trace-events"
-                    "algebraic-graphs" "hie-bios" "stan" "modern-uri"
-                    "ghc-lib-parser" "ghc-lib-parser-ex" "ghc-syntax-highlighter"
-                    "colourista" "extensions" "trial" "trial-optparse-applicative"
-                    "trial-tomland" "tomland" "validation-selective" "slist"
-                    "ihp-zip"
-                ])
+                ghc914Extras
+                ghc914Jailbreaks
             ];
         }
         else throw "ghc914 is not available in this nixpkgs";
+
+    # Alias so existing `pkgs.ghc914` / `ihp.ghcCompiler = pkgs.ghc914` refs keep working.
+    ghc914 = final.ghc;
+
+    # Rollback set for apps that stay on GHC 9.12 via `ihp.ghcCompiler = pkgs.ghc912`.
+    # Bound to haskell.packages.ghc912, never haskellPackages, so it stays 9.12
+    # even if nixpkgs moves haskellPackages.
+    ghc912 = final.haskell.packages.ghc912.override {
+        overrides = final.lib.composeManyExtensions [
+            (ihpOverrides final)
+            ghc912Extras
+        ];
+    };
 }

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -201,6 +201,8 @@ let
             # time <1.15 and fails on GHC 9.14's containers-0.8 / time-1.15.
             # Jailbreaking lets that pinned version build on the new boot libs.
             "Cabal-syntax_3_14_2_0"
+            # hlint -> apply-refact 0.15 caps containers <0.8 and ghc-exactprint <1.13.
+            "apply-refact"
             # darcs 2.18.5 caps http-client-tls <0.4 and tls <2.2, while
             # the RC3 package set provides newer compatible releases.
             "darcs"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -53,8 +53,9 @@ switch is `ihp.ghcCompiler`.
 
 App devenv ships with `languages.haskell.lsp.enable = false`. GHC 9.14.1's
 package-set HLS does not configure (`hie-compat` requires `base < 4.22`).
-Do not install GHCup HLS as a workaround; keep LSP off until IHP turns it
-back on. Stay on 9.12 (`ihp.ghcCompiler = pkgs.ghc912`) if you need HLS now.
+`hlint` is also omitted from the 9.14 shell (`apply-refact` 0.15 does not
+compile). Stay on 9.12 (`ihp.ghcCompiler = pkgs.ghc912`) if you need HLS or
+hlint now.
 
 # Upgrade to 1.6.0 from 1.5.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,59 @@
 This document describes breaking changes, as well as how to fix them, that have occured at given releases.
 After updating your project, please consult the segments from your current release until now.
 
+# Upgrade to GHC 9.14.1 (IHP default compiler)
+
+IHP's default GHC is now 9.14.1. After `nix flake update`, the next
+`direnv allow` / `nix develop` will download (or, if the cache is cold,
+build) the 9.14 closure.
+
+## Stay on GHC 9.12
+
+In your app `flake.nix` `perSystem`:
+
+```nix
+ihp.ghcCompiler = pkgs.ghc912;
+```
+
+Then `nix flake update` / `direnv allow`. This uses IHP's rollback package
+set. 9.12 support will be removed in a later IHP minor.
+
+Do **not** remap the compiler with a local overlay:
+
+```nix
+# WRONG after this upgrade — and a silent 9.12 pin if you already have it
+overlays = lib.mkAfter [ (final: prev: { ghc = prev.ghc912; }) ];
+```
+
+If you copied that snippet from an older Guide ("Switching GHC Versions"),
+**delete it** unless you intentionally want to stay on 9.12. The supported
+switch is `ihp.ghcCompiler`.
+
+## What usually needs no change
+
+- Controllers, views, QueryBuilder, `typedSql`, HSX.
+- `set` / `get` / `IHP.Record.SetField` (not GHC's OverloadedRecordUpdate).
+- `base` bounds already allow 4.22.
+
+## What might need a change
+
+- If you enabled `OverloadedRecordUpdate` and `RebindableSyntax` together,
+  GHC 9.14 flipped `setField`'s argument order. Prefer IHP's `set #field`.
+- Pattern type applications now need the `TypeAbstractions` extension
+  (no longer implied by ScopedTypeVariables + TypeApplications).
+- Incomplete record selectors are in `-Wall`. If you compile with
+  `-Werror -Wall`, fix the selectors or add
+  `-Wno-incomplete-record-selectors`.
+- Extra Hackage deps with `base < 4.22`, `containers < 0.8`,
+  `template-haskell < 2.24`, or `time < 1.15` need a bump or
+  `ihp.doJailbreakPackages = [ "the-package" ];`.
+
+## HLS
+
+IHP's devenv shell uses HLS from the same GHC package set as the app
+(`languages.haskell.lsp.package = ghcCompiler.haskell-language-server`).
+Do not install GHCup HLS. VS Code: `haskell.manageHLS = PATH`.
+
 # Upgrade to 1.6.0 from 1.5.0
 
 Update your IHP flake input from the `v1.5` release branch to the `v1.6` release branch:

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -304,6 +304,8 @@ that is defined in flake-module.nix
 
             languages.haskell.stack.enable = false; # Stack is not used in IHP
             languages.haskell.lsp.package = pkgs.ghc.haskell-language-server;
+            # Off until hie-compat / apply-refact support GHC 9.14.1.
+            languages.haskell.lsp.enable = false;
         };
 
         packages = {

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -177,12 +177,12 @@ that is defined in flake-module.nix
             # Keep this check name: build.yml's ghc914-dev-env job builds it.
             // {
                 # HLS omitted: hie-compat-0.3.1.2 requires base <4.22 and does not configure on 9.14.1.
+                # hlint omitted: apply-refact 0.15 does not compile on GHC 9.14.
                 ghc914-dev-env = pkgs.ghc914.ghc.withPackages (p: [
                     p.ihp
                     p.ihp-ide
                     p.ihp-schema-compiler
                     p.cabal-install
-                    p.hlint
                     p.hoogle
                 ]);
             }

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -158,36 +158,26 @@ that is defined in flake-module.nix
                 };
             }
 
-            # No separate GHC 9.12 checks: `pkgs.ghc912` aliases the default
-            # `pkgs.ghc` (GHC 9.12), so they would duplicate the default checks above.
-
-            # GHC 9.14 compatibility checks (build and test all IHP packages)
-            // (lib.optionalAttrs (pkgs.haskell.packages ? ghc914) (let
-                ghc914 = pkgs.ghc914;
-                ihpPackageNames = [
-                    "ihp-ide" "ihp-hsx" "ihp-schema-compiler"
-                    "ihp-postgres-parser" "ihp-pagehead"
-                    "ihp-modal" "ihp-mail"
-                    "ihp-migrate" "ihp-openai" "ihp-ssc" "ihp-graphql"
-                    "ihp-datasync-typescript" "ihp-sitemap"
-                    "ihp-job-dashboard" "ihp-imagemagick"
-                    "ihp-hspec" "ihp-welcome"
-                    "wai-asset-path" "wai-flash-messages" "wai-request-params"
-                    "wai-session-maybe" "wai-session-clientsession-deferred"
-                    "ihp-router" "wai-early-return" "ihp-zip"
-                ];
-            in lib.listToAttrs (map (name: {
-                name = "ghc914-${name}";
-                value = ghc914.${name};
-            }) ihpPackageNames)
-
-            # GHC 9.14 packages that need a running PostgreSQL for their tests
+            # Default checks are GHC 9.14. Fold first-party packages that were
+            # only on the former ghc914-* extra list and are not already in
+            # packages.* so 9.14 first-party CI does not shrink.
             // {
-                ghc914-ihp = withTestPostgres pkgs.ghc914.ihp;
-                ghc914-ihp-datasync = withTestPostgres pkgs.ghc914.ihp-datasync;
-                ghc914-ihp-typed-sql = withTestPostgres pkgs.ghc914.ihp-typed-sql;
-                ghc914-ihp-pglistener = withTestPostgres pkgs.ghc914.ihp-pglistener;
-                # Include package-set HLS so the 9.14 app-shell closure is cached.
+                ihp-hsx = pkgs.ghc.ihp-hsx;
+                ihp-postgres-parser = pkgs.ghc.ihp-postgres-parser;
+                ihp-pagehead = pkgs.ghc.ihp-pagehead;
+                ihp-modal = pkgs.ghc.ihp-modal;
+                ihp-openai = pkgs.ghc.ihp-openai;
+                ihp-graphql = pkgs.ghc.ihp-graphql;
+                wai-request-params = pkgs.ghc.wai-request-params;
+                wai-session-maybe = pkgs.ghc.wai-session-maybe;
+                wai-session-clientsession-deferred = pkgs.ghc.wai-session-clientsession-deferred;
+                ihp-router = pkgs.ghc.ihp-router;
+                ihp-zip = pkgs.ghc.ihp-zip;
+            }
+
+            # Keep this check name: build.yml's ghc914-dev-env job builds it.
+            # pkgs.ghc914 aliases pkgs.ghc (now 9.14).
+            // {
                 ghc914-dev-env = pkgs.ghc914.ghc.withPackages (p: [
                     p.ihp
                     p.ihp-ide
@@ -197,94 +187,18 @@ that is defined in flake-module.nix
                     p.hoogle
                     p.haskell-language-server
                 ]);
+            }
 
-                # Same allocation check as ihp-hsx-bench, on the 9.14 package set.
-                ghc914-ihp-hsx-bench = (pkgs.haskell.lib.doBenchmark pkgs.ghc914.ihp-hsx).overrideAttrs (old: {
-                    postCheck = (old.postCheck or "") + ''
-                        # The shared ARM runner concurrently builds the multi-GHC
-                        # checks. Keep tasty-bench's per-case timeout above its
-                        # 100s default so transient runner load does not turn an
-                        # allocation-regression check into a timing failure.
-                        ./Setup bench --benchmark-options='+RTS -T -RTS --timeout 300s --csv bench-results.csv'
-
-                        # Compare allocations (column 4) against baseline.
-                        # Allocations are deterministic — same code = same count — so
-                        # any increase signals a real regression, not noise.
-                        ${pkgs.gawk}/bin/awk -F, '
-                          NR==FNR && FNR>1 { baseline[$1]=$4; next }
-                          FNR>1 {
-                            name=$1; alloc=$4; base=baseline[name]
-                            if (base > 0 && alloc > base * 1.1) {
-                              printf "REGRESSION: %s allocates %d bytes (baseline %d, +%.0f%%)\n", name, alloc, base, (alloc-base)/base*100
-                              fail=1
-                            }
-                          }
-                          END { if (fail) exit 1 }
-                        ' bench-baseline.csv bench-results.csv
-                    '';
-                });
-
-                # Same app compile as integration-test, but with GHC 9.14.
-                ghc914-integration-test = pkgs.stdenv.mkDerivation {
-                    name = "ihp-ghc914-integration-test";
-                    src = self;
-                    sourceRoot = "source/integration-test";
-                    nativeBuildInputs = [
-                        (pkgs.ghc914.ghc.withPackages (p: with p; [
-                            ihp ihp-hsx ihp-hspec ihp-ide ihp-schema-compiler
-                            ihp-typed-sql
-                            hspec
-                        ]))
-                        pkgs.gnumake
-                        pkgs.postgresql
-                    ];
-                    buildPhase = ''
-                        export IHP_LIB=${ihpLib}
-
-                        # Start temporary PostgreSQL
-                        export PGDATA="$TMPDIR/pgdata"
-                        export PGHOST="$TMPDIR/pghost"
-                        mkdir -p "$PGHOST"
-                        initdb -D "$PGDATA" --no-locale --encoding=UTF8
-                        echo "unix_socket_directories = '$PGHOST'" >> "$PGDATA/postgresql.conf"
-                        echo "listen_addresses = '''" >> "$PGDATA/postgresql.conf"
-                        pg_ctl -D "$PGDATA" -l "$TMPDIR/pg.log" start
-
-                        # Create the test database (withIHPApp replaces '/app' in the URL)
-                        createdb -h "$PGHOST" app
-                        export DATABASE_URL="postgresql:///app?host=$PGHOST"
-
-                        # Test/TypedSqlSpec.hs uses [typedSql| … |], which describes each
-                        # query against DATABASE_URL at COMPILE time, so the schema must
-                        # exist before we compile. (withIHPApp creates its own per-test
-                        # databases at runtime; this load only serves the compile-time
-                        # describe.) Load IHP's schema first, then the app's.
-                        psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f ${self}/ihp-schema-compiler/data/IHPSchema.sql
-                        psql -h "$PGHOST" -d app -v ON_ERROR_STOP=1 -f Application/Schema.sql
-
-                        # Generate types from Schema.sql
-                        make -f $IHP_LIB/lib/IHP/Makefile.dist build/Generated/Types.hs
-
-                        # Compile and run integration tests
-                        GHC_EXTS=$(make -f $IHP_LIB/lib/IHP/Makefile.dist print-ghc-extensions | sed 's/-fbyte-code//g')
-                        ghc --make \
-                            $GHC_EXTS \
-                            -threaded \
-                            -i. -ibuild -iConfig \
-                            -package-env - \
-                            -package ihp -package ihp-hspec -package ihp-typed-sql -package hspec \
-                            -main-is Test.Main \
-                            Test/Main.hs -o test-runner
-                        ./test-runner
-
-                        # Cleanup
-                        pg_ctl -D "$PGDATA" stop || true
-                    '';
-                    installPhase = ''
-                        touch $out
-                    '';
-                };
-            }))
+            # Slim GHC 9.12 dual-support matrix. Default checks are 9.14;
+            # these are the rollback-set cost.
+            // (lib.optionalAttrs (pkgs.haskell.packages ? ghc912) {
+                ghc912-ihp = withTestPostgres pkgs.ghc912.ihp;
+                ghc912-ihp-ide = pkgs.ghc912.ihp-ide;
+                ghc912-ihp-hsx = pkgs.ghc912.ihp-hsx;
+                ghc912-ihp-datasync = withTestPostgres pkgs.ghc912.ihp-datasync;
+                ghc912-ihp-typed-sql = withTestPostgres pkgs.ghc912.ihp-typed-sql;
+                ghc912-ihp-pglistener = withTestPostgres pkgs.ghc912.ihp-pglistener;
+            })
         ;
 
         devenv.shells.default = {

--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -158,9 +158,8 @@ that is defined in flake-module.nix
                 };
             }
 
-            # Default checks are GHC 9.14. Fold first-party packages that were
-            # only on the former ghc914-* extra list and are not already in
-            # packages.* so 9.14 first-party CI does not shrink.
+            # First-party packages that are not packages.* outputs still need a
+            # default-compiler check.
             // {
                 ihp-hsx = pkgs.ghc.ihp-hsx;
                 ihp-postgres-parser = pkgs.ghc.ihp-postgres-parser;
@@ -176,7 +175,6 @@ that is defined in flake-module.nix
             }
 
             # Keep this check name: build.yml's ghc914-dev-env job builds it.
-            # pkgs.ghc914 aliases pkgs.ghc (now 9.14).
             // {
                 ghc914-dev-env = pkgs.ghc914.ghc.withPackages (p: [
                     p.ihp

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -209,6 +209,12 @@ ihpFlake:
             cfg = config.ihp;
             ihp = ihpFlake.inputs.self;
             ghcCompiler = cfg.ghcCompiler;
+            # apply-refact 0.15 (hlint) does not compile on GHC 9.14.
+            devGhcPackages = p:
+                let requested = cfg.haskellPackages p ++ cfg.devHaskellPackages p;
+                in if lib.versionOlder ghcCompiler.ghc.version "9.14"
+                   then requested
+                   else lib.filter (x: (x.pname or "") != "hlint") requested;
             ihpLib = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
             # Auto-detect whether a build-time PostgreSQL is needed (e.g. ihp-typed-sql)
             buildWithPostgres = builtins.any (p: (p.pname or "") == "ihp-typed-sql") (cfg.haskellPackages ghcCompiler);
@@ -372,7 +378,7 @@ ihpFlake:
                     tests = pkgs.stdenv.mkDerivation {
                             name = "${config.ihp.appName}-tests";
                             src = builtins.path { path = config.ihp.projectPath; name = "source"; };
-                            nativeBuildInputs = with pkgs; [ (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler])) ]
+                            nativeBuildInputs = with pkgs; [ (ghcCompiler.ghcWithPackages (p: devGhcPackages p ++ [p.ihp-ide p.ihp-schema-compiler])) ]
                                 # typedSql's quasi-quoter boots an ephemeral PostgreSQL at
                                 # compile time to describe queries (see IHP_TYPED_SQL_AUTO_DB
                                 # below), so the postgres tools must be on PATH whenever the
@@ -407,7 +413,7 @@ ihpFlake:
                             name = "${config.ihp.appName}-integration-tests";
                             src = builtins.path { path = config.ihp.projectPath; name = "source"; };
                             nativeBuildInputs = with pkgs; [
-                                (ghcCompiler.ghcWithPackages (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p ++ [p.ihp-ide p.ihp-schema-compiler]))
+                                (ghcCompiler.ghcWithPackages (p: devGhcPackages p ++ [p.ihp-ide p.ihp-schema-compiler]))
                                 gnumake
                                 postgresql
                             ];
@@ -478,14 +484,7 @@ ihpFlake:
                 languages.haskell.enable = true;
                 languages.haskell.package = (if cfg.withHoogle
                                              then ghcCompiler.ghc.withHoogle
-                                             else ghcCompiler.ghc.withPackages) (p:
-                    let
-                        requested = cfg.haskellPackages p ++ cfg.devHaskellPackages p;
-                    # apply-refact 0.15 (hlint) does not compile on GHC 9.14.
-                    in if lib.versionOlder ghcCompiler.ghc.version "9.14"
-                       then requested
-                       else lib.filter (x: (x.pname or "") != "hlint") requested
-                );
+                                             else ghcCompiler.ghc.withPackages) devGhcPackages
 
                 languages.haskell.stack.enable = false; # Stack is not used in IHP
                 # Use the package-set HLS. devenv's default override rejects GHC RC version strings.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -26,8 +26,8 @@ ihpFlake:
                     description = ''
                         The GHC compiler to use for IHP.
 
-                        Defaults to `pkgs.ghc` (GHC 9.10, binary-cached). Set to
-                        `pkgs.ghc914` to opt into GHC 9.14 (built from source).
+                        Defaults to `pkgs.ghc` (GHC 9.14.1). Set `pkgs.ghc912`
+                        to stay on GHC 9.12.
                     '';
                     default = pkgs.ghc;
                 };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -484,7 +484,7 @@ ihpFlake:
                 languages.haskell.enable = true;
                 languages.haskell.package = (if cfg.withHoogle
                                              then ghcCompiler.ghc.withHoogle
-                                             else ghcCompiler.ghc.withPackages) devGhcPackages
+                                             else ghcCompiler.ghc.withPackages) devGhcPackages;
 
                 languages.haskell.stack.enable = false; # Stack is not used in IHP
                 # Use the package-set HLS. devenv's default override rejects GHC RC version strings.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -210,11 +210,15 @@ ihpFlake:
             ihp = ihpFlake.inputs.self;
             ghcCompiler = cfg.ghcCompiler;
             # apply-refact 0.15 (hlint) does not compile on GHC 9.14.
+            # Completions wrappers may omit pname, so match name too.
+            isHlint = x:
+                let n = lib.toLower (x.pname or x.name or "");
+                in n == "hlint" || lib.hasPrefix "hlint-" n;
             devGhcPackages = p:
                 let requested = cfg.haskellPackages p ++ cfg.devHaskellPackages p;
                 in if lib.versionOlder ghcCompiler.ghc.version "9.14"
                    then requested
-                   else lib.filter (x: (x.pname or "") != "hlint") requested;
+                   else lib.filter (x: !(isHlint x)) requested;
             ihpLib = ihpFlake.inputs.self.packages.${system}.ihp-env-var-backwards-compat;
             # Auto-detect whether a build-time PostgreSQL is needed (e.g. ihp-typed-sql)
             buildWithPostgres = builtins.any (p: (p.pname or "") == "ihp-typed-sql") (cfg.haskellPackages ghcCompiler);

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -478,7 +478,14 @@ ihpFlake:
                 languages.haskell.enable = true;
                 languages.haskell.package = (if cfg.withHoogle
                                              then ghcCompiler.ghc.withHoogle
-                                             else ghcCompiler.ghc.withPackages) (p: cfg.haskellPackages p ++ cfg.devHaskellPackages p);
+                                             else ghcCompiler.ghc.withPackages) (p:
+                    let
+                        requested = cfg.haskellPackages p ++ cfg.devHaskellPackages p;
+                    # apply-refact 0.15 (hlint) does not compile on GHC 9.14.
+                    in if lib.versionOlder ghcCompiler.ghc.version "9.14"
+                       then requested
+                       else lib.filter (x: (x.pname or "") != "hlint") requested
+                );
 
                 languages.haskell.stack.enable = false; # Stack is not used in IHP
                 # Use the package-set HLS. devenv's default override rejects GHC RC version strings.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -26,7 +26,7 @@ ihpFlake:
                     description = ''
                         The GHC compiler to use for IHP.
 
-                        Defaults to `pkgs.ghc` (GHC 9.14.1). Set `pkgs.ghc912`
+                        Defaults to `pkgs.ghc` (GHC 9.14.1). Set to `pkgs.ghc912`
                         to stay on GHC 9.12.
                     '';
                     default = pkgs.ghc;


### PR DESCRIPTION
## Summary
Invert the overlay so `pkgs.ghc` is GHC **9.14.1**. `pkgs.ghc914` aliases the default. `pkgs.ghc912` is a real `haskell.packages.ghc912` rollback set.

User-facing docs ship in this PR: `UPGRADE.md`, CHANGELOG, and Guide "Switching GHC Versions" (delete the old `ghc = prev.ghc912` overlay; use `ihp.ghcCompiler = pkgs.ghc912`).

Default CI folds former `ghc914-*` extras. Slim `ghc912-*` dual-support matrix remains.

**Emergency rollback:** revert this whole PR, not `overlay.nix` alone.

## App authors
```nix
# stay on 9.12
ihp.ghcCompiler = pkgs.ghc912;
```
Delete any `overlays = lib.mkAfter [ (final: prev: { ghc = prev.ghc912; }) ];` copied from the old Guide.

Do not merge until the 9.14 devenv cache-warm job has had a green `master` run of the previous PRs (or accept a cold first 9.14 build).