### PR TITLE
Fix unreadable code blocks in the Guide's dark mode

### DIFF
--- a/Guide/layout.html
+++ b/Guide/layout.html
@@ -237,6 +237,24 @@
       }
       .source-code pre::-webkit-scrollbar{height:10px}
       .source-code pre::-webkit-scrollbar-thumb{background:var(--code-border);border-radius:8px}
+
+      /* Fenced blocks without a language are emitted as a bare <pre><code>, without
+         the .source-code wrapper. Without this they fall back to Bootstrap's
+         `pre{color:#212529}`, which is unreadable on the dark mode background. */
+      .doc pre:not(.source-code pre){
+        background:var(--code-bg); color:var(--sx-base);
+        border:1px solid var(--code-border); border-radius:var(--r);
+        margin:1.6rem 0 1.9rem; padding:18px 20px; overflow-x:auto;
+        box-shadow:var(--shadow-code);
+        font-family:"JetBrains Mono",ui-monospace,monospace; font-size:14px; line-height:1.7;
+      }
+      .doc pre:not(.source-code pre)>code{
+        background:transparent; color:inherit; border:0; padding:0;
+        font-family:inherit; font-size:inherit; white-space:pre;
+      }
+      .doc pre:not(.source-code pre)::-webkit-scrollbar{height:10px}
+      .doc pre:not(.source-code pre)::-webkit-scrollbar-thumb{background:var(--code-border);border-radius:8px}
+
       .copy-btn{
         position:absolute; top:7px; right:10px; z-index:3;
         font:500 11px/1 "JetBrains Mono",monospace; letter-spacing:.04em;


### PR DESCRIPTION
Fenced code blocks written without a language are rendered as a bare `<pre><code>`, without the `.source-code` wrapper that carries the code block styling. They therefore fall through to Bootstrap's `pre{color:#212529}` — near-black text on the dark mode background, which is effectively invisible.

Seen for example on [Deployment → Configuring the Instance](https://ihp.digitallyinduced.com/Guide/deployment.html#configuring-the-instance), where the file-tree block right below the paragraph is unreadable in dark mode, while the `.nix` block just under it (which has a language, so it gets the `.source-code` wrapper) renders fine.

This styles unwrapped `<pre>` blocks the same way as the wrapped ones — dark box, border, light monospace text — so they are readable and visually consistent in both themes. The `:not(.source-code pre)` guard keeps the existing wrapped blocks untouched (they also occur nested in list items, so a `.doc > pre` child selector would have missed some).

Verified by rendering the built `deployment.html` against the patched `layout.html` in Chrome, in both dark and light mode.

<!-- screenshots: before / after -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)