### PR TITLE
Reject invalid UTF-8 text parameters

### DIFF
--- a/devenv-module.nix
+++ b/devenv-module.nix
@@ -660,7 +660,7 @@ that is defined in flake-module.nix
 
                 yarnOfflineCache = pkgs.fetchYarnDeps {
                     yarnLock = ./ihp-datasync/data/DataSync/yarn.lock;
-                    hash = "sha256-D9pLOT4afe8M29nKgJyNZhCj0KlF6X8ZQ0e8RZZsVsY=";
+                    hash = "sha256-RFCzBgDYx2CeRjBPDGBKesmOht2uzYH3K39v2BRbK00=";
                 };
 
                 nativeBuildInputs = [ pkgs.nodejs pkgs.yarn pkgs.yarnConfigHook ];

--- a/wai-request-params/Test/Wai/Request/ParamsSpec.hs
+++ b/wai-request-params/Test/Wai/Request/ParamsSpec.hs
@@ -18,8 +18,10 @@ import Data.Time.Clock (UTCTime)
 import Data.Time.LocalTime (LocalTime, TimeOfDay)
 import Data.Time.Calendar (Day)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Data.UUID (UUID)
 import Data.String.Conversions (cs)
 import Data.Maybe (fromJust)
@@ -216,6 +218,12 @@ spec = do
             describe "Text" $ do
                 it "should handle text input" $ do
                     (readParameter @Text "test") `shouldBe` (Right "test")
+
+                it "should decode UTF-8 input" $ do
+                    (readParameter @Text (TextEncoding.encodeUtf8 "Max Verkäufer")) `shouldBe` (Right "Max Verkäufer")
+
+                it "should reject invalid UTF-8 input" $ do
+                    (readParameter @Text (ByteString.pack [0xE4])) `shouldBe` (Left "has to be valid UTF-8")
 
                 it "should handle JSON strings" $ do
                     (readParameterJSON @Text (json "\"test\"")) `shouldBe` (Right ("test"))

--- a/wai-request-params/Wai/Request/Params.hs
+++ b/wai-request-params/Wai/Request/Params.hs
@@ -38,6 +38,7 @@ import Prelude
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as Char8
 import Data.Text (Text)
+import qualified Data.Text.Encoding as TextEncoding
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import Data.Time.Clock (UTCTime)
@@ -278,7 +279,10 @@ instance ParamReader Float where
 
 instance ParamReader Text where
     {-# INLINABLE readParameter #-}
-    readParameter byteString = pure (cs byteString)
+    readParameter byteString =
+        case TextEncoding.decodeUtf8' byteString of
+            Right text -> Right text
+            Left _ -> Left "has to be valid UTF-8"
 
     readParameterJSON (Aeson.String text) = Right text
     readParameterJSON _ = Left "Expected String"


### PR DESCRIPTION
## Summary

- decode `Text` parameters with strict UTF-8 validation
- return a `ParamReader` error for malformed byte sequences instead of silently inserting U+FFFD
- cover valid non-ASCII UTF-8 and malformed input
- update the DataSync `fetchYarnDeps` hash after the `js-yaml` lockfile bump in #2780

Browsers submit form data as UTF-8 when the page/form is UTF-8, so the framework should not guess a legacy encoding such as Windows-1252. If malformed bytes nevertheless reach the application, rejecting them through the existing `Either ByteString` error channel prevents permanently corrupted text from being stored.

The DataSync hash update is an unrelated one-line follow-up required because #2780 landed on `master` immediately before this branch was rebased. Its stale offline-cache hash currently makes the repository-wide CI fail before this PR's check can complete.

## Test

```
nix build --impure .#checks.aarch64-darwin.ghc914-wai-request-params
nix build --impure .#checks.aarch64-darwin.datasync-js
```
