### PR TITLE
Handle PostgreSQL line comments inside statements

### DIFF
--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -30,7 +30,8 @@ import qualified Data.List as List
 import Control.Monad (when)
 import Text.Megaparsec
 import Data.Void
-import Text.Megaparsec.Char
+import Text.Megaparsec.Char hiding (space)
+import qualified Text.Megaparsec.Char as Char
 import qualified Text.Megaparsec.Char.Lexer as Lexer
 import System.OsPath (OsPath, decodeUtf)
 import Control.Monad.Combinators.Expr
@@ -207,11 +208,26 @@ dropDollarQuoted delimiter (_ : rest) = dropDollarQuoted delimiter rest
 
 type Parser = Parsec Void Text
 
+-- | Whitespace between two tokens of the same statement.
+--
+-- PostgreSQL's line comment is @--@, not @\/\/@, so an inline comment such as
+-- @id UUID PRIMARY KEY, -- surrogate key@ used to stop the parser mid statement
+-- even though the server accepts it.
+--
+-- At statement level a @--@ comment is not trivia: 'comment' turns it into a
+-- 'Comment' statement so the schema keeps it. 'statement' and 'parseDDL'
+-- therefore consume plain whitespace with 'Char.space' and leave comments for
+-- 'comment' to claim.
 spaceConsumer :: Parser ()
 spaceConsumer = Lexer.space
     space1
-    (Lexer.skipLineComment "//")
+    (Lexer.skipLineComment "--")
     (Lexer.skipBlockComment "/*" "*/")
+
+-- | Whitespace inside a statement, where a comment is trivia. Shadows
+-- 'Char.space' so that every statement parser gets comment handling.
+space :: Parser ()
+space = spaceConsumer
 
 lexeme :: Parser a -> Parser a
 lexeme = Lexer.lexeme spaceConsumer
@@ -226,16 +242,16 @@ stringLiteral :: Parser String
 stringLiteral = char '\'' *> manyTill Lexer.charLiteral (char '\'')
 
 parseDDL :: Parser [Statement]
-parseDDL = optional space >> (manyTill statement eof)
+parseDDL = optional Char.space >> (manyTill statement eof)
 
 statement = do
-    space
+    Char.space
     let create = try createExtension <|> try (StatementCreateTable <$> createTable) <|> try createIndex <|> try createFunction <|> try createTrigger <|> try createEnumType <|> try createPolicy <|> try createSequence
     let alter = do
             lexeme "ALTER"
             alterTable <|> alterType <|> alterSequence
     s <- setStatement <|> create <|> alter <|> selectStatement <|> try dropTable <|> try dropIndex <|> try dropPolicy <|> try dropFunction <|> try dropType <|> dropTrigger <|> commentStatement <|> comment <|> begin <|> commit <|> restrict <|> unrestrict
-    space
+    Char.space
     pure s
 
 
@@ -1322,12 +1338,18 @@ removeTypeCasts :: Expression -> Expression
 removeTypeCasts (TypeCastExpression value _) = value
 removeTypeCasts otherwise = otherwise
 
+-- | pg_dump 17.5 and later fence their output with @\restrict <key>@. The key is
+-- read with 'restrictKey' rather than 'identifier' because 'identifier' consumes
+-- the trivia behind it, and here that trivia is the next statement: a comment.
 restrict = do
     lexeme "\\restrict"
-    key <- identifier
+    key <- restrictKey
     pure Comment { content = "" }
 
 unrestrict = do
     lexeme "\\unrestrict"
-    key <- identifier
+    key <- restrictKey
     pure Comment { content = "" }
+
+restrictKey :: Parser Text
+restrictKey = takeWhile1P (Just "restrict key") (\c -> isAlphaNum c || c == '_')

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -468,6 +468,27 @@ spec = do
         it "should parse negative DoubleExpression's" do
             parseExpression "-1.337" `shouldBe` (DoubleExpression (-1.337))
 
+        it "should ignore a comment inside a statement" do
+            parseSql "CREATE TABLE users (\n    id UUID PRIMARY KEY, -- surrogate key\n    email TEXT NOT NULL /* the login */\n);" `shouldBe`
+                StatementCreateTable (table "users")
+                    { columns = [col "id" PUUID, (col "email" PText) { notNull = True }]
+                    , primaryKeyConstraint = PrimaryKeyConstraint ["id"]
+                    }
+
+        it "should keep a comment between two statements as its own statement" do
+            parseSqlStatements "CREATE TABLE a ();\n-- about b\nCREATE TABLE b ();" `shouldBe`
+                [ StatementCreateTable (table "a")
+                , Comment { content = " about b" }
+                , StatementCreateTable (table "b")
+                ]
+
+        it "should keep the comment behind a pg_dump restrict fence" do
+            parseSqlStatements "\\restrict aBcD1\n-- kept\nCREATE TABLE a ();" `shouldBe`
+                [ Comment { content = "" }
+                , Comment { content = " kept" }
+                , StatementCreateTable (table "a")
+                ]
+
 parseSql :: Text -> Statement
 parseSql sql = let [statement] = parseSqlStatements sql in statement
 


### PR DESCRIPTION
## Bug

A PostgreSQL line comment inside a statement is currently consumed as ordinary whitespace:

```sql
CREATE TABLE users (
    id UUID, -- public identifier
    email TEXT
);
```

This can make the parser join tokens across the comment or stop at the wrong place.

## Fix

Treat `-- ...` as a real SQL comment while preserving standalone comments as schema statements. The PostgreSQL dump guard `\restrict` remains a distinct statement.

## Independence

This branch is based directly on the current `upstream/master`; it has no dependency on another parser PR.

## Validation

- `nix build --impure --no-link .#checks.aarch64-darwin.ghc914-ihp-postgres-parser`

Not PostgreSQL 18-specific.
