### PR TITLE
Parse real PostgreSQL schema expressions

### DIFF
--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -579,6 +579,7 @@ normalizeExpression (GreaterThanOrEqualToExpression a b) = GreaterThanOrEqualToE
 normalizeExpression e@(DoubleExpression {}) = e
 normalizeExpression e@(IntExpression {}) = e
 normalizeExpression (ConcatenationExpression a b) = ConcatenationExpression (normalizeExpression a) (normalizeExpression b)
+normalizeExpression (BinaryOperatorExpression operator a b) = BinaryOperatorExpression operator (normalizeExpression a) (normalizeExpression b)
 -- Enum default values from pg_dump always have an explicit type cast. Inside the Schema.sql they typically don't have those.
 -- Therefore we remove these typecasts here
 --
@@ -627,6 +628,7 @@ unqualifyExpression scope expression = doUnqualify expression
         doUnqualify e@(DoubleExpression {}) = e
         doUnqualify e@(IntExpression {}) = e
         doUnqualify (ConcatenationExpression a b) = ConcatenationExpression (doUnqualify a) (doUnqualify b)
+        doUnqualify (BinaryOperatorExpression operator a b) = BinaryOperatorExpression operator (doUnqualify a) (doUnqualify b)
         doUnqualify (TypeCastExpression a b) = TypeCastExpression (doUnqualify a) b
         doUnqualify e@(SelectExpression Select { columns, from, whereClause, alias }) =
             let recurse = case from of
@@ -671,6 +673,7 @@ resolveAlias (Just alias) fromExpression expression =
         e@(DotExpression a b) -> DotExpression (rec a) b
         e@(ExistsExpression a) -> ExistsExpression (rec a)
         e@(ConcatenationExpression a b) -> ConcatenationExpression (rec a) (rec b)
+        e@(BinaryOperatorExpression operator a b) -> BinaryOperatorExpression operator (rec a) (rec b)
         e@(InArrayExpression exprs) -> InArrayExpression (map rec exprs)
         e@(ArrayLiteralExpression exprs) -> ArrayLiteralExpression (map rec exprs)
         e@(VariadicExpression expr) -> VariadicExpression (rec expr)

--- a/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
@@ -602,6 +602,7 @@ deleteColumn DeleteColumnOptions { .. } schema =
                 isRef (SelectExpression _) = False
                 isRef (DotExpression a _) = isRef a
                 isRef (ConcatenationExpression a b) = isRef a || isRef b
+                isRef (BinaryOperatorExpression _ a b) = isRef a || isRef b
         deletePolicyReferencingPolicy otherwise = True
 
 -- | Returns True if a CreateIndex statement references a specific column
@@ -664,6 +665,7 @@ isIndexStatementReferencingTableColumn statement tableName columnName = isRefere
             SelectExpression _ -> False
             DotExpression a _ -> expressionReferencesColumn a
             ConcatenationExpression a b -> expressionReferencesColumn a || expressionReferencesColumn b
+            BinaryOperatorExpression _ a b -> expressionReferencesColumn a || expressionReferencesColumn b
 
 doesHaveExistingPolicies :: [Statement] -> Text -> Bool
 doesHaveExistingPolicies statements tableName = statements

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -165,6 +165,7 @@ compileExpression (SelectExpression Select { columns, from, whereClause }) = "SE
 compileExpression (ExistsExpression a) = "EXISTS " <> compileExpressionWithOptionalParenthese a
 compileExpression (DotExpression a b) = compileExpressionWithOptionalParenthese a <> "." <> compileIdentifier b
 compileExpression (ConcatenationExpression a b) = compileExpressionWithOptionalParenthese a <> " || " <> compileExpressionWithOptionalParenthese b
+compileExpression (BinaryOperatorExpression "ESCAPE" patternExpression escapeCharacter) = compileExpression patternExpression <> " ESCAPE " <> compileExpressionWithOptionalParenthese escapeCharacter
 compileExpression (BinaryOperatorExpression operator a b) = compileExpressionWithOptionalParenthese a <> " " <> operator <> " " <> compileExpressionWithOptionalParenthese b
 
 compileEqualityOperand :: Expression -> Text

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -166,7 +166,13 @@ compileExpression (ExistsExpression a) = "EXISTS " <> compileExpressionWithOptio
 compileExpression (DotExpression a b) = compileExpressionWithOptionalParenthese a <> "." <> compileIdentifier b
 compileExpression (ConcatenationExpression a b) = compileExpressionWithOptionalParenthese a <> " || " <> compileExpressionWithOptionalParenthese b
 compileExpression (BinaryOperatorExpression "ESCAPE" patternExpression escapeCharacter) = compileExpression patternExpression <> " ESCAPE " <> compileExpressionWithOptionalParenthese escapeCharacter
-compileExpression (BinaryOperatorExpression operator a b) = compileExpressionWithOptionalParenthese a <> " " <> operator <> " " <> compileExpressionWithOptionalParenthese b
+compileExpression (BinaryOperatorExpression operator a b) = compileBinaryOperatorOperand a <> " " <> operator <> " " <> compileBinaryOperatorOperand b
+
+compileBinaryOperatorOperand :: Expression -> Text
+compileBinaryOperatorOperand expression@(EqExpression {}) = "(" <> compileExpression expression <> ")"
+compileBinaryOperatorOperand expression@(IsExpression {}) = "(" <> compileExpression expression <> ")"
+compileBinaryOperatorOperand expression@(ConcatenationExpression {}) = "(" <> compileExpression expression <> ")"
+compileBinaryOperatorOperand expression = compileExpressionWithOptionalParenthese expression
 
 compileEqualityOperand :: Expression -> Text
 compileEqualityOperand expression@(IsExpression {}) = "(" <> compileExpression expression <> ")"

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -140,7 +140,7 @@ compileExpression (VarExpression name) =
     where
         nameContainsSpaces = Text.any (== ' ') name
 compileExpression (CallExpression func args) = func <> "(" <> intercalate ", " (map compileExpressionWithOptionalParenthese args) <> ")"
-compileExpression (NotEqExpression a b) = compileExpression a <> " <> " <> compileExpression b
+compileExpression (NotEqExpression a b) = compileEqualityOperand a <> " <> " <> compileEqualityOperand b
 compileExpression (EqExpression a b) = compileEqualityOperand a <> " = " <> compileEqualityOperand b
 compileExpression (IsExpression a (NotExpression b)) = compileExpressionWithOptionalParenthese a <> " IS NOT " <> compileExpressionWithOptionalParenthese b -- 'IS (NOT NULL)' => 'IS NOT NULL'
 compileExpression (IsExpression a b) = compileExpressionWithOptionalParenthese a <> " IS " <> compileExpressionWithOptionalParenthese b

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -157,7 +157,7 @@ compileExpression (GreaterThanExpression a b) = compileExpressionWithOptionalPar
 compileExpression (GreaterThanOrEqualToExpression a b) = compileExpressionWithOptionalParenthese a <> " >= " <> compileExpressionWithOptionalParenthese b
 compileExpression (DoubleExpression double) = tshow double
 compileExpression (IntExpression integer) = tshow integer
-compileExpression (TypeCastExpression value type_) = compileExpression value <> "::" <> compilePostgresType type_
+compileExpression (TypeCastExpression value type_) = compileExpressionWithOptionalParenthese value <> "::" <> compilePostgresType type_
 compileExpression (SelectExpression Select { columns, from, whereClause }) = "SELECT " <> intercalate ", " (map compileExpression columns) <> " FROM " <> compileExpression from <> " WHERE " <> compileExpression whereClause
 compileExpression (ExistsExpression a) = "EXISTS " <> compileExpressionWithOptionalParenthese a
 compileExpression (DotExpression a b) = compileExpressionWithOptionalParenthese a <> "." <> compileIdentifier b

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -141,7 +141,7 @@ compileExpression (VarExpression name) =
         nameContainsSpaces = Text.any (== ' ') name
 compileExpression (CallExpression func args) = func <> "(" <> intercalate ", " (map compileExpressionWithOptionalParenthese args) <> ")"
 compileExpression (NotEqExpression a b) = compileExpression a <> " <> " <> compileExpression b
-compileExpression (EqExpression a b) = compileExpressionWithOptionalParenthese a <> " = " <> compileExpressionWithOptionalParenthese b
+compileExpression (EqExpression a b) = compileEqualityOperand a <> " = " <> compileEqualityOperand b
 compileExpression (IsExpression a (NotExpression b)) = compileExpressionWithOptionalParenthese a <> " IS NOT " <> compileExpressionWithOptionalParenthese b -- 'IS (NOT NULL)' => 'IS NOT NULL'
 compileExpression (IsExpression a b) = compileExpressionWithOptionalParenthese a <> " IS " <> compileExpressionWithOptionalParenthese b
 compileExpression (InExpression a b) = compileExpressionWithOptionalParenthese a <> " IN " <> compileExpressionWithOptionalParenthese b
@@ -163,6 +163,10 @@ compileExpression (ExistsExpression a) = "EXISTS " <> compileExpressionWithOptio
 compileExpression (DotExpression a b) = compileExpressionWithOptionalParenthese a <> "." <> compileIdentifier b
 compileExpression (ConcatenationExpression a b) = compileExpressionWithOptionalParenthese a <> " || " <> compileExpressionWithOptionalParenthese b
 compileExpression (BinaryOperatorExpression operator a b) = compileExpressionWithOptionalParenthese a <> " " <> operator <> " " <> compileExpressionWithOptionalParenthese b
+
+compileEqualityOperand :: Expression -> Text
+compileEqualityOperand expression@(IsExpression {}) = "(" <> compileExpression expression <> ")"
+compileEqualityOperand expression = compileExpressionWithOptionalParenthese expression
 
 compileExpressionWithOptionalParenthese :: Expression -> Text
 compileExpressionWithOptionalParenthese expr@(VarExpression {}) = compileExpression expr

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -162,6 +162,7 @@ compileExpression (SelectExpression Select { columns, from, whereClause }) = "SE
 compileExpression (ExistsExpression a) = "EXISTS " <> compileExpressionWithOptionalParenthese a
 compileExpression (DotExpression a b) = compileExpressionWithOptionalParenthese a <> "." <> compileIdentifier b
 compileExpression (ConcatenationExpression a b) = compileExpressionWithOptionalParenthese a <> " || " <> compileExpressionWithOptionalParenthese b
+compileExpression (BinaryOperatorExpression operator a b) = compileExpressionWithOptionalParenthese a <> " " <> operator <> " " <> compileExpressionWithOptionalParenthese b
 
 compileExpressionWithOptionalParenthese :: Expression -> Text
 compileExpressionWithOptionalParenthese expr@(VarExpression {}) = compileExpression expr

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -385,7 +385,12 @@ parseExcludeConstraint name = do
             operator <- parseCommutativeInfixOperator
             pure ExcludeConstraintElement { element, operator }
 
-        excludeElementChunk = quotedChunk '\'' <|> quotedChunk '"' <|> (Text.singleton <$> anySingle)
+        excludeElementChunk =
+            quotedChunk '\''
+            <|> quotedChunk '"'
+            <|> (fst <$> match (Lexer.skipLineComment "--"))
+            <|> (fst <$> match (Lexer.skipBlockCommentNested "/*" "*/"))
+            <|> (Text.singleton <$> anySingle)
 
         quotedChunk quote = fst <$> match do
             char quote

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -768,7 +768,7 @@ table = highPrecedenceTable <> genericOperatorTable <>
 
         escapeOp = do
             keyword "ESCAPE"
-            escapeCharacter <- term
+            escapeCharacter <- boundExpression
             pure (\patternExpression -> BinaryOperatorExpression "ESCAPE" patternExpression escapeCharacter)
 
         -- Cannot be implemented as a infix operator as that requires two expression operands,
@@ -840,6 +840,9 @@ typedLiteralExpr :: Parser Expression
 typedLiteralExpr = do
     literalType <- sqlType
     value <- textExpr <* space
+    literalType <- case literalType of
+        PInterval Nothing -> PInterval <$> optional (choice (map symbol' intervalFields))
+        _ -> pure literalType
     pure (TypeCastExpression value literalType)
 
 callExpr :: Parser Expression

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -692,7 +692,7 @@ term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try typedLit
 
 table = highPrecedenceTable <> genericOperatorTable <>
         [
-            [ Postfix (foldl1 (flip (.)) <$> some (try notInOp <|> try betweenOp <|> inOp))
+            [ Postfix (foldl1 (flip (.)) <$> some (try notInOp <|> try notBetweenOp <|> try betweenOp <|> inOp))
             ],
             [ keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
             , keywordOperator "LIKE", keywordOperator "ILIKE"
@@ -726,12 +726,7 @@ table = highPrecedenceTable <> genericOperatorTable <>
             , [ operator "+", minusOperator ]
             ]
 
-        genericOperatorTable =
-            [ [ operator "->>", operator "->"
-              , operator "!~*", operator "!~", operator "~*", operator "~"
-              , operator "?", operator "&&"
-              ]
-            ]
+        genericOperatorTable = [[genericOperator]]
 
         binary  name f = InfixL  (f <$ try (symbol name))
         prefix  name f = Prefix  (f <$ symbol name)
@@ -739,6 +734,16 @@ table = highPrecedenceTable <> genericOperatorTable <>
 
         -- | An operator kept verbatim in 'BinaryOperatorExpression'.
         operator name = InfixL (BinaryOperatorExpression name <$ try (symbol name))
+
+        genericOperator = InfixL do
+            name <- try do
+                name <- lexeme (Text.pack <$> some (satisfy isOperatorCharacter))
+                when (name `elem` dedicatedOperators) (fail "operator has dedicated precedence")
+                pure name
+            pure (BinaryOperatorExpression name)
+
+        isOperatorCharacter character = character `elem` ("+-*/<>=~!@#%^&|`?" :: String)
+        dedicatedOperators = ["*", "/", "%", "+", "-", "<>", "!=", "=", "<=", "<", ">=", ">", "||"]
 
         -- Do not consume the prefix of PostgreSQL's JSON operators here.
         minusOperator = InfixL (BinaryOperatorExpression "-" <$ try (lexeme (string "-" <* notFollowedBy (char '>'))))
@@ -772,6 +777,14 @@ table = highPrecedenceTable <> genericOperatorTable <>
             keyword "IN"
             right <- try inArrayExpression <|> expression
             pure $ \expr -> BinaryOperatorExpression "NOT IN" expr right
+
+        notBetweenOp = do
+            keyword "NOT"
+            keyword "BETWEEN"
+            lower <- boundExpression
+            keyword "AND"
+            upper <- boundExpression
+            pure $ \expr -> NotExpression (AndExpression (GreaterThanOrEqualToExpression expr lower) (LessThanOrEqualToExpression expr upper))
 
         betweenOp = do
             keyword "BETWEEN"

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -703,6 +703,8 @@ table = highPrecedenceTable <> genericOperatorTable <>
             [ keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
             , keywordOperator "LIKE", keywordOperator "ILIKE"
             ],
+            [ Postfix escapeOp
+            ],
             [ binary  "<>"  NotEqExpression
             -- `!=` is PostgreSQL's spelling of `<>`; the compiler prints the
             -- canonical `<>` back, which is what pg_dump emits.
@@ -713,8 +715,6 @@ table = highPrecedenceTable <> genericOperatorTable <>
             , binary "<"  LessThanExpression
             , binary ">="  GreaterThanOrEqualToExpression
             , binary ">"  GreaterThanExpression
-            , binary "||" ConcatenationExpression
-
             , binary "IS" IsExpression
             , prefix "NOT" NotExpression
             , prefix "EXISTS" ExistsExpression
@@ -730,17 +730,17 @@ table = highPrecedenceTable <> genericOperatorTable <>
             , [ keywordOperator "AT TIME ZONE" ]
             , [ operator "^" ]
             , [ operator "*", operator "/", operator "%" ]
-            , [ operator "+", minusOperator ]
+            , [ operator "+", operator "-" ]
             ]
 
-        genericOperatorTable = [[genericOperator]]
+        genericOperatorTable = [[genericOperator, InfixL (ConcatenationExpression <$ try (symbol "||"))]]
 
         binary  name f = InfixL  (f <$ try (symbol name))
         prefix  name f = Prefix  (f <$ symbol name)
         postfix name f = Postfix (f <$ symbol name)
 
         -- | An operator kept verbatim in 'BinaryOperatorExpression'.
-        operator name = InfixL (BinaryOperatorExpression name <$ try (symbol name))
+        operator name = InfixL (BinaryOperatorExpression name <$ try (lexeme (string name <* notFollowedBy (satisfy isOperatorCharacter))))
 
         genericOperator = InfixL do
             name <- try do
@@ -752,15 +752,17 @@ table = highPrecedenceTable <> genericOperatorTable <>
         isOperatorCharacter character = character `elem` ("+-*/<>=~!@#%^&|`?" :: String)
         dedicatedOperators = ["*", "/", "%", "+", "-", "<>", "!=", "=", "<=", "<", ">=", ">", "||"]
 
-        -- Do not consume the prefix of PostgreSQL's JSON operators here.
-        minusOperator = InfixL (BinaryOperatorExpression "-" <$ try (lexeme (string "-" <* notFollowedBy (char '>'))))
-
         -- | Same, for operators spelled as words, which need a word boundary so
         -- that e.g. `LIKE` does not match the start of a `likelihood` column.
         keywordOperator name = InfixL (BinaryOperatorExpression name <$ try (mapM_ keyword (Text.words name)))
 
         keyword name = try do
             lexeme (string' name <* notFollowedBy (satisfy isIdentifierCharacter))
+
+        escapeOp = do
+            keyword "ESCAPE"
+            escapeCharacter <- term
+            pure (\patternExpression -> BinaryOperatorExpression "ESCAPE" patternExpression escapeCharacter)
 
         -- Cannot be implemented as a infix operator as that requires two expression operands,
         -- but the second is the type-cast type which is not an expression

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -392,6 +392,7 @@ parseExcludeConstraint name = do
 
         excludeElementChunk =
             try dollarQuotedChunk
+            <|> try escapeStringChunk
             <|> quotedChunk '\''
             <|> quotedChunk '"'
             <|> (fst <$> match (Lexer.skipLineComment "--"))
@@ -417,6 +418,12 @@ parseExcludeConstraint name = do
             char quote
             many (try (char quote >> char quote) <|> anySingleBut quote)
             char quote
+
+        escapeStringChunk = fst <$> match do
+            oneOf ['e', 'E']
+            char '\''
+            many (try (char '\\' >> anySingle) <|> try (char '\'' >> char '\'') <|> anySingleBut '\'')
+            char '\''
 
         parseCommutativeInfixOperator = lexeme do
             try identifier <|> takeWhile1P (Just "operator") (`elem` ("+-*/<>=~!@#%^&|`?" :: String))

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -386,11 +386,22 @@ parseExcludeConstraint name = do
             pure ExcludeConstraintElement { element, operator }
 
         excludeElementChunk =
-            quotedChunk '\''
+            try dollarQuotedChunk
+            <|> quotedChunk '\''
             <|> quotedChunk '"'
             <|> (fst <$> match (Lexer.skipLineComment "--"))
             <|> (fst <$> match (Lexer.skipBlockCommentNested "/*" "*/"))
             <|> (Text.singleton <$> anySingle)
+
+        dollarQuotedChunk :: Parser Text
+        dollarQuotedChunk = fst <$> match do
+            delimiter <- do
+                char '$'
+                tag <- takeWhileP (Just "dollar quote tag") (\c -> isAlphaNum c || c == '_')
+                char '$'
+                pure ("$" <> tag <> "$")
+            _ <- manyTill anySingle (try (string delimiter))
+            pure ()
 
         quotedChunk quote = fst <$> match do
             char quote
@@ -683,6 +694,9 @@ table = highPrecedenceTable <> genericOperatorTable <>
         [
             [ Postfix (foldl1 (flip (.)) <$> some (try notInOp <|> try betweenOp <|> inOp))
             ],
+            [ keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
+            , keywordOperator "LIKE", keywordOperator "ILIKE"
+            ],
             [ binary  "<>"  NotEqExpression
             -- `!=` is PostgreSQL's spelling of `<>`; the compiler prints the
             -- canonical `<>` back, which is what pg_dump emits.
@@ -694,9 +708,6 @@ table = highPrecedenceTable <> genericOperatorTable <>
             , binary ">="  GreaterThanOrEqualToExpression
             , binary ">"  GreaterThanExpression
             , binary "||" ConcatenationExpression
-
-            , keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
-            , keywordOperator "LIKE", keywordOperator "ILIKE"
 
             , binary "IS" IsExpression
             , prefix "NOT" NotExpression
@@ -734,7 +745,7 @@ table = highPrecedenceTable <> genericOperatorTable <>
 
         -- | Same, for operators spelled as words, which need a word boundary so
         -- that e.g. `LIKE` does not match the start of a `likelihood` column.
-        keywordOperator name = InfixL (BinaryOperatorExpression name <$ keyword name)
+        keywordOperator name = InfixL (BinaryOperatorExpression name <$ try (mapM_ keyword (Text.words name)))
 
         keyword name = try do
             lexeme (string' name <* notFollowedBy (satisfy isIdentifierCharacter))

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -381,9 +381,15 @@ parseExcludeConstraint name = do
     pure ExcludeConstraint { name, excludeElements, predicate, indexType }
     where
         excludeElement = do
-            element <- Text.stripEnd . mconcat <$> someTill excludeElementChunk (try (space1 >> string' "WITH" <* notFollowedBy (satisfy isIdentifierCharacter) <* space))
+            element <- Text.stripEnd . mconcat <$> someTill excludeElementChunk withDelimiter
             operator <- parseCommutativeInfixOperator
             pure ExcludeConstraintElement { element, operator }
+
+        withDelimiter = try do
+            optional space1
+            string' "WITH"
+            notFollowedBy (satisfy isIdentifierCharacter)
+            space
 
         excludeElementChunk =
             try dollarQuotedChunk
@@ -391,7 +397,12 @@ parseExcludeConstraint name = do
             <|> quotedChunk '"'
             <|> (fst <$> match (Lexer.skipLineComment "--"))
             <|> (fst <$> match (Lexer.skipBlockCommentNested "/*" "*/"))
+            <|> identifierChunk
             <|> (Text.singleton <$> anySingle)
+
+        identifierChunk = fst <$> match do
+            _ <- satisfy (\character -> isAlpha character || character == '_')
+            takeWhileP Nothing isIdentifierCharacter
 
         dollarQuotedChunk :: Parser Text
         dollarQuotedChunk = fst <$> match do
@@ -722,6 +733,7 @@ table = highPrecedenceTable <> genericOperatorTable <>
               [ Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp))
               ]
             , [ keywordOperator "AT TIME ZONE" ]
+            , [ operator "^" ]
             , [ operator "*", operator "/", operator "%" ]
             , [ operator "+", minusOperator ]
             ]
@@ -794,7 +806,7 @@ table = highPrecedenceTable <> genericOperatorTable <>
             pure $ \expr -> AndExpression (GreaterThanOrEqualToExpression expr lower) (LessThanOrEqualToExpression expr upper)
 
         boundExpression = do
-            value <- makeExprParser term (highPrecedenceTable <> genericOperatorTable)
+            value <- makeExprParser term (highPrecedenceTable <> genericOperatorTable <> [[binary "||" ConcatenationExpression]])
             space
             pure value
 

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -365,7 +365,7 @@ parseExcludeConstraint name = do
     pure ExcludeConstraint { name, excludeElements, predicate, indexType }
     where
         excludeElement = do
-            element <- Text.stripEnd . mconcat <$> someTill excludeElementChunk (try (space1 >> string' "WITH" >> space1))
+            element <- Text.stripEnd . mconcat <$> someTill excludeElementChunk (try (space1 >> string' "WITH" <* notFollowedBy (satisfy isIdentifierCharacter) <* space))
             operator <- parseCommutativeInfixOperator
             pure ExcludeConstraintElement { element, operator }
 
@@ -658,12 +658,8 @@ term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try typedLit
     where
         parens f = between (char '(' >> space) (char ')' >> space) f
 
-table = highPrecedenceTable <>
+table = highPrecedenceTable <> genericOperatorTable <>
         [
-            [ operator "->>", operator "->"
-            , operator "!~*", operator "!~", operator "~*", operator "~"
-            , operator "?", operator "&&"
-            ],
             [ Postfix (foldl1 (flip (.)) <$> some (try notInOp <|> try betweenOp <|> inOp))
             ],
             [ binary  "<>"  NotEqExpression
@@ -696,6 +692,13 @@ table = highPrecedenceTable <>
             , [ keywordOperator "AT TIME ZONE" ]
             , [ operator "*", operator "/", operator "%" ]
             , [ operator "+", minusOperator ]
+            ]
+
+        genericOperatorTable =
+            [ [ operator "->>", operator "->"
+              , operator "!~*", operator "!~", operator "~*", operator "~"
+              , operator "?", operator "&&"
+              ]
             ]
 
         binary  name f = InfixL  (f <$ try (symbol name))
@@ -740,13 +743,13 @@ table = highPrecedenceTable <>
 
         betweenOp = do
             keyword "BETWEEN"
-            lower <- arithmeticExpression
+            lower <- boundExpression
             keyword "AND"
-            upper <- arithmeticExpression
+            upper <- boundExpression
             pure $ \expr -> AndExpression (GreaterThanOrEqualToExpression expr lower) (LessThanOrEqualToExpression expr upper)
 
-        arithmeticExpression = do
-            value <- makeExprParser term highPrecedenceTable
+        boundExpression = do
+            value <- makeExprParser term (highPrecedenceTable <> genericOperatorTable)
             space
             pure value
 

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -365,7 +365,7 @@ parseExcludeConstraint name = do
     pure ExcludeConstraint { name, excludeElements, predicate, indexType }
     where
         excludeElement = do
-            element <- Text.stripEnd . cs <$> someTill anySingle (try (space >> string' "WITH" >> space))
+            element <- Text.stripEnd . cs <$> someTill anySingle (try (space1 >> string' "WITH" >> space1))
             operator <- parseCommutativeInfixOperator
             pure ExcludeConstraintElement { element, operator }
 
@@ -653,6 +653,9 @@ term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try typedLit
 
 table = highPrecedenceTable <>
         [
+            [ operator "!~*", operator "!~", operator "~*", operator "~"
+            , operator "?", operator "&&"
+            ],
             [ Postfix (foldl1 (flip (.)) <$> some (try notInOp <|> try betweenOp <|> inOp))
             ],
             [ binary  "<>"  NotEqExpression
@@ -667,10 +670,6 @@ table = highPrecedenceTable <>
             , binary ">"  GreaterThanExpression
             , binary "||" ConcatenationExpression
 
-            -- Regular expression matching. Longest operator first, otherwise
-            -- `~` would match the prefix of `~*` and leave a stray `*`.
-            , operator "!~*", operator "!~", operator "~*", operator "~"
-            , operator "?", operator "&&"
             , keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
             , keywordOperator "LIKE", keywordOperator "ILIKE"
 

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -466,7 +466,7 @@ sqlType = choice $ map optionalArray
                     pure PTimestampWithTimezone
 
                 timestampZ' = do
-                    try (symbol' "TIMESTAMPZ")
+                    try (symbol' "TIMESTAMPTZ") <|> try (symbol' "TIMESTAMPZ")
                     pure PTimestampWithTimezone
 
                 timestamp' = do

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -660,7 +660,19 @@ term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try callExpr
         parens f = between (char '(' >> space) (char ')' >> space) f
 
 table = [
+            -- Chain multiple postfix operators at the same precedence so we can
+            -- parse e.g. `table.col IN (SELECT …)` — pg_dump qualifies columns
+            -- with their table name and `makeExprParser`'s `Postfix` only
+            -- applies one postfix per term. They bind tighter than every infix
+            -- operator so that e.g. `a::integer + 1` casts `a` and not the sum.
+            [ Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp <|> inOp))
+            ],
+            [ operator "*", operator "/", operator "%" ],
+            [ operator "+", operator "-" ],
             [ binary  "<>"  NotEqExpression
+            -- `!=` is PostgreSQL's spelling of `<>`; the compiler prints the
+            -- canonical `<>` back, which is what pg_dump emits.
+            , binary  "!="  NotEqExpression
             , binary "="  EqExpression
 
             , binary "<=" LessThanOrEqualToExpression
@@ -669,14 +681,15 @@ table = [
             , binary ">"  GreaterThanExpression
             , binary "||" ConcatenationExpression
 
+            -- Regular expression matching. Longest operator first, otherwise
+            -- `~` would match the prefix of `~*` and leave a stray `*`.
+            , operator "!~*", operator "!~", operator "~*", operator "~"
+            , keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
+            , keywordOperator "LIKE", keywordOperator "ILIKE"
+
             , binary "IS" IsExpression
             , prefix "NOT" NotExpression
             , prefix "EXISTS" ExistsExpression
-            -- Chain multiple postfix operators at the same precedence so we can
-            -- parse e.g. `table.col IN (SELECT …)` — pg_dump qualifies columns
-            -- with their table name and `makeExprParser`'s `Postfix` only
-            -- applies one postfix per term.
-            , Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp <|> inOp))
             ],
             [ binary "AND" AndExpression, binary "OR" OrExpression ]
         ]
@@ -684,6 +697,15 @@ table = [
         binary  name f = InfixL  (f <$ try (symbol name))
         prefix  name f = Prefix  (f <$ symbol name)
         postfix name f = Postfix (f <$ symbol name)
+
+        -- | An operator kept verbatim in 'BinaryOperatorExpression'.
+        operator name = InfixL (BinaryOperatorExpression name <$ try (symbol name))
+
+        -- | Same, for operators spelled as words, which need a word boundary so
+        -- that e.g. `LIKE` does not match the start of a `likelihood` column.
+        keywordOperator name = InfixL (BinaryOperatorExpression name <$ try do
+            symbol' name
+            notFollowedBy (satisfy isIdentifierCharacter))
 
         -- Cannot be implemented as a infix operator as that requires two expression operands,
         -- but the second is the type-cast type which is not an expression
@@ -714,11 +736,14 @@ expression = do
 varExpr :: Parser Expression
 varExpr = VarExpression <$> identifier
 
+-- | Numeric literals are lexemes: without consuming the whitespace that follows
+-- them, `makeExprParser` cannot see the operator behind it and
+-- @CHECK (a > 0 AND b > 0)@ fails where @CHECK (a > 'x' AND …)@ succeeds.
 doubleExpr :: Parser Expression
-doubleExpr = DoubleExpression <$> (Lexer.signed spaceConsumer Lexer.float)
+doubleExpr = DoubleExpression <$> lexeme (Lexer.signed spaceConsumer Lexer.float)
 
 intExpr :: Parser Expression
-intExpr = IntExpression <$> (Lexer.signed spaceConsumer Lexer.decimal)
+intExpr = IntExpression <$> lexeme (Lexer.signed spaceConsumer Lexer.decimal)
 
 callExpr :: Parser Expression
 callExpr = do

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -365,20 +365,12 @@ parseExcludeConstraint name = do
     pure ExcludeConstraint { name, excludeElements, predicate, indexType }
     where
         excludeElement = do
-            element <- identifier
-            space
-            lexeme "WITH"
-            space
+            element <- Text.stripEnd . cs <$> someTill anySingle (try (space >> string' "WITH" >> space))
             operator <- parseCommutativeInfixOperator
             pure ExcludeConstraintElement { element, operator }
 
-        parseCommutativeInfixOperator = choice $ map lexeme
-            [ "="
-            , "<>"
-            , "!="
-            , "AND"
-            , "OR"
-            ]
+        parseCommutativeInfixOperator = lexeme do
+            try identifier <|> takeWhile1P (Just "operator") (`elem` ("+-*/<>=~!@#%^&|`?" :: String))
 
 parseOnDelete = choice
         [ (lexeme "NO" >> lexeme "ACTION") >> pure NoAction
@@ -655,7 +647,7 @@ intervalFields =  [ "YEAR TO MONTH", "DAY TO HOUR", "DAY TO MINUTE", "DAY TO SEC
                    , "YEAR",  "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"]
 
 
-term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try callExpr <|> try doubleExpr <|> try intExpr <|> selectExpr <|> varExpr <|> (textExpr <* optional space)
+term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try typedLiteralExpr <|> try callExpr <|> try doubleExpr <|> try intExpr <|> selectExpr <|> varExpr <|> (textExpr <* optional space)
     where
         parens f = between (char '(' >> space) (char ')' >> space) f
 
@@ -665,8 +657,9 @@ table = [
             -- with their table name and `makeExprParser`'s `Postfix` only
             -- applies one postfix per term. They bind tighter than every infix
             -- operator so that e.g. `a::integer + 1` casts `a` and not the sum.
-            [ Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp <|> inOp))
+            [ Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp <|> try notInOp <|> try betweenOp <|> inOp))
             ],
+            [ operator "->>", operator "->" ],
             [ operator "*", operator "/", operator "%" ],
             [ operator "+", operator "-" ],
             [ binary  "<>"  NotEqExpression
@@ -684,6 +677,8 @@ table = [
             -- Regular expression matching. Longest operator first, otherwise
             -- `~` would match the prefix of `~*` and leave a stray `*`.
             , operator "!~*", operator "!~", operator "~*", operator "~"
+            , operator "?", operator "&&"
+            , keywordOperator "AT TIME ZONE"
             , keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
             , keywordOperator "LIKE", keywordOperator "ILIKE"
 
@@ -724,6 +719,19 @@ table = [
             right <- try inArrayExpression <|> expression
             pure $ \expr -> InExpression expr right
 
+        notInOp = do
+            lexeme "NOT"
+            lexeme "IN"
+            right <- try inArrayExpression <|> expression
+            pure $ \expr -> BinaryOperatorExpression "NOT IN" expr right
+
+        betweenOp = do
+            lexeme "BETWEEN"
+            lower <- term
+            lexeme "AND"
+            upper <- term
+            pure $ \expr -> AndExpression (GreaterThanOrEqualToExpression expr lower) (LessThanOrEqualToExpression expr upper)
+
 -- | Parses a SQL expression
 --
 -- This parser makes use of makeExprParser as described in https://hackage.haskell.org/package/parser-combinators-1.2.0/docs/Control-Monad-Combinators-Expr.html
@@ -744,6 +752,13 @@ doubleExpr = DoubleExpression <$> lexeme (Lexer.signed spaceConsumer Lexer.float
 
 intExpr :: Parser Expression
 intExpr = IntExpression <$> lexeme (Lexer.signed spaceConsumer Lexer.decimal)
+
+-- | PostgreSQL's @TYPE 'value'@ syntax, normalized to the equivalent cast.
+typedLiteralExpr :: Parser Expression
+typedLiteralExpr = do
+    literalType <- sqlType
+    value <- textExpr <* space
+    pure (TypeCastExpression value literalType)
 
 callExpr :: Parser Expression
 callExpr = do

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -365,9 +365,16 @@ parseExcludeConstraint name = do
     pure ExcludeConstraint { name, excludeElements, predicate, indexType }
     where
         excludeElement = do
-            element <- Text.stripEnd . cs <$> someTill anySingle (try (space1 >> string' "WITH" >> space1))
+            element <- Text.stripEnd . mconcat <$> someTill excludeElementChunk (try (space1 >> string' "WITH" >> space1))
             operator <- parseCommutativeInfixOperator
             pure ExcludeConstraintElement { element, operator }
+
+        excludeElementChunk = quotedChunk '\'' <|> quotedChunk '"' <|> (Text.singleton <$> anySingle)
+
+        quotedChunk quote = fst <$> match do
+            char quote
+            many (try (char quote >> char quote) <|> anySingleBut quote)
+            char quote
 
         parseCommutativeInfixOperator = lexeme do
             try identifier <|> takeWhile1P (Just "operator") (`elem` ("+-*/<>=~!@#%^&|`?" :: String))
@@ -653,7 +660,8 @@ term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try typedLit
 
 table = highPrecedenceTable <>
         [
-            [ operator "!~*", operator "!~", operator "~*", operator "~"
+            [ operator "->>", operator "->"
+            , operator "!~*", operator "!~", operator "~*", operator "~"
             , operator "?", operator "&&"
             ],
             [ Postfix (foldl1 (flip (.)) <$> some (try notInOp <|> try betweenOp <|> inOp))
@@ -686,9 +694,8 @@ table = highPrecedenceTable <>
               [ Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp))
               ]
             , [ keywordOperator "AT TIME ZONE" ]
-            , [ operator "->>", operator "->" ]
             , [ operator "*", operator "/", operator "%" ]
-            , [ operator "+", operator "-" ]
+            , [ operator "+", minusOperator ]
             ]
 
         binary  name f = InfixL  (f <$ try (symbol name))
@@ -697,6 +704,9 @@ table = highPrecedenceTable <>
 
         -- | An operator kept verbatim in 'BinaryOperatorExpression'.
         operator name = InfixL (BinaryOperatorExpression name <$ try (symbol name))
+
+        -- Do not consume the prefix of PostgreSQL's JSON operators here.
+        minusOperator = InfixL (BinaryOperatorExpression "-" <$ try (lexeme (string "-" <* notFollowedBy (char '>'))))
 
         -- | Same, for operators spelled as words, which need a word boundary so
         -- that e.g. `LIKE` does not match the start of a `likelihood` column.

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -701,8 +701,7 @@ table = [
         keywordOperator name = InfixL (BinaryOperatorExpression name <$ keyword name)
 
         keyword name = try do
-            symbol' name
-            notFollowedBy (satisfy isIdentifierCharacter)
+            lexeme (string' name <* notFollowedBy (satisfy isIdentifierCharacter))
 
         -- Cannot be implemented as a infix operator as that requires two expression operands,
         -- but the second is the type-cast type which is not an expression

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -651,17 +651,10 @@ term = parens expression <|> try variadicExpr <|> try arrayExpr <|> try typedLit
     where
         parens f = between (char '(' >> space) (char ')' >> space) f
 
-table = [
-            -- Chain multiple postfix operators at the same precedence so we can
-            -- parse e.g. `table.col IN (SELECT …)` — pg_dump qualifies columns
-            -- with their table name and `makeExprParser`'s `Postfix` only
-            -- applies one postfix per term. They bind tighter than every infix
-            -- operator so that e.g. `a::integer + 1` casts `a` and not the sum.
-            [ Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp <|> try notInOp <|> try betweenOp <|> inOp))
+table = highPrecedenceTable <>
+        [
+            [ Postfix (foldl1 (flip (.)) <$> some (try notInOp <|> try betweenOp <|> inOp))
             ],
-            [ operator "->>", operator "->" ],
-            [ operator "*", operator "/", operator "%" ],
-            [ operator "+", operator "-" ],
             [ binary  "<>"  NotEqExpression
             -- `!=` is PostgreSQL's spelling of `<>`; the compiler prints the
             -- canonical `<>` back, which is what pg_dump emits.
@@ -678,7 +671,6 @@ table = [
             -- `~` would match the prefix of `~*` and leave a stray `*`.
             , operator "!~*", operator "!~", operator "~*", operator "~"
             , operator "?", operator "&&"
-            , keywordOperator "AT TIME ZONE"
             , keywordOperator "NOT LIKE", keywordOperator "NOT ILIKE"
             , keywordOperator "LIKE", keywordOperator "ILIKE"
 
@@ -689,6 +681,17 @@ table = [
             [ binary "AND" AndExpression, binary "OR" OrExpression ]
         ]
     where
+        highPrecedenceTable =
+            [ -- Chained postfix operators bind tighter than every infix
+              -- operator, so `a::integer + 1` casts `a`, not the sum.
+              [ Postfix (foldl1 (flip (.)) <$> some (typeCastOp <|> dotOp))
+              ]
+            , [ keywordOperator "AT TIME ZONE" ]
+            , [ operator "->>", operator "->" ]
+            , [ operator "*", operator "/", operator "%" ]
+            , [ operator "+", operator "-" ]
+            ]
+
         binary  name f = InfixL  (f <$ try (symbol name))
         prefix  name f = Prefix  (f <$ symbol name)
         postfix name f = Postfix (f <$ symbol name)
@@ -728,10 +731,15 @@ table = [
 
         betweenOp = do
             keyword "BETWEEN"
-            lower <- term
+            lower <- arithmeticExpression
             keyword "AND"
-            upper <- term
+            upper <- arithmeticExpression
             pure $ \expr -> AndExpression (GreaterThanOrEqualToExpression expr lower) (LessThanOrEqualToExpression expr upper)
+
+        arithmeticExpression = do
+            value <- makeExprParser term highPrecedenceTable
+            space
+            pure value
 
 -- | Parses a SQL expression
 --

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -698,9 +698,11 @@ table = [
 
         -- | Same, for operators spelled as words, which need a word boundary so
         -- that e.g. `LIKE` does not match the start of a `likelihood` column.
-        keywordOperator name = InfixL (BinaryOperatorExpression name <$ try do
+        keywordOperator name = InfixL (BinaryOperatorExpression name <$ keyword name)
+
+        keyword name = try do
             symbol' name
-            notFollowedBy (satisfy isIdentifierCharacter))
+            notFollowedBy (satisfy isIdentifierCharacter)
 
         -- Cannot be implemented as a infix operator as that requires two expression operands,
         -- but the second is the type-cast type which is not an expression
@@ -715,20 +717,20 @@ table = [
             pure $ \expr -> DotExpression expr name
 
         inOp = do
-            lexeme "IN"
+            keyword "IN"
             right <- try inArrayExpression <|> expression
             pure $ \expr -> InExpression expr right
 
         notInOp = do
-            lexeme "NOT"
-            lexeme "IN"
+            keyword "NOT"
+            keyword "IN"
             right <- try inArrayExpression <|> expression
             pure $ \expr -> BinaryOperatorExpression "NOT IN" expr right
 
         betweenOp = do
-            lexeme "BETWEEN"
+            keyword "BETWEEN"
             lower <- term
-            lexeme "AND"
+            keyword "AND"
             upper <- term
             pure $ \expr -> AndExpression (GreaterThanOrEqualToExpression expr lower) (LessThanOrEqualToExpression expr upper)
 

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -206,6 +206,13 @@ data Expression =
     | SelectExpression Select
     | DotExpression Expression Text
     | ConcatenationExpression Expression Expression -- ^ a || b
+    -- | An infix operator the schema representation does not model on its own,
+    -- carrying the operator verbatim, e.g. @a + b@ or @name ~ '^[A-Z]+$'@.
+    --
+    -- PostgreSQL has hundreds of operators and accepts user defined ones, so a
+    -- dedicated constructor per operator cannot be complete. Keeping the operator
+    -- as text lets any of them round-trip unchanged.
+    | BinaryOperatorExpression Text Expression Expression
     deriving (Eq, Show)
 
 data Select = Select

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -271,6 +271,12 @@ spec = do
             let statement = DropTable { tableName = "private.users" }
             parseSql (compileSql [statement]) `shouldBe` statement
 
+        it "should compile LIKE escape clauses without changing their grouping" do
+            let expression = BinaryOperatorExpression "ESCAPE"
+                    (BinaryOperatorExpression "LIKE" (VarExpression "code") (TextExpression "A!_%"))
+                    (TextExpression "!")
+            compileExpression expression `shouldBe` "code LIKE 'A!_%' ESCAPE '!'"
+
         it "should round-trip a schema-qualified CREATE FUNCTION" do
             -- parse -> compile -> parse must preserve a non-public schema like `private.`
             let statement = CreateFunction

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -277,6 +277,10 @@ spec = do
                     (TextExpression "!")
             compileExpression expression `shouldBe` "code LIKE 'A!_%' ESCAPE '!'"
 
+        it "should parenthesize comparisons used by generic operators" do
+            let expression = BinaryOperatorExpression "##" (EqExpression (VarExpression "a") (VarExpression "b")) (VarExpression "flag")
+            compileExpression expression `shouldBe` "(a = b) ## flag"
+
         it "should round-trip a schema-qualified CREATE FUNCTION" do
             -- parse -> compile -> parse must preserve a non-public schema like `private.`
             let statement = CreateFunction

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -301,6 +301,13 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should preserve grouping for inequality predicate operands" do
+            compileExpression
+                (NotEqExpression
+                    (IsExpression (VarExpression "a") (VarExpression "NULL"))
+                    (IsExpression (VarExpression "b") (VarExpression "NULL")))
+                `shouldBe` "(a IS NULL) <> (b IS NULL)"
+
         it "should compile 'ENABLE ROW LEVEL SECURITY' statements" do
             let sql = "ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;\n"
             let statements = [EnableRowLevelSecurity { tableName = "tasks" }]

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -6,7 +6,7 @@ module Postgres.CompilerSpec where
 
 import Prelude
 import Test.Hspec
-import IHP.Postgres.Compiler (compileSql)
+import IHP.Postgres.Compiler (compileExpression, compileSql)
 import IHP.Postgres.Types
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -365,6 +365,13 @@ spec = do
                             }
                         ]
             compileSql statements `shouldBe` sql
+
+        it "should parenthesize binary expressions before type casts" do
+            compileExpression
+                (TypeCastExpression
+                    (BinaryOperatorExpression "+" (VarExpression "price") (VarExpression "tax"))
+                    (PNumeric Nothing Nothing))
+                `shouldBe` "(price + tax)::NUMERIC"
 
 parseSql :: Text -> Statement
 parseSql sql =

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -233,6 +233,10 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should keep boolean IS expressions grouped inside equality" do
+            let sql = "ALTER TABLE t ADD CONSTRAINT t_pair CHECK ((a IS NULL) = (b IS NULL));"
+            compileSql [parseSql sql] `shouldBe` (sql <> "\n")
+
         it "should round-trip a schema-qualified CREATE FUNCTION" do
             -- parse -> compile -> parse must preserve a non-public schema like `private.`
             let statement = CreateFunction

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -540,6 +540,9 @@ spec = do
                     (VarExpression "cutoff")
                     (BinaryOperatorExpression "AT TIME ZONE" (VarExpression "created_at") (TextExpression "UTC"))
 
+            parseExpression "created_at AT /* normalize */ TIME\nZONE 'UTC'" `shouldBe`
+                BinaryOperatorExpression "AT TIME ZONE" (VarExpression "created_at") (TextExpression "UTC")
+
         it "should parse typed PostgreSQL literals" do
             parseExpression "closed_at - INTERVAL '30 days' > opened_at" `shouldBe`
                 GreaterThanExpression
@@ -575,6 +578,12 @@ spec = do
             parseExpression "name LIKE 'a%'" `shouldBe`
                 BinaryOperatorExpression "LIKE" (VarExpression "name") (TextExpression "a%")
             parseExpression "likelihood" `shouldBe` VarExpression "likelihood"
+
+        it "should bind LIKE before prefix NOT and allow trivia in NOT LIKE" do
+            parseExpression "NOT name LIKE 'a%'" `shouldBe`
+                NotExpression (BinaryOperatorExpression "LIKE" (VarExpression "name") (TextExpression "a%"))
+            parseExpression "name NOT /* pattern */ LIKE 'a%'" `shouldBe`
+                BinaryOperatorExpression "NOT LIKE" (VarExpression "name") (TextExpression "a%")
 
         it "should read != as the canonical <> operator" do
             parseExpression "a != b" `shouldBe` NotEqExpression (VarExpression "a") (VarExpression "b")
@@ -624,6 +633,19 @@ spec = do
                         [ ExcludeConstraint
                             { name = Nothing
                             , excludeElements = [ExcludeConstraintElement { element = "room_id /* WITH marker */", operator = "=" }]
+                            , predicate = Nothing
+                            , indexType = Nothing
+                            }
+                        ]
+                    }
+
+        it "should ignore WITH inside dollar-quoted exclusion literals" do
+            parseSql "CREATE TABLE reservations (EXCLUDE ((name || $tag$ WITH $tag$) WITH =));" `shouldBe`
+                StatementCreateTable (table "reservations")
+                    { constraints =
+                        [ ExcludeConstraint
+                            { name = Nothing
+                            , excludeElements = [ExcludeConstraintElement { element = "(name || $tag$ WITH $tag$)", operator = "=" }]
                             , predicate = Nothing
                             , indexType = Nothing
                             }

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -617,6 +617,19 @@ spec = do
                         ]
                     }
 
+        it "should ignore WITH inside comments in exclusion elements" do
+            parseSql "CREATE TABLE reservations (EXCLUDE (room_id /* WITH marker */ WITH =));" `shouldBe`
+                StatementCreateTable (table "reservations")
+                    { constraints =
+                        [ ExcludeConstraint
+                            { name = Nothing
+                            , excludeElements = [ExcludeConstraintElement { element = "room_id /* WITH marker */", operator = "=" }]
+                            , predicate = Nothing
+                            , indexType = Nothing
+                            }
+                        ]
+                    }
+
         it "should parse compact exclusion operators" do
             parseSql "CREATE TABLE reservations (EXCLUDE (room_id WITH=));" `shouldBe`
                 StatementCreateTable (table "reservations")

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -556,6 +556,18 @@ spec = do
             parseExpression "left_value ## right_value" `shouldBe`
                 BinaryOperatorExpression "##" (VarExpression "left_value") (VarExpression "right_value")
 
+        it "should keep concatenation at the generic operator precedence" do
+            parseExpression "defaults || payload ->> 'name'" `shouldBe`
+                BinaryOperatorExpression "->>"
+                    (ConcatenationExpression (VarExpression "defaults") (VarExpression "payload"))
+                    (TextExpression "name")
+
+        it "should parse user-defined operators beginning with arithmetic characters" do
+            parseExpression "lhs +> rhs" `shouldBe`
+                BinaryOperatorExpression "+>" (VarExpression "lhs") (VarExpression "rhs")
+            parseExpression "lhs ^@ rhs" `shouldBe`
+                BinaryOperatorExpression "^@" (VarExpression "lhs") (VarExpression "rhs")
+
         it "should parse BETWEEN and NOT IN" do
             parseExpression "month BETWEEN 1 AND 12" `shouldBe`
                 AndExpression
@@ -637,6 +649,12 @@ spec = do
             parseExpression "name LIKE 'a%'" `shouldBe`
                 BinaryOperatorExpression "LIKE" (VarExpression "name") (TextExpression "a%")
             parseExpression "likelihood" `shouldBe` VarExpression "likelihood"
+
+        it "should preserve LIKE escape clauses" do
+            parseExpression "code LIKE 'A!_%' ESCAPE '!'" `shouldBe`
+                BinaryOperatorExpression "ESCAPE"
+                    (BinaryOperatorExpression "LIKE" (VarExpression "code") (TextExpression "A!_%"))
+                    (TextExpression "!")
 
         it "should bind LIKE before prefix NOT and allow trivia in NOT LIKE" do
             parseExpression "NOT name LIKE 'a%'" `shouldBe`

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -628,6 +628,10 @@ spec = do
                     (VarExpression "opened_at")
             parseExpression "TIMESTAMPTZ '2026-08-09 18:00:00+00'" `shouldBe`
                 TypeCastExpression (TextExpression "2026-08-09 18:00:00+00") PTimestampWithTimezone
+            parseExpression "created_at + INTERVAL '1' DAY" `shouldBe`
+                BinaryOperatorExpression "+"
+                    (VarExpression "created_at")
+                    (TypeCastExpression (TextExpression "1") (PInterval (Just "DAY")))
 
         it "should parse expression-based EXCLUDE constraints" do
             parseSql "ALTER TABLE bookings ADD CONSTRAINT bookings_no_overlap EXCLUDE USING gist (room_id WITH =, daterange(starts_on, ends_on) WITH &&);" `shouldBe`
@@ -660,6 +664,10 @@ spec = do
                 BinaryOperatorExpression "ESCAPE"
                     (BinaryOperatorExpression "LIKE" (VarExpression "code") (TextExpression "A!_%"))
                     (TextExpression "!")
+            parseExpression "code LIKE pattern ESCAPE escape_prefix || ''" `shouldBe`
+                BinaryOperatorExpression "ESCAPE"
+                    (BinaryOperatorExpression "LIKE" (VarExpression "code") (VarExpression "pattern"))
+                    (ConcatenationExpression (VarExpression "escape_prefix") (TextExpression ""))
 
         it "should bind LIKE before prefix NOT and allow trivia in NOT LIKE" do
             parseExpression "NOT name LIKE 'a%'" `shouldBe`

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -509,8 +509,8 @@ spec = do
         it "should parse an operator behind a double literal" do
             parseExpression "a > 0.5 AND b > 0.5" `shouldBe`
                 AndExpression
-                    (GreaterThanExpression (VarExpression "a") (DoubleExpression 0.5))
-                    (GreaterThanExpression (VarExpression "b") (DoubleExpression 0.5))
+                    (GreaterThanExpression (VarExpression "a") (NumericExpression "0.5"))
+                    (GreaterThanExpression (VarExpression "b") (NumericExpression "0.5"))
 
         it "should parse arithmetic operators" do
             parseExpression "a + b <= 100" `shouldBe`

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -568,6 +568,11 @@ spec = do
             parseExpression "lhs ^@ rhs" `shouldBe`
                 BinaryOperatorExpression "^@" (VarExpression "lhs") (VarExpression "rhs")
 
+        it "should ignore WITH inside PostgreSQL escape strings in exclusion elements" do
+            let parsed = parseSql "CREATE TABLE bookings (EXCLUDE (room_id || E'foo\\' WITH bar' WITH =));"
+            parsed.unsafeGetCreateTable.constraints `shouldBe`
+                [ExcludeConstraint Nothing [ExcludeConstraintElement "room_id || E'foo\\' WITH bar'" "="] Nothing Nothing]
+
         it "should parse BETWEEN and NOT IN" do
             parseExpression "month BETWEEN 1 AND 12" `shouldBe`
                 AndExpression

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -496,6 +496,12 @@ spec = do
                     (VarExpression "a")
                     (BinaryOperatorExpression "*" (VarExpression "b") (VarExpression "c"))
 
+        it "should give exponentiation tighter precedence than multiplication" do
+            parseExpression "2 * 3 ^ 2" `shouldBe`
+                BinaryOperatorExpression "*"
+                    (IntExpression 2)
+                    (BinaryOperatorExpression "^" (IntExpression 3) (IntExpression 2))
+
         it "should parse regular expression operators" do
             parseExpression "code ~ '^[A-Z]{3}$'" `shouldBe`
                 BinaryOperatorExpression "~" (VarExpression "code") (TextExpression "^[A-Z]{3}$")
@@ -552,6 +558,12 @@ spec = do
                 AndExpression
                     (GreaterThanOrEqualToExpression (VarExpression "value") (BinaryOperatorExpression "->>" (VarExpression "bounds") (TextExpression "lower")))
                     (LessThanOrEqualToExpression (VarExpression "value") (BinaryOperatorExpression "->>" (VarExpression "bounds") (TextExpression "upper")))
+
+        it "should parse concatenation in BETWEEN bounds" do
+            parseExpression "value BETWEEN prefix || suffix AND upper" `shouldBe`
+                AndExpression
+                    (GreaterThanOrEqualToExpression (VarExpression "value") (ConcatenationExpression (VarExpression "prefix") (VarExpression "suffix")))
+                    (LessThanOrEqualToExpression (VarExpression "value") (VarExpression "upper"))
 
         it "should give AT TIME ZONE precedence over comparisons" do
             parseExpression "cutoff < created_at AT TIME ZONE 'UTC'" `shouldBe`
@@ -683,6 +695,17 @@ spec = do
                             }
                         ]
                     }
+
+        it "should accept punctuation before the exclusion WITH delimiter" do
+            let parsed = parseSql "CREATE TABLE reservations (EXCLUDE ((lower(room_id))WITH=));"
+            parsed.unsafeGetCreateTable.constraints `shouldBe`
+                [ ExcludeConstraint
+                    { name = Nothing
+                    , excludeElements = [ExcludeConstraintElement { element = "(lower(room_id))", operator = "=" }]
+                    , predicate = Nothing
+                    , indexType = Nothing
+                    }
+                ]
 
         it "should cast the operand rather than the sum" do
             parseExpression "a::integer + 1" `shouldBe`

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -503,7 +503,16 @@ spec = do
 
         it "should not read INCREMENT as the IN expression operator" do
             parseSql "CREATE SEQUENCE a START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;"
-                `shouldBe` CreateSequence { name = "a" }
+                `shouldBe` CreateSequence
+                    { name = "a"
+                    , sequenceOptions =
+                        [ SequenceStart (IntExpression 1)
+                        , SequenceIncrement (IntExpression 1)
+                        , SequenceNoMinValue
+                        , SequenceNoMaxValue
+                        , SequenceCache (IntExpression 1)
+                        ]
+                    }
 
         it "should parse 'BEGIN' statements" do
             parseSql "BEGIN;" `shouldBe` Begin

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -507,6 +507,20 @@ spec = do
                     (TextExpression "invoice")
             parseExpression "metadata ? 'kind'" `shouldBe`
                 BinaryOperatorExpression "?" (VarExpression "metadata") (TextExpression "kind")
+            parseExpression "payload @> '{\"kind\":\"booking\"}'" `shouldBe`
+                BinaryOperatorExpression "@>" (VarExpression "payload") (TextExpression "{\"kind\":\"booking\"}")
+            parseExpression "payload <@ expected #> '{items}'" `shouldBe`
+                BinaryOperatorExpression "#>"
+                    (BinaryOperatorExpression "<@" (VarExpression "payload") (VarExpression "expected"))
+                    (TextExpression "{items}")
+            parseExpression "payload ?| keys" `shouldBe`
+                BinaryOperatorExpression "?|" (VarExpression "payload") (VarExpression "keys")
+            parseExpression "payload ?& keys" `shouldBe`
+                BinaryOperatorExpression "?&" (VarExpression "payload") (VarExpression "keys")
+            parseExpression "payload #>> '{items,0}'" `shouldBe`
+                BinaryOperatorExpression "#>>" (VarExpression "payload") (TextExpression "{items,0}")
+            parseExpression "left_value ## right_value" `shouldBe`
+                BinaryOperatorExpression "##" (VarExpression "left_value") (VarExpression "right_value")
 
         it "should parse BETWEEN and NOT IN" do
             parseExpression "month BETWEEN 1 AND 12" `shouldBe`
@@ -517,6 +531,11 @@ spec = do
                 BinaryOperatorExpression "NOT IN"
                     (VarExpression "kind")
                     (InArrayExpression [TextExpression "draft", TextExpression "void"])
+            parseExpression "age NOT BETWEEN 13 AND 19" `shouldBe`
+                NotExpression
+                    (AndExpression
+                        (GreaterThanOrEqualToExpression (VarExpression "age") (IntExpression 13))
+                        (LessThanOrEqualToExpression (VarExpression "age") (IntExpression 19)))
 
         it "should parse BETWEEN after arithmetic expressions" do
             parseExpression "subtotal + tax BETWEEN minimum + 1 AND maximum" `shouldBe`

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -579,6 +579,12 @@ spec = do
                     (VarExpression "flag")
                     (BinaryOperatorExpression "~" (VarExpression "code") (TextExpression "^x"))
 
+        it "should bind arithmetic before JSON operators" do
+            parseExpression "payload -> 0 + 1" `shouldBe`
+                BinaryOperatorExpression "->"
+                    (VarExpression "payload")
+                    (BinaryOperatorExpression "+" (IntExpression 0) (IntExpression 1))
+
         it "should parse WITH only as an exclusion-element delimiter" do
             parseSql "CREATE TABLE reservations (EXCLUDE (overlaps_with WITH =));" `shouldBe`
                 StatementCreateTable (table "reservations")
@@ -586,6 +592,19 @@ spec = do
                         [ ExcludeConstraint
                             { name = Nothing
                             , excludeElements = [ExcludeConstraintElement { element = "overlaps_with", operator = "=" }]
+                            , predicate = Nothing
+                            , indexType = Nothing
+                            }
+                        ]
+                    }
+
+        it "should ignore quoted WITH text inside exclusion elements" do
+            parseSql "CREATE TABLE reservations (EXCLUDE ((name || ' WITH ') WITH =));" `shouldBe`
+                StatementCreateTable (table "reservations")
+                    { constraints =
+                        [ ExcludeConstraint
+                            { name = Nothing
+                            , excludeElements = [ExcludeConstraintElement { element = "(name || ' WITH ')", operator = "=" }]
                             , predicate = Nothing
                             , indexType = Nothing
                             }

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -444,6 +444,10 @@ spec = do
         it "should parse 'CREATE SEQUENCE ..' statements" do
             parseSql "CREATE SEQUENCE a;" `shouldBe` CreateSequence { name = "a" }
 
+        it "should not read INCREMENT as the IN expression operator" do
+            parseSql "CREATE SEQUENCE a START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;"
+                `shouldBe` CreateSequence { name = "a" }
+
         it "should parse 'BEGIN' statements" do
             parseSql "BEGIN;" `shouldBe` Begin
 

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -528,6 +528,12 @@ spec = do
                         (BinaryOperatorExpression "+" (VarExpression "subtotal") (VarExpression "tax"))
                         (VarExpression "maximum"))
 
+        it "should parse generic operators in BETWEEN bounds" do
+            parseExpression "value BETWEEN bounds ->> 'lower' AND bounds ->> 'upper'" `shouldBe`
+                AndExpression
+                    (GreaterThanOrEqualToExpression (VarExpression "value") (BinaryOperatorExpression "->>" (VarExpression "bounds") (TextExpression "lower")))
+                    (LessThanOrEqualToExpression (VarExpression "value") (BinaryOperatorExpression "->>" (VarExpression "bounds") (TextExpression "upper")))
+
         it "should give AT TIME ZONE precedence over comparisons" do
             parseExpression "cutoff < created_at AT TIME ZONE 'UTC'" `shouldBe`
                 LessThanExpression
@@ -605,6 +611,19 @@ spec = do
                         [ ExcludeConstraint
                             { name = Nothing
                             , excludeElements = [ExcludeConstraintElement { element = "(name || ' WITH ')", operator = "=" }]
+                            , predicate = Nothing
+                            , indexType = Nothing
+                            }
+                        ]
+                    }
+
+        it "should parse compact exclusion operators" do
+            parseSql "CREATE TABLE reservations (EXCLUDE (room_id WITH=));" `shouldBe`
+                StatementCreateTable (table "reservations")
+                    { constraints =
+                        [ ExcludeConstraint
+                            { name = Nothing
+                            , excludeElements = [ExcludeConstraintElement { element = "room_id", operator = "=" }]
                             , predicate = Nothing
                             , indexType = Nothing
                             }

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -496,6 +496,51 @@ spec = do
             parseExpression "code ~ '^[A-Z]{3}$'" `shouldBe`
                 BinaryOperatorExpression "~" (VarExpression "code") (TextExpression "^[A-Z]{3}$")
 
+        it "should parse PostgreSQL JSON operators" do
+            parseExpression "metadata ->> 'kind' = 'invoice'" `shouldBe`
+                EqExpression
+                    (BinaryOperatorExpression "->>" (VarExpression "metadata") (TextExpression "kind"))
+                    (TextExpression "invoice")
+            parseExpression "metadata ? 'kind'" `shouldBe`
+                BinaryOperatorExpression "?" (VarExpression "metadata") (TextExpression "kind")
+
+        it "should parse BETWEEN and NOT IN" do
+            parseExpression "month BETWEEN 1 AND 12" `shouldBe`
+                AndExpression
+                    (GreaterThanOrEqualToExpression (VarExpression "month") (IntExpression 1))
+                    (LessThanOrEqualToExpression (VarExpression "month") (IntExpression 12))
+            parseExpression "kind NOT IN ('draft', 'void')" `shouldBe`
+                BinaryOperatorExpression "NOT IN"
+                    (VarExpression "kind")
+                    (InArrayExpression [TextExpression "draft", TextExpression "void"])
+
+        it "should parse typed PostgreSQL literals" do
+            parseExpression "closed_at - INTERVAL '30 days' > opened_at" `shouldBe`
+                GreaterThanExpression
+                    (BinaryOperatorExpression "-"
+                        (VarExpression "closed_at")
+                        (TypeCastExpression (TextExpression "30 days") (PInterval Nothing)))
+                    (VarExpression "opened_at")
+            parseExpression "TIMESTAMPTZ '2026-08-09 18:00:00+00'" `shouldBe`
+                TypeCastExpression (TextExpression "2026-08-09 18:00:00+00") PTimestampWithTimezone
+
+        it "should parse expression-based EXCLUDE constraints" do
+            parseSql "ALTER TABLE bookings ADD CONSTRAINT bookings_no_overlap EXCLUDE USING gist (room_id WITH =, daterange(starts_on, ends_on) WITH &&);" `shouldBe`
+                AddConstraint
+                    { tableName = "bookings"
+                    , constraint = ExcludeConstraint
+                        { name = Just "bookings_no_overlap"
+                        , excludeElements =
+                            [ ExcludeConstraintElement { element = "room_id", operator = "=" }
+                            , ExcludeConstraintElement { element = "daterange(starts_on, ends_on)", operator = "&&" }
+                            ]
+                        , predicate = Nothing
+                        , indexType = Just Gist
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
+                    }
+
         it "should prefer the longest regular expression operator" do
             parseExpression "code !~* 'x'" `shouldBe`
                 BinaryOperatorExpression "!~*" (VarExpression "code") (TextExpression "x")

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -573,6 +573,25 @@ spec = do
         it "should read != as the canonical <> operator" do
             parseExpression "a != b" `shouldBe` NotEqExpression (VarExpression "a") (VarExpression "b")
 
+        it "should bind regular expression operators before comparisons" do
+            parseExpression "flag <> code ~ '^x'" `shouldBe`
+                NotEqExpression
+                    (VarExpression "flag")
+                    (BinaryOperatorExpression "~" (VarExpression "code") (TextExpression "^x"))
+
+        it "should parse WITH only as an exclusion-element delimiter" do
+            parseSql "CREATE TABLE reservations (EXCLUDE (overlaps_with WITH =));" `shouldBe`
+                StatementCreateTable (table "reservations")
+                    { constraints =
+                        [ ExcludeConstraint
+                            { name = Nothing
+                            , excludeElements = [ExcludeConstraintElement { element = "overlaps_with", operator = "=" }]
+                            , predicate = Nothing
+                            , indexType = Nothing
+                            }
+                        ]
+                    }
+
         it "should cast the operand rather than the sum" do
             parseExpression "a::integer + 1" `shouldBe`
                 BinaryOperatorExpression "+"

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -518,6 +518,22 @@ spec = do
                     (VarExpression "kind")
                     (InArrayExpression [TextExpression "draft", TextExpression "void"])
 
+        it "should parse BETWEEN after arithmetic expressions" do
+            parseExpression "subtotal + tax BETWEEN minimum + 1 AND maximum" `shouldBe`
+                AndExpression
+                    (GreaterThanOrEqualToExpression
+                        (BinaryOperatorExpression "+" (VarExpression "subtotal") (VarExpression "tax"))
+                        (BinaryOperatorExpression "+" (VarExpression "minimum") (IntExpression 1)))
+                    (LessThanOrEqualToExpression
+                        (BinaryOperatorExpression "+" (VarExpression "subtotal") (VarExpression "tax"))
+                        (VarExpression "maximum"))
+
+        it "should give AT TIME ZONE precedence over comparisons" do
+            parseExpression "cutoff < created_at AT TIME ZONE 'UTC'" `shouldBe`
+                LessThanExpression
+                    (VarExpression "cutoff")
+                    (BinaryOperatorExpression "AT TIME ZONE" (VarExpression "created_at") (TextExpression "UTC"))
+
         it "should parse typed PostgreSQL literals" do
             parseExpression "closed_at - INTERVAL '30 days' > opened_at" `shouldBe`
                 GreaterThanExpression

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -468,6 +468,67 @@ spec = do
         it "should parse negative DoubleExpression's" do
             parseExpression "-1.337" `shouldBe` (DoubleExpression (-1.337))
 
+        it "should parse an operator behind an integer literal" do
+            parseExpression "a > 0 AND b > 0" `shouldBe`
+                AndExpression
+                    (GreaterThanExpression (VarExpression "a") (IntExpression 0))
+                    (GreaterThanExpression (VarExpression "b") (IntExpression 0))
+
+        it "should parse an operator behind a double literal" do
+            parseExpression "a > 0.5 AND b > 0.5" `shouldBe`
+                AndExpression
+                    (GreaterThanExpression (VarExpression "a") (DoubleExpression 0.5))
+                    (GreaterThanExpression (VarExpression "b") (DoubleExpression 0.5))
+
+        it "should parse arithmetic operators" do
+            parseExpression "a + b <= 100" `shouldBe`
+                LessThanOrEqualToExpression
+                    (BinaryOperatorExpression "+" (VarExpression "a") (VarExpression "b"))
+                    (IntExpression 100)
+
+        it "should give multiplication a tighter precedence than addition" do
+            parseExpression "a + b * c" `shouldBe`
+                BinaryOperatorExpression "+"
+                    (VarExpression "a")
+                    (BinaryOperatorExpression "*" (VarExpression "b") (VarExpression "c"))
+
+        it "should parse regular expression operators" do
+            parseExpression "code ~ '^[A-Z]{3}$'" `shouldBe`
+                BinaryOperatorExpression "~" (VarExpression "code") (TextExpression "^[A-Z]{3}$")
+
+        it "should prefer the longest regular expression operator" do
+            parseExpression "code !~* 'x'" `shouldBe`
+                BinaryOperatorExpression "!~*" (VarExpression "code") (TextExpression "x")
+
+        it "should parse LIKE without consuming an identifier that starts with it" do
+            parseExpression "name LIKE 'a%'" `shouldBe`
+                BinaryOperatorExpression "LIKE" (VarExpression "name") (TextExpression "a%")
+            parseExpression "likelihood" `shouldBe` VarExpression "likelihood"
+
+        it "should read != as the canonical <> operator" do
+            parseExpression "a != b" `shouldBe` NotEqExpression (VarExpression "a") (VarExpression "b")
+
+        it "should cast the operand rather than the sum" do
+            parseExpression "a::integer + 1" `shouldBe`
+                BinaryOperatorExpression "+"
+                    (TypeCastExpression (VarExpression "a") PInt)
+                    (IntExpression 1)
+
+        it "should parse a CHECK constraint combining comparisons with AND" do
+            parseSql "CREATE TABLE t (a INT, b INT, CONSTRAINT t_positive CHECK (a > 0 AND b > 0));" `shouldBe`
+                StatementCreateTable (table "t")
+                    { columns = [col "a" PInt, col "b" PInt]
+                    , constraints =
+                        [ CheckConstraint
+                            { name = Just "t_positive"
+                            , checkExpression =
+                                AndExpression
+                                    (GreaterThanExpression (VarExpression "a") (IntExpression 0))
+                                    (GreaterThanExpression (VarExpression "b") (IntExpression 0))
+                            }
+                        ]
+                    }
+
 parseSql :: Text -> Statement
 parseSql sql = let [statement] = parseSqlStatements sql in statement
 


### PR DESCRIPTION
## Bug

Real CHECK constraints and index expressions use operators and forms that the parser cannot currently represent, for example:

```sql
CHECK (payload ->> 'kind' = 'booking' AND amount BETWEEN 0 AND 100)
CHECK (status NOT IN ('deleted', 'archived'))
```

The parser either rejects these expressions or the compiler changes their grouping.

## Fix

Add a generic binary-operator expression and support the concrete PostgreSQL forms found in schemas: comparison/pattern/JSON operators, `NOT IN`, `BETWEEN`, typed literals, expression-based EXCLUDE elements, and stable equality grouping. Schema Designer consumers traverse the new expression node.

## Independence

This PR includes its small CHECK-expression prerequisite in the same branch and is based directly on the current `upstream/master`. It does not depend on another PR.

## Validation

- `nix build --impure --no-link .#checks.aarch64-darwin.ghc914-ihp-postgres-parser .#checks.aarch64-darwin.ghc914-ihp-ide`

Not PostgreSQL 18-specific.
