### PR TITLE
NixSupport: expose extraGhcOptions for app builds

### DIFF
--- a/NixSupport/default.nix
+++ b/NixSupport/default.nix
@@ -26,6 +26,7 @@
 , appLibGhcAllocationArea ? null # Optional app-library-specific compile-time RTS allocation area
 , buildStaticLibraries ? true # Build static Haskell libraries in addition to shared libraries
 , ghcAllocationArea ? null # Optional GHC compile-time RTS allocation area, e.g. "128M"
+, extraGhcOptions ? [] # Extra GHC options (e.g. [ "-Wall" ]) applied to the models package, the application library and all executables
 }:
 
 let
@@ -457,7 +458,8 @@ CABAL_EOF
                         "--ghc-option=+RTS"
                         "--ghc-option=-A${ghcAllocationArea}"
                         "--ghc-option=-RTS"
-                    ];
+                    ]
+                    ++ map (opt: "--ghc-option=${opt}") extraGhcOptions;
             });
 
     configureAppLibBuild = pkg:
@@ -568,6 +570,7 @@ CABAL_EOF
                     ${pkgs.lib.optionalString (mainIs != null) "-main-is '${mainIs}'"} \
                     $(make print-ghc-options) \
                     ${if optimized then prodGhcOptions else ""} \
+                    ${pkgs.lib.escapeShellArgs extraGhcOptions} \
                     ${mainPath} -o build/bin/${executableName} \
                     -odir build/obj -hidir build/obj
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -150,6 +150,17 @@ ihpFlake:
                     default = null;
                 };
 
+                extraGhcOptions = lib.mkOption {
+                    description = ''
+                        Extra GHC options applied when compiling the generated models
+                        package, the application library and all executables. For
+                        example [ "-Wall" ] to opt into the warnings the generated
+                        build does not enable by default, or linker flags.
+                    '';
+                    type = lib.types.listOf lib.types.str;
+                    default = [];
+                };
+
                 previousAppLibIntermediates = lib.mkOption {
                     description = ''
                         Combined intermediate output from a previous optimized application
@@ -268,7 +279,7 @@ ihpFlake:
                     optimized && cfg.reuseAppLibWithIntermediatesForExecutables;
                 appLibCompileCores = if optimized then cfg.appLibCompileCores else null;
                 appLibGhcAllocationArea = if optimized then cfg.appLibGhcAllocationArea else null;
-                inherit (cfg) buildStaticLibraries ghcAllocationArea;
+                inherit (cfg) buildStaticLibraries ghcAllocationArea extraGhcOptions;
                 appSchemaSql = "${self'.packages.schema}/Schema.sql";
                 ihpSchemaSql = "${self'.packages.ihp-schema}/IHPSchema.sql";
             };


### PR DESCRIPTION
## Problem

The cabal files that `NixSupport/default.nix` generates hardcode their `ghc-options`, and the executable compile line is equally closed. An app author currently has no way to pass GHC flags of their own: `-Wall` (or any warning policy), `-Werror` choices, or linker flags are all unreachable, and the only workaround is forking the builder. The internal packages aren't reachable from the outside either, so `haskell.lib.overrideCabal` can't be applied after the fact.

## Change

Adds an `extraGhcOptions` argument (list of flags, default `[]`) to `NixSupport/default.nix`, threaded through all three compilation stages:

- the generated models package and the application library receive it as `--ghc-option=` configureFlags through the existing `configureHaskellBuild` helper, composing with `ghcAllocationArea` and `buildStaticLibraries`;
- the executable builds (`RunProdServer`, `RunJobs`, scripts) append it to the `ghc` invocation after the generated options, so user flags win where they conflict (GHC last-flag-wins).

The flake module exposes it as `ihp.extraGhcOptions` next to the other build options.

## Compatibility

Default `[]` changes nothing: the configureFlags addition maps over an empty list and the shell interpolation is empty, so existing derivation behaviour is preserved.

## Tested

Verified against a real IHP 1.6 app built through `NixSupport/default.nix` directly (pinned via nix, no flakes): with the default the build is unchanged; with `extraGhcOptions = [ "-Wall" ]` the warnings appear across models, app library and executables and the build stays green. (The same patch backported onto v1.6.0 is what we run in production; this PR is the master version.)

cc @jappeace

🤖 Generated with [Claude Code](https://claude.com/claude-code)