### PR TITLE
Preserve exact SQL literals and geometry modifiers

### DIFF
--- a/ihp-graphql/IHP/GraphQL/SchemaCompiler.hs
+++ b/ihp-graphql/IHP/GraphQL/SchemaCompiler.hs
@@ -200,6 +200,7 @@ postgresTypeToGraphQLType PDouble = NamedType "Float"
 postgresTypeToGraphQLType PPoint = NamedType "Point"
 postgresTypeToGraphQLType PPolygon = error "todo"
 postgresTypeToGraphQLType PGeometry = NamedType "String" -- hex EWKB
+postgresTypeToGraphQLType (PGeometryWithModifier _) = NamedType "String" -- hex EWKB
 postgresTypeToGraphQLType PDate = NamedType "Date"
 postgresTypeToGraphQLType PBinary = NamedType "String"
 postgresTypeToGraphQLType PTime = NamedType "Time"

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -610,7 +610,7 @@ normalizeDefaultExpression columnType expression
     where
         supportsEquivalentNumericLiterals PReal = True
         supportsEquivalentNumericLiterals PDouble = True
-        supportsEquivalentNumericLiterals PNumeric {} = True
+        supportsEquivalentNumericLiterals PNumeric { scale = Just _ } = True
         supportsEquivalentNumericLiterals _ = False
 
         normalizeNumericExpression (DoubleExpression value) = NumericExpression (normalizeNumericLiteral (tshow value))

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -553,7 +553,7 @@ normalizeColumn table Column { name, columnType, defaultValue, notNull, isUnique
         normalizeName nane = Text.toLower name
 
         normalizedDefaultValue = case defaultValue of
-            Just defaultValue -> Just (normalizeExpression defaultValue)
+            Just defaultValue -> Just (normalizeDefaultExpression columnType defaultValue)
             Nothing -> if notNull || isJust generator
                 then Nothing
                 else Just (VarExpression "null") -- pg_dump columns don't have an explicit default null value
@@ -576,9 +576,9 @@ normalizeExpression (LessThanExpression a b) = LessThanExpression (normalizeExpr
 normalizeExpression (LessThanOrEqualToExpression a b) = LessThanOrEqualToExpression (normalizeExpression a) (normalizeExpression b)
 normalizeExpression (GreaterThanExpression a b) = GreaterThanExpression (normalizeExpression a) (normalizeExpression b)
 normalizeExpression (GreaterThanOrEqualToExpression a b) = GreaterThanOrEqualToExpression (normalizeExpression a) (normalizeExpression b)
-normalizeExpression (DoubleExpression value) = NumericExpression (normalizeNumericLiteral (tshow value))
-normalizeExpression (NumericExpression value) = NumericExpression (normalizeNumericLiteral value)
-normalizeExpression (IntExpression value) = NumericExpression (normalizeNumericLiteral (tshow value))
+normalizeExpression e@(DoubleExpression {}) = e
+normalizeExpression e@(NumericExpression {}) = e
+normalizeExpression e@(IntExpression {}) = e
 normalizeExpression (ConcatenationExpression a b) = ConcatenationExpression (normalizeExpression a) (normalizeExpression b)
 -- Enum default values from pg_dump always have an explicit type cast. Inside the Schema.sql they typically don't have those.
 -- Therefore we remove these typecasts here
@@ -602,6 +602,21 @@ normalizeExpression (ExistsExpression a) = ExistsExpression (normalizeExpression
 normalizeExpression (InArrayExpression exprs) = InArrayExpression (map normalizeExpression exprs)
 normalizeExpression (ArrayLiteralExpression exprs) = ArrayLiteralExpression (map normalizeExpression exprs)
 normalizeExpression (VariadicExpression expr) = VariadicExpression (normalizeExpression expr)
+
+normalizeDefaultExpression :: PostgresType -> Expression -> Expression
+normalizeDefaultExpression columnType expression
+    | supportsEquivalentNumericLiterals (normalizeSqlType columnType) = normalizeNumericExpression (normalizeExpression expression)
+    | otherwise = normalizeExpression expression
+    where
+        supportsEquivalentNumericLiterals PReal = True
+        supportsEquivalentNumericLiterals PDouble = True
+        supportsEquivalentNumericLiterals PNumeric {} = True
+        supportsEquivalentNumericLiterals _ = False
+
+        normalizeNumericExpression (DoubleExpression value) = NumericExpression (normalizeNumericLiteral (tshow value))
+        normalizeNumericExpression (NumericExpression value) = NumericExpression (normalizeNumericLiteral value)
+        normalizeNumericExpression (IntExpression value) = NumericExpression (normalizeNumericLiteral (tshow value))
+        normalizeNumericExpression other = other
 
 -- | Replaces @table.field@ with just @field@
 --
@@ -682,6 +697,7 @@ resolveAlias Nothing fromExpression expression = expression
 normalizeSqlType :: PostgresType -> PostgresType
 normalizeSqlType (PCustomType customType) = PCustomType (Text.toLower customType)
 normalizeSqlType (PGeometryWithModifier modifier) = PGeometryWithModifier (Text.intercalate "," (map (Text.toLower . Text.strip) (Text.splitOn "," modifier)))
+normalizeSqlType (PArray elementType) = PArray (normalizeSqlType elementType)
 normalizeSqlType PBigserial = PBigInt
 normalizeSqlType PSerial = PInt
 normalizeSqlType otherwise = otherwise

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -576,9 +576,9 @@ normalizeExpression (LessThanExpression a b) = LessThanExpression (normalizeExpr
 normalizeExpression (LessThanOrEqualToExpression a b) = LessThanOrEqualToExpression (normalizeExpression a) (normalizeExpression b)
 normalizeExpression (GreaterThanExpression a b) = GreaterThanExpression (normalizeExpression a) (normalizeExpression b)
 normalizeExpression (GreaterThanOrEqualToExpression a b) = GreaterThanOrEqualToExpression (normalizeExpression a) (normalizeExpression b)
-normalizeExpression e@(DoubleExpression {}) = e
-normalizeExpression e@(NumericExpression {}) = e
-normalizeExpression e@(IntExpression {}) = e
+normalizeExpression (DoubleExpression value) = NumericExpression (normalizeNumericLiteral (tshow value))
+normalizeExpression (NumericExpression value) = NumericExpression (normalizeNumericLiteral value)
+normalizeExpression (IntExpression value) = NumericExpression (normalizeNumericLiteral (tshow value))
 normalizeExpression (ConcatenationExpression a b) = ConcatenationExpression (normalizeExpression a) (normalizeExpression b)
 -- Enum default values from pg_dump always have an explicit type cast. Inside the Schema.sql they typically don't have those.
 -- Therefore we remove these typecasts here
@@ -681,9 +681,30 @@ resolveAlias Nothing fromExpression expression = expression
 
 normalizeSqlType :: PostgresType -> PostgresType
 normalizeSqlType (PCustomType customType) = PCustomType (Text.toLower customType)
+normalizeSqlType (PGeometryWithModifier modifier) = PGeometryWithModifier (Text.intercalate "," (map (Text.toLower . Text.strip) (Text.splitOn "," modifier)))
 normalizeSqlType PBigserial = PBigInt
 normalizeSqlType PSerial = PInt
 normalizeSqlType otherwise = otherwise
+
+normalizeNumericLiteral :: Text -> Text
+normalizeNumericLiteral value =
+    case Read.readMaybe (cs exponentText) :: Maybe Int of
+        Nothing -> Text.toLower value
+        Just exponent
+            | Text.null significantDigits -> "0"
+            | otherwise -> sign <> significantDigits <> "e" <> tshow (exponent - Text.length fractionalPart + trailingZeroCount)
+    where
+        (mantissa, rawExponent) = Text.break (\character -> character == 'e' || character == 'E') value
+        exponentText = if Text.null rawExponent then "0" else Text.drop 1 rawExponent
+        (sign, unsignedMantissa) = case Text.uncons mantissa of
+            Just ('-', rest) -> ("-", rest)
+            Just ('+', rest) -> ("", rest)
+            _ -> ("", mantissa)
+        (integerPart, rawFractionalPart) = Text.break (== '.') unsignedMantissa
+        fractionalPart = Text.drop 1 rawFractionalPart
+        digits = Text.dropWhile (== '0') (integerPart <> fractionalPart)
+        significantDigits = Text.dropWhileEnd (== '0') digits
+        trailingZeroCount = Text.length digits - Text.length significantDigits
 
 -- | Returns every migration file created by a generation plan.
 migrationPathsFromPlan :: [GeneratorAction] -> [Text]

--- a/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
+++ b/ihp-ide/IHP/IDE/CodeGen/MigrationGenerator.hs
@@ -577,6 +577,7 @@ normalizeExpression (LessThanOrEqualToExpression a b) = LessThanOrEqualToExpress
 normalizeExpression (GreaterThanExpression a b) = GreaterThanExpression (normalizeExpression a) (normalizeExpression b)
 normalizeExpression (GreaterThanOrEqualToExpression a b) = GreaterThanOrEqualToExpression (normalizeExpression a) (normalizeExpression b)
 normalizeExpression e@(DoubleExpression {}) = e
+normalizeExpression e@(NumericExpression {}) = e
 normalizeExpression e@(IntExpression {}) = e
 normalizeExpression (ConcatenationExpression a b) = ConcatenationExpression (normalizeExpression a) (normalizeExpression b)
 -- Enum default values from pg_dump always have an explicit type cast. Inside the Schema.sql they typically don't have those.
@@ -625,6 +626,7 @@ unqualifyExpression scope expression = doUnqualify expression
         doUnqualify (GreaterThanExpression a b) = GreaterThanExpression (doUnqualify a) (doUnqualify b)
         doUnqualify (GreaterThanOrEqualToExpression a b) = GreaterThanOrEqualToExpression (doUnqualify a) (doUnqualify b)
         doUnqualify e@(DoubleExpression {}) = e
+        doUnqualify e@(NumericExpression {}) = e
         doUnqualify e@(IntExpression {}) = e
         doUnqualify (ConcatenationExpression a b) = ConcatenationExpression (doUnqualify a) (doUnqualify b)
         doUnqualify (TypeCastExpression a b) = TypeCastExpression (doUnqualify a) b
@@ -665,6 +667,7 @@ resolveAlias (Just alias) fromExpression expression =
         e@(GreaterThanExpression a b) -> GreaterThanExpression (rec a) (rec b)
         e@(GreaterThanOrEqualToExpression a b) -> GreaterThanOrEqualToExpression (rec a) (rec b)
         e@(DoubleExpression {}) -> e
+        e@(NumericExpression {}) -> e
         e@(IntExpression {}) -> e
         e@(TypeCastExpression a b) -> (TypeCastExpression (rec a) b)
         e@(SelectExpression Select { columns, from, whereClause, alias }) -> SelectExpression Select { columns = rec <$> columns, from = rec from, whereClause = rec whereClause, alias = alias }

--- a/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
+++ b/ihp-ide/IHP/IDE/SchemaDesigner/SchemaOperations.hs
@@ -597,6 +597,7 @@ deleteColumn DeleteColumnOptions { .. } schema =
                 isRef (GreaterThanExpression a b) = isRef a || isRef b
                 isRef (GreaterThanOrEqualToExpression a b) = isRef a || isRef b
                 isRef (DoubleExpression _) = False
+                isRef (NumericExpression _) = False
                 isRef (IntExpression _) = False
                 isRef (TypeCastExpression a _) = isRef a
                 isRef (SelectExpression _) = False
@@ -659,6 +660,7 @@ isIndexStatementReferencingTableColumn statement tableName columnName = isRefere
             GreaterThanExpression a b -> expressionReferencesColumn a || expressionReferencesColumn b
             GreaterThanOrEqualToExpression a b -> expressionReferencesColumn a || expressionReferencesColumn b
             DoubleExpression _ -> False
+            NumericExpression _ -> False
             IntExpression _ -> False
             TypeCastExpression a _ -> expressionReferencesColumn a
             SelectExpression _ -> False

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -92,6 +92,12 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "preserves scale for unconstrained numeric defaults" do
+                let targetSchema = sql "CREATE TABLE invoices (amount NUMERIC DEFAULT 20.0000);"
+                let actualSchema = sql "CREATE TABLE invoices (amount NUMERIC DEFAULT 20);"
+
+                diffSchemas targetSchema actualSchema `shouldNotBe` []
+
             it "preserves integer distinctions in constraints" do
                 let targetSchema = sql [i|
                     CREATE TABLE invoices (amount NUMERIC);

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -80,11 +80,29 @@ tests = do
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
 
+            it "normalizes equivalent geometry modifiers inside arrays" do
+                let targetSchema = sql "CREATE TABLE locations (shapes geometry(Point, 4326)[]);"
+                let actualSchema = sql "CREATE TABLE locations (shapes geometry(point,4326)[]);"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "normalizes equivalent numeric defaults" do
                 let targetSchema = sql "CREATE TABLE invoices (amount DOUBLE PRECISION DEFAULT 20.0000);"
                 let actualSchema = sql "CREATE TABLE invoices (amount DOUBLE PRECISION DEFAULT 20);"
 
                 diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "preserves integer distinctions in constraints" do
+                let targetSchema = sql [i|
+                    CREATE TABLE invoices (amount NUMERIC);
+                    ALTER TABLE invoices ADD CONSTRAINT amount_type CHECK (pg_typeof(1.0) = pg_typeof(amount));
+                |]
+                let actualSchema = sql [i|
+                    CREATE TABLE invoices (amount NUMERIC);
+                    ALTER TABLE invoices ADD CONSTRAINT amount_type CHECK (pg_typeof(1) = pg_typeof(amount));
+                |]
+
+                diffSchemas targetSchema actualSchema `shouldNotBe` []
 
             it "should handle a new table" do
                 let targetSchema = sql [i|

--- a/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
+++ b/ihp-ide/Test/IDE/CodeGeneration/MigrationGenerator.hs
@@ -74,6 +74,18 @@ tests = do
             it "should handle an empty schema" do
                 diffSchemas [] [] `shouldBe` []
 
+            it "normalizes equivalent geometry modifiers" do
+                let targetSchema = sql "CREATE TABLE locations (shape geometry(Point, 4326));"
+                let actualSchema = sql "CREATE TABLE locations (shape geometry(point,4326));"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
+            it "normalizes equivalent numeric defaults" do
+                let targetSchema = sql "CREATE TABLE invoices (amount DOUBLE PRECISION DEFAULT 20.0000);"
+                let actualSchema = sql "CREATE TABLE invoices (amount DOUBLE PRECISION DEFAULT 20);"
+
+                diffSchemas targetSchema actualSchema `shouldBe` []
+
             it "should handle a new table" do
                 let targetSchema = sql [i|
                     CREATE TABLE users (

--- a/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/CompilerSpec.hs
@@ -716,7 +716,7 @@ tests = do
 
         it "should compile a decimal default value with a type-cast" do
             let sql = "CREATE TABLE a (\n    electricity_unit_price DOUBLE PRECISION DEFAULT 0.17::DOUBLE PRECISION NOT NULL\n);\n"
-            let statement = StatementCreateTable (table "a") { columns = [(col "electricity_unit_price" PDouble) { defaultValue = Just (TypeCastExpression (DoubleExpression 0.17) PDouble), notNull = True }] }
+            let statement = StatementCreateTable (table "a") { columns = [(col "electricity_unit_price" PDouble) { defaultValue = Just (TypeCastExpression (NumericExpression "0.17") PDouble), notNull = True }] }
             compileSql [statement] `shouldBe` sql
 
         it "should compile a integer default value" do

--- a/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -598,12 +598,12 @@ tests = do
 
         it "should parse a CREATE TABLE statement with a PostGIS geometry column" do
             parseSql "CREATE TABLE locations (\n    geom GEOMETRY\n);\n" `shouldBe` StatementCreateTable (table "locations")
-                    { columns = [ col "geom" (PGeometryWithModifier "Point, 4326") ]
+                    { columns = [ col "geom" PGeometry ]
                     }
 
         it "should parse a CREATE TABLE statement with a PostGIS geometry(subtype, srid) column" do
             parseSql "CREATE TABLE locations (\n    geom geometry(Point, 4326)\n);\n" `shouldBe` StatementCreateTable (table "locations")
-                    { columns = [ col "geom" PGeometry ]
+                    { columns = [ col "geom" (PGeometryWithModifier "Point, 4326") ]
                     }
 
         it "should parse a CREATE TABLE statement with a PostGIS geometry(subtype) column" do

--- a/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
+++ b/ihp-ide/Test/IDE/SchemaDesigner/ParserSpec.hs
@@ -598,7 +598,7 @@ tests = do
 
         it "should parse a CREATE TABLE statement with a PostGIS geometry column" do
             parseSql "CREATE TABLE locations (\n    geom GEOMETRY\n);\n" `shouldBe` StatementCreateTable (table "locations")
-                    { columns = [ col "geom" PGeometry ]
+                    { columns = [ col "geom" (PGeometryWithModifier "Point, 4326") ]
                     }
 
         it "should parse a CREATE TABLE statement with a PostGIS geometry(subtype, srid) column" do
@@ -608,7 +608,7 @@ tests = do
 
         it "should parse a CREATE TABLE statement with a PostGIS geometry(subtype) column" do
             parseSql "CREATE TABLE areas (\n    shape geometry(MultiPolygon)\n);\n" `shouldBe` StatementCreateTable (table "areas")
-                    { columns = [ col "shape" PGeometry ]
+                    { columns = [ col "shape" (PGeometryWithModifier "MultiPolygon") ]
                     }
 
         it "should parse a CREATE INDEX statement" do
@@ -845,7 +845,7 @@ $$;
         it "should parse a decimal default value with a type-cast" do
             let sql = "CREATE TABLE a(electricity_unit_price DOUBLE PRECISION DEFAULT 0.17::double precision NOT NULL);"
             let statements =
-                    [ StatementCreateTable (table "a") { columns = [(col "electricity_unit_price" PDouble) { defaultValue = Just (TypeCastExpression (DoubleExpression 0.17) PDouble), notNull = True }] }
+                    [ StatementCreateTable (table "a") { columns = [(col "electricity_unit_price" PDouble) { defaultValue = Just (TypeCastExpression (NumericExpression "0.17") PDouble), notNull = True }] }
                     ]
             parseSqlStatements sql `shouldBe` statements
 
@@ -1142,11 +1142,11 @@ COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UU
         it "should parse negative IntExpression's" do
             parseExpression "-1" `shouldBe` (IntExpression (-1))
 
-        it "should parse positive DoubleExpression's" do
-            parseExpression "1.337" `shouldBe` (DoubleExpression 1.337)
+        it "should preserve positive numeric literals exactly" do
+            parseExpression "1.337" `shouldBe` NumericExpression "1.337"
 
-        it "should parse negative DoubleExpression's" do
-            parseExpression "-1.337" `shouldBe` (DoubleExpression (-1.337))
+        it "should preserve negative numeric literals exactly" do
+            parseExpression "-1.337" `shouldBe` NumericExpression "-1.337"
 
         it "should parse lower-cased SELECT expressions" do
             parseExpression "(select company_id from users where id = ihp_user_id())" `shouldBe` SelectExpression (Select {columns = [VarExpression "company_id"], from = VarExpression "users", alias = Nothing, whereClause = EqExpression (VarExpression "id") (CallExpression "ihp_user_id" [])})

--- a/ihp-ide/Test/SchemaCompilerSpec.hs
+++ b/ihp-ide/Test/SchemaCompilerSpec.hs
@@ -201,7 +201,7 @@ tests = do
                         { columns =
                             [ (col "id" PUUID) { notNull = True, isUnique = True }
                             , col "ids" (PArray PUUID)
-                            , (col "electricity_unit_price" PDouble) { defaultValue = Just (TypeCastExpression (DoubleExpression 0.17) PDouble), notNull = True }
+                            , (col "electricity_unit_price" PDouble) { defaultValue = Just (TypeCastExpression (NumericExpression "0.17") PDouble), notNull = True }
                             ]
                         , primaryKeyConstraint = PrimaryKeyConstraint ["id"]
                         }

--- a/ihp-postgres-parser/IHP/Postgres/Compiler.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Compiler.hs
@@ -132,13 +132,15 @@ compileDefaultValue :: Expression -> Text
 compileDefaultValue value = "DEFAULT " <> compileExpression value
 
 compileExpression :: Expression -> Text
-compileExpression (TextExpression value) = "'" <> value <> "'"
+compileExpression (TextExpression value) = "'" <> Text.replace "'" "''" value <> "'"
 compileExpression (VarExpression name) =
         if nameContainsSpaces
             then compileIdentifier name
             else name
     where
         nameContainsSpaces = Text.any (== ' ') name
+compileExpression (CallExpression func [InExpression needle haystack])
+    | Text.toUpper func == "POSITION" = func <> "(" <> compileExpressionWithOptionalParenthese needle <> " IN " <> compileExpressionWithOptionalParenthese haystack <> ")"
 compileExpression (CallExpression func args) = func <> "(" <> intercalate ", " (map compileExpressionWithOptionalParenthese args) <> ")"
 compileExpression (NotEqExpression a b) = compileExpression a <> " <> " <> compileExpression b
 compileExpression (EqExpression a b) = compileExpressionWithOptionalParenthese a <> " = " <> compileExpressionWithOptionalParenthese b
@@ -156,6 +158,7 @@ compileExpression (LessThanOrEqualToExpression a b) = compileExpressionWithOptio
 compileExpression (GreaterThanExpression a b) = compileExpressionWithOptionalParenthese a <> " > " <> compileExpressionWithOptionalParenthese b
 compileExpression (GreaterThanOrEqualToExpression a b) = compileExpressionWithOptionalParenthese a <> " >= " <> compileExpressionWithOptionalParenthese b
 compileExpression (DoubleExpression double) = tshow double
+compileExpression (NumericExpression value) = value
 compileExpression (IntExpression integer) = tshow integer
 compileExpression (TypeCastExpression value type_) = compileExpression value <> "::" <> compilePostgresType type_
 compileExpression (SelectExpression Select { columns, from, whereClause }) = "SELECT " <> intercalate ", " (map compileExpression columns) <> " FROM " <> compileExpression from <> " WHERE " <> compileExpression whereClause
@@ -175,6 +178,7 @@ compileExpressionWithOptionalParenthese expr@(CallExpression {}) = compileExpres
 compileExpressionWithOptionalParenthese expr@(TextExpression {}) = compileExpression expr
 compileExpressionWithOptionalParenthese expr@(IntExpression {}) = compileExpression expr
 compileExpressionWithOptionalParenthese expr@(DoubleExpression {}) = compileExpression expr
+compileExpressionWithOptionalParenthese expr@(NumericExpression {}) = compileExpression expr
 compileExpressionWithOptionalParenthese expr@(DotExpression (VarExpression {}) b) = compileExpression expr
 compileExpressionWithOptionalParenthese expr@(ConcatenationExpression a b ) = compileExpression expr
 compileExpressionWithOptionalParenthese expr@(InArrayExpression values) = compileExpression expr
@@ -204,6 +208,7 @@ compilePostgresType PDouble = "DOUBLE PRECISION"
 compilePostgresType PPoint = "POINT"
 compilePostgresType PPolygon = "POLYGON"
 compilePostgresType PGeometry = "GEOMETRY"
+compilePostgresType (PGeometryWithModifier modifier) = "GEOMETRY(" <> modifier <> ")"
 compilePostgresType PDate = "DATE"
 compilePostgresType PBinary = "BYTEA"
 compilePostgresType PTime = "TIME"

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -755,7 +755,7 @@ textExpr' = cs <$> do
     let emptyByteString = do
             string "'\\x'"
             pure ""
-    (try (char '\'' *> many (try (string "''" $> '\'') <|> Lexer.charLiteral) <* char '\'')) <|> emptyByteString
+    (try (char '\'' *> many (try (string "''" $> '\'') <|> (notFollowedBy (char '\'') *> Lexer.charLiteral)) <* char '\'')) <|> emptyByteString
 
 selectExpr :: Parser Expression
 selectExpr = do

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -755,7 +755,7 @@ textExpr' = cs <$> do
     let emptyByteString = do
             string "'\\x'"
             pure ""
-    (try (char '\'' *> manyTill Lexer.charLiteral (char '\''))) <|> emptyByteString
+    (try (char '\'' *> many (try (string "''" $> '\'') <|> Lexer.charLiteral) <* char '\'')) <|> emptyByteString
 
 selectExpr :: Parser Expression
 selectExpr = do

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -713,7 +713,7 @@ varExpr :: Parser Expression
 varExpr = VarExpression <$> identifier
 
 doubleExpr :: Parser Expression
-doubleExpr = NumericExpression . fst <$> match (Lexer.signed spaceConsumer Lexer.float)
+doubleExpr = NumericExpression . fst <$> lexeme (match (Lexer.signed spaceConsumer Lexer.float))
 
 intExpr :: Parser Expression
 intExpr = IntExpression <$> (Lexer.signed spaceConsumer Lexer.decimal)

--- a/ihp-postgres-parser/IHP/Postgres/Parser.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Parser.hs
@@ -223,7 +223,9 @@ symbol' :: Text -> Parser Text
 symbol' = Lexer.symbol' spaceConsumer
 
 stringLiteral :: Parser String
-stringLiteral = char '\'' *> manyTill Lexer.charLiteral (char '\'')
+stringLiteral = char '\'' *> manyTill stringCharacter (try (char '\'' <* notFollowedBy (char '\'')))
+    where
+        stringCharacter = try (string "''" $> '\'') <|> Lexer.charLiteral
 
 parseDDL :: Parser [Statement]
 parseDDL = optional space >> (manyTill statement eof)
@@ -521,15 +523,11 @@ sqlType = choice $ map optionalArray
                     try (symbol' "POLYGON")
                     pure PPolygon
 
-                -- PostGIS @geometry@ type. Accepts the optional
-                -- @geometry(SubType[, SRID])@ modifier used in PostGIS schemas;
-                -- the modifier is dropped from the AST because PostgreSQL
-                -- enforces it at DDL time.
                 geometry = do
                     try (symbol' "GEOMETRY")
-                    optional $ between (char '(' >> space) (char ')' >> space)
+                    modifier <- optional $ between (char '(' >> space) (char ')' >> space)
                         (takeWhile1P (Just "geometry type modifier") (/= ')'))
-                    pure PGeometry
+                    pure (maybe PGeometry (PGeometryWithModifier . Text.strip) modifier)
 
                 date = do
                     try (symbol' "DATE")
@@ -715,7 +713,7 @@ varExpr :: Parser Expression
 varExpr = VarExpression <$> identifier
 
 doubleExpr :: Parser Expression
-doubleExpr = DoubleExpression <$> (Lexer.signed spaceConsumer Lexer.float)
+doubleExpr = NumericExpression . fst <$> match (Lexer.signed spaceConsumer Lexer.float)
 
 intExpr :: Parser Expression
 intExpr = IntExpression <$> (Lexer.signed spaceConsumer Lexer.decimal)

--- a/ihp-postgres-parser/IHP/Postgres/Types.hs
+++ b/ihp-postgres-parser/IHP/Postgres/Types.hs
@@ -199,6 +199,8 @@ data Expression =
     | GreaterThanOrEqualToExpression Expression Expression
     -- | Double literal value, e.g. 0.1337
     | DoubleExpression Double
+    -- | Exact SQL decimal literal, retaining significant scale and exponent.
+    | NumericExpression Text
     -- | Integer literal value, e.g. 1337
     | IntExpression Int
     -- | value::type
@@ -229,6 +231,7 @@ data PostgresType
     | PPoint
     | PPolygon
     | PGeometry
+    | PGeometryWithModifier Text
     | PDate
     | PBinary
     | PTime

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -362,6 +362,21 @@ spec = do
                         ]
             compileSql statements `shouldBe` sql
 
+        describe "literal and type round trips" do
+            let roundTrip sql = compileSql [parseSql sql] `shouldBe` (sql <> "\n")
+
+            it "keeps numeric scale" do
+                roundTrip "CREATE TABLE fees (\n    vat NUMERIC(7,4) DEFAULT 20.0000 NOT NULL\n);"
+
+            it "keeps PostGIS geometry modifiers" do
+                roundTrip "CREATE TABLE locations (\n    geom GEOMETRY(Point, 4326)\n);"
+
+            it "escapes apostrophes in string literals" do
+                roundTrip "ALTER TABLE fees ADD CHECK (label <> 'owner''s fee');"
+
+            it "keeps POSITION's SQL-standard IN syntax" do
+                roundTrip "ALTER TABLE users ADD CHECK (POSITION('@' IN email) > 1);"
+
 parseSql :: Text -> Statement
 parseSql sql =
     case Megaparsec.runParser parseDDL "input" sql of

--- a/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/CompilerSpec.hs
@@ -372,10 +372,10 @@ spec = do
                 roundTrip "CREATE TABLE locations (\n    geom GEOMETRY(Point, 4326)\n);"
 
             it "escapes apostrophes in string literals" do
-                roundTrip "ALTER TABLE fees ADD CHECK (label <> 'owner''s fee');"
+                roundTrip "ALTER TABLE fees ADD CONSTRAINT fees_label_check CHECK (label <> 'owner''s fee');"
 
             it "keeps POSITION's SQL-standard IN syntax" do
-                roundTrip "ALTER TABLE users ADD CHECK (POSITION('@' IN email) > 1);"
+                roundTrip "ALTER TABLE users ADD CONSTRAINT users_email_position_check CHECK (POSITION('@' IN email) > 1);"
 
 parseSql :: Text -> Statement
 parseSql sql =

--- a/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
+++ b/ihp-postgres-parser/Test/Postgres/ParserSpec.hs
@@ -462,11 +462,15 @@ spec = do
         it "should parse negative IntExpression's" do
             parseExpression "-1" `shouldBe` (IntExpression (-1))
 
-        it "should parse positive DoubleExpression's" do
-            parseExpression "1.337" `shouldBe` (DoubleExpression 1.337)
+        it "should preserve positive numeric literals exactly" do
+            parseExpression "1.337" `shouldBe` NumericExpression "1.337"
 
-        it "should parse negative DoubleExpression's" do
-            parseExpression "-1.337" `shouldBe` (DoubleExpression (-1.337))
+        it "should preserve negative numeric literals exactly" do
+            parseExpression "-1.337" `shouldBe` NumericExpression "-1.337"
+
+        it "should preserve PostGIS geometry modifiers" do
+            parseSql "CREATE TABLE locations (geom geometry(Point, 4326));"
+                `shouldBe` StatementCreateTable (table "locations") { columns = [col "geom" (PGeometryWithModifier "Point, 4326")] }
 
 parseSql :: Text -> Statement
 parseSql sql = let [statement] = parseSqlStatements sql in statement

--- a/ihp-schema-compiler/IHP/SchemaCompiler.hs
+++ b/ihp-schema-compiler/IHP/SchemaCompiler.hs
@@ -217,6 +217,7 @@ atomicType = \case
     PPoint -> "Point"
     PPolygon -> "Polygon"
     PGeometry -> "Geometry"
+    PGeometryWithModifier _ -> "Geometry"
     PInet -> "Inet"
     PTSVector -> "Tsvector"
     PSingleChar -> "Text"
@@ -992,6 +993,7 @@ hasqlValueDecoder = \case
     PPoint -> "Mapping.decoder"
     PPolygon -> "Mapping.decoder"
     PGeometry -> "Mapping.decoder"
+    PGeometryWithModifier _ -> "Mapping.decoder"
     PInet -> "Mapping.decoder"
     PTSVector -> "Mapping.decoder"
     PArray innerType -> "(Decoders.listArray (" <> hasqlArrayElementDecoder innerType <> "))"
@@ -1045,6 +1047,7 @@ toDefaultValueExpr Column { columnType, notNull, defaultValue = Just theDefaultV
                                 otherwise           -> error ("toDefaultValueExpr: BOOL column needs to have a VarExpression as default value. Got: " <> show otherwise)
                             PDouble -> case theNormalizedDefaultValue of
                                 DoubleExpression value -> wrapNull notNull (tshow value)
+                                NumericExpression value -> wrapNull notNull value
                                 IntExpression value -> wrapNull notNull (tshow value)
                                 otherwise           -> error ("toDefaultValueExpr: DOUBLE column needs to have a DoubleExpression as default value. Got: " <> show otherwise)
                             _ -> "def"
@@ -1363,6 +1366,7 @@ hasqlValueEncoder = \case
     PPoint -> "Mapping.encoder"
     PPolygon -> "Mapping.encoder"
     PGeometry -> "Mapping.encoder"
+    PGeometryWithModifier _ -> "Mapping.encoder"
     PInet -> "Mapping.encoder"
     PTSVector -> "Mapping.encoder"
     PArray innerType -> "(Encoders.foldableArray (Encoders.nonNullable " <> hasqlValueEncoder innerType <> "))"
@@ -1733,4 +1737,3 @@ compileDynamicCreateManyStatement moduleName qualifiedModelName tableName writab
         , "decoder :: Decoders.Result [" <> qualifiedModelName <> "]"
         , "decoder = Decoders.rowList RowDecoder.rowDecoder"
         ]
-


### PR DESCRIPTION
## Bug

Several valid values are silently changed by a parse/compile round trip:

```sql
DEFAULT 20.0000
geometry(Point, 4326)
CHECK (label <> 'owner''s fee')
CHECK (POSITION('@' IN email) > 1)
```

`Double` loses decimal scale, PostGIS modifiers are discarded, apostrophes are not re-escaped, and POSITION is compiled as an ordinary function call.

## Fix

Keep numeric tokens exactly, retain PostGIS geometry modifiers, escape SQL string literals, and compile POSITION's SQL-standard IN syntax. All expression and type consumers handle the new AST constructors.

## Independence

This branch is based directly on the current `upstream/master` and has no dependency on another parser PR.

## Validation

- `nix build --impure --no-link .#checks.aarch64-darwin.ghc914-ihp-postgres-parser .#checks.aarch64-darwin.ghc914-ihp-ide .#checks.aarch64-darwin.ghc914-ihp-schema-compiler .#checks.aarch64-darwin.ghc914-ihp-graphql`

Not PostgreSQL 18-specific.
