### PR TITLE
Preserve non-public schema-qualified identifiers

### DIFF
--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -227,7 +227,10 @@ compilePostgresType PEventTrigger = "EVENT_TRIGGER"
 compilePostgresType (PCustomType theType) = theType
 
 compileIdentifier :: Text -> Text
-compileIdentifier identifier = if identifierNeedsQuoting then tshow identifier else identifier
+compileIdentifier identifier
+    | Text.any (== '.') identifier = Text.intercalate "." (map compileIdentifier (Text.splitOn "." identifier))
+    | identifierNeedsQuoting = tshow identifier
+    | otherwise = identifier
     where
         identifierNeedsQuoting = isKeyword || containsChar ' ' || containsChar '-' || isUsingUppercase
         isKeyword = Text.toUpper identifier `elem` keywords

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -32,39 +32,39 @@ compileSql statements = statements
     & unlines
 
 compileStatement :: Statement -> Text
-compileStatement (StatementCreateTable CreateTable { name, columns, primaryKeyConstraint, constraints, unlogged, inherits }) = "CREATE" <> (if unlogged then " UNLOGGED" else "") <> " TABLE " <> compileIdentifier name <> " (\n" <> intercalate ",\n" (map (\col -> "    " <> compileColumn primaryKeyConstraint col) columns <> maybe [] ((:[]) . indent) (compilePrimaryKeyConstraint primaryKeyConstraint) <> map (indent . compileConstraint) constraints) <> "\n)" <> maybe "" (\parent -> " INHERITS (" <> compileIdentifier parent <> ")") inherits <> ";"
-compileStatement CreateEnumType { name, values } = "CREATE TYPE " <> compileIdentifier name <> " AS ENUM (" <> intercalate ", " (values & map TextExpression & map compileExpression) <> ");"
+compileStatement (StatementCreateTable CreateTable { name, columns, primaryKeyConstraint, constraints, unlogged, inherits }) = "CREATE" <> (if unlogged then " UNLOGGED" else "") <> " TABLE " <> compileQualifiedIdentifier name <> " (\n" <> intercalate ",\n" (map (\col -> "    " <> compileColumn primaryKeyConstraint col) columns <> maybe [] ((:[]) . indent) (compilePrimaryKeyConstraint primaryKeyConstraint) <> map (indent . compileConstraint) constraints) <> "\n)" <> maybe "" (\parent -> " INHERITS (" <> compileQualifiedIdentifier parent <> ")") inherits <> ";"
+compileStatement CreateEnumType { name, values } = "CREATE TYPE " <> compileQualifiedIdentifier name <> " AS ENUM (" <> intercalate ", " (values & map TextExpression & map compileExpression) <> ");"
 compileStatement CreateExtension { name, ifNotExists } = "CREATE EXTENSION " <> (if ifNotExists then "IF NOT EXISTS " else "") <> compileIdentifier name <> ";"
-compileStatement AddConstraint { tableName, constraint = UniqueConstraint { name = Nothing, columnNames } } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD UNIQUE (" <> intercalate ", " columnNames <> ")" <> ";"
-compileStatement AddConstraint { tableName, constraint, deferrable, deferrableType } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD CONSTRAINT " <> compileIdentifier (fromMaybe (error "compileStatement: Expected constraint name") (constraint.name)) <> " " <> compileConstraint constraint <> compileDeferrable deferrable deferrableType <> ";"
-compileStatement AddColumn { tableName, column } = "ALTER TABLE " <> compileIdentifier tableName <> " ADD COLUMN " <> (compileColumn (PrimaryKeyConstraint []) column) <> ";"
-compileStatement DropColumn { tableName, columnName } = "ALTER TABLE " <> compileIdentifier tableName <> " DROP COLUMN " <> compileIdentifier columnName <> ";"
-compileStatement RenameColumn { tableName, from, to } = "ALTER TABLE " <> compileIdentifier tableName <> " RENAME COLUMN " <> compileIdentifier from <> " TO " <> compileIdentifier to <> ";"
-compileStatement DropTable { tableName } = "DROP TABLE " <> compileIdentifier tableName <> ";"
+compileStatement AddConstraint { tableName, constraint = UniqueConstraint { name = Nothing, columnNames } } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ADD UNIQUE (" <> intercalate ", " columnNames <> ")" <> ";"
+compileStatement AddConstraint { tableName, constraint, deferrable, deferrableType } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ADD CONSTRAINT " <> compileIdentifier (fromMaybe (error "compileStatement: Expected constraint name") (constraint.name)) <> " " <> compileConstraint constraint <> compileDeferrable deferrable deferrableType <> ";"
+compileStatement AddColumn { tableName, column } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ADD COLUMN " <> (compileColumn (PrimaryKeyConstraint []) column) <> ";"
+compileStatement DropColumn { tableName, columnName } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " DROP COLUMN " <> compileIdentifier columnName <> ";"
+compileStatement RenameColumn { tableName, from, to } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " RENAME COLUMN " <> compileIdentifier from <> " TO " <> compileIdentifier to <> ";"
+compileStatement DropTable { tableName } = "DROP TABLE " <> compileQualifiedIdentifier tableName <> ";"
 compileStatement Comment { content } = "--" <> content
-compileStatement CreateIndex { indexName, unique, tableName, columns, whereClause, indexType, nullsDistinct } = "CREATE" <> (if unique then " UNIQUE " else " ") <> "INDEX " <> compileIdentifier indexName <> " ON " <> compileIdentifier tableName <> (maybe "" (\indexType -> " USING " <> compileIndexType indexType) indexType) <> " (" <> (intercalate ", " (map compileIndexColumn columns)) <> ")" <> (if nullsDistinct then "" else " NULLS NOT DISTINCT") <> (case whereClause of Just expression -> " WHERE " <> compileExpression expression; Nothing -> "") <> ";"
+compileStatement CreateIndex { indexName, unique, tableName, columns, whereClause, indexType, nullsDistinct } = "CREATE" <> (if unique then " UNIQUE " else " ") <> "INDEX " <> compileQualifiedIdentifier indexName <> " ON " <> compileQualifiedIdentifier tableName <> (maybe "" (\indexType -> " USING " <> compileIndexType indexType) indexType) <> " (" <> (intercalate ", " (map compileIndexColumn columns)) <> ")" <> (if nullsDistinct then "" else " NULLS NOT DISTINCT") <> (case whereClause of Just expression -> " WHERE " <> compileExpression expression; Nothing -> "") <> ";"
 compileStatement CreateFunction { functionName, functionArguments, functionBody, orReplace, returns, language, securityDefiner, functionSettings } = "CREATE " <> (if orReplace then "OR REPLACE " else "") <> "FUNCTION " <> functionName <> "(" <> (functionArguments & map (\(argName, argType) -> argName <> " " <> compilePostgresType argType) & intercalate  ", ") <> ")" <> " RETURNS " <> compilePostgresType returns <> (if securityDefiner then " SECURITY DEFINER" else "") <> mconcat (map compileFunctionSetting functionSettings) <> " AS $$" <> functionBody <> "$$ language " <> language <> ";"
-compileStatement EnableRowLevelSecurity { tableName } = "ALTER TABLE " <> compileIdentifier tableName <> " ENABLE ROW LEVEL SECURITY;"
-compileStatement CreatePolicy { name, action, tableName, using, check } = "CREATE POLICY " <> compileIdentifier name <> " ON " <> compileIdentifier tableName <> maybe "" (\action -> " FOR " <> compilePolicyAction action) action  <> maybe "" (\expr -> " USING (" <> compileExpression expr <> ")") using <> maybe "" (\expr -> " WITH CHECK (" <> compileExpression expr <> ")") check <> ";"
-compileStatement CreateSequence { name } = "CREATE SEQUENCE " <> compileIdentifier name <> ";"
-compileStatement DropConstraint { tableName, constraintName } = "ALTER TABLE " <> compileIdentifier tableName <> " DROP CONSTRAINT " <> compileIdentifier constraintName <> ";"
-compileStatement DropEnumType { name } = "DROP TYPE " <> compileIdentifier name <> ";"
-compileStatement DropIndex { indexName } = "DROP INDEX " <> compileIdentifier indexName <> ";"
-compileStatement DropNotNull { tableName, columnName } = "ALTER TABLE " <> compileIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " DROP NOT NULL;"
-compileStatement SetNotNull { tableName, columnName } = "ALTER TABLE " <> compileIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " SET NOT NULL;"
-compileStatement RenameTable { from, to } = "ALTER TABLE " <> compileIdentifier from <> " RENAME TO " <> compileIdentifier to <> ";"
-compileStatement DropPolicy { tableName, policyName } =  "DROP POLICY " <> compileIdentifier policyName <> " ON " <> compileIdentifier tableName <> ";"
-compileStatement SetDefaultValue { tableName, columnName, value } = "ALTER TABLE " <> compileIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " SET DEFAULT " <> compileExpression value <> ";"
-compileStatement DropDefaultValue { tableName, columnName } = "ALTER TABLE " <> compileIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " DROP DEFAULT;"
-compileStatement AddValueToEnumType { enumName, newValue } = "ALTER TYPE " <> compileIdentifier enumName <> " ADD VALUE " <> compileExpression (TextExpression newValue) <> ";"
-compileStatement CreateTrigger { name, eventWhen, event, tableName, for, whenCondition, functionName, arguments } = "CREATE TRIGGER " <> compileIdentifier name <> " " <> compileTriggerEventWhen eventWhen <> " " <> intercalate " OR " (map compileTriggerEvent event) <> " ON " <> compileIdentifier tableName <> " " <> compileTriggerFor for <> " EXECUTE FUNCTION " <> compileExpression (CallExpression functionName arguments) <> ";"
+compileStatement EnableRowLevelSecurity { tableName } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ENABLE ROW LEVEL SECURITY;"
+compileStatement CreatePolicy { name, action, tableName, using, check } = "CREATE POLICY " <> compileIdentifier name <> " ON " <> compileQualifiedIdentifier tableName <> maybe "" (\action -> " FOR " <> compilePolicyAction action) action  <> maybe "" (\expr -> " USING (" <> compileExpression expr <> ")") using <> maybe "" (\expr -> " WITH CHECK (" <> compileExpression expr <> ")") check <> ";"
+compileStatement CreateSequence { name } = "CREATE SEQUENCE " <> compileQualifiedIdentifier name <> ";"
+compileStatement DropConstraint { tableName, constraintName } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " DROP CONSTRAINT " <> compileIdentifier constraintName <> ";"
+compileStatement DropEnumType { name } = "DROP TYPE " <> compileQualifiedIdentifier name <> ";"
+compileStatement DropIndex { indexName } = "DROP INDEX " <> compileQualifiedIdentifier indexName <> ";"
+compileStatement DropNotNull { tableName, columnName } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " DROP NOT NULL;"
+compileStatement SetNotNull { tableName, columnName } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " SET NOT NULL;"
+compileStatement RenameTable { from, to } = "ALTER TABLE " <> compileQualifiedIdentifier from <> " RENAME TO " <> compileIdentifier to <> ";"
+compileStatement DropPolicy { tableName, policyName } =  "DROP POLICY " <> compileIdentifier policyName <> " ON " <> compileQualifiedIdentifier tableName <> ";"
+compileStatement SetDefaultValue { tableName, columnName, value } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " SET DEFAULT " <> compileExpression value <> ";"
+compileStatement DropDefaultValue { tableName, columnName } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ALTER COLUMN " <> compileIdentifier columnName <> " DROP DEFAULT;"
+compileStatement AddValueToEnumType { enumName, newValue } = "ALTER TYPE " <> compileQualifiedIdentifier enumName <> " ADD VALUE " <> compileExpression (TextExpression newValue) <> ";"
+compileStatement CreateTrigger { name, eventWhen, event, tableName, for, whenCondition, functionName, arguments } = "CREATE TRIGGER " <> compileIdentifier name <> " " <> compileTriggerEventWhen eventWhen <> " " <> intercalate " OR " (map compileTriggerEvent event) <> " ON " <> compileQualifiedIdentifier tableName <> " " <> compileTriggerFor for <> " EXECUTE FUNCTION " <> compileExpression (CallExpression functionName arguments) <> ";"
 compileStatement Begin = "BEGIN;"
 compileStatement Commit = "COMMIT;"
-compileStatement DropFunction { functionName } = "DROP FUNCTION " <> compileIdentifier functionName <> ";"
+compileStatement DropFunction { functionName } = "DROP FUNCTION " <> compileQualifiedIdentifier functionName <> ";"
 compileStatement UnknownStatement { raw } = raw <> ";"
 compileStatement Set { name, value } = "SET " <> compileIdentifier name <> " = " <> compileExpression value <> ";"
 compileStatement SelectStatement { query } = "SELECT " <> query <> ";"
-compileStatement DropTrigger { name, tableName } = "DROP TRIGGER " <> compileIdentifier name <> " ON " <> compileIdentifier tableName <> ";"
+compileStatement DropTrigger { name, tableName } = "DROP TRIGGER " <> compileIdentifier name <> " ON " <> compileQualifiedIdentifier tableName <> ";"
 compileStatement CreateEventTrigger { name, eventOn, whenCondition, functionName, arguments } = "CREATE EVENT TRIGGER " <> compileIdentifier name <> " ON " <> compileIdentifier eventOn <> " " <> (maybe "" (\expression -> "WHEN " <> compileExpression expression) whenCondition) <> " EXECUTE FUNCTION " <> compileExpression (CallExpression functionName arguments) <> ";"
 compileStatement DropEventTrigger { name } = "DROP EVENT TRIGGER " <> compileIdentifier name <> ";"
 
@@ -77,7 +77,7 @@ compilePrimaryKeyConstraint PrimaryKeyConstraint { primaryKeyColumnNames } =
         names -> Just $ "PRIMARY KEY(" <> intercalate ", " names <> ")"
 
 compileConstraint :: Constraint -> Text
-compileConstraint ForeignKeyConstraint { columnName, referenceTable, referenceColumn, onDelete } = "FOREIGN KEY (" <> compileIdentifier columnName <> ") REFERENCES " <> compileIdentifier referenceTable <> (if isJust referenceColumn then " (" <> fromJust referenceColumn <> ")" else "") <> " " <> compileOnDelete onDelete
+compileConstraint ForeignKeyConstraint { columnName, referenceTable, referenceColumn, onDelete } = "FOREIGN KEY (" <> compileIdentifier columnName <> ") REFERENCES " <> compileQualifiedIdentifier referenceTable <> (if isJust referenceColumn then " (" <> fromJust referenceColumn <> ")" else "") <> " " <> compileOnDelete onDelete
 compileConstraint UniqueConstraint { columnNames } = "UNIQUE(" <> intercalate ", " columnNames <> ")"
 compileConstraint CheckConstraint { checkExpression } = "CHECK (" <> compileExpression checkExpression <> ")"
 compileConstraint AlterTableAddPrimaryKey { primaryKeyConstraint } = fromMaybe "" (compilePrimaryKeyConstraint primaryKeyConstraint)
@@ -226,9 +226,11 @@ compilePostgresType PTrigger = "TRIGGER"
 compilePostgresType PEventTrigger = "EVENT_TRIGGER"
 compilePostgresType (PCustomType theType) = theType
 
+compileQualifiedIdentifier :: Text -> Text
+compileQualifiedIdentifier = Text.intercalate "." . map compileIdentifier . Text.splitOn "."
+
 compileIdentifier :: Text -> Text
 compileIdentifier identifier
-    | Text.any (== '.') identifier = Text.intercalate "." (map compileIdentifier (Text.splitOn "." identifier))
     | identifierNeedsQuoting = tshow identifier
     | otherwise = identifier
     where

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -42,7 +42,7 @@ compileStatement DropColumn { tableName, columnName } = "ALTER TABLE " <> compil
 compileStatement RenameColumn { tableName, from, to } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " RENAME COLUMN " <> compileIdentifier from <> " TO " <> compileIdentifier to <> ";"
 compileStatement DropTable { tableName } = "DROP TABLE " <> compileQualifiedIdentifier tableName <> ";"
 compileStatement Comment { content } = "--" <> content
-compileStatement CreateIndex { indexName, unique, tableName, columns, whereClause, indexType, nullsDistinct } = "CREATE" <> (if unique then " UNIQUE " else " ") <> "INDEX " <> compileQualifiedIdentifier indexName <> " ON " <> compileQualifiedIdentifier tableName <> (maybe "" (\indexType -> " USING " <> compileIndexType indexType) indexType) <> " (" <> (intercalate ", " (map compileIndexColumn columns)) <> ")" <> (if nullsDistinct then "" else " NULLS NOT DISTINCT") <> (case whereClause of Just expression -> " WHERE " <> compileExpression expression; Nothing -> "") <> ";"
+compileStatement CreateIndex { indexName, unique, tableName, columns, whereClause, indexType, nullsDistinct } = "CREATE" <> (if unique then " UNIQUE " else " ") <> "INDEX " <> compileIdentifier indexName <> " ON " <> compileQualifiedIdentifier tableName <> (maybe "" (\indexType -> " USING " <> compileIndexType indexType) indexType) <> " (" <> (intercalate ", " (map compileIndexColumn columns)) <> ")" <> (if nullsDistinct then "" else " NULLS NOT DISTINCT") <> (case whereClause of Just expression -> " WHERE " <> compileExpression expression; Nothing -> "") <> ";"
 compileStatement CreateFunction { functionName, functionArguments, functionBody, orReplace, returns, language, securityDefiner, functionSettings } = "CREATE " <> (if orReplace then "OR REPLACE " else "") <> "FUNCTION " <> functionName <> "(" <> (functionArguments & map (\(argName, argType) -> argName <> " " <> compilePostgresType argType) & intercalate  ", ") <> ")" <> " RETURNS " <> compilePostgresType returns <> (if securityDefiner then " SECURITY DEFINER" else "") <> mconcat (map compileFunctionSetting functionSettings) <> " AS $$" <> functionBody <> "$$ language " <> language <> ";"
 compileStatement EnableRowLevelSecurity { tableName } = "ALTER TABLE " <> compileQualifiedIdentifier tableName <> " ENABLE ROW LEVEL SECURITY;"
 compileStatement CreatePolicy { name, action, tableName, using, check } = "CREATE POLICY " <> compileIdentifier name <> " ON " <> compileQualifiedIdentifier tableName <> maybe "" (\action -> " FOR " <> compilePolicyAction action) action  <> maybe "" (\expr -> " USING (" <> compileExpression expr <> ")") using <> maybe "" (\expr -> " WITH CHECK (" <> compileExpression expr <> ")") check <> ";"
@@ -234,7 +234,7 @@ compileIdentifier identifier
     | identifierNeedsQuoting = tshow identifier
     | otherwise = identifier
     where
-        identifierNeedsQuoting = isKeyword || containsChar ' ' || containsChar '-' || isUsingUppercase
+        identifierNeedsQuoting = isKeyword || containsChar ' ' || containsChar '-' || containsChar '.' || isUsingUppercase
         isKeyword = Text.toUpper identifier `elem` keywords
         containsChar char = Text.any (char ==) identifier
         isUsingUppercase = Text.toLower identifier /= identifier

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -291,10 +291,7 @@ createTable = do
 createEnumType = do
     lexeme "CREATE"
     lexeme "TYPE"
-    optional do
-        lexeme "public"
-        char '.'
-    name <- identifier
+    name <- qualifiedIdentifier
     lexeme "AS"
     lexeme "ENUM"
     values <- between (char '(' >> space) (space >> char ')' >> space) (textExpr' `sepBy` (char ',' >> space))

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -1211,7 +1211,7 @@ renameTable tableName = do
 dropTable = do
     lexeme "DROP"
     lexeme "TABLE"
-    tableName <- identifier
+    tableName <- qualifiedIdentifier
     char ';'
     pure DropTable { tableName }
 

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -1147,11 +1147,17 @@ commentStatement = do
     char ';'
     pure Comment { content }
 
+-- | Parse a possibly schema-qualified identifier. The default public schema is
+-- normalized away for backward compatibility; every other schema is preserved.
+qualifiedIdentifier :: Parser Text
 qualifiedIdentifier = do
-    optional $ try do
-        lexeme "public"
-        char '.'
-    identifier
+    schemaOrName <- identifier
+    maybeName <- optional (char '.' >> identifier)
+    pure $ case maybeName of
+        Nothing -> schemaOrName
+        Just name
+            | schemaOrName == "public" -> name
+            | otherwise -> schemaOrName <> "." <> name
 
 -- | Parses a (possibly schema-qualified) function name.
 --

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -233,6 +233,10 @@ spec = do
                     }
             compileSql [statement] `shouldBe` sql
 
+        it "should round-trip non-public schema-qualified table names" do
+            let statement = StatementCreateTable (table "private.users")
+            parseSql (compileSql [statement]) `shouldBe` statement
+
         it "should round-trip a schema-qualified CREATE FUNCTION" do
             -- parse -> compile -> parse must preserve a non-public schema like `private.`
             let statement = CreateFunction

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -237,6 +237,15 @@ spec = do
             let statement = StatementCreateTable (table "private.users")
             parseSql (compileSql [statement]) `shouldBe` statement
 
+        it "should quote qualified identifier components independently" do
+            let statement = StatementCreateTable (table "tenant-a.MixedUsers")
+            compileSql [statement] `shouldBe` "CREATE TABLE \"tenant-a\".\"MixedUsers\" (\n\n);\n"
+            parseSql (compileSql [statement]) `shouldBe` statement
+
+        it "should round-trip a schema-qualified DROP TABLE" do
+            let statement = DropTable { tableName = "private.users" }
+            parseSql (compileSql [statement]) `shouldBe` statement
+
         it "should round-trip a schema-qualified CREATE FUNCTION" do
             -- parse -> compile -> parse must preserve a non-public schema like `private.`
             let statement = CreateFunction

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -242,6 +242,11 @@ spec = do
             compileSql [statement] `shouldBe` "CREATE TABLE \"tenant-a\".\"MixedUsers\" (\n\n);\n"
             parseSql (compileSql [statement]) `shouldBe` statement
 
+        it "does not split dots in ordinary quoted identifiers" do
+            let statement = StatementCreateTable (table "users")
+                    { columns = [(col "A.b" PText)] }
+            compileSql [statement] `shouldBe` "CREATE TABLE users (\n    \"A.b\" TEXT\n);\n"
+
         it "should round-trip a schema-qualified DROP TABLE" do
             let statement = DropTable { tableName = "private.users" }
             parseSql (compileSql [statement]) `shouldBe` statement

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -247,6 +247,22 @@ spec = do
                     { columns = [(col "A.b" PText)] }
             compileSql [statement] `shouldBe` "CREATE TABLE users (\n    \"A.b\" TEXT\n);\n"
 
+        it "round-trips schema-qualified enum types" do
+            let statement = CreateEnumType { name = "private.status", values = ["active"] }
+            parseSql (compileSql [statement]) `shouldBe` statement
+
+        it "keeps dotted CREATE INDEX names as single identifiers" do
+            let statement = CreateIndex
+                    { indexName = "audit.v1"
+                    , unique = False
+                    , tableName = "users"
+                    , columns = [indexCol (VarExpression "id")]
+                    , whereClause = Nothing
+                    , indexType = Nothing
+                    , nullsDistinct = True
+                    }
+            compileSql [statement] `shouldBe` "CREATE INDEX \"audit.v1\" ON users (id);\n"
+
         it "should round-trip a schema-qualified DROP TABLE" do
             let statement = DropTable { tableName = "private.users" }
             parseSql (compileSql [statement]) `shouldBe` statement

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -459,6 +459,9 @@ spec = do
         it "should parse 'DROP TABLE ..' statements" do
             parseSql "DROP TABLE tasks;" `shouldBe` DropTable { tableName = "tasks" }
 
+        it "should parse a schema-qualified DROP TABLE" do
+            parseSql "DROP TABLE private.tasks;" `shouldBe` DropTable { tableName = "private.tasks" }
+
         it "should parse 'DROP TYPE ..' statements" do
             parseSql "DROP TYPE colors;" `shouldBe` DropEnumType { name = "colors" }
 

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -100,6 +100,27 @@ spec = do
         it "should parse a CREATE TABLE with quoted identifiers" do
             parseSql "CREATE TABLE \"quoted name\" ();" `shouldBe` StatementCreateTable (table "quoted name")
 
+        it "should preserve non-public schema-qualified table names" do
+            parseSql "CREATE TABLE private.users ();" `shouldBe`
+                StatementCreateTable (table "private.users")
+            parseSql "CREATE TABLE public.users ();" `shouldBe`
+                StatementCreateTable (table "users")
+
+        it "should preserve non-public schemas across foreign keys" do
+            parseSql "CREATE TABLE private.tokens (user_id UUID REFERENCES auth.users(id));" `shouldBe`
+                StatementCreateTable (table "private.tokens")
+                    { columns = [col "user_id" PUUID]
+                    , constraints =
+                        [ ForeignKeyConstraint
+                            { name = Nothing
+                            , columnName = "user_id"
+                            , referenceTable = "auth.users"
+                            , referenceColumn = Just "id"
+                            , onDelete = Nothing
+                            }
+                        ]
+                    }
+
         it "should parse a CREATE TABLE with public schema prefix" do
             parseSql "CREATE TABLE public.users ();" `shouldBe` StatementCreateTable (table "users")
 

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -107,18 +107,18 @@ spec = do
                 StatementCreateTable (table "users")
 
         it "should preserve non-public schemas across foreign keys" do
-            parseSql "CREATE TABLE private.tokens (user_id UUID REFERENCES auth.users(id));" `shouldBe`
-                StatementCreateTable (table "private.tokens")
-                    { columns = [col "user_id" PUUID]
-                    , constraints =
-                        [ ForeignKeyConstraint
-                            { name = Nothing
-                            , columnName = "user_id"
-                            , referenceTable = "auth.users"
-                            , referenceColumn = Just "id"
-                            , onDelete = Nothing
-                            }
-                        ]
+            parseSql "ALTER TABLE private.tokens ADD CONSTRAINT tokens_user_fk FOREIGN KEY (user_id) REFERENCES auth.users (id);" `shouldBe`
+                AddConstraint
+                    { tableName = "private.tokens"
+                    , constraint = ForeignKeyConstraint
+                        { name = Just "tokens_user_fk"
+                        , columnName = "user_id"
+                        , referenceTable = "auth.users"
+                        , referenceColumn = Just "id"
+                        , onDelete = Nothing
+                        }
+                    , deferrable = Nothing
+                    , deferrableType = Nothing
                     }
 
         it "should parse a CREATE TABLE with public schema prefix" do


### PR DESCRIPTION
## Bug

The qualified-identifier parser only accepts the `public.` prefix. A valid non-public schema therefore fails or is moved to public on a round trip:

```sql
ALTER TABLE private.tokens
ADD CONSTRAINT tokens_user_fk
FOREIGN KEY (user_id) REFERENCES auth.users (id);
```

## Fix

Continue normalizing `public.users` to `users` for backward compatibility, while preserving ordinary non-public schema qualifiers in tables, functions and references. The existing AST still cannot distinguish a quoted identifier that itself contains a dot from a qualified name; this PR does not widen that representation.

## Independence

This branch is based directly on the current `upstream/master` and has no dependency on another parser PR.

## Validation

- `nix build --impure --no-link .#checks.aarch64-darwin.ghc914-ihp-postgres-parser`

Not PostgreSQL 18-specific.
