### PR TITLE
Harden self-hosted ARM64 workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,8 @@ jobs:
       pull-requests: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
 
     - name: Build baseline (master IHP) and PR benchmark
       working-directory: ihp/Bench

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Build baseline (master IHP) and PR benchmark
       working-directory: ihp/Bench

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - uses: wimpysworld/nothing-but-nix@main
       with:
         hatchet-protocol: 'rampage'
@@ -81,6 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - uses: wimpysworld/nothing-but-nix@main
       with:
         hatchet-protocol: 'rampage'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - 'v.+'
     tags: ['**']
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -13,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, ARM64]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - uses: wimpysworld/nothing-but-nix@main
       with:
         hatchet-protocol: 'rampage'
@@ -35,7 +39,8 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       if: matrix.os != 'ARM64'
     # ARM64 (self-hosted) runs the full check suite including multi-GHC checks.
-    # It also pushes to the self-hosted Attic cache via a daemon post-build-hook.
+    # The dedicated non-admin runner has no daemon post-build hook or persistent
+    # cache credential; hosted package jobs below perform explicit cache pushes.
     - run: nix flake check --impure --override-input ihp-boilerplate/ihp "github:${{ github.event.repository.full_name }}/${{ github.sha }}" -L
       if: matrix.os == 'ARM64'
     # GitHub-hosted runners only build packages to populate the binary caches.
@@ -75,7 +80,7 @@ jobs:
   ghc914-dev-env:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - uses: wimpysworld/nothing-but-nix@main
       with:
         hatchet-protocol: 'rampage'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,11 +4,15 @@ on:
     branches: [master]
   push:
     branches: 'master'
+
+permissions:
+  contents: read
+
 jobs:
   nix-flake-check:
     runs-on: ARM64
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Free disk space on the self-hosted runner
       run: nix store gc --max 30G
     - run: nix flake check --impure --override-input ihp-boilerplate/ihp "github:${{ github.event.repository.full_name }}/${{ github.sha }}" -L

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ARM64
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - name: Free disk space on the self-hosted runner
       run: nix store gc --max 30G
     - run: nix flake check --impure --override-input ihp-boilerplate/ihp "github:${{ github.event.repository.full_name }}/${{ github.sha }}" -L


### PR DESCRIPTION
## Summary
- restrict the build and test workflow tokens to read-only repository contents
- pin checkout to the reviewed v7 commit on workflows that execute on the self-hosted ARM64 runner
- document that the isolated runner has no daemon cache hook or persistent cache credential

## Validation
- `nix run nixpkgs#actionlint -- -shellcheck= .github/workflows/build.yml .github/workflows/tests.yml .github/workflows/benchmark.yml`
- `git diff --check`
- Binary Build run 33438689290 checked out successfully and is running the ARM64 flake checks on `macstadium-ihp`
