### PR TITLE
Preserve PostgreSQL 18 named NOT NULL constraints

### DIFF
--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -542,7 +542,7 @@ normalizeConstraint tableName constraint@(UniqueConstraint { name = Just uniqueN
 normalizeConstraint _ otherwise = otherwise
 
 normalizeColumn :: CreateTable -> Column -> (Column, [Statement])
-normalizeColumn table Column { name, columnType, defaultValue, notNull, isUnique, generator } = (Column { name = normalizeName name, columnType = normalizeSqlType columnType, defaultValue = normalizedDefaultValue, notNull, isUnique = False, generator = normalizeColumnGenerator <$> generator }, uniqueConstraint)
+normalizeColumn table Column { name, columnType, defaultValue, notNull, isUnique, generator } = (Column { name = normalizeName name, columnType = normalizeSqlType columnType, defaultValue = normalizedDefaultValue, notNull, notNullConstraintName = Nothing, isUnique = False, generator = normalizeColumnGenerator <$> generator }, uniqueConstraint)
     where
         uniqueConstraint =
             if isUnique

--- a/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
@@ -27,6 +27,7 @@ addTable tableName uuidFunction list = list <> [StatementCreateTable CreateTable
             , columnType = PUUID
             , defaultValue = Just (CallExpression uuidFunction [])
             , notNull = True
+            , notNullConstraintName = Nothing
             , isUnique = False
             , generator = Nothing
             }]
@@ -205,6 +206,7 @@ newColumn AddColumnOptions { .. } = Column
     , columnType = arrayifytype isArray columnType
     , defaultValue = defaultValue
     , notNull = (not allowNull)
+    , notNullConstraintName = Nothing
     , isUnique = isUnique
     , generator = Nothing
     }

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -110,14 +110,14 @@ compileOnDelete (Just SetDefault) = "ON DELETE SET DEFAULT"
 compileOnDelete (Just Cascade) = "ON DELETE CASCADE"
 
 compileColumn :: PrimaryKeyConstraint -> Column -> Text
-compileColumn primaryKeyConstraint Column { name, columnType, defaultValue, notNull, isUnique, generator } =
+compileColumn primaryKeyConstraint Column { name, columnType, defaultValue, notNull, notNullConstraintName, isUnique, generator } =
     unwords (catMaybes
         [ Just (compileIdentifier name)
         , Just (compilePostgresType columnType)
         , fmap compileDefaultValue defaultValue
         , fmap compileGenerator generator
         , primaryKeyColumnConstraint
-        , if notNull then Just "NOT NULL" else Nothing
+        , if notNull then Just (maybe "NOT NULL" (\constraintName -> "CONSTRAINT " <> compileIdentifier constraintName <> " NOT NULL") notNullConstraintName) else Nothing
         , if isUnique then Just "UNIQUE" else Nothing
         ])
     where

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -398,6 +398,7 @@ parseColumn = do
             , columnType
             , defaultValue = Nothing
             , notNull = False
+            , notNullConstraintName = Nothing
             , isUnique = False
             , generator = Nothing
             }
@@ -428,10 +429,10 @@ parseColumn = do
             -- constraint names for columns, but it must accept this spelling.
             , do
                 lexeme "CONSTRAINT"
-                _constraintName <- identifier
+                constraintName <- identifier
                 lexeme "NOT"
                 lexeme "NULL"
-                parseColumnAttributes column { notNull = True } primaryKey
+                parseColumnAttributes column { notNull = True, notNullConstraintName = Just constraintName } primaryKey
             , do
                 lexeme "UNIQUE"
                 parseColumnAttributes column { isUnique = True } primaryKey

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -423,6 +423,15 @@ parseColumn = do
                 lexeme "NOT"
                 lexeme "NULL"
                 parseColumnAttributes column { notNull = True } primaryKey
+            -- PostgreSQL 18 stores NOT NULL constraints in pg_constraint, so
+            -- pg_dump can emit their name before NOT NULL. IHP does not model
+            -- constraint names for columns, but it must accept this spelling.
+            , do
+                lexeme "CONSTRAINT"
+                _constraintName <- identifier
+                lexeme "NOT"
+                lexeme "NULL"
+                parseColumnAttributes column { notNull = True } primaryKey
             , do
                 lexeme "UNIQUE"
                 parseColumnAttributes column { isUnique = True } primaryKey

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -105,6 +105,7 @@ data Column = Column
     , columnType :: PostgresType
     , defaultValue :: Maybe Expression
     , notNull :: Bool
+    , notNullConstraintName :: Maybe Text
     , isUnique :: Bool
     , generator :: Maybe ColumnGenerator
     }
@@ -303,6 +304,7 @@ col columnName columnType = Column
     , columnType = columnType
     , defaultValue = Nothing
     , notNull = False
+    , notNullConstraintName = Nothing
     , isUnique = False
     , generator = Nothing
     }

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -233,6 +233,10 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should round-trip PostgreSQL 18 named NOT NULL constraints" do
+            let sql = "CREATE TABLE users (\n    email TEXT CONSTRAINT users_email_not_null NOT NULL\n);"
+            compileSql [parseSql sql] `shouldBe` (sql <> "\n")
+
         it "should round-trip a schema-qualified CREATE FUNCTION" do
             -- parse -> compile -> parse must preserve a non-public schema like `private.`
             let statement = CreateFunction

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -100,6 +100,16 @@ spec = do
         it "should parse a CREATE TABLE with quoted identifiers" do
             parseSql "CREATE TABLE \"quoted name\" ();" `shouldBe` StatementCreateTable (table "quoted name")
 
+        it "should parse PostgreSQL 18 named NOT NULL constraints" do
+            let sql = "CREATE TABLE context_search_email_binary_signatures (\n                    embedding_provider text CONSTRAINT context_search_email_binary_signatu_embedding_provider_not_null NOT NULL,\n                    embedding_dimensions integer CONSTRAINT context_search_email_binary_signa_embedding_dimensions_not_null NOT NULL,\n                    embedding_model text\n                );"
+            parseSql sql `shouldBe` StatementCreateTable (table "context_search_email_binary_signatures")
+                    { columns =
+                        [ (col "embedding_provider" PText) { notNull = True }
+                        , (col "embedding_dimensions" PInt) { notNull = True }
+                        , col "embedding_model" PText
+                        ]
+                    }
+
         it "should parse a CREATE TABLE with public schema prefix" do
             parseSql "CREATE TABLE public.users ();" `shouldBe` StatementCreateTable (table "users")
 

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -104,8 +104,8 @@ spec = do
             let sql = "CREATE TABLE context_search_email_binary_signatures (\n                    embedding_provider text CONSTRAINT context_search_email_binary_signatu_embedding_provider_not_null NOT NULL,\n                    embedding_dimensions integer CONSTRAINT context_search_email_binary_signa_embedding_dimensions_not_null NOT NULL,\n                    embedding_model text\n                );"
             parseSql sql `shouldBe` StatementCreateTable (table "context_search_email_binary_signatures")
                     { columns =
-                        [ (col "embedding_provider" PText) { notNull = True }
-                        , (col "embedding_dimensions" PInt) { notNull = True }
+                        [ (col "embedding_provider" PText) { notNull = True, notNullConstraintName = Just "context_search_email_binary_signatu_embedding_provider_not_null" }
+                        , (col "embedding_dimensions" PInt) { notNull = True, notNullConstraintName = Just "context_search_email_binary_signa_embedding_dimensions_not_null" }
                         , col "embedding_model" PText
                         ]
                     }


### PR DESCRIPTION
## Bug

PostgreSQL 18 can emit named NOT NULL constraints in `pg_dump` output:

```sql
email TEXT CONSTRAINT users_email_not_null NOT NULL
```

IHP currently rejects that column form.

## Fix

Parse the constraint name, retain it in the column AST, compile it back, and ignore generated-name-only differences when producing migrations.

## Independence

This branch is based directly on the current `upstream/master` and has no dependency on another parser PR.

## Validation

- `nix build --impure --no-link .#checks.aarch64-darwin.ghc914-ihp-postgres-parser .#checks.aarch64-darwin.ghc914-ihp-ide`

This is the only PR in this set that is specifically motivated by PostgreSQL 18.
