### PR TITLE
Update typed SQL parser to postgresql-syntax 0.5

### DIFF
--- a/NixSupport/hackage/postgresql-syntax.nix
+++ b/NixSupport/hackage/postgresql-syntax.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, base, bytestring, case-insensitive, clock
+, containers, criterion, fetchzip, hashable, headed-megaparsec
+, hspec, hspec-discover, lib, megaparsec, parser-combinators
+, QuickCheck, rerebase, text, text-builder, unordered-containers
+}:
+mkDerivation {
+  pname = "postgresql-syntax";
+  version = "0.5.0.3";
+  src = fetchzip {
+    url = "https://hackage.haskell.org/package/postgresql-syntax-0.5.0.3/postgresql-syntax-0.5.0.3.tar.gz";
+    sha256 = "1ivnig1rc2gyihhx2g4ny9y8xnmvjrcs58bxkly1rr3pszcfqkr8";
+  };
+  libraryHaskellDepends = [
+    base bytestring case-insensitive hashable headed-megaparsec
+    megaparsec parser-combinators QuickCheck text text-builder
+    unordered-containers
+  ];
+  testHaskellDepends = [ hspec megaparsec QuickCheck rerebase ];
+  testToolDepends = [ hspec-discover ];
+  benchmarkHaskellDepends = [
+    clock containers criterion headed-megaparsec megaparsec QuickCheck
+    rerebase
+  ];
+  doHaddock = false;
+  homepage = "https://github.com/nikita-volkov/postgresql-syntax";
+  description = "PostgreSQL AST parsing and rendering";
+  license = lib.licenses.mit;
+}

--- a/NixSupport/overlay.nix
+++ b/NixSupport/overlay.nix
@@ -80,6 +80,13 @@ let
             ihp-hspec = localPackage "ihp-hspec";
             ihp-welcome = localPackage "ihp-welcome";
 
+            postgresql-syntax = (final.haskell.lib.doJailbreak
+                (hackagePackage "postgresql-syntax")).overrideAttrs (old: {
+                    patches = (old.patches or []) ++ [
+                        ./patches/postgresql-syntax-quickcheck-2.16.patch
+                    ];
+                });
+
             # wai-session-maybe / wai-session-clientsession-deferred (deferred
             # session decryption + optional Set-Cookie) are shipped by the pinned
             # nixpkgs at 1.0.0, so we consume them from the default set verbatim

--- a/NixSupport/patches/postgresql-syntax-quickcheck-2.16.patch
+++ b/NixSupport/patches/postgresql-syntax-quickcheck-2.16.patch
@@ -1,0 +1,22 @@
+diff --git a/library-internal/PostgresqlSyntax/Prelude.hs b/library-internal/PostgresqlSyntax/Prelude.hs
+--- a/library-internal/PostgresqlSyntax/Prelude.hs
++++ b/library-internal/PostgresqlSyntax/Prelude.hs
+@@ -1,3 +1,5 @@
++{-# LANGUAGE CPP #-}
++
+ module PostgresqlSyntax.Prelude
+   ( module Exports,
+     suffixRec,
+@@ -75,6 +77,11 @@ import Text.Read as Exports (Read (..), readEither, readMaybe)
+ import TextBuilder as Exports (TextBuilder)
+ import Unsafe.Coerce as Exports
+-
++#if !MIN_VERSION_QuickCheck(2,17,0)
++instance (Arbitrary a) => Arbitrary (NonEmpty a) where
++  arbitrary = (:|) <$> arbitrary <*> listOf arbitrary
++  shrink value = [x :| xs | x : xs <- shrink (toList value)]
++#endif
++
+ -- |
+ -- Compose a monad, which attempts to extend a value, based on the following input.
+ -- It does so recursively until the suffix alternative fails.

--- a/ihp-typed-sql/IHP/TypedSql/Cardinality.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Cardinality.hs
@@ -11,12 +11,27 @@ import qualified Data.Set                         as Set
 import qualified Data.Text                        as Text
 import qualified Database.PostgreSQL.LibPQ        as PQ
 import           IHP.Prelude
-import qualified PostgresqlSyntax.Ast             as Ast
+import qualified PostgresqlSyntax                 as Ast
 
 import           IHP.TypedSql.Metadata            (ColumnMeta (..), TableMeta (..))
 import           IHP.TypedSql.Types               (QueryCardinality (..))
 
 type SourceCardinalityMap = Map.Map Text QueryCardinality
+
+fromClauseItems :: Ast.FromClause -> [Ast.TableRef]
+fromClauseItems (Ast.FromClause (Ast.FromList items)) = toList items
+
+targetListItems :: Ast.TargetList -> [Ast.TargetEl]
+targetListItems (Ast.TargetList items) = toList items
+
+indirectionItems :: Ast.Indirection -> [Ast.IndirectionEl]
+indirectionItems (Ast.Indirection items) = toList items
+
+exprListItems :: Ast.ExprList -> [Ast.AExpr]
+exprListItems (Ast.ExprList items) = toList items
+
+valuesClauseItems :: Ast.ValuesClause -> [Ast.ExprList]
+valuesClauseItems (Ast.ValuesClause items) = toList items
 
 -- | Conservatively infer the maximum number of rows a parsed statement can
 -- return. Unknown cases intentionally stay at 'ManyRows'.
@@ -39,8 +54,8 @@ inferInsertStmt tables (Ast.InsertStmt _with _target insertRest _onConflict mayb
 
 inferSelectStmt :: Map.Map PQ.Oid TableMeta -> Ast.SelectStmt -> QueryCardinality
 inferSelectStmt tables = \case
-    Left selectNoParens -> inferSelectNoParens tables selectNoParens
-    Right selectWithParens -> inferSelectWithParens tables selectWithParens
+    Ast.NoParensSelectStmt selectNoParens -> inferSelectNoParens tables selectNoParens
+    Ast.WithParensSelectStmt selectWithParens -> inferSelectWithParens tables selectWithParens
 
 inferSelectWithParens :: Map.Map PQ.Oid TableMeta -> Ast.SelectWithParens -> QueryCardinality
 inferSelectWithParens tables = \case
@@ -54,8 +69,8 @@ inferSelectNoParens tables (Ast.SelectNoParens maybeWith selectClause _sort mayb
 
 inferSelectClause :: Map.Map PQ.Oid TableMeta -> SourceCardinalityMap -> Ast.SelectClause -> QueryCardinality
 inferSelectClause tables sourceCardinalities = \case
-    Left simpleSelect -> inferSimpleSelect tables sourceCardinalities simpleSelect
-    Right selectWithParens -> inferSelectWithParens tables selectWithParens
+    Ast.SimpleSelectSelectClause simpleSelect -> inferSimpleSelect tables sourceCardinalities simpleSelect
+    Ast.WithParensSelectClause selectWithParens -> inferSelectWithParens tables selectWithParens
 
 inferSimpleSelect :: Map.Map PQ.Oid TableMeta -> SourceCardinalityMap -> Ast.SimpleSelect -> QueryCardinality
 inferSimpleSelect tables sourceCardinalities = \case
@@ -72,7 +87,7 @@ inferSimpleSelect tables sourceCardinalities = \case
         | otherwise ->
             ManyRows
     Ast.ValuesSimpleSelect values
-        | length (toList values) == 1 -> ExactlyOneRow
+        | length (valuesClauseItems values) == 1 -> ExactlyOneRow
         | otherwise -> ManyRows
     Ast.TableSimpleSelect _ -> ManyRows
     Ast.BinSimpleSelect _op _left _distinct _right -> ManyRows
@@ -87,7 +102,7 @@ cteCardinalities tables (Ast.WithClause _recursive ctes) =
 singleSourceCardinality :: Map.Map PQ.Oid TableMeta -> SourceCardinalityMap -> Maybe Ast.FromClause -> Maybe QueryCardinality
 singleSourceCardinality tables sourceCardinalities maybeFrom = do
     fromClause <- maybeFrom
-    case toList fromClause of
+    case fromClauseItems fromClause of
         [tableRef] -> tableRefCardinality tables sourceCardinalities tableRef
         _ -> Nothing
 
@@ -150,7 +165,7 @@ exprAtMostOne = \case
 
 cExprAtMostOne :: Ast.CExpr -> Bool
 cExprAtMostOne = \case
-    Ast.AexprConstCExpr (Ast.IAexprConst value) -> value <= 1
+    Ast.AexprConstCExpr (Ast.IAexprConst (Ast.Iconst value)) -> value <= 1
     _ -> False
 
 numericLimitAtMostOne :: Either Int64 Double -> Bool
@@ -160,8 +175,8 @@ numericLimitAtMostOne = \case
 
 isAggregateTargeting :: Maybe Ast.Targeting -> Bool
 isAggregateTargeting = \case
-    Just (Ast.NormalTargeting targets) -> any targetContainsAggregate (toList targets)
-    Just (Ast.DistinctTargeting _ targets) -> any targetContainsAggregate (toList targets)
+    Just (Ast.NormalTargeting targets) -> any targetContainsAggregate (targetListItems targets)
+    Just (Ast.DistinctTargeting _ targets) -> any targetContainsAggregate (targetListItems targets)
     _ -> False
 
 targetContainsAggregate :: Ast.TargetEl -> Bool
@@ -181,7 +196,6 @@ exprContainsAggregate = \case
     Ast.MinusAExpr expr -> exprContainsAggregate expr
     Ast.SymbolicBinOpAExpr left _ right -> exprContainsAggregate left || exprContainsAggregate right
     Ast.PrefixQualOpAExpr _ expr -> exprContainsAggregate expr
-    Ast.SuffixQualOpAExpr expr _ -> exprContainsAggregate expr
     Ast.AndAExpr left right -> exprContainsAggregate left || exprContainsAggregate right
     Ast.OrAExpr left right -> exprContainsAggregate left || exprContainsAggregate right
     Ast.NotAExpr expr -> exprContainsAggregate expr
@@ -210,9 +224,9 @@ cExprContainsAggregate = \case
 
 subexprContainsAggregate :: Ast.FuncExprCommonSubexpr -> Bool
 subexprContainsAggregate = \case
-    Ast.CoalesceFuncExprCommonSubexpr args -> any exprContainsAggregate (toList args)
-    Ast.GreatestFuncExprCommonSubexpr args -> any exprContainsAggregate (toList args)
-    Ast.LeastFuncExprCommonSubexpr args -> any exprContainsAggregate (toList args)
+    Ast.CoalesceFuncExprCommonSubexpr args -> any exprContainsAggregate (exprListItems args)
+    Ast.GreatestFuncExprCommonSubexpr args -> any exprContainsAggregate (exprListItems args)
+    Ast.LeastFuncExprCommonSubexpr args -> any exprContainsAggregate (exprListItems args)
     Ast.NullIfFuncExprCommonSubexpr left right -> exprContainsAggregate left || exprContainsAggregate right
     Ast.CastFuncExprCommonSubexpr expr _ -> exprContainsAggregate expr
     Ast.CollationForFuncExprCommonSubexpr expr -> exprContainsAggregate expr
@@ -224,7 +238,7 @@ reversibleOpContainsAggregate = \case
     Ast.DistinctFromAExprReversableOp expr -> exprContainsAggregate expr
     Ast.BetweenAExprReversableOp _ _ right -> exprContainsAggregate right
     Ast.BetweenSymmetricAExprReversableOp _ right -> exprContainsAggregate right
-    Ast.InAExprReversableOp (Ast.ExprListInExpr exprs) -> any exprContainsAggregate (toList exprs)
+    Ast.InAExprReversableOp (Ast.ExprListInExpr exprs) -> any exprContainsAggregate (exprListItems exprs)
     Ast.InAExprReversableOp (Ast.SelectInExpr _) -> False
     _ -> False
 
@@ -258,7 +272,7 @@ provesPrimaryKeyLookup tables maybeFrom maybeWhere =
                 |> map (\table@TableMeta { tmName } -> (tmName, table))
                 |> Map.fromList
     in case (singleSimpleTableRef maybeFrom, maybeWhere) of
-        (Just (tableName, tableQualifier), Just whereExpr) ->
+        (Just (tableName, tableQualifier), Just (Ast.WhereClause whereExpr)) ->
             case Map.lookup tableName tableByName of
                 Just tableMeta ->
                     let primaryKeyColumns = primaryKeyColumnNames tableMeta
@@ -277,7 +291,7 @@ primaryKeyColumnNames TableMeta { tmColumns, tmPrimaryKeys } =
 singleSimpleTableRef :: Maybe Ast.FromClause -> Maybe (Text, Text)
 singleSimpleTableRef maybeFrom = do
     fromClause <- maybeFrom
-    case toList fromClause of
+    case fromClauseItems fromClause of
         [Ast.RelationExprTableRef relExpr maybeAlias _sample] ->
             let tableName = relationExprName relExpr
                 qualifier = case maybeAlias of
@@ -304,7 +318,7 @@ columnRefForQualifier qualifier = \case
                 | qualifier == "" -> Just (identToText ident)
                 | otherwise -> Just (identToText ident)
             Just indirection ->
-                case toList indirection of
+                case indirectionItems indirection of
                     [Ast.AttrNameIndirectionEl columnIdent]
                         | identToText ident == qualifier -> Just (identToText columnIdent)
                     _ -> Nothing
@@ -319,7 +333,7 @@ qualifiedNameToText :: Ast.QualifiedName -> Text
 qualifiedNameToText = \case
     Ast.SimpleQualifiedName ident -> identToText ident
     Ast.IndirectedQualifiedName schema indirection ->
-        case toList indirection of
+        case indirectionItems indirection of
             [] -> identToText schema
             els -> case List.last els of
                 Ast.AttrNameIndirectionEl ident -> identToText ident
@@ -329,7 +343,7 @@ funcNameToText :: Ast.FuncName -> Text
 funcNameToText = \case
     Ast.TypeFuncName ident -> identToText ident
     Ast.IndirectedFuncName _ indirection ->
-        case toList indirection of
+        case indirectionItems indirection of
             [Ast.AttrNameIndirectionEl ident] -> identToText ident
             _ -> ""
 

--- a/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
+++ b/ihp-typed-sql/IHP/TypedSql/ParamHints.hs
@@ -21,8 +21,7 @@ import qualified Database.PostgreSQL.LibPQ   as PQ
 import qualified Language.Haskell.TH         as TH
 import           IHP.Prelude
 
-import qualified PostgresqlSyntax.Ast        as Ast
-import qualified PostgresqlSyntax.Parsing    as Parsing
+import qualified PostgresqlSyntax            as Ast
 
 import           IHP.TypedSql.Metadata       (ColumnMeta (..), DescribeColumn (..),
                                               PgTypeInfo, TableMeta (..))
@@ -43,9 +42,24 @@ data ParamHint = ParamHint
 -- so we strip it before parsing.
 parseSql :: String -> Maybe Ast.PreparableStmt
 parseSql sql =
-    case Parsing.run Parsing.preparableStmt (Text.strip (Text.pack sql)) of
+    case Ast.parse mempty (Text.strip (Text.pack sql)) of
         Left _err -> Nothing
         Right stmt -> Just stmt
+
+fromClauseItems :: Ast.FromClause -> [Ast.TableRef]
+fromClauseItems (Ast.FromClause (Ast.FromList items)) = toList items
+
+targetListItems :: Ast.TargetList -> [Ast.TargetEl]
+targetListItems (Ast.TargetList items) = toList items
+
+indirectionItems :: Ast.Indirection -> [Ast.IndirectionEl]
+indirectionItems (Ast.Indirection items) = toList items
+
+exprListItems :: Ast.ExprList -> [Ast.AExpr]
+exprListItems (Ast.ExprList items) = toList items
+
+setClauseListItems :: Ast.SetClauseList -> [Ast.SetClause]
+setClauseListItems (Ast.SetClauseList items) = toList items
 
 -- | Extract parameter hints by parsing SQL and walking the AST.
 -- Falls back to empty map if parsing fails.
@@ -82,19 +96,19 @@ nullableTablesFromStmt = \case
     _ -> Set.empty
 
 nullableTablesFromSelectStmt :: Ast.SelectStmt -> Set.Set Text
-nullableTablesFromSelectStmt (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
+nullableTablesFromSelectStmt (Ast.NoParensSelectStmt (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
     nullableTablesFromSelectClause selectClause
-nullableTablesFromSelectStmt (Right _) = Set.empty
+nullableTablesFromSelectStmt (Ast.WithParensSelectStmt _) = Set.empty
 
 nullableTablesFromSelectClause :: Ast.SelectClause -> Set.Set Text
-nullableTablesFromSelectClause (Left simpleSelect) = nullableTablesFromSimpleSelect simpleSelect
-nullableTablesFromSelectClause (Right _) = Set.empty
+nullableTablesFromSelectClause (Ast.SimpleSelectSelectClause simpleSelect) = nullableTablesFromSimpleSelect simpleSelect
+nullableTablesFromSelectClause (Ast.WithParensSelectClause _) = Set.empty
 
 nullableTablesFromSimpleSelect :: Ast.SimpleSelect -> Set.Set Text
 nullableTablesFromSimpleSelect = \case
     Ast.NormalSimpleSelect _targeting _into maybeFrom _where _group _having _window ->
         case maybeFrom of
-            Just fromClause -> foldMap nullableTablesFromTableRef (toList fromClause)
+            Just fromClause -> foldMap nullableTablesFromTableRef (fromClauseItems fromClause)
             Nothing -> Set.empty
     Ast.BinSimpleSelect _op left _distinct right ->
         Set.union (nullableTablesFromSelectClause left) (nullableTablesFromSelectClause right)
@@ -108,19 +122,18 @@ nullableTablesFromTableRef = \case
 nullableTablesFromJoinedTable :: Ast.JoinedTable -> Set.Set Text
 nullableTablesFromJoinedTable = \case
     Ast.InParensJoinedTable inner -> nullableTablesFromJoinedTable inner
-    Ast.MethJoinedTable meth left right ->
-        let nested = Set.union (nullableTablesFromTableRef left) (nullableTablesFromTableRef right)
-        in case joinTypeFromMeth meth of
-            Just (Ast.LeftJoinType _)  -> Set.union nested (tableNamesFromTableRef right)
-            Just (Ast.RightJoinType _) -> Set.union nested (tableNamesFromTableRef left)
-            Just (Ast.FullJoinType _)  -> Set.union nested (Set.union (tableNamesFromTableRef left) (tableNamesFromTableRef right))
-            _ -> nested
+    Ast.CrossJoinedTable left right -> nullableTablesFromJoin Nothing left right
+    Ast.QualJoinedTable left maybeJoinType right _qual -> nullableTablesFromJoin maybeJoinType left right
+    Ast.NaturalJoinedTable left maybeJoinType right -> nullableTablesFromJoin maybeJoinType left right
 
-joinTypeFromMeth :: Ast.JoinMeth -> Maybe Ast.JoinType
-joinTypeFromMeth = \case
-    Ast.QualJoinMeth maybeJoinType _ -> maybeJoinType
-    Ast.NaturalJoinMeth maybeJoinType -> maybeJoinType
-    Ast.CrossJoinMeth -> Nothing
+nullableTablesFromJoin :: Maybe Ast.JoinType -> Ast.TableRef -> Ast.TableRef -> Set.Set Text
+nullableTablesFromJoin maybeJoinType left right =
+    let nested = Set.union (nullableTablesFromTableRef left) (nullableTablesFromTableRef right)
+    in case maybeJoinType of
+        Just (Ast.LeftJoinType _)  -> Set.union nested (tableNamesFromTableRef right)
+        Just (Ast.RightJoinType _) -> Set.union nested (tableNamesFromTableRef left)
+        Just (Ast.FullJoinType _)  -> Set.union nested (Set.union (tableNamesFromTableRef left) (tableNamesFromTableRef right))
+        _ -> nested
 
 -- | Collect all resolved table names from a TableRef.
 tableNamesFromTableRef :: Ast.TableRef -> Set.Set Text
@@ -138,7 +151,7 @@ qualifiedNameToText :: Ast.QualifiedName -> Text
 qualifiedNameToText (Ast.SimpleQualifiedName ident) = identToText ident
 qualifiedNameToText (Ast.IndirectedQualifiedName _schema indirection) =
     -- schema.table -> take the last attr name
-    case toList indirection of
+    case indirectionItems indirection of
         [] -> identToText _schema
         els -> case List.last els of
             Ast.AttrNameIndirectionEl ident -> identToText ident
@@ -179,20 +192,20 @@ buildAliasMapFromStmt = \case
     Ast.CallPreparableStmt _ -> Map.empty
 
 buildAliasMapFromSelectStmt :: Ast.SelectStmt -> Map.Map Text Text
-buildAliasMapFromSelectStmt (Left (Ast.SelectNoParens maybeWith selectClause _sort _limit _lock)) =
+buildAliasMapFromSelectStmt (Ast.NoParensSelectStmt (Ast.SelectNoParens maybeWith selectClause _sort _limit _lock)) =
     let withMap = case maybeWith of
             Just (Ast.WithClause _recursive ctes) -> foldMap buildAliasMapFromCte (toList ctes)
             Nothing -> Map.empty
     in Map.union withMap (buildAliasMapFromSelectClause selectClause)
-buildAliasMapFromSelectStmt (Right _parens) = Map.empty
+buildAliasMapFromSelectStmt (Ast.WithParensSelectStmt _parens) = Map.empty
 
 buildAliasMapFromCte :: Ast.CommonTableExpr -> Map.Map Text Text
 buildAliasMapFromCte (Ast.CommonTableExpr _name _cols _mat innerStmt) =
     buildAliasMapFromStmt innerStmt
 
 buildAliasMapFromSelectClause :: Ast.SelectClause -> Map.Map Text Text
-buildAliasMapFromSelectClause (Left simpleSelect) = buildAliasMapFromSimpleSelect simpleSelect
-buildAliasMapFromSelectClause (Right _parens) = Map.empty
+buildAliasMapFromSelectClause (Ast.SimpleSelectSelectClause simpleSelect) = buildAliasMapFromSimpleSelect simpleSelect
+buildAliasMapFromSelectClause (Ast.WithParensSelectClause _parens) = Map.empty
 
 buildAliasMapFromSimpleSelect :: Ast.SimpleSelect -> Map.Map Text Text
 buildAliasMapFromSimpleSelect = \case
@@ -208,7 +221,7 @@ buildAliasMapFromSimpleSelect = \case
     Ast.ValuesSimpleSelect _ -> Map.empty
 
 buildAliasMapFromFrom :: Ast.FromClause -> Map.Map Text Text
-buildAliasMapFromFrom = foldMap buildAliasMapFromTableRef . toList
+buildAliasMapFromFrom = foldMap buildAliasMapFromTableRef . fromClauseItems
 
 buildAliasMapFromTableRef :: Ast.TableRef -> Map.Map Text Text
 buildAliasMapFromTableRef = \case
@@ -230,7 +243,11 @@ buildAliasMapFromTableRef = \case
 buildAliasMapFromJoinedTable :: Ast.JoinedTable -> Map.Map Text Text
 buildAliasMapFromJoinedTable = \case
     Ast.InParensJoinedTable inner -> buildAliasMapFromJoinedTable inner
-    Ast.MethJoinedTable _meth left right ->
+    Ast.CrossJoinedTable left right ->
+        Map.union (buildAliasMapFromTableRef left) (buildAliasMapFromTableRef right)
+    Ast.QualJoinedTable left _joinType right _qual ->
+        Map.union (buildAliasMapFromTableRef left) (buildAliasMapFromTableRef right)
+    Ast.NaturalJoinedTable left _joinType right ->
         Map.union (buildAliasMapFromTableRef left) (buildAliasMapFromTableRef right)
 
 relationExprName :: Ast.RelationExpr -> Text
@@ -247,7 +264,7 @@ collectFromStmt aliasMap defTable = \case
         collectFromSelectStmt aliasMap defTable selectStmt
     Ast.UpdatePreparableStmt (Ast.UpdateStmt _with (Ast.RelationExprOptAlias relExpr _) setClauses _from maybeWhere _ret) ->
         let updateTable = relationExprName relExpr
-            setHints = foldMap (collectFromSetClause aliasMap defTable updateTable) (toList setClauses)
+            setHints = foldMap (collectFromSetClause aliasMap defTable updateTable) (setClauseListItems setClauses)
             whereHints = case maybeWhere of
                 Just (Ast.ExprWhereOrCurrentClause expr) -> collectFromAExpr aliasMap defTable expr
                 _ -> Map.empty
@@ -261,7 +278,7 @@ collectFromStmt aliasMap defTable = \case
             Just (Ast.OnConflict _confExpr (Ast.UpdateOnConflictDo setClauses maybeWhere)) ->
                 let insertTable = case _target of
                         Ast.InsertTarget qname _ -> qualifiedNameToText qname
-                    setHints = foldMap (collectFromSetClause aliasMap defTable insertTable) (toList setClauses)
+                    setHints = foldMap (collectFromSetClause aliasMap defTable insertTable) (setClauseListItems setClauses)
                     whereHints = case maybeWhere of
                         Just whereExpr -> collectFromAExpr aliasMap defTable whereExpr
                         Nothing -> Map.empty
@@ -270,20 +287,20 @@ collectFromStmt aliasMap defTable = \case
     Ast.CallPreparableStmt _ -> Map.empty
 
 collectFromSelectStmt :: Map.Map Text Text -> Maybe Text -> Ast.SelectStmt -> Map.Map Int ParamHint
-collectFromSelectStmt aliasMap defTable (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
+collectFromSelectStmt aliasMap defTable (Ast.NoParensSelectStmt (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
     collectFromSelectClause aliasMap defTable selectClause
-collectFromSelectStmt _ _ (Right _) = Map.empty
+collectFromSelectStmt _ _ (Ast.WithParensSelectStmt _) = Map.empty
 
 collectFromSelectClause :: Map.Map Text Text -> Maybe Text -> Ast.SelectClause -> Map.Map Int ParamHint
-collectFromSelectClause aliasMap defTable (Left simpleSelect) =
+collectFromSelectClause aliasMap defTable (Ast.SimpleSelectSelectClause simpleSelect) =
     collectFromSimpleSelect aliasMap defTable simpleSelect
-collectFromSelectClause _ _ (Right _) = Map.empty
+collectFromSelectClause _ _ (Ast.WithParensSelectClause _) = Map.empty
 
 collectFromSimpleSelect :: Map.Map Text Text -> Maybe Text -> Ast.SimpleSelect -> Map.Map Int ParamHint
 collectFromSimpleSelect aliasMap defTable = \case
     Ast.NormalSimpleSelect _targeting _into _from maybeWhere _group _having _window ->
         case maybeWhere of
-            Just whereExpr -> collectFromAExpr aliasMap defTable whereExpr
+            Just (Ast.WhereClause whereExpr) -> collectFromAExpr aliasMap defTable whereExpr
             Nothing -> Map.empty
     Ast.BinSimpleSelect _op left _distinct right ->
         mergeHintMaps
@@ -339,7 +356,7 @@ collectFromAExpr aliasMap defTable = \case
                             , phArray = True
                             }
                     Nothing -> Map.empty
-                    ) (toList exprs)
+                    ) (exprListItems exprs)
             Nothing -> Map.empty
     -- column = ANY($N) pattern via SubqueryAExpr
     Ast.SubqueryAExpr colExpr (Ast.AllSubqueryOp (Ast.MathAllOp Ast.EqualsMathOp)) Ast.AnySubType (Right paramExpr) ->
@@ -378,7 +395,7 @@ resolveColumnRef aliasMap defTable = \case
         case maybeIndirection of
             -- qualified: tableOrAlias.column
             Just indirection ->
-                case toList indirection of
+                case indirectionItems indirection of
                     [Ast.AttrNameIndirectionEl colIdent] ->
                         let tableRef = identToText colId
                             colName = identToText colIdent
@@ -420,27 +437,27 @@ extractNonNullableComputedColumnsFromAst = \case
     _ -> Set.empty
 
 nonNullFromSelectStmt :: Ast.SelectStmt -> Set.Set Int
-nonNullFromSelectStmt (Left (Ast.SelectNoParens maybeWith selectClause _sort _limit _lock)) =
+nonNullFromSelectStmt (Ast.NoParensSelectStmt (Ast.SelectNoParens maybeWith selectClause _sort _limit _lock)) =
     let cteMap = case maybeWith of
             Just (Ast.WithClause _recursive ctes) -> foldMap buildSubqueryTargetMapFromCte (toList ctes)
             Nothing -> Map.empty
     in nonNullFromSelectClause cteMap selectClause
-nonNullFromSelectStmt (Right _) = Set.empty
+nonNullFromSelectStmt (Ast.WithParensSelectStmt _) = Set.empty
 
 nonNullFromSelectClause :: SubqueryTargetMap -> Ast.SelectClause -> Set.Set Int
-nonNullFromSelectClause sqMap (Left simpleSelect) = nonNullFromSimpleSelect sqMap simpleSelect
-nonNullFromSelectClause _ (Right _) = Set.empty
+nonNullFromSelectClause sqMap (Ast.SimpleSelectSelectClause simpleSelect) = nonNullFromSimpleSelect sqMap simpleSelect
+nonNullFromSelectClause _ (Ast.WithParensSelectClause _) = Set.empty
 
 nonNullFromSimpleSelect :: SubqueryTargetMap -> Ast.SimpleSelect -> Set.Set Int
 nonNullFromSimpleSelect sqMap = \case
     Ast.NormalSimpleSelect maybeTargeting _into maybeFrom _where _group _having _window ->
         let fromMap = case maybeFrom of
-                Just fromClause -> foldMap buildSubqueryTargetMapFromTableRef (toList fromClause)
+                Just fromClause -> foldMap buildSubqueryTargetMapFromTableRef (fromClauseItems fromClause)
                 Nothing -> Map.empty
             fullMap = Map.union fromMap sqMap
         in case maybeTargeting of
-            Just (Ast.NormalTargeting targets) -> analyzeTargets fullMap (toList targets)
-            Just (Ast.DistinctTargeting _ targets) -> analyzeTargets fullMap (toList targets)
+            Just (Ast.NormalTargeting targets) -> analyzeTargets fullMap (targetListItems targets)
+            Just (Ast.DistinctTargeting _ targets) -> analyzeTargets fullMap (targetListItems targets)
             _ -> Set.empty
     _ -> Set.empty
 
@@ -474,7 +491,7 @@ isExprNonNullable sqMap = \case
     Ast.CExprAExpr (Ast.AexprConstCExpr constant) -> not (isNullConstant constant)
     -- Column reference: alias.col where alias is a subquery/CTE
     Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref aliasId (Just indirection))) ->
-        case toList indirection of
+        case indirectionItems indirection of
             [Ast.AttrNameIndirectionEl colIdent] ->
                 let aliasName = identToText aliasId
                     colName = identToText colIdent
@@ -521,7 +538,7 @@ isSubexprNonNullable :: SubqueryTargetMap -> Ast.FuncExprCommonSubexpr -> Bool
 isSubexprNonNullable sqMap = \case
     -- COALESCE(a, b, ...) is non-null when any argument is non-null
     Ast.CoalesceFuncExprCommonSubexpr args ->
-        any (isExprNonNullable sqMap) (toList args)
+        any (isExprNonNullable sqMap) (exprListItems args)
     -- CAST(expr AS type) preserves nullability
     Ast.CastFuncExprCommonSubexpr inner _ -> isExprNonNullable sqMap inner
     -- CURRENT_DATE, CURRENT_TIME, etc. are always non-null
@@ -548,7 +565,7 @@ funcNameToText :: Ast.FuncName -> Text
 funcNameToText = \case
     Ast.TypeFuncName ident -> identToText ident
     Ast.IndirectedFuncName _ indirection ->
-        case toList indirection of
+        case indirectionItems indirection of
             [Ast.AttrNameIndirectionEl funcIdent] -> identToText funcIdent
             _ -> ""
 
@@ -576,7 +593,11 @@ buildSubqueryTargetMapFromTableRef = \case
 buildSubqueryTargetMapFromJoinedTable :: Ast.JoinedTable -> SubqueryTargetMap
 buildSubqueryTargetMapFromJoinedTable = \case
     Ast.InParensJoinedTable inner -> buildSubqueryTargetMapFromJoinedTable inner
-    Ast.MethJoinedTable _meth left right ->
+    Ast.CrossJoinedTable left right ->
+        Map.union (buildSubqueryTargetMapFromTableRef left) (buildSubqueryTargetMapFromTableRef right)
+    Ast.QualJoinedTable left _joinType right _qual ->
+        Map.union (buildSubqueryTargetMapFromTableRef left) (buildSubqueryTargetMapFromTableRef right)
+    Ast.NaturalJoinedTable left _joinType right ->
         Map.union (buildSubqueryTargetMapFromTableRef left) (buildSubqueryTargetMapFromTableRef right)
 
 -- | Extract (name, expr) pairs from a SelectWithParens.
@@ -588,20 +609,20 @@ extractTargetsFromSelectWithParens = \case
         extractTargetsFromSelectWithParens inner
 
 extractTargetsFromSelectStmt :: Ast.SelectStmt -> Maybe [(Text, Ast.AExpr)]
-extractTargetsFromSelectStmt (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
+extractTargetsFromSelectStmt (Ast.NoParensSelectStmt (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
     extractTargetsFromSelectClause selectClause
-extractTargetsFromSelectStmt (Right _) = Nothing
+extractTargetsFromSelectStmt (Ast.WithParensSelectStmt _) = Nothing
 
 extractTargetsFromSelectClause :: Ast.SelectClause -> Maybe [(Text, Ast.AExpr)]
-extractTargetsFromSelectClause (Left simpleSelect) = extractTargetsFromSimpleSelect simpleSelect
-extractTargetsFromSelectClause (Right _) = Nothing
+extractTargetsFromSelectClause (Ast.SimpleSelectSelectClause simpleSelect) = extractTargetsFromSimpleSelect simpleSelect
+extractTargetsFromSelectClause (Ast.WithParensSelectClause _) = Nothing
 
 extractTargetsFromSimpleSelect :: Ast.SimpleSelect -> Maybe [(Text, Ast.AExpr)]
 extractTargetsFromSimpleSelect = \case
     Ast.NormalSimpleSelect maybeTargeting _into _from _where _group _having _window ->
         case maybeTargeting of
-            Just (Ast.NormalTargeting targets) -> Just (map targetToNameExpr (toList targets))
-            Just (Ast.DistinctTargeting _ targets) -> Just (map targetToNameExpr (toList targets))
+            Just (Ast.NormalTargeting targets) -> Just (map targetToNameExpr (targetListItems targets))
+            Just (Ast.DistinctTargeting _ targets) -> Just (map targetToNameExpr (targetListItems targets))
             _ -> Nothing
     _ -> Nothing
 
@@ -621,12 +642,12 @@ implicitName = \case
         case funcName of
             Ast.TypeFuncName ident -> identToText ident
             Ast.IndirectedFuncName _ indirection ->
-                case toList indirection of
+                case indirectionItems indirection of
                     [Ast.AttrNameIndirectionEl ident] -> identToText ident
                     _ -> ""
     Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref colId Nothing)) -> identToText colId
     Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref _ (Just indirection))) ->
-        case toList indirection of
+        case indirectionItems indirection of
             [Ast.AttrNameIndirectionEl ident] -> identToText ident
             _ -> ""
     _ -> ""
@@ -692,9 +713,9 @@ detectStarSelects = \case
     _ -> []
 
 starFromSelectStmt :: Ast.SelectStmt -> [String]
-starFromSelectStmt (Left (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
+starFromSelectStmt (Ast.NoParensSelectStmt (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
     starFromSelectClause selectClause
-starFromSelectStmt (Right parens) = starFromSelectWithParens parens
+starFromSelectStmt (Ast.WithParensSelectStmt parens) = starFromSelectWithParens parens
 
 starFromSelectWithParens :: Ast.SelectWithParens -> [String]
 starFromSelectWithParens (Ast.NoParensSelectWithParens (Ast.SelectNoParens _with selectClause _sort _limit _lock)) =
@@ -703,15 +724,15 @@ starFromSelectWithParens (Ast.WithParensSelectWithParens inner) =
     starFromSelectWithParens inner
 
 starFromSelectClause :: Ast.SelectClause -> [String]
-starFromSelectClause (Left simpleSelect) = starFromSimpleSelect simpleSelect
-starFromSelectClause (Right parens) = starFromSelectWithParens parens
+starFromSelectClause (Ast.SimpleSelectSelectClause simpleSelect) = starFromSimpleSelect simpleSelect
+starFromSelectClause (Ast.WithParensSelectClause parens) = starFromSelectWithParens parens
 
 starFromSimpleSelect :: Ast.SimpleSelect -> [String]
 starFromSimpleSelect = \case
     Ast.NormalSimpleSelect maybeTargeting _into _from _where _group _having _window ->
         case maybeTargeting of
-            Just (Ast.NormalTargeting targets) -> concatMap starFromTargetEl (toList targets)
-            Just (Ast.DistinctTargeting _ targets) -> concatMap starFromTargetEl (toList targets)
+            Just (Ast.NormalTargeting targets) -> concatMap starFromTargetEl (targetListItems targets)
+            Just (Ast.DistinctTargeting _ targets) -> concatMap starFromTargetEl (targetListItems targets)
             _ -> []
     Ast.BinSimpleSelect _op left _distinct right ->
         starFromSelectClause left <> starFromSelectClause right
@@ -729,7 +750,7 @@ starFromTargetEl = \case
 starFromExpr :: Ast.AExpr -> [String]
 starFromExpr = \case
     Ast.CExprAExpr (Ast.ColumnrefCExpr (Ast.Columnref ident (Just indirection)))
-        | any isAllIndirection (toList indirection) ->
+        | any isAllIndirection (indirectionItems indirection) ->
             [Text.unpack (identToText ident) <> ".*"]
     _ -> []
   where

--- a/ihp-typed-sql/IHP/TypedSql/Quoter.hs
+++ b/ihp-typed-sql/IHP/TypedSql/Quoter.hs
@@ -20,7 +20,7 @@ import qualified Hasql.DynamicStatements.Snippet as Snippet
 import qualified Language.Haskell.TH            as TH
 import qualified Language.Haskell.TH.Quote      as TH
 import qualified Language.Haskell.TH.Syntax     as TH
-import qualified PostgresqlSyntax.Ast           as Ast
+import qualified PostgresqlSyntax               as Ast
 import           Text.Read                      (readMaybe)
 import qualified Prelude
 import           IHP.Prelude

--- a/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
+++ b/ihp-typed-sql/Test/Test/TypedSqlSpec.hs
@@ -815,6 +815,12 @@ tests = do
         it "parseSql handles leading/trailing whitespace from quasiquoter" do
             parseSql " SELECT 1 " `shouldSatisfy` isJust
 
+        it "parseSql accepts unspaced ANY operators" do
+            parseSql "SELECT 1 WHERE 1=ANY(ARRAY[1])" `shouldSatisfy` isJust
+
+        it "parseSql accepts the JSONB key-existence operator" do
+            parseSql "SELECT '{}'::jsonb ? 'key'" `shouldSatisfy` isJust
+
         it "extractJoinNullableTables detects LEFT JOIN nullable table" do
             let sql = " SELECT i.name, a.name FROM items i LEFT JOIN authors a ON a.id = i.aid LIMIT 1 "
             extractJoinNullableTables sql `shouldBe` Set.fromList ["authors"]

--- a/ihp-typed-sql/changelog.md
+++ b/ihp-typed-sql/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Updated `postgresql-syntax` to 0.5.0.3 so valid unspaced `ANY` expressions
+  and the JSONB key-existence operator participate in `typedSql` refinement.
+
 - Added `IHP.TypedSql.Hasql`, a request-context-independent API for converting
   typed queries to Hasql statements, sessions, and pipelines, or running them
   directly on a caller-managed Hasql pool. Pool runners expose Hasql's native

--- a/ihp-typed-sql/ihp-typed-sql.cabal
+++ b/ihp-typed-sql/ihp-typed-sql.cabal
@@ -72,7 +72,7 @@ library
             , hasql-mapping
             , hasql-pool
             , haskell-src-meta
-            , postgresql-syntax >= 0.4 && < 0.5
+            , postgresql-syntax >= 0.5.0.3 && < 0.6
             , postgresql-types
             , postgresql-libpq
             , process

--- a/update-nix-from-cabal.sh
+++ b/update-nix-from-cabal.sh
@@ -30,6 +30,7 @@ hackage_packages=(
   "wai-session-maybe 1.0.0"
   "wai-session-clientsession-deferred 1.0.0"
   "postgresql-connection-string 0.1.0.6"
+  "postgresql-syntax 0.5.0.3"
   "temporary-ospath 1.3"
   "ptr-poker 0.1.3"
   "postgresql-simple-postgresql-types 0.1.1"


### PR DESCRIPTION
## Summary

- update `ihp-typed-sql` to `postgresql-syntax` 0.5.0.3 and migrate to its public AST API
- restore refinement parsing for valid unspaced `=ANY(...)` expressions and JSONB `?` operators after nikita-volkov/postgresql-syntax#36
- keep the current IHP QuickCheck package set by backporting the guarded `NonEmpty` `Arbitrary` instance required by the dependency

## Tests

- `nix build .#packages.aarch64-darwin.ihp-typed-sql --no-link`: 124 examples, 0 failures (85 pending integration examples); local disk exhaustion only during Haddock
- the same package built successfully with `pkgs.haskell.lib.dontHaddock`