### PR TITLE
Preserve extension and sequence options

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -198,7 +198,10 @@ jobs:
         if [ -n "$COMMENT_ID" ]; then
           gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -X DELETE 2>/dev/null || true
         fi
-        gh pr comment "${{ github.event.pull_request.number }}" --body-file comment-body.md
+        # Fork pull requests receive a read-only GITHUB_TOKEN, so posting the
+        # report can fail even when the benchmark itself succeeded.
+        gh pr comment "${{ github.event.pull_request.number }}" --body-file comment-body.md \
+          || echo "::warning::Could not post benchmark report as a PR comment"
 
         # Fail if either metric regresses >10%
         if [ "$FAILED" = "1" ]; then

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -212,7 +212,7 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
                 changedActualOptions = filter (not . hasMatchingOption desiredOptions) actualOptions
                 hasMatchingOption options option = any ((== sequenceOptionKind option) . sequenceOptionKind) options
                 resetOption SequenceAs {} = Just (SequenceAs PBigInt)
-                resetOption SequenceStart {} = Just (SequenceStart (IntExpression implicitStart))
+                resetOption SequenceStart {} = Just (SequenceStart implicitStart)
                 resetOption SequenceIncrement {} = Just (SequenceIncrement (IntExpression 1))
                 resetOption SequenceMinValue {} = Just SequenceNoMinValue
                 resetOption SequenceMaxValue {} = Just SequenceNoMaxValue
@@ -221,11 +221,13 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
                 resetOption _ = Nothing
                 targetDirection = sequenceDirection targetOptions
                 actualDirection = sequenceDirection actualOptions
-                implicitStart = if targetDirection < 0 then -1 else 1
+                implicitStart
+                    | targetDirection < 0 = fromMaybe (IntExpression (-1)) (listToMaybe [value | SequenceMaxValue value <- targetOptions])
+                    | otherwise = fromMaybe (IntExpression 1) (listToMaybe [value | SequenceMinValue value <- targetOptions])
                 directionDefaults
                     | targetDirection == actualDirection = []
                     | otherwise = filter (not . hasMatchingOption targetOptions)
-                        [ SequenceStart (IntExpression implicitStart)
+                        [ SequenceStart implicitStart
                         , SequenceNoMinValue
                         , SequenceNoMaxValue
                         ]

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -212,7 +212,7 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
 
         sequenceAlterOptions targetOptions actualOptions = desiredOptions <> mapMaybe resetOption changedActualOptions
             where
-                desiredOptions = targetOptions <> directionDefaults
+                desiredOptions = targetOptions <> boundStartDefault <> directionDefaults
                 changedActualOptions = filter (not . hasMatchingOption desiredOptions) actualOptions
                 hasMatchingOption options option = any ((== sequenceOptionKind option) . sequenceOptionKind) options
                 resetOption SequenceAs {} = Just (SequenceAs PBigInt)
@@ -235,6 +235,16 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
                         , SequenceNoMinValue
                         , SequenceNoMaxValue
                         ]
+                boundStartDefault
+                    | targetDirection /= actualDirection = []
+                    | relevantStartBound targetOptions /= relevantStartBound actualOptions
+                    , not (any isStartOption targetOptions) = [SequenceStart implicitStart]
+                    | otherwise = []
+                relevantStartBound options
+                    | targetDirection < 0 = listToMaybe [value | SequenceMaxValue value <- options]
+                    | otherwise = listToMaybe [value | SequenceMinValue value <- options]
+                isStartOption SequenceStart {} = True
+                isStartOption _ = False
 
         sequenceDirection options = if any isDescendingIncrement options then (-1 :: Int) else 1
 

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -507,7 +507,9 @@ normalizeStatement otherwise = [otherwise]
 normalizeSequenceOptions :: [SequenceOption] -> [SequenceOption]
 normalizeSequenceOptions options = sortOn sequenceOptionKind (filter (not . isImplicitSequenceOption implicitStart) options)
     where
-        implicitStart = if any isDescendingIncrement options then -1 else 1
+        implicitStart
+            | any isDescendingIncrement options = fromMaybe (IntExpression (-1)) (listToMaybe [value | SequenceMaxValue value <- options])
+            | otherwise = fromMaybe (IntExpression 1) (listToMaybe [value | SequenceMinValue value <- options])
         isDescendingIncrement (SequenceIncrement (IntExpression value)) = value < 0
         isDescendingIncrement _ = False
 
@@ -523,8 +525,8 @@ sequenceOptionKind = \case
     SequenceCache {} -> 5
     SequenceCycle {} -> 6
 
-isImplicitSequenceOption :: Int -> SequenceOption -> Bool
-isImplicitSequenceOption implicitStart (SequenceStart (IntExpression value)) = value == implicitStart
+isImplicitSequenceOption :: Expression -> SequenceOption -> Bool
+isImplicitSequenceOption implicitStart (SequenceStart value) = value == implicitStart
 isImplicitSequenceOption _ (SequenceAs PBigInt) = True
 isImplicitSequenceOption _ (SequenceIncrement (IntExpression 1)) = True
 isImplicitSequenceOption _ SequenceNoMinValue = True

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -150,7 +150,11 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
             |> applyReplaceFunction
     where
         create :: [Statement]
-        create = targetSchema \\ actualSchema
+        create = map restoreExtensionOptions (targetSchema \\ actualSchema)
+
+        restoreExtensionOptions statement@CreateExtension { name } =
+            fromMaybe statement (find (\case CreateExtension { name = targetName } -> targetName == name; _ -> False) targetSchema')
+        restoreExtensionOptions statement = statement
 
         drop :: [Statement]
         drop = (actualSchema \\ targetSchema)

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -507,8 +507,19 @@ normalizeStatement statement@CreateExtension { extensionOptions } = [statement {
 normalizeStatement otherwise = [otherwise]
 
 normalizeSequenceOptions :: [SequenceOption] -> [SequenceOption]
-normalizeSequenceOptions options = sortOn sequenceOptionKind (filter (not . isImplicitSequenceOption implicitStart) options)
+normalizeSequenceOptions options = sortOn sequenceOptionKind (filter (not . isImplicitSequenceOption implicitStart defaultMinValue defaultMaxValue) options)
     where
+        sequenceType = fromMaybe PBigInt (listToMaybe [postgresType | SequenceAs postgresType <- options])
+        typeMinValue = IntExpression case sequenceType of
+            PSmallInt -> -32768
+            PInt -> -2147483648
+            _ -> -9223372036854775808
+        typeMaxValue = IntExpression case sequenceType of
+            PSmallInt -> 32767
+            PInt -> 2147483647
+            _ -> 9223372036854775807
+        defaultMinValue = if any isDescendingIncrement options then typeMinValue else IntExpression 1
+        defaultMaxValue = if any isDescendingIncrement options then IntExpression (-1) else typeMaxValue
         implicitStart
             | any isDescendingIncrement options = fromMaybe (IntExpression (-1)) (listToMaybe [value | SequenceMaxValue value <- options])
             | otherwise = fromMaybe (IntExpression 1) (listToMaybe [value | SequenceMinValue value <- options])
@@ -527,21 +538,22 @@ sequenceOptionKind = \case
     SequenceCache {} -> 5
     SequenceCycle {} -> 6
 
-isImplicitSequenceOption :: Expression -> SequenceOption -> Bool
-isImplicitSequenceOption implicitStart (SequenceStart value) = value == implicitStart
-isImplicitSequenceOption _ (SequenceAs PBigInt) = True
-isImplicitSequenceOption _ (SequenceIncrement (IntExpression 1)) = True
-isImplicitSequenceOption _ SequenceNoMinValue = True
-isImplicitSequenceOption _ SequenceNoMaxValue = True
-isImplicitSequenceOption _ (SequenceCache (IntExpression 1)) = True
-isImplicitSequenceOption _ (SequenceCycle False) = True
-isImplicitSequenceOption _ _ = False
+isImplicitSequenceOption :: Expression -> Expression -> Expression -> SequenceOption -> Bool
+isImplicitSequenceOption implicitStart _ _ (SequenceStart value) = value == implicitStart
+isImplicitSequenceOption _ _ _ (SequenceAs PBigInt) = True
+isImplicitSequenceOption _ _ _ (SequenceIncrement (IntExpression 1)) = True
+isImplicitSequenceOption _ _ _ SequenceNoMinValue = True
+isImplicitSequenceOption _ _ _ SequenceNoMaxValue = True
+isImplicitSequenceOption _ defaultMinValue _ (SequenceMinValue value) = value == defaultMinValue
+isImplicitSequenceOption _ _ defaultMaxValue (SequenceMaxValue value) = value == defaultMaxValue
+isImplicitSequenceOption _ _ _ (SequenceCache (IntExpression 1)) = True
+isImplicitSequenceOption _ _ _ (SequenceCycle False) = True
+isImplicitSequenceOption _ _ _ _ = False
 
 isImplicitExtensionOption :: ExtensionOption -> Bool
-isImplicitExtensionOption (ExtensionSchema "public") = True
+isImplicitExtensionOption ExtensionSchema {} = True
 isImplicitExtensionOption ExtensionVersion {} = True
 isImplicitExtensionOption ExtensionCascade = True
-isImplicitExtensionOption _ = False
 
 normalizePolicyAction (Just PolicyForAll) = Nothing
 normalizePolicyAction otherwise = otherwise

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -232,17 +232,6 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
 
         sequenceDirection options = if any isDescendingIncrement options then (-1 :: Int) else 1
 
-        sequenceOptionKind = \case
-            SequenceAs {} -> (0 :: Int)
-            SequenceStart {} -> 1
-            SequenceIncrement {} -> 2
-            SequenceNoMinValue -> 3
-            SequenceMinValue {} -> 3
-            SequenceNoMaxValue -> 4
-            SequenceMaxValue {} -> 4
-            SequenceCache {} -> 5
-            SequenceCycle {} -> 6
-
         isDescendingIncrement (SequenceIncrement (IntExpression value)) = value < 0
         isDescendingIncrement _ = False
 
@@ -516,11 +505,23 @@ normalizeStatement statement@CreateExtension { extensionOptions } = [statement {
 normalizeStatement otherwise = [otherwise]
 
 normalizeSequenceOptions :: [SequenceOption] -> [SequenceOption]
-normalizeSequenceOptions options = filter (not . isImplicitSequenceOption implicitStart) options
+normalizeSequenceOptions options = sortOn sequenceOptionKind (filter (not . isImplicitSequenceOption implicitStart) options)
     where
         implicitStart = if any isDescendingIncrement options then -1 else 1
         isDescendingIncrement (SequenceIncrement (IntExpression value)) = value < 0
         isDescendingIncrement _ = False
+
+sequenceOptionKind :: SequenceOption -> Int
+sequenceOptionKind = \case
+    SequenceAs {} -> 0
+    SequenceStart {} -> 1
+    SequenceIncrement {} -> 2
+    SequenceNoMinValue -> 3
+    SequenceMinValue {} -> 3
+    SequenceNoMaxValue -> 4
+    SequenceMaxValue {} -> 4
+    SequenceCache {} -> 5
+    SequenceCycle {} -> 6
 
 isImplicitSequenceOption :: Int -> SequenceOption -> Bool
 isImplicitSequenceOption implicitStart (SequenceStart (IntExpression value)) = value == implicitStart

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -143,6 +143,7 @@ diffSchemas :: [Statement] -> [Statement] -> [Statement]
 diffSchemas targetSchema' actualSchema' = (drop <> create)
             |> patchTable
             |> patchEnumType
+            |> patchSequence
             |> applyRenameTable
             |> removeImplicitDeletions actualSchema
             |> disableTransactionWhileAddingEnumValues
@@ -197,6 +198,53 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
                         otherwise                      -> False
         patchEnumType (s:rest) = s:(patchEnumType rest)
         patchEnumType [] = []
+
+        patchSequence :: [Statement] -> [Statement]
+        patchSequence = map \case
+            CreateSequence { name, sequenceOptions }
+                | Just actualOptions <- listToMaybe (mapMaybe (\case CreateSequence { name = actualName, sequenceOptions = options } | actualName == name -> Just options; _ -> Nothing) actualSchema) ->
+                    AlterSequence { name, sequenceOptions = sequenceAlterOptions sequenceOptions actualOptions }
+            statement -> statement
+
+        sequenceAlterOptions targetOptions actualOptions = desiredOptions <> mapMaybe resetOption changedActualOptions
+            where
+                desiredOptions = targetOptions <> directionDefaults
+                changedActualOptions = filter (not . hasMatchingOption desiredOptions) actualOptions
+                hasMatchingOption options option = any ((== sequenceOptionKind option) . sequenceOptionKind) options
+                resetOption SequenceAs {} = Just (SequenceAs PBigInt)
+                resetOption SequenceStart {} = Just (SequenceStart (IntExpression implicitStart))
+                resetOption SequenceIncrement {} = Just (SequenceIncrement (IntExpression 1))
+                resetOption SequenceMinValue {} = Just SequenceNoMinValue
+                resetOption SequenceMaxValue {} = Just SequenceNoMaxValue
+                resetOption SequenceCache {} = Just (SequenceCache (IntExpression 1))
+                resetOption SequenceCycle {} = Just (SequenceCycle False)
+                resetOption _ = Nothing
+                targetDirection = sequenceDirection targetOptions
+                actualDirection = sequenceDirection actualOptions
+                implicitStart = if targetDirection < 0 then -1 else 1
+                directionDefaults
+                    | targetDirection == actualDirection = []
+                    | otherwise = filter (not . hasMatchingOption targetOptions)
+                        [ SequenceStart (IntExpression implicitStart)
+                        , SequenceNoMinValue
+                        , SequenceNoMaxValue
+                        ]
+
+        sequenceDirection options = if any isDescendingIncrement options then (-1 :: Int) else 1
+
+        sequenceOptionKind = \case
+            SequenceAs {} -> (0 :: Int)
+            SequenceStart {} -> 1
+            SequenceIncrement {} -> 2
+            SequenceNoMinValue -> 3
+            SequenceMinValue {} -> 3
+            SequenceNoMaxValue -> 4
+            SequenceMaxValue {} -> 4
+            SequenceCache {} -> 5
+            SequenceCycle {} -> 6
+
+        isDescendingIncrement (SequenceIncrement (IntExpression value)) = value < 0
+        isDescendingIncrement _ = False
 
         -- | Replaces 'DROP TABLE a; CREATE TABLE b;' DDL sequences with a more efficient 'ALTER TABLE a RENAME TO b' sequence if
         -- the tables have no differences except the name.
@@ -463,17 +511,32 @@ normalizeStatement CreateEnumType { name, values } = [ CreateEnumType { name = T
 normalizeStatement CreatePolicy { name, action, tableName, using, check } = [ CreatePolicy { name = truncateIdentifier name, tableName, using = (unqualifyExpression tableName . normalizeExpression) <$> using, check = (unqualifyExpression tableName . normalizeExpression) <$> check, action = normalizePolicyAction action } ]
 normalizeStatement CreateIndex { columns, indexType, indexName, .. } = [ CreateIndex { columns = map normalizeIndexColumn columns, indexType = normalizeIndexType indexType, indexName = truncateIdentifier indexName, .. } ]
 normalizeStatement CreateFunction { .. } = [ CreateFunction { orReplace = False, language = Text.toUpper language, functionBody = removeIndentation $ normalizeNewLines functionBody, .. } ]
-normalizeStatement statement@CreateSequence { sequenceOptions } = [statement { sequenceOptions = filter (not . isImplicitSequenceOption) sequenceOptions }]
-normalizeStatement statement@CreateExtension { extensionOptions } = [statement { extensionOptions = filter (/= ExtensionSchema "public") extensionOptions }]
+normalizeStatement statement@CreateSequence { sequenceOptions } = [statement { sequenceOptions = normalizeSequenceOptions sequenceOptions }]
+normalizeStatement statement@CreateExtension { extensionOptions } = [statement { extensionOptions = filter (not . isImplicitExtensionOption) extensionOptions }]
 normalizeStatement otherwise = [otherwise]
 
-isImplicitSequenceOption :: SequenceOption -> Bool
-isImplicitSequenceOption (SequenceStart (IntExpression 1)) = True
-isImplicitSequenceOption (SequenceIncrement (IntExpression 1)) = True
-isImplicitSequenceOption SequenceNoMinValue = True
-isImplicitSequenceOption SequenceNoMaxValue = True
-isImplicitSequenceOption (SequenceCache (IntExpression 1)) = True
-isImplicitSequenceOption _ = False
+normalizeSequenceOptions :: [SequenceOption] -> [SequenceOption]
+normalizeSequenceOptions options = filter (not . isImplicitSequenceOption implicitStart) options
+    where
+        implicitStart = if any isDescendingIncrement options then -1 else 1
+        isDescendingIncrement (SequenceIncrement (IntExpression value)) = value < 0
+        isDescendingIncrement _ = False
+
+isImplicitSequenceOption :: Int -> SequenceOption -> Bool
+isImplicitSequenceOption implicitStart (SequenceStart (IntExpression value)) = value == implicitStart
+isImplicitSequenceOption _ (SequenceAs PBigInt) = True
+isImplicitSequenceOption _ (SequenceIncrement (IntExpression 1)) = True
+isImplicitSequenceOption _ SequenceNoMinValue = True
+isImplicitSequenceOption _ SequenceNoMaxValue = True
+isImplicitSequenceOption _ (SequenceCache (IntExpression 1)) = True
+isImplicitSequenceOption _ (SequenceCycle False) = True
+isImplicitSequenceOption _ _ = False
+
+isImplicitExtensionOption :: ExtensionOption -> Bool
+isImplicitExtensionOption (ExtensionSchema "public") = True
+isImplicitExtensionOption ExtensionVersion {} = True
+isImplicitExtensionOption ExtensionCascade = True
+isImplicitExtensionOption _ = False
 
 normalizePolicyAction (Just PolicyForAll) = Nothing
 normalizePolicyAction otherwise = otherwise

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -463,7 +463,17 @@ normalizeStatement CreateEnumType { name, values } = [ CreateEnumType { name = T
 normalizeStatement CreatePolicy { name, action, tableName, using, check } = [ CreatePolicy { name = truncateIdentifier name, tableName, using = (unqualifyExpression tableName . normalizeExpression) <$> using, check = (unqualifyExpression tableName . normalizeExpression) <$> check, action = normalizePolicyAction action } ]
 normalizeStatement CreateIndex { columns, indexType, indexName, .. } = [ CreateIndex { columns = map normalizeIndexColumn columns, indexType = normalizeIndexType indexType, indexName = truncateIdentifier indexName, .. } ]
 normalizeStatement CreateFunction { .. } = [ CreateFunction { orReplace = False, language = Text.toUpper language, functionBody = removeIndentation $ normalizeNewLines functionBody, .. } ]
+normalizeStatement statement@CreateSequence { sequenceOptions } = [statement { sequenceOptions = filter (not . isImplicitSequenceOption) sequenceOptions }]
+normalizeStatement statement@CreateExtension { extensionOptions } = [statement { extensionOptions = filter (/= ExtensionSchema "public") extensionOptions }]
 normalizeStatement otherwise = [otherwise]
+
+isImplicitSequenceOption :: SequenceOption -> Bool
+isImplicitSequenceOption (SequenceStart (IntExpression 1)) = True
+isImplicitSequenceOption (SequenceIncrement (IntExpression 1)) = True
+isImplicitSequenceOption SequenceNoMinValue = True
+isImplicitSequenceOption SequenceNoMaxValue = True
+isImplicitSequenceOption (SequenceCache (IntExpression 1)) = True
+isImplicitSequenceOption _ = False
 
 normalizePolicyAction (Just PolicyForAll) = Nothing
 normalizePolicyAction otherwise = otherwise

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -132,6 +132,20 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "resets a removed sequence start to the target bound" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq MINVALUE 10;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq START WITH 20 MINVALUE 10;"
+
+                diffSchemas targetSchema actualSchema `shouldBe`
+                    [ AlterSequence
+                        { name = "events_id_seq"
+                        , sequenceOptions =
+                            [ SequenceMinValue (IntExpression 10)
+                            , SequenceStart (IntExpression 10)
+                            ]
+                        }
+                    ]
+
             it "resets direction-dependent defaults when a sequence becomes descending" do
                 let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY -1;"
                 let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2;"

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -152,6 +152,20 @@ tests = do
                         }
                     ]
 
+            it "moves the implicit sequence start when a bound changes" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq MINVALUE 20;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq START WITH 10 MINVALUE 10;"
+
+                diffSchemas targetSchema actualSchema `shouldBe`
+                    [ AlterSequence
+                        { name = "events_id_seq"
+                        , sequenceOptions =
+                            [ SequenceMinValue (IntExpression 20)
+                            , SequenceStart (IntExpression 20)
+                            ]
+                        }
+                    ]
+
             it "resets direction-dependent defaults when a sequence becomes descending" do
                 let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY -1;"
                 let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2;"

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -126,6 +126,12 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "derives an implicit sequence start from custom bounds" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq MINVALUE 10;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq START WITH 10 MINVALUE 10;"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "resets direction-dependent defaults when a sequence becomes descending" do
                 let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY -1;"
                 let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2;"

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -132,6 +132,12 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "normalizes explicitly spelled default sequence bounds" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq MINVALUE 1 MAXVALUE 9223372036854775807;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq NO MINVALUE NO MAXVALUE;"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "resets a removed sequence start to the target bound" do
                 let targetSchema = sql "CREATE SEQUENCE events_id_seq MINVALUE 10;"
                 let actualSchema = sql "CREATE SEQUENCE events_id_seq START WITH 20 MINVALUE 10;"
@@ -165,6 +171,12 @@ tests = do
             it "normalizes the default extension schema" do
                 let targetSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
                 let actualSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "leaves extension relocation to explicit migrations" do
+                let targetSchema = sql "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA new_schema;"
+                let actualSchema = sql "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA old_schema;"
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -186,6 +186,11 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "preserves options when creating a missing extension" do
+                let targetSchema = sql "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA geo VERSION '3.4.2' CASCADE;"
+
+                diffSchemas targetSchema [] `shouldBe` targetSchema
+
             it "should handle a new table" do
                 let targetSchema = sql [i|
                     CREATE TABLE users (

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -90,6 +90,12 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "canonicalizes sequence option ordering" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq CACHE 10 INCREMENT BY 2;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2 CACHE 10;"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "alters changed options on an existing sequence" do
                 let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 3;"
                 let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2;"

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -74,6 +74,28 @@ tests = do
             it "should handle an empty schema" do
                 diffSchemas [] [] `shouldBe` []
 
+            it "normalizes PostgreSQL's implicit sequence options" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq;"
+                let actualSchema = sql [i|
+                    CREATE SEQUENCE events_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+                |]
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "keeps non-default sequence options" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2;"
+                let actualSchema = sql [i|
+                    CREATE SEQUENCE events_id_seq START WITH 1 INCREMENT BY 2 NO MINVALUE NO MAXVALUE CACHE 1;
+                |]
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "normalizes the default extension schema" do
+                let targetSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+                let actualSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "should handle a new table" do
                 let targetSchema = sql [i|
                     CREATE TABLE users (

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -90,9 +90,61 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "alters changed options on an existing sequence" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 3;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2;"
+
+                diffSchemas targetSchema actualSchema `shouldBe`
+                    [AlterSequence { name = "events_id_seq", sequenceOptions = [SequenceIncrement (IntExpression 3)] }]
+
+            it "resets removed sequence options to PostgreSQL defaults" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2 CACHE 10 CYCLE;"
+
+                diffSchemas targetSchema actualSchema `shouldBe`
+                    [ AlterSequence
+                        { name = "events_id_seq"
+                        , sequenceOptions =
+                            [ SequenceIncrement (IntExpression 1)
+                            , SequenceCache (IntExpression 1)
+                            , SequenceCycle False
+                            ]
+                        }
+                    ]
+
+            it "normalizes PostgreSQL's implicit descending sequence start" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY -1;"
+                let actualSchema = sql [i|
+                    CREATE SEQUENCE events_id_seq START WITH -1 INCREMENT BY -1 NO MINVALUE NO MAXVALUE CACHE 1;
+                |]
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "resets direction-dependent defaults when a sequence becomes descending" do
+                let targetSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY -1;"
+                let actualSchema = sql "CREATE SEQUENCE events_id_seq INCREMENT BY 2;"
+
+                diffSchemas targetSchema actualSchema `shouldBe`
+                    [ AlterSequence
+                        { name = "events_id_seq"
+                        , sequenceOptions =
+                            [ SequenceIncrement (IntExpression (-1))
+                            , SequenceStart (IntExpression (-1))
+                            , SequenceNoMinValue
+                            , SequenceNoMaxValue
+                            ]
+                        }
+                    ]
+
             it "normalizes the default extension schema" do
                 let targetSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
                 let actualSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "ignores installation-only extension options" do
+                let targetSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm VERSION '1.6' CASCADE;"
+                let actualSchema = sql "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 

--- a/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
@@ -16,7 +16,7 @@ tests = do
             compileSql [StatementCreateTable (table "users")] `shouldBe` "CREATE TABLE users (\n\n);\n"
 
         it "should compile a CREATE EXTENSION for the UUID extension" do
-            compileSql [CreateExtension { name = "uuid-ossp", ifNotExists = True }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";\n"
+            compileSql [CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [] }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";\n"
 
         it "should compile a line comment" do
             compileSql [Comment { content = " Comment value" }] `shouldBe` "-- Comment value\n"
@@ -814,7 +814,7 @@ tests = do
 
         it "should compile 'CREATE SEQUENCE ..' statements" do
             let sql = "CREATE SEQUENCE a;\n"
-            let statements = [ CreateSequence { name = "a" } ]
+            let statements = [ CreateSequence { name = "a", sequenceOptions = [] } ]
             compileSql statements `shouldBe` sql
 
         it "should compile 'ALTER TABLE .. RENAME COLUMN .. TO ..' statements" do
@@ -874,7 +874,7 @@ tests = do
 
         it "should compile 'CREATE EXTENSION IF NOT EXISTS;' statements with an unqualified name" do
             let sql = "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;\n"
-            let statements = [ CreateExtension { name = "fuzzystrmatch", ifNotExists = True } ]
+            let statements = [ CreateExtension { name = "fuzzystrmatch", ifNotExists = True, extensionOptions = [] } ]
             compileSql statements `shouldBe` sql
 
         it "should compile 'CREATE POLICY ..;' statements with an EXISTS condition" do

--- a/ihp-ide/Test/IDE/SchemaDesigner/Controller/EnumValuesSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/Controller/EnumValuesSpec.hs
@@ -11,11 +11,11 @@ tests = do
         describe "getAllEnumValues" do
             it "should return a list of all enum values" do
                 getAllEnumValues [] `shouldBe` []
-                getAllEnumValues [ CreateExtension { name ="a", ifNotExists = True } ] `shouldBe` []
+                getAllEnumValues [ CreateExtension { name ="a", ifNotExists = True, extensionOptions = [] } ] `shouldBe` []
                 getAllEnumValues [ CreateEnumType { name = "first_enum", values=["a", "b", "c"] }] `shouldBe` ["a", "b", "c"]
                 getAllEnumValues
                     [ CreateEnumType {name = "first_enum", values = ["a", "b"]}
-                    , CreateExtension {name = "extension", ifNotExists = True}
+                    , CreateExtension {name = "extension", ifNotExists = True, extensionOptions = []}
                     , CreateEnumType {name = "second_enum", values = ["c"]}
                     , CreateEnumType {name = "third_enum", values = []}
                     ]

--- a/ihp-ide/Test/IDE/SchemaDesigner/Controller/HelperSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/Controller/HelperSpec.hs
@@ -11,13 +11,13 @@ tests = do
         describe "getAllObjectNames" do
             it "should return a list of all names of tables and enum types" do
                 getAllObjectNames [] `shouldBe` []
-                getAllObjectNames [ CreateExtension { name ="a", ifNotExists = True } ] `shouldBe` []
+                getAllObjectNames [ CreateExtension { name ="a", ifNotExists = True, extensionOptions = [] } ] `shouldBe` []
                 getAllObjectNames [ CreateEnumType { name = "first_enum", values=["a", "b", "c"] }] `shouldBe` ["first_enum"]
                 getAllObjectNames [ StatementCreateTable (table "table_name") ]
                     `shouldBe` ["table_name"]
                 getAllObjectNames
                     [ CreateEnumType {name = "first_enum", values = ["a", "b"]}
-                    , CreateExtension {name = "extension", ifNotExists = True}
+                    , CreateExtension {name = "extension", ifNotExists = True, extensionOptions = []}
                     , StatementCreateTable (table "table_name")
                     , CreateEnumType {name = "second_enum", values = []}
                     ]

--- a/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -17,13 +17,13 @@ tests = do
             parseSql "CREATE TABLE users ();"  `shouldBe` StatementCreateTable (table "users")
 
         it "should parse an CREATE EXTENSION for the UUID extension" do
-            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True }
+            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [] }
 
         it "should parse an CREATE EXTENSION with schema suffix" do
-            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True }
+            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [ExtensionSchema "public"] }
 
         it "should parse an CREATE EXTENSION without quotes" do
-            parseSql "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch WITH SCHEMA public;" `shouldBe` CreateExtension { name = "fuzzystrmatch", ifNotExists = True }
+            parseSql "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch WITH SCHEMA public;" `shouldBe` CreateExtension { name = "fuzzystrmatch", ifNotExists = True, extensionOptions = [ExtensionSchema "public"] }
 
         it "should parse a line comment" do
             parseSql "-- Comment value" `shouldBe` Comment { content = " Comment value" }
@@ -909,10 +909,10 @@ $$;
             parseSql "ALTER TABLE tasks DROP CONSTRAINT tasks_title_key;" `shouldBe` DropConstraint { tableName = "tasks", constraintName = "tasks_title_key" }
 
         it "should parse 'CREATE SEQUENCE ..' statements" do
-            parseSql "CREATE SEQUENCE a;" `shouldBe` CreateSequence { name = "a" }
+            parseSql "CREATE SEQUENCE a;" `shouldBe` CreateSequence { name = "a", sequenceOptions = [] }
 
         it "should parse 'CREATE SEQUENCE ..' statements with qualified name" do
-            parseSql "CREATE SEQUENCE public.a;" `shouldBe` CreateSequence { name = "a" }
+            parseSql "CREATE SEQUENCE public.a;" `shouldBe` CreateSequence { name = "a", sequenceOptions = [] }
 
         it "should parse 'CREATE SEQUENCE .. AS .. START WITH .. INCREMENT BY .. NO MINVALUE NO MAXVALUE CACHE ..;'" do
             let sql = [trimming|
@@ -924,7 +924,17 @@ $$;
                     NO MAXVALUE
                     CACHE 1;
             |]
-            parseSql sql `shouldBe` CreateSequence { name = "a" }
+            parseSql sql `shouldBe` CreateSequence
+                { name = "a"
+                , sequenceOptions =
+                    [ SequenceAs PInt
+                    , SequenceStart (IntExpression 1)
+                    , SequenceIncrement (IntExpression 1)
+                    , SequenceNoMinValue
+                    , SequenceNoMaxValue
+                    , SequenceCache (IntExpression 1)
+                    ]
+                }
 
         it "should parse 'SET' statements" do
             parseSql "SET statement_timeout = 0;" `shouldBe` Set { name = "statement_timeout", value = IntExpression 0 }
@@ -1026,7 +1036,7 @@ COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UU
                     , Comment {content = ""}
                     , Comment {content = " Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -"}
                     , Comment {content = ""}
-                    , CreateExtension {name = "uuid-ossp", ifNotExists = True}
+                    , CreateExtension {name = "uuid-ossp", ifNotExists = True, extensionOptions = []}
                     , Comment {content = ""}
                     , Comment {content = " Name: EXTENSION \"uuid-ossp\"; Type: COMMENT; Schema: -; Owner: -"}
                     , Comment {content = ""}

--- a/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -1036,7 +1036,7 @@ COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UU
                     , Comment {content = ""}
                     , Comment {content = " Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -"}
                     , Comment {content = ""}
-                    , CreateExtension {name = "uuid-ossp", ifNotExists = True, extensionOptions = []}
+                    , CreateExtension {name = "uuid-ossp", ifNotExists = True, extensionOptions = [ExtensionSchema "public"]}
                     , Comment {content = ""}
                     , Comment {content = " Name: EXTENSION \"uuid-ossp\"; Type: COMMENT; Schema: -; Owner: -"}
                     , Comment {content = ""}

--- a/ihp-migrate/IHP/SchemaMigration.hs
+++ b/ihp-migrate/IHP/SchemaMigration.hs
@@ -190,7 +190,7 @@ extensionNamesFromMigration migrationSql =
         Left parserError -> Left (cs parserError)
         Right statements -> traverse extensionName statements
     where
-        extensionName (CreateExtension name _) = Right name
+        extensionName CreateExtension { name } = Right name
         extensionName _ = Left "Expected a CREATE EXTENSION statement"
 
 -- | Extracts extension creation statements from a complete schema. The result

--- a/ihp-migrate/IHP/SchemaMigration.hs
+++ b/ihp-migrate/IHP/SchemaMigration.hs
@@ -190,7 +190,7 @@ extensionNamesFromMigration migrationSql =
         Left parserError -> Left (cs parserError)
         Right statements -> traverse extensionName statements
     where
-        extensionName CreateExtension { name } = Right name
+        extensionName (CreateExtension name _ _) = Right name
         extensionName _ = Left "Expected a CREATE EXTENSION statement"
 
 -- | Extracts extension creation statements from a complete schema. The result

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -537,7 +537,7 @@ compileSequenceOption (SequenceCycle enabled) = if enabled then "CYCLE" else "NO
 
 compileExtensionOption :: ExtensionOption -> Text
 compileExtensionOption (ExtensionSchema schema) = "WITH SCHEMA " <> compileExtensionSchema schema
-compileExtensionOption (ExtensionVersion version) = "VERSION " <> compileExpression (TextExpression version)
+compileExtensionOption (ExtensionVersion version) = "VERSION '" <> Text.replace "'" "''" version <> "'"
 compileExtensionOption ExtensionCascade = "CASCADE"
 
 compileExtensionSchema :: Text -> Text

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -11,6 +11,7 @@ import Data.Maybe (fromJust, isJust, catMaybes, fromMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Function ((&))
+import Data.Char (isAlpha, isAlphaNum)
 
 -- | Text versions of list functions
 intercalate :: Text -> [Text] -> Text
@@ -535,9 +536,18 @@ compileSequenceOption (SequenceCache value) = "CACHE " <> compileExpression valu
 compileSequenceOption (SequenceCycle enabled) = if enabled then "CYCLE" else "NO CYCLE"
 
 compileExtensionOption :: ExtensionOption -> Text
-compileExtensionOption (ExtensionSchema schema) = "WITH SCHEMA " <> compileIdentifier schema
+compileExtensionOption (ExtensionSchema schema) = "WITH SCHEMA " <> compileExtensionSchema schema
 compileExtensionOption (ExtensionVersion version) = "VERSION " <> compileExpression (TextExpression version)
 compileExtensionOption ExtensionCascade = "CASCADE"
+
+compileExtensionSchema :: Text -> Text
+compileExtensionSchema schema
+    | isSimpleIdentifier schema = compileIdentifier schema
+    | otherwise = "\"" <> Text.replace "\"" "\"\"" schema <> "\""
+    where
+        isSimpleIdentifier value = case Text.uncons value of
+            Just (first, rest) -> (isAlpha first || first == '_') && Text.all (\character -> isAlphaNum character || character == '_' || character == '$') rest
+            Nothing -> False
 
 compileIndexColumn :: IndexColumn -> Text
 compileIndexColumn IndexColumn { column, columnOperatorClass, columnOrder } =

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -35,7 +35,10 @@ compileSql statements = statements
 compileStatement :: Statement -> Text
 compileStatement (StatementCreateTable CreateTable { name, columns, primaryKeyConstraint, constraints, unlogged, inherits }) = "CREATE" <> (if unlogged then " UNLOGGED" else "") <> " TABLE " <> compileIdentifier name <> " (\n" <> intercalate ",\n" (map (\col -> "    " <> compileColumn primaryKeyConstraint col) columns <> maybe [] ((:[]) . indent) (compilePrimaryKeyConstraint primaryKeyConstraint) <> map (indent . compileConstraint) constraints) <> "\n)" <> maybe "" (\parent -> " INHERITS (" <> compileIdentifier parent <> ")") inherits <> ";"
 compileStatement CreateEnumType { name, values } = "CREATE TYPE " <> compileIdentifier name <> " AS ENUM (" <> intercalate ", " (values & map TextExpression & map compileExpression) <> ");"
-compileStatement CreateExtension { name, ifNotExists, extensionOptions } = "CREATE EXTENSION " <> (if ifNotExists then "IF NOT EXISTS " else "") <> compileIdentifier name <> mconcat (map ((" " <>) . compileExtensionOption) extensionOptions) <> ";"
+compileStatement CreateExtension { name, ifNotExists, extensionOptions } = "CREATE EXTENSION " <> (if ifNotExists then "IF NOT EXISTS " else "") <> compileIdentifier name <> (if any isSchemaOption extensionOptions then " WITH" else "") <> mconcat (map ((" " <>) . compileExtensionOption) extensionOptions) <> ";"
+    where
+        isSchemaOption ExtensionSchema {} = True
+        isSchemaOption _ = False
 compileStatement AddConstraint { tableName, constraint = UniqueConstraint { name = Nothing, columnNames } } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD UNIQUE (" <> intercalate ", " columnNames <> ")" <> ";"
 compileStatement AddConstraint { tableName, constraint, deferrable, deferrableType } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD CONSTRAINT " <> compileIdentifier (fromMaybe (error "compileStatement: Expected constraint name") (constraint.name)) <> " " <> compileConstraint constraint <> compileDeferrable deferrable deferrableType <> ";"
 compileStatement AddColumn { tableName, column } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD COLUMN " <> (compileColumn (PrimaryKeyConstraint []) column) <> ";"
@@ -536,7 +539,7 @@ compileSequenceOption (SequenceCache value) = "CACHE " <> compileExpression valu
 compileSequenceOption (SequenceCycle enabled) = if enabled then "CYCLE" else "NO CYCLE"
 
 compileExtensionOption :: ExtensionOption -> Text
-compileExtensionOption (ExtensionSchema schema) = "WITH SCHEMA " <> compileExtensionSchema schema
+compileExtensionOption (ExtensionSchema schema) = "SCHEMA " <> compileExtensionSchema schema
 compileExtensionOption (ExtensionVersion version) = "VERSION '" <> Text.replace "'" "''" version <> "'"
 compileExtensionOption ExtensionCascade = "CASCADE"
 

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -47,6 +47,7 @@ compileStatement CreateFunction { functionName, functionArguments, functionBody,
 compileStatement EnableRowLevelSecurity { tableName } = "ALTER TABLE " <> compileIdentifier tableName <> " ENABLE ROW LEVEL SECURITY;"
 compileStatement CreatePolicy { name, action, tableName, using, check } = "CREATE POLICY " <> compileIdentifier name <> " ON " <> compileIdentifier tableName <> maybe "" (\action -> " FOR " <> compilePolicyAction action) action  <> maybe "" (\expr -> " USING (" <> compileExpression expr <> ")") using <> maybe "" (\expr -> " WITH CHECK (" <> compileExpression expr <> ")") check <> ";"
 compileStatement CreateSequence { name, sequenceOptions } = "CREATE SEQUENCE " <> compileIdentifier name <> (if null sequenceOptions then "" else " " <> intercalate " " (map compileSequenceOption sequenceOptions)) <> ";"
+compileStatement AlterSequence { name, sequenceOptions } = "ALTER SEQUENCE " <> compileIdentifier name <> " " <> intercalate " " (map compileSequenceOption sequenceOptions) <> ";"
 compileStatement DropConstraint { tableName, constraintName } = "ALTER TABLE " <> compileIdentifier tableName <> " DROP CONSTRAINT " <> compileIdentifier constraintName <> ";"
 compileStatement DropEnumType { name } = "DROP TYPE " <> compileIdentifier name <> ";"
 compileStatement DropIndex { indexName } = "DROP INDEX " <> compileIdentifier indexName <> ";"

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -34,7 +34,7 @@ compileSql statements = statements
 compileStatement :: Statement -> Text
 compileStatement (StatementCreateTable CreateTable { name, columns, primaryKeyConstraint, constraints, unlogged, inherits }) = "CREATE" <> (if unlogged then " UNLOGGED" else "") <> " TABLE " <> compileIdentifier name <> " (\n" <> intercalate ",\n" (map (\col -> "    " <> compileColumn primaryKeyConstraint col) columns <> maybe [] ((:[]) . indent) (compilePrimaryKeyConstraint primaryKeyConstraint) <> map (indent . compileConstraint) constraints) <> "\n)" <> maybe "" (\parent -> " INHERITS (" <> compileIdentifier parent <> ")") inherits <> ";"
 compileStatement CreateEnumType { name, values } = "CREATE TYPE " <> compileIdentifier name <> " AS ENUM (" <> intercalate ", " (values & map TextExpression & map compileExpression) <> ");"
-compileStatement CreateExtension { name, ifNotExists } = "CREATE EXTENSION " <> (if ifNotExists then "IF NOT EXISTS " else "") <> compileIdentifier name <> ";"
+compileStatement CreateExtension { name, ifNotExists, extensionOptions } = "CREATE EXTENSION " <> (if ifNotExists then "IF NOT EXISTS " else "") <> compileIdentifier name <> mconcat (map ((" " <>) . compileExtensionOption) extensionOptions) <> ";"
 compileStatement AddConstraint { tableName, constraint = UniqueConstraint { name = Nothing, columnNames } } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD UNIQUE (" <> intercalate ", " columnNames <> ")" <> ";"
 compileStatement AddConstraint { tableName, constraint, deferrable, deferrableType } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD CONSTRAINT " <> compileIdentifier (fromMaybe (error "compileStatement: Expected constraint name") (constraint.name)) <> " " <> compileConstraint constraint <> compileDeferrable deferrable deferrableType <> ";"
 compileStatement AddColumn { tableName, column } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD COLUMN " <> (compileColumn (PrimaryKeyConstraint []) column) <> ";"
@@ -46,7 +46,7 @@ compileStatement CreateIndex { indexName, unique, tableName, columns, whereClaus
 compileStatement CreateFunction { functionName, functionArguments, functionBody, orReplace, returns, language, securityDefiner, functionSettings } = "CREATE " <> (if orReplace then "OR REPLACE " else "") <> "FUNCTION " <> functionName <> "(" <> (functionArguments & map (\(argName, argType) -> argName <> " " <> compilePostgresType argType) & intercalate  ", ") <> ")" <> " RETURNS " <> compilePostgresType returns <> (if securityDefiner then " SECURITY DEFINER" else "") <> mconcat (map compileFunctionSetting functionSettings) <> " AS $$" <> functionBody <> "$$ language " <> language <> ";"
 compileStatement EnableRowLevelSecurity { tableName } = "ALTER TABLE " <> compileIdentifier tableName <> " ENABLE ROW LEVEL SECURITY;"
 compileStatement CreatePolicy { name, action, tableName, using, check } = "CREATE POLICY " <> compileIdentifier name <> " ON " <> compileIdentifier tableName <> maybe "" (\action -> " FOR " <> compilePolicyAction action) action  <> maybe "" (\expr -> " USING (" <> compileExpression expr <> ")") using <> maybe "" (\expr -> " WITH CHECK (" <> compileExpression expr <> ")") check <> ";"
-compileStatement CreateSequence { name } = "CREATE SEQUENCE " <> compileIdentifier name <> ";"
+compileStatement CreateSequence { name, sequenceOptions } = "CREATE SEQUENCE " <> compileIdentifier name <> (if null sequenceOptions then "" else " " <> intercalate " " (map compileSequenceOption sequenceOptions)) <> ";"
 compileStatement DropConstraint { tableName, constraintName } = "ALTER TABLE " <> compileIdentifier tableName <> " DROP CONSTRAINT " <> compileIdentifier constraintName <> ";"
 compileStatement DropEnumType { name } = "DROP TYPE " <> compileIdentifier name <> ";"
 compileStatement DropIndex { indexName } = "DROP INDEX " <> compileIdentifier indexName <> ";"
@@ -521,6 +521,22 @@ compileIndexType Ivfflat = "IVFFLAT"
 
 compileFunctionSetting :: FunctionSetting -> Text
 compileFunctionSetting FunctionSetting { settingName, settingValue } = " SET " <> settingName <> " = " <> settingValue
+
+compileSequenceOption :: SequenceOption -> Text
+compileSequenceOption (SequenceAs type_) = "AS " <> compilePostgresType type_
+compileSequenceOption (SequenceStart value) = "START WITH " <> compileExpression value
+compileSequenceOption (SequenceIncrement value) = "INCREMENT BY " <> compileExpression value
+compileSequenceOption SequenceNoMinValue = "NO MINVALUE"
+compileSequenceOption SequenceNoMaxValue = "NO MAXVALUE"
+compileSequenceOption (SequenceMinValue value) = "MINVALUE " <> compileExpression value
+compileSequenceOption (SequenceMaxValue value) = "MAXVALUE " <> compileExpression value
+compileSequenceOption (SequenceCache value) = "CACHE " <> compileExpression value
+compileSequenceOption (SequenceCycle enabled) = if enabled then "CYCLE" else "NO CYCLE"
+
+compileExtensionOption :: ExtensionOption -> Text
+compileExtensionOption (ExtensionSchema schema) = "WITH SCHEMA " <> compileIdentifier schema
+compileExtensionOption (ExtensionVersion version) = "VERSION " <> compileExpression (TextExpression version)
+compileExtensionOption ExtensionCascade = "CASCADE"
 
 compileIndexColumn :: IndexColumn -> Text
 compileIndexColumn IndexColumn { column, columnOperatorClass, columnOrder } =

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -86,16 +86,16 @@ createExtensionForMigration = do
         extensionKeyword "EXISTS"
     name <- extensionIdentifier
     optional (extensionKeyword "WITH")
-    schema <- optional do
-        extensionKeyword "SCHEMA"
-        extensionIdentifier
-    version <- optional do
-        extensionKeyword "VERSION"
-        extensionVersionText
-    cascade <- isJust <$> optional (extensionKeyword "CASCADE")
+    extensionOptions <- many extensionOption
+    when (hasDuplicateExtensionOptions extensionOptions) (fail "duplicate CREATE EXTENSION option")
     extensionSymbol ";"
-    let extensionOptions = maybe [] ((:[]) . ExtensionSchema) schema <> maybe [] ((:[]) . ExtensionVersion) version <> [ExtensionCascade | cascade]
     pure CreateExtension { name, ifNotExists, extensionOptions }
+    where
+        extensionOption = choice
+            [ extensionKeyword "SCHEMA" >> (ExtensionSchema <$> extensionIdentifier)
+            , extensionKeyword "VERSION" >> (ExtensionVersion <$> extensionVersionText)
+            , extensionKeyword "CASCADE" $> ExtensionCascade
+            ]
 
 extensionSpaceConsumer :: Parser ()
 extensionSpaceConsumer = Lexer.space
@@ -246,12 +246,21 @@ createExtension = do
     ifNotExists <- isJust <$> optional (lexeme "IF" >> lexeme "NOT" >> lexeme "EXISTS")
     name <- qualifiedIdentifier
     optional (lexeme "WITH")
-    schema <- optional (lexeme "SCHEMA" >> extensionIdentifier)
-    version <- optional (lexeme "VERSION" >> (lexeme textExpr' <|> identifier))
-    cascade <- isJust <$> optional (lexeme "CASCADE")
+    extensionOptions <- many extensionOption
+    when (hasDuplicateExtensionOptions extensionOptions) (fail "duplicate CREATE EXTENSION option")
     char ';'
-    let extensionOptions = maybe [] ((:[]) . ExtensionSchema) schema <> maybe [] ((:[]) . ExtensionVersion) version <> [ExtensionCascade | cascade]
     pure CreateExtension { name, ifNotExists, extensionOptions }
+    where
+        extensionOption = choice
+            [ lexeme "SCHEMA" >> (ExtensionSchema <$> extensionIdentifier)
+            , lexeme "VERSION" >> (ExtensionVersion <$> extensionVersionText)
+            , lexeme "CASCADE" $> ExtensionCascade
+            ]
+
+hasDuplicateExtensionOptions :: [ExtensionOption] -> Bool
+hasDuplicateExtensionOptions options = length optionKinds /= length (List.nub optionKinds)
+    where
+        optionKinds = map (\case ExtensionSchema {} -> (0 :: Int); ExtensionVersion {} -> 1; ExtensionCascade -> 2) options
 
 createTable = do
     lexeme "CREATE"

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -247,7 +247,7 @@ createExtension = do
     name <- qualifiedIdentifier
     optional (lexeme "WITH")
     schema <- optional (lexeme "SCHEMA" >> identifier)
-    version <- optional (lexeme "VERSION" >> (textExpr' <|> identifier))
+    version <- optional (lexeme "VERSION" >> (lexeme textExpr' <|> identifier))
     cascade <- isJust <$> optional (lexeme "CASCADE")
     char ';'
     let extensionOptions = maybe [] ((:[]) . ExtensionSchema) schema <> maybe [] ((:[]) . ExtensionVersion) version <> [ExtensionCascade | cascade]

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -246,7 +246,7 @@ createExtension = do
     ifNotExists <- isJust <$> optional (lexeme "IF" >> lexeme "NOT" >> lexeme "EXISTS")
     name <- qualifiedIdentifier
     optional (lexeme "WITH")
-    schema <- optional (lexeme "SCHEMA" >> identifier)
+    schema <- optional (lexeme "SCHEMA" >> extensionIdentifier)
     version <- optional (lexeme "VERSION" >> (lexeme textExpr' <|> identifier))
     cascade <- isJust <$> optional (lexeme "CASCADE")
     char ';'

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -86,15 +86,16 @@ createExtensionForMigration = do
         extensionKeyword "EXISTS"
     name <- extensionIdentifier
     optional (extensionKeyword "WITH")
-    optional do
+    schema <- optional do
         extensionKeyword "SCHEMA"
         extensionIdentifier
-    optional do
+    version <- optional do
         extensionKeyword "VERSION"
-        extensionVersion
-    optional (extensionKeyword "CASCADE")
+        extensionVersionText
+    cascade <- isJust <$> optional (extensionKeyword "CASCADE")
     extensionSymbol ";"
-    pure CreateExtension { name, ifNotExists }
+    let extensionOptions = maybe [] ((:[]) . ExtensionSchema) schema <> maybe [] ((:[]) . ExtensionVersion) version <> [ExtensionCascade | cascade]
+    pure CreateExtension { name, ifNotExists, extensionOptions }
 
 extensionSpaceConsumer :: Parser ()
 extensionSpaceConsumer = Lexer.space
@@ -121,12 +122,12 @@ extensionIdentifier = extensionLexeme (quotedIdentifier <|> unquotedIdentifier)
             remainingCharacters <- many (satisfy isIdentifierCharacter)
             pure (Text.toLower (Text.pack (firstCharacter : remainingCharacters)))
 
-extensionVersion :: Parser ()
-extensionVersion = extensionLexeme (quotedVersion <|> unquotedVersion) $> ()
+extensionVersionText :: Parser Text
+extensionVersionText = extensionLexeme (quotedVersion <|> unquotedVersion)
     where
-        quotedVersion = between (char '\'') (char '\'') (many quotedVersionCharacter)
+        quotedVersion = Text.pack <$> between (char '\'') (char '\'') (many quotedVersionCharacter)
         quotedVersionCharacter = try (string "''" $> '\'') <|> satisfy (/= '\'')
-        unquotedVersion = some (satisfy isIdentifierCharacter)
+        unquotedVersion = Text.pack <$> some (satisfy isIdentifierCharacter)
 
 isIdentifierCharacter :: Char -> Bool
 isIdentifierCharacter character = isAlphaNum character || character == '_' || character == '$'
@@ -244,13 +245,13 @@ createExtension = do
     lexeme "EXTENSION"
     ifNotExists <- isJust <$> optional (lexeme "IF" >> lexeme "NOT" >> lexeme "EXISTS")
     name <- qualifiedIdentifier
-    optional do
-        space
-        lexeme "WITH"
-        lexeme "SCHEMA"
-        lexeme "public"
+    optional (lexeme "WITH")
+    schema <- optional (lexeme "SCHEMA" >> identifier)
+    version <- optional (lexeme "VERSION" >> (textExpr' <|> identifier))
+    cascade <- isJust <$> optional (lexeme "CASCADE")
     char ';'
-    pure CreateExtension { name, ifNotExists }
+    let extensionOptions = maybe [] ((:[]) . ExtensionSchema) schema <> maybe [] ((:[]) . ExtensionVersion) version <> [ExtensionCascade | cascade]
+    pure CreateExtension { name, ifNotExists, extensionOptions }
 
 createTable = do
     lexeme "CREATE"
@@ -1264,37 +1265,21 @@ createSequence = do
     lexeme "CREATE"
     lexeme "SEQUENCE"
     name <- qualifiedIdentifier
-
-    -- We accept all the following SEQUENCE attributes, but don't save them
-    -- This is mostly to void issues in migrations when parsing the pg_dump output
-    optional do
-        lexeme "AS"
-        sqlType
-
-    optional do
-        lexeme "START"
-        lexeme "WITH"
-        expression
-
-    optional do
-        lexeme "INCREMENT"
-        lexeme "BY"
-        expression
-
-    optional do
-        lexeme "NO"
-        lexeme "MINVALUE"
-
-    optional do
-        lexeme "NO"
-        lexeme "MAXVALUE"
-
-    optional do
-        lexeme "CACHE"
-        expression
-
+    sequenceOptions <- many sequenceOption
     char ';'
-    pure CreateSequence { name }
+    pure CreateSequence { name, sequenceOptions }
+    where
+        sequenceOption = choice
+            [ lexeme "AS" >> (SequenceAs <$> sqlType)
+            , lexeme "START" >> optional (lexeme "WITH") >> (SequenceStart <$> sequenceValue)
+            , lexeme "INCREMENT" >> optional (lexeme "BY") >> (SequenceIncrement <$> sequenceValue)
+            , lexeme "NO" >> ((lexeme "MINVALUE" $> SequenceNoMinValue) <|> (lexeme "MAXVALUE" $> SequenceNoMaxValue) <|> (lexeme "CYCLE" $> SequenceCycle False))
+            , lexeme "MINVALUE" >> (SequenceMinValue <$> sequenceValue)
+            , lexeme "MAXVALUE" >> (SequenceMaxValue <$> sequenceValue)
+            , lexeme "CACHE" >> (SequenceCache <$> sequenceValue)
+            , lexeme "CYCLE" $> SequenceCycle True
+            ]
+        sequenceValue = try doubleExpr <|> intExpr
 
 addValue typeName = do
     lexeme "ADD"

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -1279,7 +1279,7 @@ createSequence = do
             , lexeme "CACHE" >> (SequenceCache <$> sequenceValue)
             , lexeme "CYCLE" $> SequenceCycle True
             ]
-        sequenceValue = try doubleExpr <|> intExpr
+        sequenceValue = lexeme (try doubleExpr <|> intExpr)
 
 addValue typeName = do
     lexeme "ADD"

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -90,6 +90,7 @@ data FunctionSetting = FunctionSetting
     }
     deriving (Eq, Show)
 
+-- | PostgreSQL sequence parameters preserved for schema comparison and ALTER SEQUENCE generation.
 data SequenceOption
     = SequenceAs PostgresType
     | SequenceStart Expression
@@ -102,6 +103,7 @@ data SequenceOption
     | SequenceCycle Bool
     deriving (Eq, Show)
 
+-- | CREATE EXTENSION installation options. Schema diffs intentionally ignore these; use an explicit migration to relocate or update an installed extension.
 data ExtensionOption
     = ExtensionSchema Text
     | ExtensionVersion Text

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -47,6 +47,7 @@ data Statement
     | SelectStatement { query :: Text }
     -- CREATE SEQUENCE name;
     | CreateSequence { name :: Text, sequenceOptions :: [SequenceOption] }
+    -- | ALTER SEQUENCE name sequenceOptions; each item is one clause to emit, not a complete sequence definition.
     | AlterSequence { name :: Text, sequenceOptions :: [SequenceOption] }
     -- ALTER TABLE tableName RENAME COLUMN from TO to;
     | RenameColumn { tableName :: Text, from :: Text, to :: Text }

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -17,7 +17,7 @@ data Statement
     -- | DROP TYPE name;
     | DropEnumType { name :: Text }
     -- | CREATE EXTENSION IF NOT EXISTS "name";
-    | CreateExtension { name :: Text, ifNotExists :: Bool }
+    | CreateExtension { name :: Text, ifNotExists :: Bool, extensionOptions :: [ExtensionOption] }
     -- | ALTER TABLE tableName ADD CONSTRAINT constraint;
     | AddConstraint { tableName :: Text, constraint :: Constraint, deferrable :: Maybe Bool, deferrableType :: Maybe DeferrableType }
     -- | ALTER TABLE tableName DROP CONSTRAINT constraintName;
@@ -46,7 +46,7 @@ data Statement
     -- SELECT query;
     | SelectStatement { query :: Text }
     -- CREATE SEQUENCE name;
-    | CreateSequence { name :: Text }
+    | CreateSequence { name :: Text, sequenceOptions :: [SequenceOption] }
     -- ALTER TABLE tableName RENAME COLUMN from TO to;
     | RenameColumn { tableName :: Text, from :: Text, to :: Text }
     -- ALTER TYPE enumName ADD VALUE newValue;
@@ -87,6 +87,24 @@ data FunctionSetting = FunctionSetting
     { settingName :: Text
     , settingValue :: Text
     }
+    deriving (Eq, Show)
+
+data SequenceOption
+    = SequenceAs PostgresType
+    | SequenceStart Expression
+    | SequenceIncrement Expression
+    | SequenceNoMinValue
+    | SequenceNoMaxValue
+    | SequenceMinValue Expression
+    | SequenceMaxValue Expression
+    | SequenceCache Expression
+    | SequenceCycle Bool
+    deriving (Eq, Show)
+
+data ExtensionOption
+    = ExtensionSchema Text
+    | ExtensionVersion Text
+    | ExtensionCascade
     deriving (Eq, Show)
 
 data CreateTable

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -47,6 +47,7 @@ data Statement
     | SelectStatement { query :: Text }
     -- CREATE SEQUENCE name;
     | CreateSequence { name :: Text, sequenceOptions :: [SequenceOption] }
+    | AlterSequence { name :: Text, sequenceOptions :: [SequenceOption] }
     -- ALTER TABLE tableName RENAME COLUMN from TO to;
     | RenameColumn { tableName :: Text, from :: Text, to :: Text }
     -- ALTER TYPE enumName ADD VALUE newValue;

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -23,6 +23,12 @@ spec = do
         it "should compile a CREATE EXTENSION for the UUID extension" do
             compileSql [CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [] }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";\n"
 
+        it "should quote punctuation in extension schema names" do
+            compileSql [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionSchema "geo.data"] }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA \"geo.data\";\n"
+
+        it "should escape quotes in extension schema names" do
+            compileSql [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionSchema "geo\"data"] }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA \"geo\"\"data\";\n"
+
         it "should compile a line comment" do
             compileSql [Comment { content = " Comment value" }] `shouldBe` "-- Comment value\n"
 

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -29,6 +29,9 @@ spec = do
         it "should escape quotes in extension schema names" do
             compileSql [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionSchema "geo\"data"] }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA \"geo\"\"data\";\n"
 
+        it "should emit WITH before arbitrarily ordered extension options" do
+            compileSql [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionCascade, ExtensionSchema "geo"] }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS postgis WITH CASCADE SCHEMA geo;\n"
+
         it "should compile a line comment" do
             compileSql [Comment { content = " Comment value" }] `shouldBe` "-- Comment value\n"
 

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -334,6 +334,11 @@ spec = do
             let statements = [ CreateSequence { name = "a", sequenceOptions = [] } ]
             compileSql statements `shouldBe` sql
 
+        it "should escape quotes in extension versions" do
+            let sql = "CREATE EXTENSION extension_name VERSION '1''beta';\n"
+            let statements = [ CreateExtension { name = "extension_name", ifNotExists = False, extensionOptions = [ExtensionVersion "1'beta"] } ]
+            compileSql statements `shouldBe` sql
+
         it "should compile 'ALTER SEQUENCE ..' statements" do
             let sql = "ALTER SEQUENCE a INCREMENT BY 3 CACHE 10;\n"
             let statements = [ AlterSequence { name = "a", sequenceOptions = [SequenceIncrement (IntExpression 3), SequenceCache (IntExpression 10)] } ]

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -21,7 +21,7 @@ spec = do
             compileSql [StatementCreateTable (table "users")] `shouldBe` "CREATE TABLE users (\n\n);\n"
 
         it "should compile a CREATE EXTENSION for the UUID extension" do
-            compileSql [CreateExtension { name = "uuid-ossp", ifNotExists = True }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";\n"
+            compileSql [CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [] }] `shouldBe` "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";\n"
 
         it "should compile a line comment" do
             compileSql [Comment { content = " Comment value" }] `shouldBe` "-- Comment value\n"
@@ -325,7 +325,7 @@ spec = do
 
         it "should compile 'CREATE SEQUENCE ..' statements" do
             let sql = "CREATE SEQUENCE a;\n"
-            let statements = [ CreateSequence { name = "a" } ]
+            let statements = [ CreateSequence { name = "a", sequenceOptions = [] } ]
             compileSql statements `shouldBe` sql
 
         it "should compile 'DROP TYPE ..;' statements" do

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -328,6 +328,11 @@ spec = do
             let statements = [ CreateSequence { name = "a", sequenceOptions = [] } ]
             compileSql statements `shouldBe` sql
 
+        it "should compile 'ALTER SEQUENCE ..' statements" do
+            let sql = "ALTER SEQUENCE a INCREMENT BY 3 CACHE 10;\n"
+            let statements = [ AlterSequence { name = "a", sequenceOptions = [SequenceIncrement (IntExpression 3), SequenceCache (IntExpression 10)] } ]
+            compileSql statements `shouldBe` sql
+
         it "should compile 'DROP TYPE ..;' statements" do
             let sql = "DROP TYPE colors;\n"
             let statements = [ DropEnumType { name = "colors" } ]

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -31,6 +31,9 @@ spec = do
         it "should parse an CREATE EXTENSION with schema suffix" do
             parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [ExtensionSchema "public"] }
 
+        it "should fold an unquoted extension schema to lowercase" do
+            parseSql "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA Geo;" `shouldBe` CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionSchema "geo"] }
+
         it "should parse CREATE EXTENSION version and cascade options" do
             parseSql "CREATE EXTENSION pg_trgm VERSION '1.6' CASCADE;" `shouldBe`
                 CreateExtension { name = "pg_trgm", ifNotExists = False, extensionOptions = [ExtensionVersion "1.6", ExtensionCascade] }

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -31,6 +31,10 @@ spec = do
         it "should parse an CREATE EXTENSION with schema suffix" do
             parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [ExtensionSchema "public"] }
 
+        it "should parse CREATE EXTENSION version and cascade options" do
+            parseSql "CREATE EXTENSION pg_trgm VERSION '1.6' CASCADE;" `shouldBe`
+                CreateExtension { name = "pg_trgm", ifNotExists = False, extensionOptions = [ExtensionVersion "1.6", ExtensionCascade] }
+
         describe "parseCreateExtensionMigration" do
             it "accepts one or more extension statements and comments" do
                 parseCreateExtensionMigration "-- Required for earthdistance\nCREATE EXTENSION IF NOT EXISTS cube;\nCREATE EXTENSION IF NOT EXISTS \"earthdistance\" WITH SCHEMA public;"

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -42,6 +42,10 @@ spec = do
             parseSql "CREATE EXTENSION pg_trgm VERSION '1.6' CASCADE;" `shouldBe`
                 CreateExtension { name = "pg_trgm", ifNotExists = False, extensionOptions = [ExtensionVersion "1.6", ExtensionCascade] }
 
+        it "should decode doubled quotes in extension versions" do
+            parseSql "CREATE EXTENSION extension_name VERSION '1''beta';" `shouldBe`
+                CreateExtension { name = "extension_name", ifNotExists = False, extensionOptions = [ExtensionVersion "1'beta"] }
+
         describe "parseCreateExtensionMigration" do
             it "accepts one or more extension statements and comments" do
                 parseCreateExtensionMigration "-- Required for earthdistance\nCREATE EXTENSION IF NOT EXISTS cube;\nCREATE EXTENSION IF NOT EXISTS \"earthdistance\" WITH SCHEMA public;"
@@ -60,6 +64,9 @@ spec = do
 
                 parseCreateExtensionMigration "CREATE EXTENSION IF NOT EXISTS postgis WITH VERSION stable CASCADE;"
                     `shouldBe` Right [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionVersion "stable", ExtensionCascade] }]
+
+                parseCreateExtensionMigration "CREATE EXTENSION IF NOT EXISTS postgis CASCADE VERSION '3.4.2' SCHEMA geo;"
+                    `shouldBe` Right [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionCascade, ExtensionVersion "3.4.2", ExtensionSchema "geo"] }]
 
             it "preserves quoted extension names" do
                 parseCreateExtensionMigration "CREATE EXTENSION IF NOT EXISTS \"MixedCase\";"

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -31,6 +31,10 @@ spec = do
         it "should parse an CREATE EXTENSION with schema suffix" do
             parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [ExtensionSchema "public"] }
 
+        it "should round-trip quoted extension schema names" do
+            let statement = parseSql "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA \"geo.data\";"
+            parseSql (compileSql [statement]) `shouldBe` statement
+
         it "should fold an unquoted extension schema to lowercase" do
             parseSql "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA Geo;" `shouldBe` CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionSchema "geo"] }
 

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -7,6 +7,7 @@ module Postgres.ParserSpec where
 import Prelude
 import Test.Hspec
 import IHP.Postgres.Parser
+import IHP.Postgres.Compiler (compileSql)
 import IHP.Postgres.Types
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -22,36 +23,36 @@ spec = do
             parseSql "CREATE TABLE users ();"  `shouldBe` StatementCreateTable (table "users")
 
         it "should parse an CREATE EXTENSION for the UUID extension" do
-            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True }
+            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [] }
 
         it "should preserve a missing IF NOT EXISTS clause" do
-            parseSql "CREATE EXTENSION \"uuid-ossp\";" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = False }
+            parseSql "CREATE EXTENSION \"uuid-ossp\";" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = False, extensionOptions = [] }
 
         it "should parse an CREATE EXTENSION with schema suffix" do
-            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True }
+            parseSql "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;" `shouldBe` CreateExtension { name = "uuid-ossp", ifNotExists = True, extensionOptions = [ExtensionSchema "public"] }
 
         describe "parseCreateExtensionMigration" do
             it "accepts one or more extension statements and comments" do
                 parseCreateExtensionMigration "-- Required for earthdistance\nCREATE EXTENSION IF NOT EXISTS cube;\nCREATE EXTENSION IF NOT EXISTS \"earthdistance\" WITH SCHEMA public;"
                     `shouldBe` Right
-                        [ CreateExtension { name = "cube", ifNotExists = True }
-                        , CreateExtension { name = "earthdistance", ifNotExists = True }
+                        [ CreateExtension { name = "cube", ifNotExists = True, extensionOptions = [] }
+                        , CreateExtension { name = "earthdistance", ifNotExists = True, extensionOptions = [ExtensionSchema "public"] }
                         ]
 
             it "is case insensitive" do
                 parseCreateExtensionMigration "create extension if not exists PG_TRGM;"
-                    `shouldBe` Right [CreateExtension { name = "pg_trgm", ifNotExists = True }]
+                    `shouldBe` Right [CreateExtension { name = "pg_trgm", ifNotExists = True, extensionOptions = [] }]
 
             it "accepts PostgreSQL extension options" do
                 parseCreateExtensionMigration "CREATE EXTENSION IF NOT EXISTS PostGIS WITH SCHEMA public VERSION '3.4.2' CASCADE;"
-                    `shouldBe` Right [CreateExtension { name = "postgis", ifNotExists = True }]
+                    `shouldBe` Right [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionSchema "public", ExtensionVersion "3.4.2", ExtensionCascade] }]
 
                 parseCreateExtensionMigration "CREATE EXTENSION IF NOT EXISTS postgis WITH VERSION stable CASCADE;"
-                    `shouldBe` Right [CreateExtension { name = "postgis", ifNotExists = True }]
+                    `shouldBe` Right [CreateExtension { name = "postgis", ifNotExists = True, extensionOptions = [ExtensionVersion "stable", ExtensionCascade] }]
 
             it "preserves quoted extension names" do
                 parseCreateExtensionMigration "CREATE EXTENSION IF NOT EXISTS \"MixedCase\";"
-                    `shouldBe` Right [CreateExtension { name = "MixedCase", ifNotExists = True }]
+                    `shouldBe` Right [CreateExtension { name = "MixedCase", ifNotExists = True, extensionOptions = [] }]
 
             it "rejects a mixed migration" do
                 parseCreateExtensionMigration "CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE TABLE users ();"
@@ -442,7 +443,11 @@ spec = do
             parseSql "DROP TYPE colors;" `shouldBe` DropEnumType { name = "colors" }
 
         it "should parse 'CREATE SEQUENCE ..' statements" do
-            parseSql "CREATE SEQUENCE a;" `shouldBe` CreateSequence { name = "a" }
+            parseSql "CREATE SEQUENCE a;" `shouldBe` CreateSequence { name = "a", sequenceOptions = [] }
+
+        it "should preserve pg_dump sequence options" do
+            let sql = "CREATE SEQUENCE a AS bigint START WITH 1 INCREMENT BY 2 NO MINVALUE MAXVALUE 99 CACHE 4 NO CYCLE;"
+            parseSql (compileSql [parseSql sql]) `shouldBe` parseSql sql
 
         it "should parse 'BEGIN' statements" do
             parseSql "BEGIN;" `shouldBe` Begin


### PR DESCRIPTION
## Bug

IHP parses only the names of extensions and sequences, so a dump round trip drops options:

```sql
CREATE EXTENSION postgis WITH SCHEMA public VERSION '3.4.2' CASCADE;
CREATE SEQUENCE invoice_ids AS bigint START WITH 1000 INCREMENT BY 10;
```

## Fix

Represent, parse and compile extension options and sequence options. Migration normalization ignores PostgreSQL's default sequence options so a dump does not create spurious migrations.

## Independence

This branch is based directly on the current `upstream/master` and has no dependency on another parser PR.

## Validation

- `nix build --impure --no-link .#checks.aarch64-darwin.ghc914-ihp-postgres-parser .#checks.aarch64-darwin.ghc914-ihp-ide .#checks.aarch64-darwin.ghc914-ihp-migrate`

Not PostgreSQL 18-specific.
