### PR TITLE
Keep opaque SQL out of automatic schema diffs

### DIFF
--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -266,6 +266,12 @@ diffSchemas targetSchema' actualSchema' = (drop <> create)
 
 removeNoise = filter \case
         Comment {} -> False
+        -- IHP cannot compare unmodelled SQL safely. Never copy it from either
+        -- side into an automatically generated migration.
+        UnknownStatement {} -> False
+        -- pg_dump session setup is not part of the application schema.
+        Set {} -> False
+        SelectStatement {} -> False
         StatementCreateTable { unsafeGetCreateTable = CreateTable { name = "schema_migrations" } }      -> False
         AddConstraint { tableName = "schema_migrations" }                                               -> False
         CreateFunction { functionName } | "notify_" `Text.isPrefixOf` functionName                      -> False

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -1514,6 +1514,20 @@ CREATE POLICY "Users can read and edit their own record" ON public.users USING (
                 |]
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "should ignore unmodelled statements instead of generating raw SQL migrations" do
+                let targetSchema = [UnknownStatement { raw = "CREATE TABLE private.tokens (id UUID)" }]
+                let actualSchema = [UnknownStatement { raw = "CREATE TABLE private.tokens (id uuid NOT NULL)" }]
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "should ignore pg_dump session statements" do
+                let actualSchema =
+                        [ Set { name = "statement_timeout", value = IntExpression 0 }
+                        , SelectStatement { query = "pg_catalog.set_config('search_path', '', false)" }
+                        ]
+
+                diffSchemas [] actualSchema `shouldBe` []
+
 sql :: Text -> [Statement]
 sql code = case Megaparsec.runParser Parser.parseDDL "" code of
     Left parsingFailed -> error (cs $ Megaparsec.errorBundlePretty parsingFailed)


### PR DESCRIPTION
## Bug

Statements that IHP intentionally keeps opaque, such as privileges or anonymous blocks, should stay in `Schema.sql`, but they must not be treated as structured objects to add or remove automatically during schema diffing.

Otherwise a schema diff can propose noisy or unsafe migrations for SQL the migration generator does not understand.

## Fix

Classify opaque statements as migration noise in both schema inputs and cover the behavior with migration-generator tests.

## Independence

This branch is based directly on the current `upstream/master` and has no dependency on another parser PR. It does not broaden the parser or hide syntax errors.

## Validation

- `nix build --impure --no-link .#checks.aarch64-darwin.ghc914-ihp-ide`

Not PostgreSQL 18-specific.
