### PR TITLE
Reuse one app library derivation for single-host builds

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -21,6 +21,9 @@
 , ihpSchemaSql ? null       # Path to IHPSchema.sql (required when buildWithPostgres = true)
 , migrationCheck ? null     # Optional derivation that validates Application/Migration before building the app
 , previousIntermediates ? null # Optional combined intermediate output from a previous optimized app build
+, reuseAppLibWithIntermediatesForExecutables ? false # Reuse the cache-producing app lib when builds stay on one machine
+, appLibCompileCores ? null # Optional fixed GHC module parallelism for the optimized application library
+, appLibGhcAllocationArea ? null # Optional app-library-specific compile-time RTS allocation area
 , buildStaticLibraries ? true # Build static Haskell libraries in addition to shared libraries
 , ghcAllocationArea ? null # Optional GHC compile-time RTS allocation area, e.g. "128M"
 }:
@@ -457,7 +460,27 @@ CABAL_EOF
                     ];
             });
 
-    mkAppLibPackage = withIntermediates: configureHaskellBuild (pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
+    configureAppLibBuild = pkg:
+        let configured = configureHaskellBuild pkg;
+        in if appLibCompileCores == null && appLibGhcAllocationArea == null
+            then configured
+            else pkgs.haskell.lib.overrideCabal configured (old: ({
+                configureFlags = (old.configureFlags or [])
+                    ++ pkgs.lib.optionals (appLibCompileCores != null) [
+                        "--ghc-option=-j${toString appLibCompileCores}"
+                    ]
+                    ++ pkgs.lib.optionals (appLibGhcAllocationArea != null) [
+                        "--ghc-option=+RTS"
+                        "--ghc-option=-A${appLibGhcAllocationArea}"
+                        "--ghc-option=-RTS"
+                    ];
+            } // pkgs.lib.optionalAttrs (appLibCompileCores != null) {
+                # Avoid a second, daemon-derived parallelism flag alongside the
+                # explicit GHC module-job count above.
+                enableParallelBuilding = false;
+            }));
+
+    mkAppLibPackage = withIntermediates: configureAppLibBuild (pkgs.haskell.lib.disableLibraryProfiling (pkgs.haskell.lib.dontHaddock (
         ghc.callPackage ({ mkDerivation, base }: mkDerivation {
             pname = "${appName}-lib";
             version = "0.1.0";
@@ -491,11 +514,15 @@ CABAL_EOF
         then withBuildTimePostgres pkg
         else pkg;
 
-    # The executables link against a lib variant WITHOUT the multi-GB library
-    # intermediates output. Their own small object trees are separate outputs
-    # of the executable derivations below.
-    appLibPackage = withAppLibPostgres (mkAppLibPackage false);
     appLibPackageWithIntermediates = withAppLibPostgres (mkAppLibPackage optimized);
+    # Remote builders copy every output of a derivation back to the requesting
+    # host. Keep the smaller, separate executable dependency by default, but
+    # allow single-host build pipelines to reuse the cache-producing package's
+    # `out` and avoid realizing the application library twice.
+    appLibPackage =
+        if reuseAppLibWithIntermediatesForExecutables
+        then appLibPackageWithIntermediates
+        else withAppLibPostgres (mkAppLibPackage false);
 
     allHaskellPackagesWithAppLib = ghc.ghcWithPackages (p: [ appLibPackage ]);
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -161,6 +161,39 @@ ihpFlake:
                     default = null;
                 };
 
+                reuseAppLibWithIntermediatesForExecutables = lib.mkOption {
+                    description = ''
+                        Reuse the optimized application's cache-producing library
+                        package when linking the production server, job runner, and
+                        scripts. This avoids realizing a second library package and
+                        is intended for build pipelines that keep the intermediate
+                        output on the machine performing the build. Leave disabled
+                        for remote builders where transferring every derivation
+                        output would copy the multi-gigabyte intermediate tree.
+                    '';
+                    type = lib.types.bool;
+                    default = false;
+                };
+
+                appLibCompileCores = lib.mkOption {
+                    description = ''
+                        Optional fixed GHC module parallelism for optimized
+                        application-library builds. When set, IHP passes -jN to
+                        GHC instead of relying on the builder daemon's core count.
+                    '';
+                    type = lib.types.nullOr lib.types.ints.positive;
+                    default = null;
+                };
+
+                appLibGhcAllocationArea = lib.mkOption {
+                    description = ''
+                        Optional compile-time GHC RTS allocation area used only
+                        for the application library, such as "64M".
+                    '';
+                    type = lib.types.nullOr lib.types.str;
+                    default = null;
+                };
+
                 scripts.optimized = lib.mkOption {
                     description = ''
                         Whether packages.script-<Name> flake outputs are compiled with optimizations.
@@ -231,6 +264,10 @@ ihpFlake:
                 static = self'.packages.static;
                 inherit buildWithPostgres;
                 previousIntermediates = if optimized then cfg.previousAppLibIntermediates else null;
+                reuseAppLibWithIntermediatesForExecutables =
+                    optimized && cfg.reuseAppLibWithIntermediatesForExecutables;
+                appLibCompileCores = if optimized then cfg.appLibCompileCores else null;
+                appLibGhcAllocationArea = if optimized then cfg.appLibGhcAllocationArea else null;
                 inherit (cfg) buildStaticLibraries ghcAllocationArea;
                 appSchemaSql = "${self'.packages.schema}/Schema.sql";
                 ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";


### PR DESCRIPTION
## Summary
- add an opt-in IHP setting that lets production executables reuse the cache-producing app library derivation
- keep the remote-builder-friendly split as the default
- expose app-library GHC parallelism and allocation settings so cache and executable consumers use identical flags

## Validation
- `nix-instantiate --parse NixSupport/default.nix`
- `nix-instantiate --parse flake-module.nix`
- `git diff --check`

This removes the second Cabal realization for applications whose cache and production packages are built on the same host.